### PR TITLE
setup webpack-dev-server SPA support

### DIFF
--- a/packages/fast-components-react-base/webpack.config.js
+++ b/packages/fast-components-react-base/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
     entry: path.resolve(appDir, "index.tsx"),
     output: {
         path: outDir,
+        publicPath: "/",
         filename: "[name].js"
     },
     mode: process.env.NODE_ENV || "development",
@@ -33,9 +34,10 @@ module.exports = {
         })
     ],
     devServer: {
-        port: 7000,
         compress: false,
+        historyApiFallback: true,
         open: true,
-        overlay: true 
+        overlay: true,
+        port: 7000,
     }
 }

--- a/packages/fast-components-react-msft/webpack.config.js
+++ b/packages/fast-components-react-msft/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
     entry: path.resolve(appDir, "index.tsx"),
     output: {
         path: outDir,
+        publicPath: "/",
         filename: "[name].js"
     },
     mode: process.env.NODE_ENV || "development",
@@ -39,9 +40,10 @@ module.exports = {
         extensions: [".js", ".tsx", ".ts", ".json"],
     },
     devServer: {
-        port: 7001,
         compress: false,
+        historyApiFallback: true,
         open: true,
-        overlay: true 
+        overlay: true,
+        port: 7001
     }
 }


### PR DESCRIPTION
`fast-components-react-base` and `fast-components-react-msft` development environments should now correctly perform a page-reload when source-files change.

closes #201 