### PR TITLE
fix(fast-development-site-react): add active styles for transparency toggle

### DIFF
--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -236,11 +236,22 @@ const styles: ComponentStyles<ISiteManagedClasses, IDevSiteDesignSystem> = {
     },
     site_transparencyToggleButton: {
         border: "none",
+        borderRadius: toPx(2),
         background: "none",
         height: toPx(32),
         width: toPx(32),
         cursor: "pointer",
-        outline: "0"
+        outline: "0",
+        marginRight: toPx(4),
+        opacity: ".85",
+        paddingTop: toPx(4),
+        "&:hover": {
+            opacity: "1"
+        },
+        "&[aria-pressed=\"true\"]": {
+            background: "#FFFFFF",
+            opacity: "1"
+        }
     },
     site_transparencyToggleButtonIcon: {
         position: "relative",
@@ -714,6 +725,7 @@ class Site extends React.Component<ISiteProps & IManagedClasses<ISiteManagedClas
         return (
             <div className={this.props.managedClasses.site_infoBarConfiguration}>
                 <button
+                    aria-pressed={this.state.componentBackgroundTransparent}
                     onClick={this.handleTransparencyToggleClick}
                     className={this.props.managedClasses.site_transparencyToggleButton}
                 >


### PR DESCRIPTION
Closes [#692](https://github.com/Microsoft/fast-dna/issues/692)

Active state style:
<img width="338" alt="screen shot 2018-07-13 at 12 26 38 pm" src="https://user-images.githubusercontent.com/22480660/42710381-acc5f3e0-8698-11e8-8d4c-b44829df30f2.png">

Hover brings a slight shift in opacity, like our other form elements.

<body>

<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
