### PR TITLE
fix(dev-site): add design system provider to component example factory

### DIFF
--- a/packages/fast-components-react-msft/app/index.tsx
+++ b/packages/fast-components-react-msft/app/index.tsx
@@ -31,7 +31,7 @@ function render(): void {
                         </SiteCategoryIcon>
                     </SiteCategory>
                     <SiteCategory slot={"category"} name={"Components"}>
-                        {componentFactory(examples)}
+                        {componentFactory(examples, DesignSystemDefaults)}
                     </SiteCategory>
                 </Site>
             </DesignSystemProvider>

--- a/packages/fast-development-site-react/src/utilities/componentExampleFactory.tsx
+++ b/packages/fast-development-site-react/src/utilities/componentExampleFactory.tsx
@@ -8,7 +8,7 @@ export default function componentExampleFactory<T>(examples: any, componentExamp
     return examples[componentExample].data.map((componentExampleData: any, index: number) => {
         return (
             <SiteCategoryItem key={index} slot={"canvas"}>
-                <DesignSystemProvider designSystem={designSystem ? designSystem : null}>
+                <DesignSystemProvider designSystem={designSystem ? designSystem : void 0}>
                     <Component {...componentExampleData} />
                 </DesignSystemProvider>
             </SiteCategoryItem>

--- a/packages/fast-development-site-react/src/utilities/componentExampleFactory.tsx
+++ b/packages/fast-development-site-react/src/utilities/componentExampleFactory.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
 import { SiteCategoryItem } from "../";
+import { DesignSystemProvider } from "@microsoft/fast-jss-manager-react";
 
-export default function componentExampleFactory(examples: any, componentExample: string): JSX.Element[] {
+export default function componentExampleFactory<T>(examples: any, componentExample: string, designSystem?: T): JSX.Element[] {
     const Component: any = examples[componentExample].component;
 
     return examples[componentExample].data.map((componentExampleData: any, index: number) => {
         return (
             <SiteCategoryItem key={index} slot={"canvas"}>
-                <Component {...componentExampleData} />
+                <DesignSystemProvider designSystem={designSystem ? designSystem : null}>
+                    <Component {...componentExampleData} />
+                </DesignSystemProvider>
             </SiteCategoryItem>
         );
     });

--- a/packages/fast-development-site-react/src/utilities/componentFactory.tsx
+++ b/packages/fast-development-site-react/src/utilities/componentFactory.tsx
@@ -2,11 +2,11 @@ import * as React from "react";
 import componentExampleFactory from "./componentExampleFactory";
 import { SiteCategory } from "../";
 
-export default function componentFactory(examples: any): JSX.Element[] {
+export default function componentFactory<T>(examples: any, designSystem?: T): JSX.Element[] {
     return Object.keys(examples).map((exampleKey: string, index: number) => {
         return (
             <SiteCategory key={index} slot={"category"} name={examples[exampleKey].name}>
-                {componentExampleFactory(examples, exampleKey)}
+                {componentExampleFactory<T>(examples, exampleKey, designSystem)}
             </SiteCategory>
         );
     });

--- a/packages/fast-markdown-msft-react/package-lock.json
+++ b/packages/fast-markdown-msft-react/package-lock.json
@@ -1,14 +1,11 @@
 {
-	"name": "@microsoft/fast-markdown-msft-react",
-	"version": "1.0.0",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0-beta.46",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
 			"integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "7.0.0-beta.46"
 			}
@@ -17,7 +14,6 @@
 			"version": "7.0.0-beta.46",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
 			"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
-			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"esutils": "2.0.2",
@@ -28,7 +24,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -37,7 +32,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -48,7 +42,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -58,26 +51,22 @@
 		"@types/jest": {
 			"version": "22.2.3",
 			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
-			"integrity": "sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==",
-			"dev": true
+			"integrity": "sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg=="
 		},
 		"@types/markdown-it": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-0.0.4.tgz",
-			"integrity": "sha512-FWR7QB7EqBRq1s9BMk0ccOSOuRLfVEWYpHQYpFPaXtCoqN6dJx2ttdsdQbUxLLnAlKpYeVjveGGhQ3583TTa7g==",
-			"dev": true
+			"integrity": "sha512-FWR7QB7EqBRq1s9BMk0ccOSOuRLfVEWYpHQYpFPaXtCoqN6dJx2ttdsdQbUxLLnAlKpYeVjveGGhQ3583TTa7g=="
 		},
 		"@types/node": {
 			"version": "9.6.7",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.7.tgz",
-			"integrity": "sha512-MuUfEDBrQ/hb7KOqMiDeItAuRxlilQUgNRthTSCU4HgilH8UBh7wiHxWrv/lcyHyFZcREaODVVRNrAunphVwlg==",
-			"dev": true
+			"integrity": "sha512-MuUfEDBrQ/hb7KOqMiDeItAuRxlilQUgNRthTSCU4HgilH8UBh7wiHxWrv/lcyHyFZcREaODVVRNrAunphVwlg=="
 		},
 		"@types/react": {
 			"version": "16.3.13",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.13.tgz",
 			"integrity": "sha512-YMFH/E9ryjUm2AoOy8KdTuG1SufaMuYmO/5xACROl0pm9dRmE2RN3d2zjv/eHALF6LGRZPVb7G9kqP0n5dWttQ==",
-			"dev": true,
 			"requires": {
 				"csstype": "2.4.1"
 			}
@@ -85,20 +74,17 @@
 		"abab": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
-			"dev": true
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
 		},
 		"acorn": {
 			"version": "5.5.3",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
-			"dev": true
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 		},
 		"acorn-globals": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
-			"dev": true,
 			"requires": {
 				"acorn": "5.5.3"
 			}
@@ -107,7 +93,6 @@
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.1.0",
@@ -119,7 +104,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2",
 				"longest": "1.0.1",
@@ -130,7 +114,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -140,32 +123,27 @@
 		"amdefine": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-			"dev": true
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"dev": true
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 		},
 		"anymatch": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-			"dev": true,
 			"requires": {
 				"micromatch": "3.1.10",
 				"normalize-path": "2.1.1"
@@ -175,7 +153,6 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-			"dev": true,
 			"requires": {
 				"default-require-extensions": "1.0.0"
 			}
@@ -191,86 +168,72 @@
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-			"dev": true
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"dev": true
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-			"dev": true
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
 		},
 		"array-filter": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-			"dev": true
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
 		},
 		"array-map": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-			"dev": true
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
 		},
 		"array-reduce": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-			"dev": true
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
 		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-			"dev": true
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-			"dev": true
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
 		},
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-			"dev": true
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"dev": true
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
 		},
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-			"dev": true
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
 		},
 		"async": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-			"dev": true,
 			"requires": {
 				"lodash": "4.17.10"
 			}
@@ -278,44 +241,37 @@
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-			"dev": true
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
 		},
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-			"dev": true
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
-			"dev": true
+			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-			"dev": true
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -326,7 +282,6 @@
 			"version": "6.26.3",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-generator": "6.26.1",
@@ -353,7 +308,6 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.26.0",
@@ -369,7 +323,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -380,7 +333,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -391,7 +343,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -403,7 +354,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -415,7 +365,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -426,7 +375,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -439,7 +387,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -449,7 +396,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -459,7 +405,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -469,7 +414,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -480,7 +424,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -493,7 +436,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
@@ -507,7 +449,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -517,7 +458,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.3.tgz",
 			"integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-istanbul": "4.1.6",
 				"babel-preset-jest": "22.4.3"
@@ -527,7 +467,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -536,7 +475,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -545,7 +483,6 @@
 			"version": "4.1.6",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"find-up": "2.1.0",
@@ -556,50 +493,42 @@
 		"babel-plugin-jest-hoist": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz",
-			"integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g==",
-			"dev": true
+			"integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g=="
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-			"dev": true
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-			"dev": true
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
-			"dev": true
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-			"dev": true
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-			"dev": true
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-			"dev": true
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
 		},
 		"babel-plugin-transform-async-to-generator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -610,7 +539,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -619,7 +547,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -628,7 +555,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0",
@@ -641,7 +567,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "6.26.0",
 				"babel-helper-function-name": "6.24.1",
@@ -658,7 +583,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -668,7 +592,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -677,7 +600,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -687,7 +609,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -696,7 +617,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -707,7 +627,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -716,7 +635,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
 				"babel-runtime": "6.26.0",
@@ -727,7 +645,6 @@
 			"version": "6.26.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -739,7 +656,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -750,7 +666,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -761,7 +676,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-runtime": "6.26.0"
@@ -771,7 +685,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -785,7 +698,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -795,7 +707,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -804,7 +715,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -815,7 +725,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -824,7 +733,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -833,7 +741,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -844,7 +751,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -855,7 +761,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -865,7 +770,6 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -874,7 +778,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
-			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "6.26.0",
 				"babel-plugin-syntax-jsx": "6.18.0",
@@ -885,7 +788,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -895,7 +797,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -905,7 +806,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.10.1"
 			}
@@ -914,7 +814,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -924,7 +823,6 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
 			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -962,7 +860,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
@@ -971,7 +868,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",
 			"integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-jest-hoist": "22.4.3",
 				"babel-plugin-syntax-object-rest-spread": "6.13.0"
@@ -981,7 +877,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
@@ -995,7 +890,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"dev": true,
 			"requires": {
 				"babel-core": "6.26.3",
 				"babel-runtime": "6.26.0",
@@ -1010,7 +904,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
 			"requires": {
 				"core-js": "2.5.5",
 				"regenerator-runtime": "0.11.1"
@@ -1020,7 +913,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -1033,7 +925,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-messages": "6.23.0",
@@ -1050,7 +941,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"esutils": "2.0.2",
@@ -1061,20 +951,17 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-			"dev": true
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"dev": true,
 			"requires": {
 				"cache-base": "1.0.1",
 				"class-utils": "0.3.6",
@@ -1089,7 +976,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "1.0.2"
 					}
@@ -1098,7 +984,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "6.0.2"
 					}
@@ -1107,7 +992,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "6.0.2"
 					}
@@ -1116,7 +1000,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "1.0.0",
 						"is-data-descriptor": "1.0.0",
@@ -1129,7 +1012,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "0.14.5"
@@ -1138,14 +1020,12 @@
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-			"dev": true
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
 		},
 		"boom": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-			"dev": true,
 			"requires": {
 				"hoek": "4.2.1"
 			}
@@ -1154,7 +1034,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1164,7 +1043,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-			"dev": true,
 			"requires": {
 				"arr-flatten": "1.1.0",
 				"array-unique": "0.3.2",
@@ -1182,7 +1060,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "0.1.1"
 					}
@@ -1192,14 +1069,12 @@
 		"browser-process-hrtime": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
-			"dev": true
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
 		},
 		"browser-resolve": {
 			"version": "1.11.2",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
 			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-			"dev": true,
 			"requires": {
 				"resolve": "1.1.7"
 			}
@@ -1208,7 +1083,6 @@
 			"version": "2.11.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-			"dev": true,
 			"requires": {
 				"caniuse-lite": "1.0.30000830",
 				"electron-to-chromium": "1.3.44"
@@ -1218,7 +1092,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-			"dev": true,
 			"requires": {
 				"node-int64": "0.4.0"
 			}
@@ -1226,20 +1099,17 @@
 		"buffer-from": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-			"dev": true
+			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"dev": true,
 			"requires": {
 				"collection-visit": "1.0.0",
 				"component-emitter": "1.2.1",
@@ -1255,33 +1125,28 @@
 		"callsites": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-			"dev": true
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 		},
 		"camelcase": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
 			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-			"dev": true,
 			"optional": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000830",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz",
-			"integrity": "sha512-yMqGkujkoOIZfvOYiWdqPALgY/PVGiqCHUJb6yNq7xhI/pR+gQO0U2K6lRDqAiJv4+CIU3CtTLblNGw0QGnr6g==",
-			"dev": true
+			"integrity": "sha512-yMqGkujkoOIZfvOYiWdqPALgY/PVGiqCHUJb6yNq7xhI/pR+gQO0U2K6lRDqAiJv4+CIU3CtTLblNGw0QGnr6g=="
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"center-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"align-text": "0.1.4",
@@ -1292,7 +1157,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -1305,7 +1169,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-			"dev": true,
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
@@ -1322,7 +1185,6 @@
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-					"dev": true,
 					"requires": {
 						"micromatch": "2.3.11",
 						"normalize-path": "2.1.1"
@@ -1332,7 +1194,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
@@ -1340,14 +1201,12 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -1358,7 +1217,6 @@
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -1367,7 +1225,6 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -1376,7 +1233,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -1385,7 +1241,6 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -1407,14 +1262,12 @@
 		"ci-info": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
-			"dev": true
+			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"dev": true,
 			"requires": {
 				"arr-union": "3.1.0",
 				"define-property": "0.2.5",
@@ -1426,7 +1279,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "0.1.6"
 					}
@@ -1437,7 +1289,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"center-align": "0.1.3",
@@ -1449,7 +1300,6 @@
 					"version": "0.0.2",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
 					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-					"dev": true,
 					"optional": true
 				}
 			}
@@ -1457,20 +1307,17 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-			"dev": true,
 			"requires": {
 				"map-visit": "1.0.0",
 				"object-visit": "1.0.1"
@@ -1480,7 +1327,6 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1488,14 +1334,12 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"combined-stream": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-			"dev": true,
 			"requires": {
 				"delayed-stream": "1.0.0"
 			}
@@ -1503,56 +1347,47 @@
 		"commander": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-			"dev": true
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 		},
 		"compare-versions": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.1.0.tgz",
-			"integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ==",
-			"dev": true
+			"integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ=="
 		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-			"dev": true
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-			"dev": true
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-			"dev": true
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
 			"version": "2.5.5",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-			"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
-			"dev": true
+			"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cpx": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/cpx/-/cpx-1.5.0.tgz",
 			"integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"chokidar": "1.7.0",
@@ -1571,7 +1406,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.2",
 				"shebang-command": "1.2.0",
@@ -1582,7 +1416,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-			"dev": true,
 			"requires": {
 				"boom": "5.2.0"
 			},
@@ -1591,7 +1424,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-					"dev": true,
 					"requires": {
 						"hoek": "4.2.1"
 					}
@@ -1601,14 +1433,12 @@
 		"cssom": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-			"dev": true
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
 		},
 		"cssstyle": {
 			"version": "0.2.37",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-			"dev": true,
 			"requires": {
 				"cssom": "0.3.2"
 			}
@@ -1616,14 +1446,12 @@
 		"csstype": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.4.1.tgz",
-			"integrity": "sha512-JuXYT9dt8xtpc4mwHSOYnZtQS3TmYVhmZDyXbppTid29krM8Eyn5CmsZjIDTSvzunvutYOBwQmnziR5vgFkJGw==",
-			"dev": true
+			"integrity": "sha512-JuXYT9dt8xtpc4mwHSOYnZtQS3TmYVhmZDyXbppTid29krM8Eyn5CmsZjIDTSvzunvutYOBwQmnziR5vgFkJGw=="
 		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			}
@@ -1632,7 +1460,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
 			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
-			"dev": true,
 			"requires": {
 				"abab": "1.0.4",
 				"whatwg-mimetype": "2.1.0",
@@ -1643,7 +1470,6 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1651,26 +1477,22 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-			"dev": true
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"default-require-extensions": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-			"dev": true,
 			"requires": {
 				"strip-bom": "2.0.0"
 			}
@@ -1679,7 +1501,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-			"dev": true,
 			"requires": {
 				"foreach": "2.0.5",
 				"object-keys": "1.0.11"
@@ -1689,7 +1510,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"dev": true,
 			"requires": {
 				"is-descriptor": "1.0.2",
 				"isobject": "3.0.1"
@@ -1699,7 +1519,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "6.0.2"
 					}
@@ -1708,7 +1527,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "6.0.2"
 					}
@@ -1717,7 +1535,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "1.0.0",
 						"is-data-descriptor": "1.0.0",
@@ -1729,14 +1546,12 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1744,20 +1559,17 @@
 		"detect-newline": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-			"dev": true
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
 		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"domexception": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-			"dev": true,
 			"requires": {
 				"webidl-conversions": "4.0.2"
 			}
@@ -1765,14 +1577,12 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-			"dev": true
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "0.1.1"
@@ -1781,8 +1591,7 @@
 		"electron-to-chromium": {
 			"version": "1.3.44",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.44.tgz",
-			"integrity": "sha1-72sVCmDVIwgjiMra2ICF7NL9RoQ=",
-			"dev": true
+			"integrity": "sha1-72sVCmDVIwgjiMra2ICF7NL9RoQ="
 		},
 		"entities": {
 			"version": "1.1.1",
@@ -1793,7 +1602,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "0.2.1"
 			}
@@ -1802,7 +1610,6 @@
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
 			"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
-			"dev": true,
 			"requires": {
 				"es-to-primitive": "1.1.1",
 				"function-bind": "1.1.1",
@@ -1815,7 +1622,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-			"dev": true,
 			"requires": {
 				"is-callable": "1.1.3",
 				"is-date-object": "1.0.1",
@@ -1825,14 +1631,12 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
 			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
-			"dev": true,
 			"requires": {
 				"esprima": "3.1.3",
 				"estraverse": "4.2.0",
@@ -1844,14 +1648,12 @@
 				"esprima": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-					"dev": true
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
 					"optional": true
 				}
 			}
@@ -1859,26 +1661,22 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-			"dev": true
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 		},
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-			"dev": true
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"exec-sh": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
-			"dev": true,
 			"requires": {
 				"merge": "1.2.0"
 			}
@@ -1887,7 +1685,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"get-stream": "3.0.0",
@@ -1901,14 +1698,12 @@
 		"exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-			"dev": true
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
 		},
 		"expand-brackets": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
 				"define-property": "0.2.5",
@@ -1923,7 +1718,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "0.1.6"
 					}
@@ -1932,7 +1726,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "0.1.1"
 					}
@@ -1943,7 +1736,6 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
 			"requires": {
 				"fill-range": "2.2.3"
 			},
@@ -1952,7 +1744,6 @@
 					"version": "2.2.3",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-					"dev": true,
 					"requires": {
 						"is-number": "2.1.0",
 						"isobject": "2.1.0",
@@ -1965,7 +1756,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
@@ -1974,7 +1764,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
@@ -1983,7 +1772,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -1994,7 +1782,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
 			"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "3.2.1",
 				"jest-diff": "22.4.3",
@@ -2008,7 +1795,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -2018,14 +1804,12 @@
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-			"dev": true
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"dev": true,
 			"requires": {
 				"assign-symbols": "1.0.0",
 				"is-extendable": "1.0.1"
@@ -2035,7 +1819,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "2.0.4"
 					}
@@ -2046,7 +1829,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-			"dev": true,
 			"requires": {
 				"array-unique": "0.3.2",
 				"define-property": "1.0.0",
@@ -2062,7 +1844,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "1.0.2"
 					}
@@ -2071,7 +1852,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "0.1.1"
 					}
@@ -2080,7 +1860,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "6.0.2"
 					}
@@ -2089,7 +1868,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "6.0.2"
 					}
@@ -2098,7 +1876,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "1.0.0",
 						"is-data-descriptor": "1.0.0",
@@ -2110,32 +1887,27 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-			"dev": true
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fb-watchman": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-			"dev": true,
 			"requires": {
 				"bser": "2.0.0"
 			}
@@ -2143,14 +1915,12 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"fileset": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-			"dev": true,
 			"requires": {
 				"glob": "7.1.2",
 				"minimatch": "3.0.4"
@@ -2160,7 +1930,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "2.0.1",
 				"is-number": "3.0.0",
@@ -2172,7 +1941,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "0.1.1"
 					}
@@ -2182,14 +1950,12 @@
 		"find-index": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-			"integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-			"dev": true
+			"integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
 		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
 			"requires": {
 				"locate-path": "2.0.0"
 			}
@@ -2197,14 +1963,12 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
 			"requires": {
 				"for-in": "1.0.2"
 			}
@@ -2212,20 +1976,17 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-			"dev": true
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
 		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-			"dev": true,
 			"requires": {
 				"asynckit": "0.4.0",
 				"combined-stream": "1.0.6",
@@ -2236,7 +1997,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-			"dev": true,
 			"requires": {
 				"map-cache": "0.2.2"
 			}
@@ -2245,7 +2005,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"jsonfile": "4.0.0",
@@ -2255,14 +2014,12 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
 			"integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "2.10.0",
@@ -2272,24 +2029,20 @@
 				"abbrev": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -2298,13 +2051,11 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -2313,34 +2064,28 @@
 				"chownr": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2349,25 +2094,21 @@
 				"deep-extend": {
 					"version": "0.4.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "2.2.4"
@@ -2376,13 +2117,11 @@
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.2.0",
@@ -2398,7 +2137,6 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
@@ -2412,13 +2150,11 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safer-buffer": "2.1.2"
@@ -2427,7 +2163,6 @@
 				"ignore-walk": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimatch": "3.0.4"
@@ -2436,7 +2171,6 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"once": "1.4.0",
@@ -2445,19 +2179,16 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -2465,26 +2196,22 @@
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"safe-buffer": "5.1.1",
 						"yallist": "3.0.2"
@@ -2493,7 +2220,6 @@
 				"minizlib": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "2.2.4"
@@ -2502,7 +2228,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2510,13 +2235,11 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.9",
@@ -2527,7 +2250,6 @@
 				"node-pre-gyp": {
 					"version": "0.9.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "1.0.3",
@@ -2545,7 +2267,6 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.1",
@@ -2555,13 +2276,11 @@
 				"npm-bundled": {
 					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "3.0.1",
@@ -2571,7 +2290,6 @@
 				"npmlog": {
 					"version": "4.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -2582,19 +2300,16 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -2602,19 +2317,16 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "1.0.2",
@@ -2624,19 +2336,16 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -2648,7 +2357,6 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -2656,7 +2364,6 @@
 				"readable-stream": {
 					"version": "2.3.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"core-util-is": "1.0.2",
@@ -2671,7 +2378,6 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "7.1.2"
@@ -2679,43 +2385,36 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2725,7 +2424,6 @@
 				"string_decoder": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.1.1"
@@ -2734,7 +2432,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -2742,13 +2439,11 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"chownr": "1.0.1",
@@ -2763,13 +2458,11 @@
 				"util-deprecate": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -2777,45 +2470,38 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-			"dev": true
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-			"dev": true
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			}
@@ -2824,7 +2510,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2838,7 +2523,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
 			"requires": {
 				"glob-parent": "2.0.0",
 				"is-glob": "2.0.1"
@@ -2848,7 +2532,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2857,7 +2540,6 @@
 			"version": "0.0.12",
 			"resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
 			"integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-			"dev": true,
 			"requires": {
 				"find-index": "0.1.1"
 			}
@@ -2865,26 +2547,22 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-			"dev": true
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 		},
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-			"dev": true
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 		},
 		"growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-			"dev": true
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
 		},
 		"handlebars": {
 			"version": "4.0.11",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-			"dev": true,
 			"requires": {
 				"async": "1.5.2",
 				"optimist": "0.6.1",
@@ -2895,14 +2573,12 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"source-map": {
 					"version": "0.4.4",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"dev": true,
 					"requires": {
 						"amdefine": "1.0.1"
 					}
@@ -2912,14 +2588,12 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"har-schema": "2.0.0"
@@ -2929,7 +2603,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-			"dev": true,
 			"requires": {
 				"function-bind": "1.1.1"
 			}
@@ -2938,7 +2611,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2946,14 +2618,12 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-			"dev": true,
 			"requires": {
 				"get-value": "2.0.6",
 				"has-values": "1.0.0",
@@ -2964,7 +2634,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
 				"kind-of": "4.0.0"
@@ -2974,7 +2643,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -2985,7 +2653,6 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-			"dev": true,
 			"requires": {
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
@@ -2996,14 +2663,12 @@
 		"hoek": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-			"dev": true
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -3012,14 +2677,12 @@
 		"hosted-git-info": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
-			"dev": true
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-			"dev": true,
 			"requires": {
 				"whatwg-encoding": "1.0.3"
 			}
@@ -3028,7 +2691,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"jsprim": "1.4.1",
@@ -3038,14 +2700,12 @@
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-			"dev": true
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
 		},
 		"import-local": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-			"dev": true,
 			"requires": {
 				"pkg-dir": "2.0.0",
 				"resolve-cwd": "2.0.0"
@@ -3054,14 +2714,12 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -3070,14 +2728,12 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -3085,14 +2741,12 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			},
@@ -3101,7 +2755,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -3111,14 +2764,12 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"dev": true,
 			"requires": {
 				"binary-extensions": "1.11.0"
 			}
@@ -3126,14 +2777,12 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1"
 			}
@@ -3141,14 +2790,12 @@
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-			"dev": true
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
 		},
 		"is-ci": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-			"dev": true,
 			"requires": {
 				"ci-info": "1.1.3"
 			}
@@ -3157,7 +2804,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			},
@@ -3166,7 +2812,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -3176,14 +2821,12 @@
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-			"dev": true
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "0.1.6",
 				"is-data-descriptor": "0.1.4",
@@ -3193,22 +2836,19 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
 			"requires": {
 				"is-primitive": "2.0.0"
 			}
@@ -3216,20 +2856,17 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-			"dev": true
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -3237,20 +2874,17 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-generator-fn": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-			"dev": true
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -3259,7 +2893,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			},
@@ -3268,7 +2901,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -3279,7 +2911,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-			"dev": true,
 			"requires": {
 				"is-number": "4.0.0"
 			},
@@ -3287,8 +2918,7 @@
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				}
 			}
 		},
@@ -3296,7 +2926,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"requires": {
 				"isobject": "3.0.1"
 			}
@@ -3304,20 +2933,17 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-			"dev": true,
 			"requires": {
 				"has": "1.0.1"
 			}
@@ -3325,62 +2951,52 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-			"dev": true
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-			"dev": true
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istanbul-api": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
 			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
-			"dev": true,
 			"requires": {
 				"async": "2.6.0",
 				"compare-versions": "3.1.0",
@@ -3400,7 +3016,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3409,7 +3024,6 @@
 					"version": "1.2.4",
 					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
 					"integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
-					"dev": true,
 					"requires": {
 						"debug": "3.1.0",
 						"istanbul-lib-coverage": "1.2.0",
@@ -3423,14 +3037,12 @@
 		"istanbul-lib-coverage": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-			"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
-			"dev": true
+			"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
 		},
 		"istanbul-lib-hook": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
 			"integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
-			"dev": true,
 			"requires": {
 				"append-transform": "0.4.0"
 			}
@@ -3439,7 +3051,6 @@
 			"version": "1.10.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
 			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
-			"dev": true,
 			"requires": {
 				"babel-generator": "6.26.1",
 				"babel-template": "6.26.0",
@@ -3454,7 +3065,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
 			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
-			"dev": true,
 			"requires": {
 				"istanbul-lib-coverage": "1.2.0",
 				"mkdirp": "0.5.1",
@@ -3465,14 +3075,12 @@
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
 					"requires": {
 						"has-flag": "1.0.0"
 					}
@@ -3483,7 +3091,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
 			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
-			"dev": true,
 			"requires": {
 				"debug": "3.1.0",
 				"istanbul-lib-coverage": "1.2.0",
@@ -3496,7 +3103,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3507,7 +3113,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
 			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
-			"dev": true,
 			"requires": {
 				"handlebars": "4.0.11"
 			}
@@ -3516,7 +3121,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.3.tgz",
 			"integrity": "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
-			"dev": true,
 			"requires": {
 				"import-local": "1.0.0",
 				"jest-cli": "22.4.3"
@@ -3525,14 +3129,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -3541,7 +3143,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
@@ -3549,14 +3150,12 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -3567,7 +3166,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3578,7 +3176,6 @@
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -3587,7 +3184,6 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -3596,7 +3192,6 @@
 					"version": "22.4.3",
 					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.3.tgz",
 					"integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
-					"dev": true,
 					"requires": {
 						"ansi-escapes": "3.1.0",
 						"chalk": "2.4.1",
@@ -3638,7 +3233,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -3647,7 +3241,6 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -3668,7 +3261,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -3677,7 +3269,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -3688,7 +3279,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
 			"integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
-			"dev": true,
 			"requires": {
 				"throat": "4.1.0"
 			}
@@ -3697,7 +3287,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.3.tgz",
 			"integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"glob": "7.1.2",
@@ -3716,7 +3305,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -3725,7 +3313,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3736,7 +3323,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -3747,7 +3333,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
 			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
-			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"diff": "3.5.0",
@@ -3759,7 +3344,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -3768,7 +3352,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3779,7 +3362,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -3790,7 +3372,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
 			"integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
-			"dev": true,
 			"requires": {
 				"detect-newline": "2.1.0"
 			}
@@ -3799,7 +3380,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
 			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
-			"dev": true,
 			"requires": {
 				"jest-mock": "22.4.3",
 				"jest-util": "22.4.3",
@@ -3810,7 +3390,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
 			"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
-			"dev": true,
 			"requires": {
 				"jest-mock": "22.4.3",
 				"jest-util": "22.4.3"
@@ -3819,14 +3398,12 @@
 		"jest-get-type": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
-			"dev": true
+			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
 		},
 		"jest-haste-map": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
 			"integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
-			"dev": true,
 			"requires": {
 				"fb-watchman": "2.0.0",
 				"graceful-fs": "4.1.11",
@@ -3841,7 +3418,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
@@ -3849,14 +3425,12 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -3867,7 +3441,6 @@
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -3876,7 +3449,6 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -3885,7 +3457,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -3894,7 +3465,6 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -3917,7 +3487,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz",
 			"integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
-			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"co": "4.6.0",
@@ -3936,7 +3505,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -3945,7 +3513,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3955,14 +3522,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"source-map-support": {
 					"version": "0.5.5",
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
 					"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
-					"dev": true,
 					"requires": {
 						"buffer-from": "1.0.0",
 						"source-map": "0.6.1"
@@ -3972,7 +3537,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -3983,7 +3547,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
 			"integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
-			"dev": true,
 			"requires": {
 				"pretty-format": "22.4.3"
 			}
@@ -3992,7 +3555,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
 			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
-			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"jest-get-type": "22.4.3",
@@ -4003,7 +3565,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -4012,7 +3573,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -4023,7 +3583,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -4034,7 +3593,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
 			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.46",
 				"chalk": "2.4.1",
@@ -4047,7 +3605,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -4056,7 +3613,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
@@ -4064,14 +3620,12 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -4082,7 +3636,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -4093,7 +3646,6 @@
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -4102,7 +3654,6 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -4111,7 +3662,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -4120,7 +3670,6 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -4141,7 +3690,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -4151,20 +3699,17 @@
 		"jest-mock": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
-			"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
-			"dev": true
+			"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q=="
 		},
 		"jest-regex-util": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
-			"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
-			"dev": true
+			"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg=="
 		},
 		"jest-resolve": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
 			"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
-			"dev": true,
 			"requires": {
 				"browser-resolve": "1.11.2",
 				"chalk": "2.4.1"
@@ -4174,7 +3719,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -4183,7 +3727,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -4194,7 +3737,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -4205,7 +3747,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
 			"integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
-			"dev": true,
 			"requires": {
 				"jest-regex-util": "22.4.3"
 			}
@@ -4214,7 +3755,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.3.tgz",
 			"integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
-			"dev": true,
 			"requires": {
 				"exit": "0.1.2",
 				"jest-config": "22.4.3",
@@ -4233,7 +3773,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
 			"integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
-			"dev": true,
 			"requires": {
 				"babel-core": "6.26.3",
 				"babel-jest": "22.4.3",
@@ -4261,7 +3800,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -4270,7 +3808,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
@@ -4278,14 +3815,12 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -4296,7 +3831,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -4307,7 +3841,6 @@
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -4316,7 +3849,6 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -4325,7 +3857,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -4334,7 +3865,6 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -4354,14 +3884,12 @@
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"supports-color": {
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -4371,14 +3899,12 @@
 		"jest-serializer": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
-			"integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
-			"dev": true
+			"integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw=="
 		},
 		"jest-snapshot": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
 			"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"jest-diff": "22.4.3",
@@ -4392,7 +3918,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -4401,7 +3926,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -4412,7 +3936,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -4423,7 +3946,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
 			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
-			"dev": true,
 			"requires": {
 				"callsites": "2.0.0",
 				"chalk": "2.4.1",
@@ -4438,7 +3960,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -4447,7 +3968,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -4457,14 +3977,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"supports-color": {
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -4475,7 +3993,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.3.tgz",
 			"integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
-			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"jest-config": "22.4.3",
@@ -4488,7 +4005,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -4497,7 +4013,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -4508,7 +4023,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -4519,7 +4033,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
 			"integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
-			"dev": true,
 			"requires": {
 				"merge-stream": "1.0.1"
 			}
@@ -4527,14 +4040,12 @@
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-			"dev": true,
 			"requires": {
 				"argparse": "1.0.10",
 				"esprima": "4.0.0"
@@ -4544,14 +4055,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
 			"optional": true
 		},
 		"jsdom": {
 			"version": "11.9.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.9.0.tgz",
 			"integrity": "sha512-sb3omwJTJ+HwAltLZevM/KQBusY+l2Ar5UfnTCWk9oUVBiDnQPBNiG1BaTAKttCnneonYbNo7vi4EFDY2lBfNA==",
-			"dev": true,
 			"requires": {
 				"abab": "1.0.4",
 				"acorn": "5.5.3",
@@ -4584,26 +4093,22 @@
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-			"dev": true
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-			"dev": true
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
 			"requires": {
 				"jsonify": "0.0.0"
 			}
@@ -4611,20 +4116,17 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11"
 			}
@@ -4632,14 +4134,12 @@
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-			"dev": true
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -4650,21 +4150,18 @@
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-			"dev": true
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 		},
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
 			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-			"dev": true,
 			"optional": true
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
 			"requires": {
 				"invert-kv": "1.0.0"
 			}
@@ -4672,20 +4169,17 @@
 		"left-pad": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-			"dev": true
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
 		},
 		"leven": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-			"dev": true
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -4703,7 +4197,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"parse-json": "2.2.0",
@@ -4716,7 +4209,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
 			"requires": {
 				"p-locate": "2.0.0",
 				"path-exists": "3.0.0"
@@ -4725,32 +4217,27 @@
 		"lodash": {
 			"version": "4.17.10",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-			"dev": true
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
 		"lodash-es": {
 			"version": "4.17.10",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
-			"integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg==",
-			"dev": true
+			"integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-			"dev": true
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-			"dev": true,
 			"requires": {
 				"js-tokens": "3.0.2"
 			}
@@ -4759,7 +4246,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
 			"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -4769,7 +4255,6 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-			"dev": true,
 			"requires": {
 				"tmpl": "1.0.4"
 			}
@@ -4777,14 +4262,12 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-			"dev": true,
 			"requires": {
 				"object-visit": "1.0.1"
 			}
@@ -4810,7 +4293,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
 			}
@@ -4818,14 +4300,12 @@
 		"merge": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-			"dev": true
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
 		},
 		"merge-stream": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "2.3.6"
 			}
@@ -4834,7 +4314,6 @@
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "4.0.0",
 				"array-unique": "0.3.2",
@@ -4854,14 +4333,12 @@
 		"mime-db": {
 			"version": "1.33.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-			"dev": true
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
 			"version": "2.1.18",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-			"dev": true,
 			"requires": {
 				"mime-db": "1.33.0"
 			}
@@ -4869,14 +4346,12 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.11"
 			}
@@ -4884,14 +4359,12 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mixin-deep": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-			"dev": true,
 			"requires": {
 				"for-in": "1.0.2",
 				"is-extendable": "1.0.1"
@@ -4901,7 +4374,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "2.0.4"
 					}
@@ -4912,7 +4384,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -4920,21 +4391,18 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"nan": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
 			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-			"dev": true,
 			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "4.0.0",
 				"array-unique": "0.3.2",
@@ -4953,20 +4421,17 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-			"dev": true
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
-			"dev": true
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
 		},
 		"node-notifier": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
 			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
-			"dev": true,
 			"requires": {
 				"growly": "1.3.0",
 				"semver": "5.5.0",
@@ -4978,7 +4443,6 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.6.0",
 				"is-builtin-module": "1.0.0",
@@ -4990,7 +4454,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.1.0"
 			}
@@ -4999,7 +4462,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "2.0.1"
 			}
@@ -5007,32 +4469,27 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwmatcher": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
-			"dev": true
+			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
 		},
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-			"dev": true
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"dev": true,
 			"requires": {
 				"copy-descriptor": "0.1.1",
 				"define-property": "0.2.5",
@@ -5043,7 +4500,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "0.1.6"
 					}
@@ -5052,7 +4508,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -5062,14 +4517,12 @@
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-			"dev": true
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
 		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-			"dev": true,
 			"requires": {
 				"isobject": "3.0.1"
 			}
@@ -5078,7 +4531,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"es-abstract": "1.11.0"
@@ -5088,7 +4540,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
 			"requires": {
 				"for-own": "0.1.5",
 				"is-extendable": "0.1.1"
@@ -5098,7 +4549,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-			"dev": true,
 			"requires": {
 				"isobject": "3.0.1"
 			}
@@ -5107,7 +4557,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -5116,7 +4565,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8",
 				"wordwrap": "0.0.3"
@@ -5126,7 +4574,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -5139,22 +4586,19 @@
 				"wordwrap": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-					"dev": true
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 				}
 			}
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-			"dev": true,
 			"requires": {
 				"execa": "0.7.0",
 				"lcid": "1.0.0",
@@ -5164,20 +4608,17 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-			"dev": true,
 			"requires": {
 				"p-try": "1.0.0"
 			}
@@ -5186,7 +4627,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
 			"requires": {
 				"p-limit": "1.2.0"
 			}
@@ -5194,14 +4634,12 @@
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-			"dev": true
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
 			"requires": {
 				"glob-base": "0.3.0",
 				"is-dotfile": "1.0.3",
@@ -5213,7 +4651,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"dev": true,
 			"requires": {
 				"error-ex": "1.3.1"
 			}
@@ -5221,44 +4658,37 @@
 		"parse5": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
-			"dev": true
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"dev": true
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-			"dev": true
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
 		},
 		"path-type": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"pify": "2.3.0",
@@ -5268,26 +4698,22 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-			"dev": true
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-			"dev": true
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
@@ -5296,7 +4722,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-			"dev": true,
 			"requires": {
 				"find-up": "2.1.0"
 			}
@@ -5304,32 +4729,27 @@
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-			"dev": true
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-			"dev": true
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"pretty-format": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
 			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "3.0.0",
 				"ansi-styles": "3.2.1"
@@ -5338,14 +4758,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -5355,38 +4773,32 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-			"dev": true
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-			"dev": true
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"punycode": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-			"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-			"dev": true
+			"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
 		},
 		"qs": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-			"dev": true
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
 				"kind-of": "4.0.0"
@@ -5396,7 +4808,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -5407,7 +4818,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-			"dev": true,
 			"requires": {
 				"load-json-file": "1.1.0",
 				"normalize-package-data": "2.4.0",
@@ -5418,7 +4828,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-			"dev": true,
 			"requires": {
 				"find-up": "1.1.2",
 				"read-pkg": "1.1.0"
@@ -5428,7 +4837,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
 					"requires": {
 						"path-exists": "2.1.0",
 						"pinkie-promise": "2.0.1"
@@ -5438,7 +4846,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "2.0.1"
 					}
@@ -5449,7 +4856,6 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -5464,7 +4870,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"minimatch": "3.0.4",
@@ -5476,7 +4881,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
 			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
-			"dev": true,
 			"requires": {
 				"util.promisify": "1.0.0"
 			}
@@ -5484,20 +4888,17 @@
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
-			"dev": true
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-			"dev": true
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -5508,7 +4909,6 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"dev": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
 			}
@@ -5517,7 +4917,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "3.0.2",
 				"safe-regex": "1.1.0"
@@ -5527,7 +4926,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-			"dev": true,
 			"requires": {
 				"regenerate": "1.3.3",
 				"regjsgen": "0.2.0",
@@ -5537,14 +4935,12 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-			"dev": true
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			},
@@ -5552,34 +4948,29 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-			"dev": true
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -5588,7 +4979,6 @@
 			"version": "2.85.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
 			"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
-			"dev": true,
 			"requires": {
 				"aws-sign2": "0.7.0",
 				"aws4": "1.7.0",
@@ -5618,7 +5008,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-			"dev": true,
 			"requires": {
 				"lodash": "4.17.10"
 			}
@@ -5627,7 +5016,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
 				"stealthy-require": "1.1.1",
@@ -5637,26 +5025,22 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-			"dev": true
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 		},
 		"resolve-cwd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-			"dev": true,
 			"requires": {
 				"resolve-from": "3.0.0"
 			}
@@ -5664,26 +5048,22 @@
 		"resolve-from": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-			"dev": true
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-			"dev": true
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"dev": true
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"align-text": "0.1.4"
@@ -5693,7 +5073,6 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
@@ -5701,14 +5080,12 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"dev": true,
 			"requires": {
 				"ret": "0.1.15"
 			}
@@ -5717,7 +5094,6 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.0.tgz",
 			"integrity": "sha512-glfKd7YH4UCrh/7dD+UESsr8ylKWRE7UQPoXuz28FgmcF0ViJQhCTCCZHICRKxf8G8O1KdLEn20dcICK54c7ew==",
-			"dev": true,
 			"requires": {
 				"anymatch": "2.0.0",
 				"exec-sh": "0.2.1",
@@ -5732,14 +5108,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"watch": {
 					"version": "0.18.0",
 					"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
 					"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-					"dev": true,
 					"requires": {
 						"exec-sh": "0.2.1",
 						"minimist": "1.2.0"
@@ -5750,32 +5124,27 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-			"dev": true
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-			"dev": true
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-			"dev": true
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "2.0.1",
 				"is-extendable": "0.1.1",
@@ -5787,7 +5156,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "0.1.1"
 					}
@@ -5798,7 +5166,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -5806,14 +5173,12 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"shell-quote": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
 			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-			"dev": true,
 			"requires": {
 				"array-filter": "0.0.1",
 				"array-map": "0.0.0",
@@ -5824,26 +5189,22 @@
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-			"dev": true
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-			"dev": true
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"dev": true,
 			"requires": {
 				"base": "0.11.2",
 				"debug": "2.6.9",
@@ -5859,7 +5220,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "0.1.6"
 					}
@@ -5868,7 +5228,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "0.1.1"
 					}
@@ -5879,7 +5238,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"dev": true,
 			"requires": {
 				"define-property": "1.0.0",
 				"isobject": "3.0.1",
@@ -5890,7 +5248,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "1.0.2"
 					}
@@ -5899,7 +5256,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "6.0.2"
 					}
@@ -5908,7 +5264,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "6.0.2"
 					}
@@ -5917,7 +5272,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "1.0.0",
 						"is-data-descriptor": "1.0.0",
@@ -5930,7 +5284,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			},
@@ -5939,7 +5292,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -5950,7 +5302,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-			"dev": true,
 			"requires": {
 				"hoek": "4.2.1"
 			}
@@ -5958,14 +5309,12 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-resolve": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
 			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
-			"dev": true,
 			"requires": {
 				"atob": "2.1.1",
 				"decode-uri-component": "0.2.0",
@@ -5978,7 +5327,6 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-			"dev": true,
 			"requires": {
 				"source-map": "0.5.7"
 			}
@@ -5986,14 +5334,12 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"dev": true
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spdx-correct": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "3.0.0",
 				"spdx-license-ids": "3.0.0"
@@ -6002,14 +5348,12 @@
 		"spdx-exceptions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
-			"dev": true
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-			"dev": true,
 			"requires": {
 				"spdx-exceptions": "2.1.0",
 				"spdx-license-ids": "3.0.0"
@@ -6018,14 +5362,12 @@
 		"spdx-license-ids": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
-			"dev": true
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
 		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "3.0.2"
 			}
@@ -6039,7 +5381,6 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-			"dev": true,
 			"requires": {
 				"asn1": "0.2.3",
 				"assert-plus": "1.0.0",
@@ -6054,14 +5395,12 @@
 		"stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
-			"dev": true
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
 		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-			"dev": true,
 			"requires": {
 				"define-property": "0.2.5",
 				"object-copy": "0.1.0"
@@ -6071,7 +5410,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "0.1.6"
 					}
@@ -6081,14 +5419,12 @@
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-			"dev": true
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-			"dev": true,
 			"requires": {
 				"astral-regex": "1.0.0",
 				"strip-ansi": "4.0.0"
@@ -6097,14 +5433,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -6115,7 +5449,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -6124,14 +5457,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -6142,7 +5473,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.2"
 			}
@@ -6150,14 +5480,12 @@
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-			"dev": true
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -6166,7 +5494,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"dev": true,
 			"requires": {
 				"is-utf8": "0.2.1"
 			}
@@ -6174,14 +5501,12 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"subarg": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
 			"integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-			"dev": true,
 			"requires": {
 				"minimist": "1.2.0"
 			},
@@ -6189,28 +5514,24 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"dev": true
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-			"dev": true
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
 		},
 		"test-exclude": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
 			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
-			"dev": true,
 			"requires": {
 				"arrify": "1.0.1",
 				"micromatch": "3.1.10",
@@ -6222,26 +5543,22 @@
 		"throat": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
-			"dev": true
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
 		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-			"dev": true
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-			"dev": true
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			},
@@ -6250,7 +5567,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -6261,7 +5577,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"dev": true,
 			"requires": {
 				"define-property": "2.0.2",
 				"extend-shallow": "3.0.2",
@@ -6273,7 +5588,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
 				"repeat-string": "1.6.1"
@@ -6283,7 +5597,6 @@
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-			"dev": true,
 			"requires": {
 				"punycode": "1.4.1"
 			},
@@ -6291,8 +5604,7 @@
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 				}
 			}
 		},
@@ -6300,7 +5612,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
 			"requires": {
 				"punycode": "2.1.0"
 			}
@@ -6308,14 +5619,12 @@
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
 		"ts-jest": {
 			"version": "22.4.4",
 			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.4.tgz",
 			"integrity": "sha512-v9pO7u4HNMDSBCN9IEvlR6taDAGm2mo7nHEDLWyoFDgYeZ4aHm8JHEPrthd8Pmcl4eCM8J4Ata4ROR/cwFRV2A==",
-			"dev": true,
 			"requires": {
 				"babel-core": "6.26.3",
 				"babel-plugin-istanbul": "4.1.6",
@@ -6331,20 +5640,17 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"dev": true,
 					"requires": {
 						"string-width": "2.1.1",
 						"strip-ansi": "4.0.0",
@@ -6355,7 +5661,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -6364,7 +5669,6 @@
 					"version": "11.0.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
 					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-					"dev": true,
 					"requires": {
 						"cliui": "4.1.0",
 						"decamelize": "1.2.0",
@@ -6384,7 +5688,6 @@
 					"version": "9.0.2",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-					"dev": true,
 					"requires": {
 						"camelcase": "4.1.0"
 					}
@@ -6394,14 +5697,12 @@
 		"tslib": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-			"dev": true
+			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
 		},
 		"tslint": {
 			"version": "5.9.1",
 			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
 			"integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"builtin-modules": "1.1.1",
@@ -6421,7 +5722,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -6430,7 +5730,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -6441,7 +5740,6 @@
 					"version": "1.7.1",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
 					"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
-					"dev": true,
 					"requires": {
 						"path-parse": "1.0.5"
 					}
@@ -6450,7 +5748,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -6461,7 +5758,6 @@
 			"version": "2.26.2",
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
 			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
-			"dev": true,
 			"requires": {
 				"tslib": "1.9.0"
 			}
@@ -6470,7 +5766,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.2"
 			}
@@ -6479,14 +5774,12 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
 			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -6494,8 +5787,7 @@
 		"typescript": {
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
-			"integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
-			"dev": true
+			"integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw=="
 		},
 		"uc.micro": {
 			"version": "1.0.5",
@@ -6506,7 +5798,6 @@
 			"version": "2.8.29",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"source-map": "0.5.7",
@@ -6518,7 +5809,6 @@
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"camelcase": "1.2.1",
@@ -6533,14 +5823,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"dev": true,
 			"optional": true
 		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-			"dev": true,
 			"requires": {
 				"arr-union": "3.1.0",
 				"get-value": "2.0.6",
@@ -6552,7 +5840,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "0.1.1"
 					}
@@ -6561,7 +5848,6 @@
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "2.0.1",
 						"is-extendable": "0.1.1",
@@ -6574,14 +5860,12 @@
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-			"dev": true
+			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
 		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-			"dev": true,
 			"requires": {
 				"has-value": "0.3.1",
 				"isobject": "3.0.1"
@@ -6591,7 +5875,6 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-					"dev": true,
 					"requires": {
 						"get-value": "2.0.6",
 						"has-values": "0.1.4",
@@ -6602,7 +5885,6 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -6612,22 +5894,19 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-					"dev": true
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
 				}
 			}
 		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-			"dev": true
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"use": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-			"dev": true,
 			"requires": {
 				"kind-of": "6.0.2"
 			}
@@ -6635,14 +5914,12 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util.promisify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"object.getownpropertydescriptors": "2.0.3"
@@ -6651,14 +5928,12 @@
 		"uuid": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-			"dev": true
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
-			"dev": true,
 			"requires": {
 				"spdx-correct": "3.0.0",
 				"spdx-expression-parse": "3.0.0"
@@ -6668,7 +5943,6 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
@@ -6679,7 +5953,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
-			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "0.1.2"
 			}
@@ -6688,7 +5961,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-			"dev": true,
 			"requires": {
 				"makeerror": "1.0.11"
 			}
@@ -6697,7 +5969,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
 			"integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
-			"dev": true,
 			"requires": {
 				"exec-sh": "0.2.1",
 				"minimist": "1.2.0"
@@ -6706,22 +5977,19 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-			"dev": true
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"whatwg-encoding": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
 			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
 			}
@@ -6729,14 +5997,12 @@
 		"whatwg-mimetype": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
-			"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
-			"dev": true
+			"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew=="
 		},
 		"whatwg-url": {
 			"version": "6.4.1",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
 			"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
-			"dev": true,
 			"requires": {
 				"lodash.sortby": "4.7.0",
 				"tr46": "1.0.1",
@@ -6747,7 +6013,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -6755,27 +6020,23 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"window-size": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
 			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-			"dev": true,
 			"optional": true
 		},
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-			"dev": true
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
@@ -6785,7 +6046,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -6794,7 +6054,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -6806,14 +6065,12 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write-file-atomic": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"imurmurhash": "0.1.4",
@@ -6824,7 +6081,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
 			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-			"dev": true,
 			"requires": {
 				"async-limiter": "1.0.0",
 				"safe-buffer": "5.1.2"
@@ -6833,26 +6089,22 @@
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-			"dev": true
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
 		},
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-			"dev": true
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
 			"version": "10.1.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
 			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-			"dev": true,
 			"requires": {
 				"cliui": "4.1.0",
 				"decamelize": "1.2.0",
@@ -6871,14 +6123,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"cliui": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"dev": true,
 					"requires": {
 						"string-width": "2.1.1",
 						"strip-ansi": "4.0.0",
@@ -6889,7 +6139,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -6900,7 +6149,6 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
 			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-			"dev": true,
 			"requires": {
 				"camelcase": "4.1.0"
 			},
@@ -6908,8 +6156,7 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				}
 			}
 		}


### PR DESCRIPTION
closes #303 
<body>
Adds a design system provider to the component example factory to allow a design system to optionally be passed to style the components that appear on the canvas
<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
