### PR TITLE
feat(dev-site): adds error boundary to dev site component wrapper to prevent entire views from breaking

### DIFF
--- a/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
@@ -6,6 +6,7 @@ import manageJss, {
     IJSSManagerProps,
     IManagedClasses
 } from "@microsoft/fast-jss-manager-react";
+import { ErrorBoundary, IErrorBoundaryProps } from "../../utilities";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
 
@@ -67,14 +68,18 @@ class ComponentWrapper extends React.Component<IComponentWrapperProps<IDevSiteDe
         if (this.props.designSystem) {
             return (
                 <DesignSystemProvider designSystem={this.props.designSystem}>
-                    {this.props.children}
+                    <ErrorBoundary>
+                        {this.props.children}
+                    </ErrorBoundary>
                 </DesignSystemProvider>
             );
         }
 
         return (
             <React.Fragment>
-                {this.props.children}
+                <ErrorBoundary>
+                    {this.props.children}
+                </ErrorBoundary>
             </React.Fragment>
         );
     }

--- a/packages/fast-development-site-react/src/utilities/error-boundary.tsx
+++ b/packages/fast-development-site-react/src/utilities/error-boundary.tsx
@@ -3,9 +3,9 @@ import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../../src/components/design-system";
 import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
-/*tslint:disable:no-empty-interface*/
+/* tslint:disable:no-empty-interface */
 export interface IErrorBoundaryProps {}
-/*tslint:disable:no-empty-interface*/
+/* tslint:enable:no-empty-interface */
 
 export interface IErrorBoundaryState {
     hasError: boolean;

--- a/packages/fast-development-site-react/src/utilities/error-boundary.tsx
+++ b/packages/fast-development-site-react/src/utilities/error-boundary.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { toPx } from "@microsoft/fast-jss-utilities";
+import { IDevSiteDesignSystem } from "../../src/components/design-system";
+import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+
+/*tslint:disable:no-empty-interface*/
+export interface IErrorBoundaryProps {}
+/*tslint:disable:no-empty-interface*/
+
+export interface IErrorBoundaryState {
+    hasError: boolean;
+    error: Error | null | undefined;
+}
+
+export interface IErrorBoundaryManagedClasses {
+    errorBoundary: string;
+    errorBoundary_error: string;
+    errorBoundary_notification: string;
+}
+
+const styles: ComponentStyles<IErrorBoundaryManagedClasses, IDevSiteDesignSystem> = {
+    errorBoundary: {
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        height: "100%"
+    },
+    errorBoundary_error: {
+        fontSize: toPx(15),
+        marginTop: "0",
+        color: "red"
+    },
+    errorBoundary_notification: {
+        fontSize: toPx(18),
+        fontWeight: "700"
+    }
+};
+
+class ErrorBoundary extends React.Component<IErrorBoundaryProps & IManagedClasses<IErrorBoundaryManagedClasses>, IErrorBoundaryState> {
+    constructor(props: IErrorBoundaryProps & IManagedClasses<IErrorBoundaryManagedClasses>) {
+        super(props);
+
+        this.state = {
+            hasError: false,
+            error: void 0
+        };
+    }
+
+    public componentDidCatch(error: Error | null | undefined, info: object): void {
+        const MISSING_ERROR: string = "Error was swallowed during propagation.";
+
+        this.setState({
+            hasError: true,
+            error: error || new Error(MISSING_ERROR)
+        });
+    }
+
+    public render(): React.ReactNode | React.ReactNode[] {
+        if (this.state.hasError && this.state.error) {
+            return (
+                <div className={this.props.managedClasses.errorBoundary}>
+                    <p className={this.props.managedClasses.errorBoundary_notification}>Something went wrong.</p>
+                    <p className={this.props.managedClasses.errorBoundary_error}>{`${this.state.error}`}</p>
+                </div>
+            );
+        }
+
+        return this.props.children;
+    }
+}
+
+export default manageJss(styles)(ErrorBoundary);

--- a/packages/fast-development-site-react/src/utilities/index.ts
+++ b/packages/fast-development-site-react/src/utilities/index.ts
@@ -6,3 +6,7 @@ export { componentExampleFactory };
 
 import formChildFromExamplesFactory from "./form-child-from-examples-factory";
 export { formChildFromExamplesFactory };
+
+import ErrorBoundary from "./error-boundary";
+export { ErrorBoundary };
+export * from "./error-boundary";


### PR DESCRIPTION
<body>
Adds an error boundary to the component example wrapper to isolate errors and prevent an issue where the entire view is unable to load due to component specific errors.

closes #436 
<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
