### PR TITLE
fix(jss): fix errors caused by un-linked JSS rules

### DIFF
--- a/packages/fast-components-class-name-contracts-base/src/toggle/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/toggle/index.ts
@@ -7,5 +7,4 @@ export interface IToggleClassNameContract {
     toggle_wrapper: string;
     toggle_input: string;
     toggle_button: string;
-    [media: string]: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/toggle/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/toggle/index.ts
@@ -7,4 +7,5 @@ export interface IToggleClassNameContract {
     toggle_wrapper: string;
     toggle_input: string;
     toggle_button: string;
+    [media: string]: string;
 }

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -16,11 +16,10 @@ function applyTransaprentBackplateStyles(): ICSSRules<IDesignSystem> {
         color: (config: IDesignSystem): string => {
             return config.brandColor;
         },
-        "&:disabled span:before, &[aria-disabled] span:before": {
+        "&:disabled span::before, &[aria-disabled] span::before": {
             background: "transparent"
         },
-        "&:focus span:before, &:active span:before, &:hover span:before": {
-            // TODO: Issue #309 https://github.com/Microsoft/fast-dna/issues/309
+        "&:focus span::before, &:active span::before, &:hover span::before": {
             background: (config: IDesignSystem): string => {
                 return config.brandColor;
             }

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -52,6 +52,11 @@ const styles: ComponentStyles<IToggleClassNameContract, IDesignSystem> = {
         width: toPx(10),
         height: toPx(10)
     },
+    "@media screen and (-ms-high-contrast: active)": {
+        toggle_button: {
+            background: (config: IDesignSystem): string => config.backgroundColor
+        }
+    },
     toggle_input: {
         position: "relative",
         margin: "0",
@@ -65,9 +70,6 @@ const styles: ComponentStyles<IToggleClassNameContract, IDesignSystem> = {
         borderRadius: toPx(20),
         appearance: "none",
         cursor: "pointer",
-        "@media screen and (-ms-high-contrast)": {
-            background: (config: IDesignSystem): string => config.backgroundColor
-        },
         // "@media screen and (-ms-high-contrast)": {
          //    "&::after, &:checked + span": {
          //        background: (config: IDesignSystem): string => {

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -12,7 +12,7 @@ const styles: ComponentStyles<IToggleClassNameContract, IDesignSystem> = {
             marginTop: "0",
             paddingBottom: "0"
         },
-        "&[aria-disabled='true']": {
+        "&[aria-disabled=\"true\"]": {
             color: (config: IDesignSystem): string => {
                 return Chroma(config.foregroundColor).alpha(0.5).css();
             }
@@ -48,7 +48,6 @@ const styles: ComponentStyles<IToggleClassNameContract, IDesignSystem> = {
         backgroundColor: (config: IDesignSystem): string => {
             return config.backgroundColor;
         },
-        content: "''",
         borderRadius: toPx(10),
         width: toPx(10),
         height: toPx(10)
@@ -67,19 +66,22 @@ const styles: ComponentStyles<IToggleClassNameContract, IDesignSystem> = {
         appearance: "none",
         cursor: "pointer",
         "@media screen and (-ms-high-contrast)": {
-            "&:after, &:checked+span": {
-                background: (config: IDesignSystem): string => {
-                    return config.backgroundColor;
-                }
-            }
+            background: (config: IDesignSystem): string => config.backgroundColor
         },
-        "@media screen and (-ms-high-contrast: black-on-white)": {
-            "&:after, &:checked+span": {
-                background: (config: IDesignSystem): string => {
-                    return config.foregroundColor;
-                }
-            }
-        },
+        // "@media screen and (-ms-high-contrast)": {
+         //    "&::after, &:checked + span": {
+         //        background: (config: IDesignSystem): string => {
+         //            return config.backgroundColor;
+         //        }
+         //    },
+        // },
+        // "@media screen and (-ms-high-contrast: black-on-white)": {
+            // "&::after, &:checked + span": {
+            //     background: (config: IDesignSystem): string => {
+            //         return config.foregroundColor;
+            //     }
+            // },
+        // },
         "&:checked": {
             backgroundColor: (config: IDesignSystem): string => {
                 return config.brandColor;

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -10,8 +10,7 @@ const styles: ComponentStyles<IToggleClassNameContract, IDesignSystem> = {
         "& span": {
             userSelect: "none",
             marginTop: "0",
-            paddingBottom: "0"
-        },
+            paddingBottom: "0" },
         "&[aria-disabled=\"true\"]": {
             color: (config: IDesignSystem): string => {
                 return Chroma(config.foregroundColor).alpha(0.5).css();
@@ -52,11 +51,6 @@ const styles: ComponentStyles<IToggleClassNameContract, IDesignSystem> = {
         width: toPx(10),
         height: toPx(10)
     },
-    "@media screen and (-ms-high-contrast: active)": {
-        toggle_button: {
-            background: (config: IDesignSystem): string => config.backgroundColor
-        }
-    },
     toggle_input: {
         position: "relative",
         margin: "0",
@@ -70,20 +64,20 @@ const styles: ComponentStyles<IToggleClassNameContract, IDesignSystem> = {
         borderRadius: toPx(20),
         appearance: "none",
         cursor: "pointer",
-        // "@media screen and (-ms-high-contrast)": {
-         //    "&::after, &:checked + span": {
-         //        background: (config: IDesignSystem): string => {
-         //            return config.backgroundColor;
-         //        }
-         //    },
-        // },
-        // "@media screen and (-ms-high-contrast: black-on-white)": {
-            // "&::after, &:checked + span": {
-            //     background: (config: IDesignSystem): string => {
-            //         return config.foregroundColor;
-            //     }
-            // },
-        // },
+        "@media screen and (-ms-high-contrast:active)": {
+            "&::after, &:checked + span": {
+                background: (config: IDesignSystem): string => {
+                    return config.backgroundColor;
+                }
+            },
+        },
+        "@media screen and (-ms-high-contrast:black-on-white)": {
+            "&::after, &:checked + span": {
+                background: (config: IDesignSystem): string => {
+                    return config.foregroundColor;
+                }
+            }
+        },
         "&:checked": {
             backgroundColor: (config: IDesignSystem): string => {
                 return config.brandColor;

--- a/packages/fast-development-site-react/src/components/site/action-bar.tsx
+++ b/packages/fast-development-site-react/src/components/site/action-bar.tsx
@@ -86,7 +86,16 @@ const styles: ComponentStyles<IActionBarClassNameContract, IDevSiteDesignSystem>
     },
     actionBar_menu_button__active: {
         ...menuButtonBase(),
-        background: "#EBEBEB"
+        background: "#EBEBEB",
+        "&::after": {
+            content: "''",
+            position: "absolute",
+            display: "block",
+            width: "100%",
+            bottom: "0",
+            height: toPx(2),
+            background: (config: IDevSiteDesignSystem) => config.brandColor
+        }
     }
 };
 

--- a/packages/fast-development-site-react/src/components/site/action-bar.tsx
+++ b/packages/fast-development-site-react/src/components/site/action-bar.tsx
@@ -94,7 +94,7 @@ const styles: ComponentStyles<IActionBarClassNameContract, IDevSiteDesignSystem>
             width: "100%",
             bottom: "0",
             height: toPx(2),
-            background: (config: IDevSiteDesignSystem) => config.brandColor
+            background: (config: IDevSiteDesignSystem): string => config.brandColor
         }
     }
 };

--- a/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
@@ -16,7 +16,7 @@ const styles: ComponentStyles<IComponentViewToggleClassNameContract, IDevSiteDes
         alignItems: "center",
         justifyContent: "center",
         "&[aria-current=\"page\"]": {
-            "&:before": {
+            "&::before": {
                 content: "''",
                 position: "absolute",
                 display: "block",
@@ -24,8 +24,7 @@ const styles: ComponentStyles<IComponentViewToggleClassNameContract, IDevSiteDes
                 left: toPx(4),
                 bottom: toPx(0),
                 height: toPx(2),
-                // TODO: use callback with brand-color when #342 is fixed
-                background: "pink"
+                background: (config: IDevSiteDesignSystem) => config.brandColor
             }
         }
     }

--- a/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
@@ -24,7 +24,7 @@ const styles: ComponentStyles<IComponentViewToggleClassNameContract, IDevSiteDes
                 left: toPx(4),
                 bottom: toPx(0),
                 height: toPx(2),
-                background: (config: IDevSiteDesignSystem) => config.brandColor
+                background: (config: IDevSiteDesignSystem): string => config.brandColor
             }
         }
     }


### PR DESCRIPTION
closes #342 

There are still 4 warnings in toggle caused by `-ms-high-contrast` media queries - I'm working with the JSS author on how best we can resolve these warnings.