### PR TITLE
chore: remove environment vars for circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ jobs:
   build:
     docker:
       - image: circleci/node:latest
-    environment:
-      ENV: CC_TEST_REPORTER_ID
-      ENV: CIRCLE_CI_TOKEN
     working_directory: ~/fast-dna
     steps:
       - checkout


### PR DESCRIPTION
Further removes environment from config.yml completely.
close #427 
