### PR TITLE
feat(form generator): add SVGs, additional JSS, and general examples

### DIFF
--- a/packages/fast-form-generator-react/app/components/align-horizontal/align-horizontal.tsx
+++ b/packages/fast-form-generator-react/app/components/align-horizontal/align-horizontal.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 
-export enum alignHorizontalEnum {
+export enum AlignHorizontalPositions {
     left = "left",
     right = "right"
 }
 
 export interface IAlignHorizontalProps {
-    alignHorizontal: alignHorizontalEnum;
+    alignHorizontal: AlignHorizontalPositions;
 }
 
 /**

--- a/packages/fast-form-generator-react/app/components/align-vertical/__snapshots__/align-vertical.spec.tsx.snap
+++ b/packages/fast-form-generator-react/app/components/align-vertical/__snapshots__/align-vertical.spec.tsx.snap
@@ -26,7 +26,7 @@ exports[`align-vertical align-vertical: 0 1`] = `
                   <input
                     aria-label="top align"
                     checked={true}
-                    className={undefined}
+                    className="formItemAlignVertical_input__top-0-1-12"
                     id="alignVertical"
                     name="alignVertical"
                     onChange={[Function]}
@@ -50,7 +50,7 @@ exports[`align-vertical align-vertical: 0 1`] = `
                   <input
                     aria-label="bottom align"
                     checked={false}
-                    className={undefined}
+                    className="formItemAlignVertical_input__bottom-0-1-14"
                     id="alignVertical"
                     name="alignVertical"
                     onChange={[Function]}

--- a/packages/fast-form-generator-react/app/components/align-vertical/align-vertical.tsx
+++ b/packages/fast-form-generator-react/app/components/align-vertical/align-vertical.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 
-export enum alignVerticalEnum {
+export enum AlignVerticalPositions {
     top = "top",
     bottom = "bottom",
     center = "center"
 }
 
 export interface IAlignVerticalProps {
-    alignVertical: alignVerticalEnum;
+    alignVertical: AlignVerticalPositions;
 }
 
 /**

--- a/packages/fast-form-generator-react/app/components/checkbox/__snapshots__/checkbox.spec.tsx.snap
+++ b/packages/fast-form-generator-react/app/components/checkbox/__snapshots__/checkbox.spec.tsx.snap
@@ -19,16 +19,16 @@ exports[`checkbox checkbox: 0 1`] = `
               htmlFor="toggle"
             >
               Checkbox
-              <input
-                checked={true}
-                className="formItemCheckbox_input-0-1-12"
-                id="toggle"
-                onChange={[Function]}
-                type="checkbox"
-                value="true"
-              />
-              <span />
             </label>
+            <input
+              checked={true}
+              className="formItemCheckbox_input-0-1-12"
+              id="toggle"
+              onChange={[Function]}
+              type="checkbox"
+              value="true"
+            />
+            <span />
           </div>
         </div>
       </div>

--- a/packages/fast-form-generator-react/app/components/general-example/__snapshots__/general-example.spec.tsx.snap
+++ b/packages/fast-form-generator-react/app/components/general-example/__snapshots__/general-example.spec.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`general-example general-example: 0 1`] = `
+<div>
+  <form
+    onSubmit={[Function]}
+  >
+    <h2>
+      Untitled
+    </h2>
+    <div>
+      <div>
+        <div />
+      </div>
+    </div>
+  </form>
+</div>
+`;

--- a/packages/fast-form-generator-react/app/components/general-example/general-example.config.ts
+++ b/packages/fast-form-generator-react/app/components/general-example/general-example.config.ts
@@ -1,0 +1,15 @@
+import {
+    IFormComponentMappingToPropertyNamesProps
+} from "../../../src/form/form.props";
+
+export default {
+    alignHorizontal: [
+        "alignHorizontal"
+    ],
+    alignVertical: [
+        "alignVertical"
+    ],
+    theme: [
+        "theme"
+    ]
+} as IFormComponentMappingToPropertyNamesProps;

--- a/packages/fast-form-generator-react/app/components/general-example/general-example.schema.json
+++ b/packages/fast-form-generator-react/app/components/general-example/general-example.schema.json
@@ -4,6 +4,7 @@
     "description": "A test component's schema definition.",
     "type": "object",
     "id": "generalExample",
+    "children": true,
     "properties": {
         "title": {
             "title": "Title",
@@ -17,6 +18,10 @@
             "title": "Details",
             "type": "string"
         },
+        "toggle2": {
+            "title": "Checkbox",
+            "type": "boolean"
+        },
         "tag": {
             "title": "HTML tag",
             "type": "string",
@@ -25,6 +30,11 @@
                 "button"
             ],
             "default": "button"
+        },
+        "level": {
+            "title": "Level",
+            "type": "number",
+            "example": 5
         },
         "text": {
             "title": "Text",
@@ -49,20 +59,80 @@
                 "center"
             ]
         },
-        "level": {
+        "level2": {
             "title": "Level",
             "type": "number",
-            "example": 5
+            "example": 100
+        },
+        "objectNoRequired": {
+            "title": "Object (no required items)",
+            "type": "object",
+            "properties": {
+                "number": {
+                    "type": "number"
+                }
+            }
+        },
+        "objectWithRequired": {
+            "title": "Object (with required items)",
+            "type": "object",
+            "properties": {
+                "boolean": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "boolean"
+            ]
+        },
+        "optionalObjectWithRequired": {
+            "title": "Optional object",
+            "type": "object",
+            "properties": {
+                "string": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "string"
+            ]
+        },
+        "optionalObjectNoRequired": {
+            "title": "Object with no required items",
+            "type": "object",
+            "properties": {
+                "boolean": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "strings": {
+            "title": "Array",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 0,
+            "maxItems": 6
+        },
+        "theme": {
+            "title": "Theme",
+            "type": "string",
+            "enum": [
+                "light",
+                "dark"
+            ]
         }
     },
     "required": [
         "alignHorizontal",
         "alignVertical",
         "level",
+        "level2",
         "title",
         "details",
         "tag",
-        "text",
-        "toggle"
+        "toggle",
+        "toggle2"
     ]
 }

--- a/packages/fast-form-generator-react/app/components/general-example/general-example.schema.json
+++ b/packages/fast-form-generator-react/app/components/general-example/general-example.schema.json
@@ -1,0 +1,68 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "General example",
+    "description": "A test component's schema definition.",
+    "type": "object",
+    "id": "generalExample",
+    "properties": {
+        "title": {
+            "title": "Title",
+            "type": "string"
+        },
+        "toggle": {
+            "title": "Checkbox",
+            "type": "boolean"
+        },
+        "details": {
+            "title": "Details",
+            "type": "string"
+        },
+        "tag": {
+            "title": "HTML tag",
+            "type": "string",
+            "enum": [
+                "span",
+                "button"
+            ],
+            "default": "button"
+        },
+        "text": {
+            "title": "Text",
+            "type": "string",
+            "example": "Example text"
+        },
+        "alignHorizontal": {
+            "title": "Align horizontal",
+            "type": "string",
+            "enum": [
+                "left",
+                "center",
+                "right"
+            ]
+        },
+        "alignVertical": {
+            "title": "Align vertical",
+            "type": "string",
+            "enum": [
+                "top",
+                "bottom",
+                "center"
+            ]
+        },
+        "level": {
+            "title": "Level",
+            "type": "number",
+            "example": 5
+        }
+    },
+    "required": [
+        "alignHorizontal",
+        "alignVertical",
+        "level",
+        "title",
+        "details",
+        "tag",
+        "text",
+        "toggle"
+    ]
+}

--- a/packages/fast-form-generator-react/app/components/general-example/general-example.spec.tsx
+++ b/packages/fast-form-generator-react/app/components/general-example/general-example.spec.tsx
@@ -4,6 +4,7 @@ import { ISnapshotTestSuite } from "@microsoft/fast-jest-snapshots-react";
 import { getExample } from "@microsoft/fast-permutator";
 import Form, { IFormProps } from "../../../src/form";
 import * as generalExampleSchema from "./general-example";
+import config from "./general-example.config";
 
 const name: string = "general-example";
 
@@ -11,7 +12,8 @@ const exampleData: IFormProps = {
     schema: generalExampleSchema,
     data: getExample(generalExampleSchema),
     /* tslint:disable-next-line */
-    onChange: (data: any): void => {}
+    onChange: (data: any): void => {},
+    componentMappingToPropertyNames: config
 };
 
 const examples: ISnapshotTestSuite<IFormProps> = {

--- a/packages/fast-form-generator-react/app/components/general-example/general-example.spec.tsx
+++ b/packages/fast-form-generator-react/app/components/general-example/general-example.spec.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
+import { ISnapshotTestSuite } from "@microsoft/fast-jest-snapshots-react";
+import { getExample } from "@microsoft/fast-permutator";
+import Form, { IFormProps } from "../../../src/form";
+import * as generalExampleSchema from "./general-example";
+
+const name: string = "general-example";
+
+const exampleData: IFormProps = {
+    schema: generalExampleSchema,
+    data: getExample(generalExampleSchema),
+    /* tslint:disable-next-line */
+    onChange: (data: any): void => {}
+};
+
+const examples: ISnapshotTestSuite<IFormProps> = {
+    name,
+    component: Form,
+    data: [
+        exampleData
+    ]
+};
+
+describe(name, () => {
+    generateSnapshots(examples);
+});

--- a/packages/fast-form-generator-react/app/components/general-example/general-example.tsx
+++ b/packages/fast-form-generator-react/app/components/general-example/general-example.tsx
@@ -3,7 +3,7 @@ import Array, { IArrayProps } from "../arrays/arrays";
 import Objects, { IObjectsProps } from "../objects/objects";
 import Theme, { IThemeProps } from "../theme/theme";
 
-export enum tagEnum {
+export enum GeneralExampleTags {
     button = "button",
     span = "span"
 }
@@ -13,7 +13,7 @@ export interface IGeneralExampleProps {
     alignVertical: string;
     level: number;
     level2: number;
-    tag: tagEnum;
+    tag: GeneralExampleTags;
     title: string;
     details: string;
     text: string;

--- a/packages/fast-form-generator-react/app/components/general-example/general-example.tsx
+++ b/packages/fast-form-generator-react/app/components/general-example/general-example.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+
+export enum tagEnum {
+    button = "button",
+    span = "span"
+}
+
+export interface IGeneralExampleProps {
+    alignHorizontal: string;
+    alignVertical: string;
+    level: number;
+    tag: tagEnum;
+    title: string;
+    details: string;
+    text: string;
+    checkbbox: boolean;
+}
+
+/**
+ * This test components API should have:
+ * - a number of required property which maps to a configuration which will organise them by weight
+ */
+export default class GeneralExample extends React.Component<IGeneralExampleProps, {}> {
+    public render(): JSX.Element {
+        return (
+            <this.props.tag>
+                {this.props.alignHorizontal}
+                {this.props.alignVertical}
+                {this.props.level}
+                {this.props.title}
+                {this.props.details}
+                {this.props.tag}
+                {this.props.text}
+                {this.props.checkbbox}
+            </this.props.tag>
+        );
+    }
+}

--- a/packages/fast-form-generator-react/app/components/general-example/general-example.tsx
+++ b/packages/fast-form-generator-react/app/components/general-example/general-example.tsx
@@ -1,4 +1,7 @@
 import * as React from "react";
+import Array, { IArrayProps } from "../arrays/arrays";
+import Objects, { IObjectsProps } from "../objects/objects";
+import Theme, { IThemeProps } from "../theme/theme";
 
 export enum tagEnum {
     button = "button",
@@ -9,11 +12,17 @@ export interface IGeneralExampleProps {
     alignHorizontal: string;
     alignVertical: string;
     level: number;
+    level2: number;
     tag: tagEnum;
     title: string;
     details: string;
     text: string;
-    checkbbox: boolean;
+    checkbox: boolean;
+    checkbox2: boolean;
+    objects: IObjectsProps;
+    array: IArrayProps;
+    theme: IThemeProps;
+    children: any;
 }
 
 /**
@@ -24,14 +33,21 @@ export default class GeneralExample extends React.Component<IGeneralExampleProps
     public render(): JSX.Element {
         return (
             <this.props.tag>
+                {this.props.title}
                 {this.props.alignHorizontal}
+                {this.props.checkbox}
                 {this.props.alignVertical}
+                {this.props.checkbox2}
                 {this.props.level}
                 {this.props.title}
                 {this.props.details}
                 {this.props.tag}
+                {this.props.level2}
                 {this.props.text}
-                {this.props.checkbbox}
+                {this.props.objects}
+                {this.props.array}
+                {this.props.theme}
+                {this.props.children}
             </this.props.tag>
         );
     }

--- a/packages/fast-form-generator-react/app/components/index.ts
+++ b/packages/fast-form-generator-react/app/components/index.ts
@@ -102,10 +102,12 @@ export const weightProperties: IExampleComponent = {
 };
 
 import GeneralExample from "./general-example/general-example";
+import GeneralExampleConfig from "./general-example/general-example.config";
 import * as GeneralExampleSchema from "./general-example/general-example.schema.json";
 
 export const generalExample: IExampleComponent = {
     component: GeneralExample,
+    config: GeneralExampleConfig,
     schema: GeneralExampleSchema
 };
 

--- a/packages/fast-form-generator-react/app/components/index.ts
+++ b/packages/fast-form-generator-react/app/components/index.ts
@@ -101,6 +101,14 @@ export const weightProperties: IExampleComponent = {
     schema: WeightPropertiesSchema
 };
 
+import GeneralExample from "./general-example/general-example";
+import * as GeneralExampleSchema from "./general-example/general-example.schema.json";
+
+export const generalExample: IExampleComponent = {
+    component: GeneralExample,
+    schema: GeneralExampleSchema
+};
+
 import AttributeAssignment from "./attribute-assignment/attribute-assignment";
 import AttributeAssignmentConfig from "./attribute-assignment/attribute-assignment.config";
 import * as AttributeAssignmentSchema from "./attribute-assignment/attribute-assignment.schema.json";

--- a/packages/fast-form-generator-react/app/components/number-field/number-field.tsx
+++ b/packages/fast-form-generator-react/app/components/number-field/number-field.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-export enum levelEnum {
+export enum Levels {
     _1 = 1,
     _2 = 2,
     _3 = 3,
@@ -8,7 +8,7 @@ export enum levelEnum {
 }
 
 export interface INumberFieldProps {
-    level: levelEnum;
+    level: Levels;
     quantity: number;
 }
 

--- a/packages/fast-form-generator-react/app/components/text-field/text-field.tsx
+++ b/packages/fast-form-generator-react/app/components/text-field/text-field.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 
-export enum tagEnum {
+export enum TextFieldTags {
     button = "button",
     span = "span"
 }
 
 export interface ITextFieldProps {
-    tag: tagEnum;
+    tag: TextFieldTags;
     text: string;
 }
 

--- a/packages/fast-form-generator-react/app/components/theme/theme.tsx
+++ b/packages/fast-form-generator-react/app/components/theme/theme.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 
-export enum themeEnum {
+export enum Themes {
     light = "light",
     dark = "dark"
 }
 
 export interface IThemeProps {
-    theme: themeEnum;
+    theme: Themes;
 }
 
 /**

--- a/packages/fast-form-generator-react/app/components/weight-properties/weight-properties.tsx
+++ b/packages/fast-form-generator-react/app/components/weight-properties/weight-properties.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-export enum tagEnum {
+export enum WeightPropertiesTags {
     button = "button",
     span = "span"
 }
@@ -9,7 +9,7 @@ export interface IWeightPropertiesProps {
     alignHorizontal: string;
     alignVertical: string;
     level: number;
-    tag: tagEnum;
+    tag: WeightPropertiesTags;
     title: string;
     details: string;
     text: string;

--- a/packages/fast-form-generator-react/app/index.tsx
+++ b/packages/fast-form-generator-react/app/index.tsx
@@ -81,7 +81,7 @@ export default class App extends React.Component<{}, IAppState> {
             <DesignSystemProvider designSystem={designSystemDefaults}>
                 <div>
                     <div
-                        style={{width: "300px", height: "100vh", background: "rgb(244, 245, 246)", float: "left"}}
+                        style={{width: "300px", minHeight: "100vh", padding: "0 8px", background: "rgb(244, 245, 246)", float: "left"}}
                     >
                         <Form {...this.coerceFormProps()} />
                     </div>

--- a/packages/fast-form-generator-react/src/class-name-contracts/form-item.array.class-name-contract.ts
+++ b/packages/fast-form-generator-react/src/class-name-contracts/form-item.array.class-name-contract.ts
@@ -3,8 +3,8 @@
  */
 export default interface IFormItemArrayClassNameContract {
     formItemArray: string;
-    formItemArray_menu: string;
+    formItemArray_actionMenu: string;
+    formItemArray_actionMenuItem__add: string;
+    formItemArray_actionMenuItem__remove: string;
     formItemArray_linkMenu: string;
-    formItemArray_linkMenuItem__add: string;
-    formItemArray_linkMenuItem__remove: string;
 }

--- a/packages/fast-form-generator-react/src/class-name-contracts/form-item.array.class-name-contract.ts
+++ b/packages/fast-form-generator-react/src/class-name-contracts/form-item.array.class-name-contract.ts
@@ -5,4 +5,6 @@ export default interface IFormItemArrayClassNameContract {
     formItemArray: string;
     formItemArray_menu: string;
     formItemArray_linkMenu: string;
+    formItemArray_linkMenuItem__add: string;
+    formItemArray_linkMenuItem__remove: string;
 }

--- a/packages/fast-form-generator-react/src/class-name-contracts/form-item.children.class-name-contract.ts
+++ b/packages/fast-form-generator-react/src/class-name-contracts/form-item.children.class-name-contract.ts
@@ -8,4 +8,5 @@ export default interface IFormItemChildrenClassNameContract {
     formItemChildren_existingChildren: string;
     formItemChildren_addedChildren: string;
     formItemChildren_optionMenu: string;
+    formItemChildren_optionMenu__listItem: string;
 }

--- a/packages/fast-form-generator-react/src/form/form-item.align-vertical.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.align-vertical.tsx
@@ -40,11 +40,11 @@ class FormItemAlignVertical extends React.Component<IFormItemComponentMappingToP
 
     private getInputClassName(direction: string): string {
         switch (direction) {
-            case "left":
+            case "top":
                 return this.props.managedClasses.formItemAlignVertical_input__top;
             case "center":
                 return this.props.managedClasses.formItemAlignVertical_input__center;
-            case "right":
+            case "bottom":
                 return this.props.managedClasses.formItemAlignVertical_input__bottom;
         }
     }

--- a/packages/fast-form-generator-react/src/form/form-item.array.style.ts
+++ b/packages/fast-form-generator-react/src/form/form-item.array.style.ts
@@ -22,24 +22,22 @@ const styles: ComponentStyles<IFormItemArrayClassNameContract, {}> = {
             background: "transparent",
             border: "none",
             padding: `${toPx(4)}`,
-            color: colors.blue,
             "&:focus": {
                 outline: "none"
             }
         }
     },
-    formItemArray_menu: {
+    formItemArray_actionMenu: {
         ...applyCleanListStyle(),
         ...applyAriaHiddenStyles(),
         ...applyPopupMenuStyles(),
-        "& li": {
-            "& $formItemArray_linkMenuItem__add, & $formItemArray_linkMenuItem__remove": {
+        "& $formItemArray_actionMenuItem__add, & $formItemArray_actionMenuItem__remove": {
                 ...localizePadding(12, 12, 12, 36),
                 width: "100%",
                 ...ellipsis(),
                 textAlign: "left",
                 color: colors.black,
-                "&:before": {
+                "&::before": {
                     position: "absolute",
                     content: "''",
                     opacity: ".6",
@@ -52,26 +50,22 @@ const styles: ComponentStyles<IFormItemArrayClassNameContract, {}> = {
                     backgroundColor: colors.grayBackground
                 }
             }
-        }
     },
-    formItemArray_linkMenu: {
-        ...applyCleanListStyle(),
-        ...applyListItemStyle(),
-        "& li button": {
-            color: colors.black
-        }
-    },
-    formItemArray_linkMenuItem__add: {
-        "&:before": {
+    formItemArray_actionMenuItem__add: {
+        "&::before": {
              /* tslint:disable-next-line */
             background: "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNSAyNSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmb250LXNpemU6MjVweDtmb250LWZhbWlseTpNV0ZNREwyQXNzZXRzLCBNV0YgTURMMiBBc3NldHM7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT5Bc3NldCAyPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iTGF5ZXJfMS0yIiBkYXRhLW5hbWU9IkxheWVyIDEiPjx0ZXh0IGNsYXNzPSJjbHMtMSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAyNSkiPu6ckDwvdGV4dD48L2c+PC9nPjwvc3ZnPg==) center no-repeat"
         }
     },
-    formItemArray_linkMenuItem__remove: {
-        "&:before": {
+    formItemArray_actionMenuItem__remove: {
+        "&::before": {
             /* tslint:disable-next-line */
             background: "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNSAyNSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmb250LXNpemU6MjVweDtmb250LWZhbWlseTpNV0ZNREwyQXNzZXRzLCBNV0YgTURMMiBBc3NldHM7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT5Bc3NldCAxPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iTGF5ZXJfMS0yIiBkYXRhLW5hbWU9IkxheWVyIDEiPjx0ZXh0IGNsYXNzPSJjbHMtMSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAyNSkiPu6cuDwvdGV4dD48L2c+PC9nPjwvc3ZnPg==) center no-repeat"
         }
+    },
+    formItemArray_linkMenu: {
+        ...applyCleanListStyle(),
+        ...applyListItemStyle()
     }
 };
 

--- a/packages/fast-form-generator-react/src/form/form-item.array.style.ts
+++ b/packages/fast-form-generator-react/src/form/form-item.array.style.ts
@@ -1,11 +1,12 @@
-import { toPx } from "@microsoft/fast-jss-utilities";
+import { ellipsis, toPx } from "@microsoft/fast-jss-utilities";
 import {
     applyAriaHiddenStyles,
     applyCleanListStyle,
     applyListItemStyle,
     applyPopupHeadingStyles,
     applyPopupMenuStyles,
-    colors
+    colors,
+    localizePadding
 } from "../utilities/form-input.style";
 import { ComponentStyles, ICSSRules } from "@microsoft/fast-jss-manager";
 import { IFormItemArrayClassNameContract } from "../class-name-contracts/";
@@ -13,6 +14,7 @@ import { IFormItemArrayClassNameContract } from "../class-name-contracts/";
 const styles: ComponentStyles<IFormItemArrayClassNameContract, {}> = {
     formItemArray: {
         ...applyPopupHeadingStyles(),
+        marginTop: toPx(8),
         "& button": {
             lineHeight: "1",
             fontSize: toPx(14),
@@ -31,8 +33,25 @@ const styles: ComponentStyles<IFormItemArrayClassNameContract, {}> = {
         ...applyAriaHiddenStyles(),
         ...applyPopupMenuStyles(),
         "& li": {
-            flex: "1 100%",
-            padding: `${toPx(12)} 0`
+            "& $formItemArray_linkMenuItem__add, & $formItemArray_linkMenuItem__remove": {
+                ...localizePadding(12, 12, 12, 36),
+                width: "100%",
+                ...ellipsis(),
+                textAlign: "left",
+                color: colors.black,
+                "&:before": {
+                    position: "absolute",
+                    content: "''",
+                    opacity: ".6",
+                    pointerEvents: "none",
+                    width: toPx(16),
+                    height: toPx(16),
+                    left: toPx(10)
+                },
+                "&:hover": {
+                    backgroundColor: colors.grayBackground
+                }
+            }
         }
     },
     formItemArray_linkMenu: {
@@ -40,6 +59,18 @@ const styles: ComponentStyles<IFormItemArrayClassNameContract, {}> = {
         ...applyListItemStyle(),
         "& li button": {
             color: colors.black
+        }
+    },
+    formItemArray_linkMenuItem__add: {
+        "&:before": {
+             /* tslint:disable-next-line */
+            background: "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNSAyNSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmb250LXNpemU6MjVweDtmb250LWZhbWlseTpNV0ZNREwyQXNzZXRzLCBNV0YgTURMMiBBc3NldHM7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT5Bc3NldCAyPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iTGF5ZXJfMS0yIiBkYXRhLW5hbWU9IkxheWVyIDEiPjx0ZXh0IGNsYXNzPSJjbHMtMSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAyNSkiPu6ckDwvdGV4dD48L2c+PC9nPjwvc3ZnPg==) center no-repeat"
+        }
+    },
+    formItemArray_linkMenuItem__remove: {
+        "&:before": {
+            /* tslint:disable-next-line */
+            background: "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNSAyNSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmb250LXNpemU6MjVweDtmb250LWZhbWlseTpNV0ZNREwyQXNzZXRzLCBNV0YgTURMMiBBc3NldHM7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT5Bc3NldCAxPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iTGF5ZXJfMS0yIiBkYXRhLW5hbWU9IkxheWVyIDEiPjx0ZXh0IGNsYXNzPSJjbHMtMSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAyNSkiPu6cuDwvdGV4dD48L2c+PC9nPjwvc3ZnPg==) center no-repeat"
         }
     }
 };

--- a/packages/fast-form-generator-react/src/form/form-item.array.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.array.tsx
@@ -88,7 +88,7 @@ class FormItemArray extends React.Component<IFormItemArrayProps & IManagedClasse
                 <div>
                     <h3>{this.getLabelText()}</h3>
                     <button onClick={this.toggleMenu} aria-expanded={!this.state.hideOptionMenu}>Options</button>
-                    <ul aria-hidden={this.state.hideOptionMenu} className={this.props.managedClasses.formItemArray_menu}>
+                    <ul aria-hidden={this.state.hideOptionMenu} className={this.props.managedClasses.formItemArray_actionMenu}>
                         {this.renderArrayMenuItems()}
                     </ul>
                 </div>
@@ -294,8 +294,8 @@ class FormItemArray extends React.Component<IFormItemArrayProps & IManagedClasse
 
         return items.map((item: any, index: number) => {
             const className: string = item.type === ArrayAction.remove
-                ? this.props.managedClasses.formItemArray_linkMenuItem__remove
-                : this.props.managedClasses.formItemArray_linkMenuItem__add;
+                ? this.props.managedClasses.formItemArray_actionMenuItem__remove
+                : this.props.managedClasses.formItemArray_actionMenuItem__add;
 
             return (
                 <li key={index}>

--- a/packages/fast-form-generator-react/src/form/form-item.array.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.array.tsx
@@ -113,6 +113,10 @@ class FormItemArray extends React.Component<IFormItemArrayProps & IManagedClasse
         return (e: React.MouseEvent<HTMLElement>): void => {
             e.preventDefault();
 
+            if (!this.state.hideOptionMenu) {
+                this.toggleMenu();
+            }
+
             type === ArrayAction.add ? this.handleAddArrayItem(dataLocation, schema) : this.handleRemoveArrayItem(dataLocation, index);
         };
     }
@@ -289,12 +293,17 @@ class FormItemArray extends React.Component<IFormItemArrayProps & IManagedClasse
         }
 
         return items.map((item: any, index: number) => {
+            const className: string = item.type === ArrayAction.remove
+                ? this.props.managedClasses.formItemArray_linkMenuItem__remove
+                : this.props.managedClasses.formItemArray_linkMenuItem__add;
+
             return (
                 <li key={index}>
                     <button
+                        className={className}
                         onClick={item.onClick}
                     >
-                        {item.type === ArrayAction.remove ? "-" : "+"} {item.text}
+                        {item.text}
                     </button>
                 </li>
             );

--- a/packages/fast-form-generator-react/src/form/form-item.checkbox.style.ts
+++ b/packages/fast-form-generator-react/src/form/form-item.checkbox.style.ts
@@ -30,7 +30,7 @@ const styles: ComponentStyles<IFormItemCheckboxClassNameContract, {}> = {
             right: "0",
             width: toPx(20),
             height: toPx(20),
-            "&:after, &:before": {
+            "&::after, &::before": {
                 position: "absolute",
                 display: "block",
                 content: "''",
@@ -40,13 +40,13 @@ const styles: ComponentStyles<IFormItemCheckboxClassNameContract, {}> = {
         },
         "&:checked": {
             "& + span": {
-                "&:before": {
+                "&::before": {
                     height: toPx(5),
                     left: toPx(6),
                     top: toPx(10),
                     transform: "rotate(-45deg)"
                 },
-                "&:after": {
+                "&::after": {
                     height: toPx(12),
                     left: toPx(12),
                     top: toPx(4),

--- a/packages/fast-form-generator-react/src/form/form-item.checkbox.style.ts
+++ b/packages/fast-form-generator-react/src/form/form-item.checkbox.style.ts
@@ -1,18 +1,15 @@
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { ComponentStyles, ICSSRules } from "@microsoft/fast-jss-manager";
 import { IFormItemCheckboxClassNameContract } from "../class-name-contracts/";
-import { applyLabelStyle, colors } from "../utilities/form-input.style";
+import { applyLabelStyle, applyWrapperStyle, colors } from "../utilities/form-input.style";
 
 const styles: ComponentStyles<IFormItemCheckboxClassNameContract, {}> = {
     formItemCheckbox: {
-        display: "flex",
-        flexDirection: "row"
+        ...applyWrapperStyle(),
+        position: "relative"
     },
     formItemCheckbox_label: {
-        ...applyLabelStyle(),
-        position: "relative",
-        lineHeight: toPx(31),
-        marginRight: "0"
+        ...applyLabelStyle()
     },
     formItemCheckbox_input: {
         appearance: "none",
@@ -22,17 +19,17 @@ const styles: ComponentStyles<IFormItemCheckboxClassNameContract, {}> = {
         boxShadow: `inset ${toPx(0)} 0${toPx(0)} ${toPx(4)} ${colors.boxShadow}`,
         backgroundColor: colors.grayBackground,
         float: "right",
+        zIndex: "1",
+        margin: "0",
         "&:focus": {
             outline: "none",
             boxShadow: `inset ${toPx(0)} ${toPx(0)} ${toPx(0)} ${toPx(1)} rgba(0,0,0, 0.5)`
         },
         "& + span": {
             position: "absolute",
-            right: toPx(8),
-            top: toPx(3),
-            width: toPx(16),
-            height: toPx(16),
-            cursor: "pointer",
+            right: "0",
+            width: toPx(20),
+            height: toPx(20),
             "&:after, &:before": {
                 position: "absolute",
                 display: "block",

--- a/packages/fast-form-generator-react/src/form/form-item.checkbox.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.checkbox.tsx
@@ -20,16 +20,16 @@ class FormItemCheckbox extends React.Component<IFormItemCommon & IManagedClasses
             <div className={this.props.managedClasses.formItemCheckbox}>
                 <label className={this.props.managedClasses.formItemCheckbox_label} htmlFor={this.props.dataLocation}>
                     {this.props.label}
-                    <input
-                        className={this.props.managedClasses.formItemCheckbox_input}
-                        id={this.props.dataLocation}
-                        type="checkbox"
-                        value={value.toString()}
-                        onChange={this.handleChange}
-                        checked={value}
-                    />
-                    <span />
                 </label>
+                <input
+                    className={this.props.managedClasses.formItemCheckbox_input}
+                    id={this.props.dataLocation}
+                    type="checkbox"
+                    value={value.toString()}
+                    onChange={this.handleChange}
+                    checked={value}
+                />
+                <span />
             </div>
         );
     }

--- a/packages/fast-form-generator-react/src/form/form-item.children.style.ts
+++ b/packages/fast-form-generator-react/src/form/form-item.children.style.ts
@@ -69,11 +69,27 @@ const styles: ComponentStyles<IFormItemChildrenClassNameContract, {}> = {
     },
     formItemChildren_addedChildren: {
         ...applyCleanListStyle(),
-        ...applyListItemStyle()
+        ...applyListItemStyle(),
     },
     formItemChildren_optionMenu: {
         ...applyCleanListStyle(),
         ...applyPopupMenuStyles()
+    },
+    formItemChildren_optionMenu__listItem: {
+        "& button": {
+            "&::before": {
+                position: "absolute",
+                content: "''",
+                opacity: ".6",
+                pointerEvents: "none",
+                top: toPx(12),
+                width: toPx(16),
+                height: toPx(16),
+                left: toPx(12),
+                /* tslint:disable-next-line */
+                background: "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNSAyNSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtpc29sYXRpb246aXNvbGF0ZTtmb250LXNpemU6MjVweDtmb250LWZhbWlseTpNV0ZNREwyQXNzZXRzLCBNV0YgTURMMiBBc3NldHM7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT50cnNzc3NBc3NldCAyPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iTGF5ZXJfMS0yIiBkYXRhLW5hbWU9IkxheWVyIDEiPjx0ZXh0IGNsYXNzPSJjbHMtMSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAyNSkiPu6djTwvdGV4dD48L2c+PC9nPjwvc3ZnPg==) center no-repeat"
+            }
+        }
     }
 };
 

--- a/packages/fast-form-generator-react/src/form/form-item.children.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.children.tsx
@@ -234,7 +234,7 @@ class FormItemChildren extends React.Component<IFormItemChildrenProps & IManaged
         // we have nothing to add or delete
         if (items.length === 0) {
             return [
-                (<li key={0}>No actions available</li>)
+                (<li key={0}><span>No actions available</span></li>)
             ];
         }
 
@@ -242,7 +242,7 @@ class FormItemChildren extends React.Component<IFormItemChildrenProps & IManaged
             return (
                 <li key={uniqueId()}>
                     <button onClick={this.clickComponentFactory("delete", void(0), index)}>
-                        remove {item}
+                        {item}
                     </button>
                 </li>
             );

--- a/packages/fast-form-generator-react/src/form/form-item.children.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.children.tsx
@@ -233,14 +233,19 @@ class FormItemChildren extends React.Component<IFormItemChildrenProps & IManaged
 
         // we have nothing to add or delete
         if (items.length === 0) {
-            return [
-                (<li key={0}><span>No actions available</span></li>)
+            return [(
+                <li
+                    key={0}
+                    className={this.props.managedClasses.formItemChildren_optionMenu__listItem}
+                >
+                    <span>No actions available</span>
+                </li>)
             ];
         }
 
         return items.map((item: any, index: number) => {
             return (
-                <li key={uniqueId()}>
+                <li key={uniqueId()} className={this.props.managedClasses.formItemChildren_optionMenu__listItem}>
                     <button onClick={this.clickComponentFactory("delete", void(0), index)}>
                         {item}
                     </button>

--- a/packages/fast-form-generator-react/src/form/form-item.number-field.style.ts
+++ b/packages/fast-form-generator-react/src/form/form-item.number-field.style.ts
@@ -11,7 +11,7 @@ const styles: ComponentStyles<IFormItemNumberFieldClassNameContract, {}> = {
         ...applyLabelStyle()
     },
     formItemNumberField_input: {
-        minWidth: toPx(75),
+        maxWidth: toPx(75),
         ...applyInputStyle()
     }
 };

--- a/packages/fast-form-generator-react/src/form/form.style.ts
+++ b/packages/fast-form-generator-react/src/form/form.style.ts
@@ -13,11 +13,11 @@ const styles: ComponentStyles<IFormClassNameContract, {}> = {
         "& li": {
             display: "inline-block",
             paddingRight: toPx(8),
-            "&:after": {
+            "&::after": {
                 content: "'/'",
                 paddingLeft: toPx(8)
             },
-            "&:last-child:after": {
+            "&:last-child::after": {
                 content: "''",
                 paddingLeft: "0"
             },

--- a/packages/fast-form-generator-react/src/utilities/form-input.style.ts
+++ b/packages/fast-form-generator-react/src/utilities/form-input.style.ts
@@ -28,6 +28,7 @@ export function applyLabelStyle(): ICSSRules<{}> {
         lineHeight: toPx(16),
         fontSize: toPx(14),
         marginRight: toPx(16),
+        paddingTop: toPx(6),
         ...ellipsis()
     };
 }
@@ -49,7 +50,7 @@ export function applyWrapperStyle(): ICSSRules<{}> {
     return {
         display: "flex",
         flexDirection: "row",
-        paddingTop: toPx(8)
+        marginTop: toPx(8)
     };
 }
 
@@ -120,28 +121,39 @@ export function applyPopupMenuStyles(): ICSSRules<{}> {
         background: colors.menuGray,
         zIndex: "1",
         top: toPx(55),
-        "& li > button": {
-            cursor: "pointer",
-            display: "block",
-            ...localizePadding(12, 12, 12, 40),
-            position: "relative",
-            border: "none",
-            background: "transparent",
-            textAlign: "left",
-            "&:before": {
-                position: "absolute",
-                content: "''",
-                opacity: ".6",
-                pointerEvents: "none",
-                top: toPx(12),
-                width: toPx(16),
-                height: toPx(16),
-                left: toPx(12),
-                /* tslint:disable-next-line */
-                background: "url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTMiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxMyAxNiIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48ZyBpZD0iQ2FudmFzIiBmaWxsPSJub25lIj48ZyBpZD0iJiMyMzg7JiMxNTk7JiMxMzE7Ij48cGF0aCBkPSJNIDE0IDQuMjg5MDZMIDE0IDE2TCAxIDE2TCAxIDBMIDkuNzEwOTQgMEwgMTQgNC4yODkwNlpNIDEwIDRMIDEyLjI4OTEgNEwgMTAgMS43MTA5NEwgMTAgNFpNIDEzIDE1TCAxMyA1TCA5IDVMIDkgMUwgMiAxTCAyIDE1TCAxMyAxNVoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xIDApIiBmaWxsPSJibGFjayIvPjwvZz48L2c+PC9zdmc+) center no-repeat"
+        "& li": {
+            "& > button": {
+                cursor: "pointer",
+                display: "block",
+                ...localizePadding(12, 12, 12, 36),
+                position: "relative",
+                border: "none",
+                background: "transparent",
+                textAlign: "left",
+                width: "100%",
+                ...ellipsis(),
+                "&:before": {
+                    position: "absolute",
+                    content: "''",
+                    opacity: ".6",
+                    pointerEvents: "none",
+                    top: toPx(12),
+                    width: toPx(16),
+                    height: toPx(16),
+                    left: toPx(12),
+                    /* tslint:disable-next-line */
+                    background: "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNSAyNSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtpc29sYXRpb246aXNvbGF0ZTtmb250LXNpemU6MjVweDtmb250LWZhbWlseTpNV0ZNREwyQXNzZXRzLCBNV0YgTURMMiBBc3NldHM7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT50cnNzc3NBc3NldCAyPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iTGF5ZXJfMS0yIiBkYXRhLW5hbWU9IkxheWVyIDEiPjx0ZXh0IGNsYXNzPSJjbHMtMSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAyNSkiPu6djTwvdGV4dD48L2c+PC9nPjwvc3ZnPg==) center no-repeat"
+                },
+                "&:focus": {
+                    outline: "none"
+                },
+                "&:hover": {
+                    backgroundColor: colors.grayBackground
+                }
             },
-            "&:focus": {
-                outline: "none"
+            "& > span": {
+                display: "block",
+                padding: toPx(12)
             }
         }
     };
@@ -198,14 +210,14 @@ export function applyInputBackplateStyle(): ICSSRules<{}> {
 
 export function applySelectInputStyles(): ICSSRules<{}> {
     return {
-        flexGrow: "1",
+        width: "100%",
         lineHeight: toPx(16),
         fontSize: toPx(14),
         backgroundColor: colors.grayBackground,
         borderRadius: toPx(2),
         boxShadow: `inset ${toPx(0)} ${toPx(0)} ${toPx(4)} ${colors.boxShadow}`,
         appearance: "none",
-        ...localizePadding(8, 24, 8, 8),
+        ...localizePadding(8, 36, 8, 10),
         border: "none",
         outline: "none",
         "&:-ms-expand": {
@@ -218,7 +230,6 @@ export function applySelectSpanStyles(): ICSSRules<{}> {
     return {
         position: "relative",
         display: "flex",
-        flexGrow: "1",
         "&:before, &:after": {
             content: "''",
             position: "absolute",

--- a/packages/fast-form-generator-react/src/utilities/form-input.style.ts
+++ b/packages/fast-form-generator-react/src/utilities/form-input.style.ts
@@ -70,7 +70,7 @@ export function applyListItemStyle(): ICSSRules<{}> {
             alignItems: "center",
             position: "relative",
             cursor: "pointer",
-            "&:after": {
+            "&::after": {
                 position: "absolute",
                 content: "''",
                 opacity: ".6",
@@ -121,6 +121,7 @@ export function applyPopupMenuStyles(): ICSSRules<{}> {
         background: colors.menuGray,
         zIndex: "1",
         top: toPx(55),
+        boxShadow: `${toPx(0)} ${toPx(1)} ${toPx(0)} ${toPx(0)} ${colors.border}`,
         "& li": {
             "& > button": {
                 cursor: "pointer",
@@ -132,18 +133,6 @@ export function applyPopupMenuStyles(): ICSSRules<{}> {
                 textAlign: "left",
                 width: "100%",
                 ...ellipsis(),
-                "&:before": {
-                    position: "absolute",
-                    content: "''",
-                    opacity: ".6",
-                    pointerEvents: "none",
-                    top: toPx(12),
-                    width: toPx(16),
-                    height: toPx(16),
-                    left: toPx(12),
-                    /* tslint:disable-next-line */
-                    background: "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNSAyNSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtpc29sYXRpb246aXNvbGF0ZTtmb250LXNpemU6MjVweDtmb250LWZhbWlseTpNV0ZNREwyQXNzZXRzLCBNV0YgTURMMiBBc3NldHM7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT50cnNzc3NBc3NldCAyPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iTGF5ZXJfMS0yIiBkYXRhLW5hbWU9IkxheWVyIDEiPjx0ZXh0IGNsYXNzPSJjbHMtMSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAyNSkiPu6djTwvdGV4dD48L2c+PC9nPjwvc3ZnPg==) center no-repeat"
-                },
                 "&:focus": {
                     outline: "none"
                 },
@@ -230,7 +219,7 @@ export function applySelectSpanStyles(): ICSSRules<{}> {
     return {
         position: "relative",
         display: "flex",
-        "&:before, &:after": {
+        "&::before, &::after": {
             content: "''",
             position: "absolute",
             top: toPx(12),
@@ -240,11 +229,11 @@ export function applySelectSpanStyles(): ICSSRules<{}> {
             height: toPx(10),
             background: colors.black
         },
-        "&:before": {
+        "&::before": {
             right: toPx(15),
             transform: "rotate(45deg)"
         },
-        "&:after": {
+        "&::after": {
             right: toPx(22),
             transform: "rotate(-45deg)"
         }


### PR DESCRIPTION
Closes [#417](https://github.com/Microsoft/fast-dna/issues/417)
<body>
Adds a general examples page that shows all form generator components together (more like they would be on the live site, updates all SVGs to be proper, and tweaks JSS as needed.
<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
