### PR TITLE
fix(fast-development-site): changed foreground color of <a/> tags to brand color

### DIFF
--- a/packages/fast-development-site-react/src/components/site/category-documentation.tsx
+++ b/packages/fast-development-site-react/src/components/site/category-documentation.tsx
@@ -13,7 +13,12 @@ export interface ICategoryDocumentationManagedClasses {
 
 const style: ComponentStyles<ICategoryDocumentationManagedClasses, IDevSiteDesignSystem> = {
     documentationPanel: {
-        maxWidth: toPx(1000)
+        maxWidth: toPx(1000),
+        "& a": {
+            color: (config: IDevSiteDesignSystem): string => {
+                return `${config.brandColor}`;
+            }
+        }
     }
 };
 


### PR DESCRIPTION
closes #581 
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
