### PR TITLE
fix(label): remove label element shift when changing HTML type in configure pane

### DIFF
--- a/packages/fast-components-react-base/src/label/label.schema.json
+++ b/packages/fast-components-react-base/src/label/label.schema.json
@@ -7,7 +7,7 @@
     "children": true,
     "properties": {
         "tag": {
-            "title": "HTML tag",
+            "title": "Element",
             "type": "string",
             "enum": [
                 "label",

--- a/packages/fast-components-react-base/src/label/label.schema.json
+++ b/packages/fast-components-react-base/src/label/label.schema.json
@@ -7,7 +7,7 @@
     "children": true,
     "properties": {
         "tag": {
-            "title": "HTML element",
+            "title": "HTML tag",
             "type": "string",
             "enum": [
                 "label",

--- a/packages/fast-components-react-base/src/label/label.schema.json
+++ b/packages/fast-components-react-base/src/label/label.schema.json
@@ -7,7 +7,7 @@
     "children": true,
     "properties": {
         "tag": {
-            "title": "Element",
+            "title": "HTML element",
             "type": "string",
             "enum": [
                 "label",

--- a/packages/fast-components-styles-msft/src/label/index.ts
+++ b/packages/fast-components-styles-msft/src/label/index.ts
@@ -12,7 +12,8 @@ const styles: ComponentStyles<ILabelClassNameContract, IDesignSystem> = {
         display: "inline-block",
         color: (config: IDesignSystem): string => {
             return get(config, "foregroundColor") || designSystemDefaults.foregroundColor;
-        }
+        },
+        padding: "0"
     },
     label_hidden: {
         ...applyScreenReader()


### PR DESCRIPTION
Closes [#656](https://github.com/Microsoft/fast-dna/issues/656)
update element shift when changing HTML element type, updates schema language

<body>

<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
