### PR TITLE
fix(fast-development-site): fix devtools stretches vertically when horizontal scrollbar is visible

### DIFF
--- a/packages/fast-development-site-react/src/components/site/dev-tools.tsx
+++ b/packages/fast-development-site-react/src/components/site/dev-tools.tsx
@@ -151,6 +151,7 @@ const style: ComponentStyles<IDevToolsManagedClasses, IDevSiteDesignSystem> = {
         }
     },
     devTools_tabPanel: {
+        display: "inline-flex",
         "&[aria-hidden=\"true\"]": {
             display: "none"
         }


### PR DESCRIPTION
Closes: #652 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
