### PR TITLE
fix(fast-development-site): fix for component detail stretching full height when dev tools is hidden

### DIFF
--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -477,6 +477,7 @@ class Site extends React.Component<ISiteProps & IManagedClasses<ISiteManagedClas
                         </ComponentView>
                         <Row
                             resizable={true}
+                            hidden={!this.state.devToolsView}
                             resizeFrom={RowResizeDirection.north}
                             minHeight={180}
                         >


### PR DESCRIPTION
Closes: #638 
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
