### PR TITLE
chore(packages): update to ignore test coverage for publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ script:
   - lerna run test --stream
 after_script:
   # See https://github.com/codeclimate/test-reporter/issues/263
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ] != "cron"; then
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then
       for f in packages/*; do
         if [ -d $f]; then
           echo $f; 
@@ -35,7 +36,7 @@ deploy:
   api_key:
     secure: AQpAGAHolfKGOkO/RCPWF0nt4W5h43NNZJ0sIjPD6rHP7uqd9I/VAU6gYHTgWW0aLvP+OD/wFYMTP9M3U5VSdPBH1O+nTZW/iB/jTdxfJnbJ+yx/KtrgShur+V+s+ldLUQoMX//F7G/ljnknV34JAv01L4veeFkytthuca/9eMEYAnRjMnMyUSJApBli6V2lVK1O/xvyOcmPnhz1llWKgZYXjs7mwVwNP5xzFsmuFYCt6Ryn5tf3yj88M6mLyEzqKtb9HRPFxdflFj4zweG1AqvNRkU1lllfV/FWs3j1bfZRPVA1DmaYFKmtplKAKdHFUZNU8I2RTB+5z8btAxmQYw2BNhaxRWuxgFHA3NjG3pOecWVy3rhEUObuaavXqXHrnc/28H43nGM3nH3EbvmsLXGHl6gBlXe4q1xoYVHjDGU7fCngvOXU1zDIoXwDnb9hl76gnUPrdX8WTjhAUYwgD9YzdS0C5IP+8K2QeiVzvyT5pZUEOzkKiB39y+Fp9GYRjOVFcaLh0c/PuYnR0NIfQM6RRyvbupUG9vCz6cXXLPnHPtiAImYeSXkNQ3zV2OlUP2MF4J+cQfQkN5o4lGmgrEeJbgSfqudRUEpRSZflEuLdywC9XSngHbv9onxXryGBkiM3U3EXuqkClEutQrdDbb68Ty/mc/QyHeMo2IpJ87c=
   script: 
-    - lerna publish --conventional-commits --yes --loglevel=verbose
+    - lerna publish --conventional-commits --yes
   on:
     branch: master
-    condition: $TRAVIS_EVENT_TYPE = "cron" 
+    condition: $TRAVIS_EVENT_TYPE = "cron"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ deploy:
   api_key:
     secure: AQpAGAHolfKGOkO/RCPWF0nt4W5h43NNZJ0sIjPD6rHP7uqd9I/VAU6gYHTgWW0aLvP+OD/wFYMTP9M3U5VSdPBH1O+nTZW/iB/jTdxfJnbJ+yx/KtrgShur+V+s+ldLUQoMX//F7G/ljnknV34JAv01L4veeFkytthuca/9eMEYAnRjMnMyUSJApBli6V2lVK1O/xvyOcmPnhz1llWKgZYXjs7mwVwNP5xzFsmuFYCt6Ryn5tf3yj88M6mLyEzqKtb9HRPFxdflFj4zweG1AqvNRkU1lllfV/FWs3j1bfZRPVA1DmaYFKmtplKAKdHFUZNU8I2RTB+5z8btAxmQYw2BNhaxRWuxgFHA3NjG3pOecWVy3rhEUObuaavXqXHrnc/28H43nGM3nH3EbvmsLXGHl6gBlXe4q1xoYVHjDGU7fCngvOXU1zDIoXwDnb9hl76gnUPrdX8WTjhAUYwgD9YzdS0C5IP+8K2QeiVzvyT5pZUEOzkKiB39y+Fp9GYRjOVFcaLh0c/PuYnR0NIfQM6RRyvbupUG9vCz6cXXLPnHPtiAImYeSXkNQ3zV2OlUP2MF4J+cQfQkN5o4lGmgrEeJbgSfqudRUEpRSZflEuLdywC9XSngHbv9onxXryGBkiM3U3EXuqkClEutQrdDbb68Ty/mc/QyHeMo2IpJ87c=
   script: 
-    - lerna publish --conventional-commits --yes
+    - lerna publish --yes
   on:
     branch: master
     condition: $TRAVIS_EVENT_TYPE = "cron"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,15 @@ script:
   - lerna run test --stream
 after_script:
   # See https://github.com/codeclimate/test-reporter/issues/263
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-      if [ "$TRAVIS_EVENT_TYPE"] != "cron" ]; then
-        for f in packages/*; do
-          if [ -d $f]; then
-            echo $f; 
-            ./cc-test-reporter format-coverage -t lcov -o coverage/coverage.${f//\//-}.json $f/coverage/lcov.info; 
-          fi 
-        done;
-        ./cc-test-reporter sum-coverage -o coverage/coverage.total.json coverage/coverage.*.json; 
-        ./cc-test-reporter upload-coverage -i coverage/coverage.total.json;
-      fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ] != "cron"; then
+      for f in packages/*; do
+        if [ -d $f]; then
+          echo $f; 
+          ./cc-test-reporter format-coverage -t lcov -o coverage/coverage.${f//\//-}.json $f/coverage/lcov.info; 
+        fi 
+      done;
+      ./cc-test-reporter sum-coverage -o coverage/coverage.total.json coverage/coverage.*.json; 
+      ./cc-test-reporter upload-coverage -i coverage/coverage.total.json;
     fi
 deploy:
   provider: npm

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,15 @@
 {
-  "lerna": "2.9.0",
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.4"
+  "version": "1.0.4",
+  "command": {
+    "publish": {
+      "allowBranch": "master",
+      "conventionalCommits": true,
+      "gitRemote": "upstream",
+      "message": "chore(release): publish %s"
+    }
+  },
+  "lerna": "2.9.0"
 }


### PR DESCRIPTION
Ignoring test coverage will eliminate any errors from blocking publish of packages.
- `loglevel=verbose` was removed as it didn't provide any extra details
- added `|` to help bash script execute cleaner
