### PR TITLE
fix(fast-form-generator-react): sets the value of the textarea to an empty string if it is undefined

### DIFF
--- a/packages/fast-form-generator-react/app/components/any-of/__snapshots__/any-of.spec.tsx.snap
+++ b/packages/fast-form-generator-react/app/components/any-of/__snapshots__/any-of.spec.tsx.snap
@@ -56,7 +56,7 @@ exports[`any-of any-of: 0 1`] = `
               name="string"
               onChange={[Function]}
               rows={3}
-              value={undefined}
+              value=""
             />
           </div>
         </div>

--- a/packages/fast-form-generator-react/app/components/one-of/__snapshots__/one-of.spec.tsx.snap
+++ b/packages/fast-form-generator-react/app/components/one-of/__snapshots__/one-of.spec.tsx.snap
@@ -56,7 +56,7 @@ exports[`one-of one-of: 0 1`] = `
               name="string"
               onChange={[Function]}
               rows={3}
-              value={undefined}
+              value=""
             />
           </div>
         </div>

--- a/packages/fast-form-generator-react/src/form/form-item.textarea.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.textarea.tsx
@@ -38,7 +38,7 @@ class FormItemTextarea extends React.Component<IFormItemTextareaProps & IManaged
                     id={this.props.dataLocation}
                     name={this.props.dataLocation}
                     rows={typeof this.props.rows === "number" ? this.props.rows : 3}
-                    value={this.props.data}
+                    value={this.props.data || ""}
                     onChange={this.handleChange}
                 />
             </div>


### PR DESCRIPTION
Resolves #684