### PR TITLE
fix(fast-development-site): fixes site component issue where state is expected for theme even if it does not exist

### DIFF
--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -302,7 +302,7 @@ class Site extends React.Component<ISiteProps & IManagedClasses<ISiteManagedClas
             formView: true,
             devToolsView: false,
             locale: "en",
-            theme: this.props.themes[0]
+            theme: this.getInitialTheme()
         };
     }
 
@@ -345,6 +345,12 @@ class Site extends React.Component<ISiteProps & IManagedClasses<ISiteManagedClas
                 componentData: this.getComponentData(),
                 detailViewComponentData: this.getDetailViewComponentData()
             });
+        }
+    }
+
+    private getInitialTheme(): ITheme {
+        if (Array.isArray(this.props.themes) && this.props.themes.length) {
+            return this.props.themes[0];
         }
     }
 


### PR DESCRIPTION
<body>
Theming shipped in 1.9.0 as optional, and while it's not a required prop from an interface level, a bug exists that causes it to be present to render the site. The Site component initial state expects `this.props.themes[0]` as a value. Since undefined is not an array, length does not exist and cannot be checked so an exception is thrown.
<br>
<br>
This PR checks for the existence of an array as well as length in order to set `theme` state on the site component.

closes #696 
<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
