### PR TITLE
fix(button): update to use enum for button types

### DIFF
--- a/packages/fast-components-react-msft/README.md
+++ b/packages/fast-components-react-msft/README.md
@@ -18,7 +18,7 @@ document.body.appendChild(root);
 
 function render(): void {
     ReactDOM.render(
-        <Button subtype="primary">
+        <Button appearance="primary">
             Click me!
         </Button>,
         root

--- a/packages/fast-components-react-msft/README.md
+++ b/packages/fast-components-react-msft/README.md
@@ -18,7 +18,7 @@ document.body.appendChild(root);
 
 function render(): void {
     ReactDOM.render(
-        <Button primary={true}>
+        <Button subtype="primary">
             Click me!
         </Button>,
         root

--- a/packages/fast-components-react-msft/src/button/button.props.ts
+++ b/packages/fast-components-react-msft/src/button/button.props.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { IButtonHandledProps as IBaseButtonHandledProps } from "@microsoft/fast-components-react-base";
 import { IManagedClasses, IMSFTButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 
-export enum Appearance {
+export enum ButtonAppearance {
     justified= "justified",
     lightweight= "lightweight",
     outline= "outline",
@@ -13,7 +13,7 @@ export interface IButtonHandledProps extends IBaseButtonHandledProps {
     /**
      * The Button subType
      */
-    appearance?: Appearance;
+    appearance?: ButtonAppearance;
 }
 
 export interface IButtonUnhandledProps extends React.AllHTMLAttributes<HTMLElement> {}

--- a/packages/fast-components-react-msft/src/button/button.props.ts
+++ b/packages/fast-components-react-msft/src/button/button.props.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { IButtonHandledProps as IBaseButtonHandledProps } from "@microsoft/fast-components-react-base";
 import { IManagedClasses, IMSFTButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 
-export enum Subtype {
+export enum Appearance {
     justified= "justified",
     lightweight= "lightweight",
     outline= "outline",
@@ -13,7 +13,7 @@ export interface IButtonHandledProps extends IBaseButtonHandledProps {
     /**
      * The Button subType
      */
-    subtype?: Subtype;
+    appearance?: Appearance;
 }
 
 export interface IButtonUnhandledProps extends React.AllHTMLAttributes<HTMLElement> {}

--- a/packages/fast-components-react-msft/src/button/button.props.ts
+++ b/packages/fast-components-react-msft/src/button/button.props.ts
@@ -11,7 +11,7 @@ export enum ButtonAppearance {
 
 export interface IButtonHandledProps extends IBaseButtonHandledProps {
     /**
-     * The Button subType
+     * The Button appearance
      */
     appearance?: ButtonAppearance;
 }

--- a/packages/fast-components-react-msft/src/button/button.props.ts
+++ b/packages/fast-components-react-msft/src/button/button.props.ts
@@ -2,26 +2,18 @@ import * as React from "react";
 import { IButtonHandledProps as IBaseButtonHandledProps } from "@microsoft/fast-components-react-base";
 import { IManagedClasses, IMSFTButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 
+export enum Subtype {
+    justified= "justified",
+    lightweight= "lightweight",
+    outline= "outline",
+    primary= "primary",
+}
+
 export interface IButtonHandledProps extends IBaseButtonHandledProps {
     /**
-     * The lightweight justified option
+     * The Button subType
      */
-    justified?: boolean;
-
-    /**
-     * The lightweight option
-     */
-    lightweight?: boolean;
-
-    /**
-     * The outline option
-     */
-    outline?: boolean;
-
-    /**
-     * The primary option
-     */
-    primary?: boolean;
+    subtype?: Subtype;
 }
 
 export interface IButtonUnhandledProps extends React.AllHTMLAttributes<HTMLElement> {}

--- a/packages/fast-components-react-msft/src/button/button.schema.json
+++ b/packages/fast-components-react-msft/src/button/button.schema.json
@@ -14,8 +14,8 @@
             "title": "HTML href attribute",
             "type": "string"
         },
-        "subtype": {
-            "title": "Subtype",
+        "appearance": {
+            "title": "Appearance",
             "type": "string",
             "enum": [
                 "justfied",

--- a/packages/fast-components-react-msft/src/button/button.schema.json
+++ b/packages/fast-components-react-msft/src/button/button.schema.json
@@ -14,21 +14,15 @@
             "title": "HTML href attribute",
             "type": "string"
         },
-        "justified": {
-            "title": "Justified",
-            "type": "boolean"
-        },
-        "lightweight": {
-            "title": "Lightweight",
-            "type": "boolean"
-        },
-        "outline": {
-            "title": "Outline",
-            "type": "boolean"
-        },
-        "primary": {
-            "title": "Primary",
-            "type": "boolean"
+        "subtype": {
+            "title": "Subtype",
+            "type": "string",
+            "enum": [
+                "justfied",
+                "lightweight",
+                "outline",
+                "primary"
+            ]
         }
     }
 }

--- a/packages/fast-components-react-msft/src/button/button.spec.tsx
+++ b/packages/fast-components-react-msft/src/button/button.spec.tsx
@@ -10,7 +10,8 @@ import {
     ButtonProps,
     IButtonHandledProps,
     IButtonManagedClasses,
-    IButtonUnhandledProps
+    IButtonUnhandledProps,
+    IMSFTButtonClassNameContract
 } from "./button";
 
 /*
@@ -39,7 +40,7 @@ describe("button", (): void => {
         const props: IButtonHandledProps & IButtonUnhandledProps = {...handledProps, ...unhandledProps};
 
         const rendered: any = shallow(
-            <Component {...props} />
+            <Component {...props}/>
         );
 
         const button: any = rendered.first().shallow();
@@ -47,8 +48,8 @@ describe("button", (): void => {
         expect(button.prop("aria-hidden")).toEqual(true);
     });
 
-    // DO this for each type and check for null
-    test("", () => {
+    /* tslint:disable-next-line */
+    test("should set a className that matches button_primary managedClass when ButtonAppearance.primary is passed to the appearance prop", () => {
         const props: IButtonHandledProps = {
             appearance: ButtonAppearance.primary
         };
@@ -58,23 +59,78 @@ describe("button", (): void => {
         );
 
         const button: any = rendered.first().shallow();
+        // Get the expected className value from the list of generated managed classes
+        const expectedClassName: string = button.instance().props.managedClasses.button_primary;
 
-        // Check to make sure prop is correct
-        expect(button.prop("appearance")).toEqual(ButtonAppearance.primary);
-        // Make sure its setting the class
-        // way to check for dynamically gebnrated class with enzym
-        expect(button.hasClass("button_primary")).toBe(true);
+        expect(button.instance().props.appearance).toEqual(ButtonAppearance.primary);
+        // Generated managedClass should be passed to className
+        expect(button.prop("className")).toBe(expectedClassName);
     });
 
-    // If appearance is not being set
-    test("If ", () => {
+    /* tslint:disable-next-line */
+    test("should set a className that matches button_outline managedClass when ButtonAppearance.outline is passed to the appearance prop", () => {
+        const props: IButtonHandledProps = {
+            appearance: ButtonAppearance.outline
+        };
+
+        const rendered: any = shallow(
+            <Component {...props}/>
+        );
+
+        const button: any = rendered.first().shallow();
+        // Get the expected className value from the list of generated managed classes
+        const expectedClassName: string = button.instance().props.managedClasses.button_outline;
+
+        expect(button.instance().props.appearance).toEqual(ButtonAppearance.outline);
+        // Generated managedClass should be passed to className
+        expect(button.prop("className")).toBe(expectedClassName);
+    });
+
+    /* tslint:disable-next-line */
+    test("should set a className that matches button_lightweight managedClass when ButtonAppearance.lightweight is passed to the appearance prop", () => {
+        const props: IButtonHandledProps = {
+            appearance: ButtonAppearance.lightweight
+        };
+
+        const rendered: any = shallow(
+            <Component {...props}/>
+        );
+
+        const button: any = rendered.first().shallow();
+        // Get the expected className value from the list of generated managed classes
+        const expectedClassName: string = button.instance().props.managedClasses.button_lightweight;
+
+        expect(button.instance().props.appearance).toEqual(ButtonAppearance.lightweight);
+        // Generated managedClass should be passed to className
+        expect(button.prop("className")).toBe(expectedClassName);
+    });
+
+    /* tslint:disable-next-line */
+    test("should set a className that matches button_justified managedClass when ButtonAppearance.justified is passed to the appearance prop", () => {
+        const props: IButtonHandledProps = {
+            appearance: ButtonAppearance.justified
+        };
+
+        const rendered: any = shallow(
+            <Component {...props}/>
+        );
+
+        const button: any = rendered.first().shallow();
+        // Get the expected className value from the list of generated managed classes
+        const expectedClassName: string = button.instance().props.managedClasses.button_justified;
+
+        expect(button.instance().props.appearance).toEqual(ButtonAppearance.justified);
+        // Generated managedClass should be passed to className
+        expect(button.prop("className")).toBe(expectedClassName);
+    });
+
+    test("should not set a className when appearance prop is not passed", () => {
         const rendered: any = shallow(
             <Component />
         );
 
         const button: any = rendered.first().shallow();
 
-        // Check to make sure prop is correct
-        expect(button.prop("appearance")).toEqual(undefined);
+        expect(button.prop("className")).toEqual(undefined);
     });
 });

--- a/packages/fast-components-react-msft/src/button/button.spec.tsx
+++ b/packages/fast-components-react-msft/src/button/button.spec.tsx
@@ -4,7 +4,9 @@ import { configure, shallow } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import { ButtonHTMLTags } from "@microsoft/fast-components-react-base";
+import { IButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import {
+    ButtonAppearance,
     ButtonProps,
     IButtonHandledProps,
     IButtonManagedClasses,
@@ -43,5 +45,36 @@ describe("button", (): void => {
         const button: any = rendered.first().shallow();
 
         expect(button.prop("aria-hidden")).toEqual(true);
+    });
+
+    // DO this for each type and check for null
+    test("", () => {
+        const props: IButtonHandledProps = {
+            appearance: ButtonAppearance.primary
+        };
+
+        const rendered: any = shallow(
+            <Component {...props}/>
+        );
+
+        const button: any = rendered.first().shallow();
+
+        // Check to make sure prop is correct
+        expect(button.prop("appearance")).toEqual(ButtonAppearance.primary);
+        // Make sure its setting the class
+        // way to check for dynamically gebnrated class with enzym
+        expect(button.hasClass("button_primary")).toBe(true);
+    });
+
+    // If appearance is not being set
+    test("If ", () => {
+        const rendered: any = shallow(
+            <Component />
+        );
+
+        const button: any = rendered.first().shallow();
+
+        // Check to make sure prop is correct
+        expect(button.prop("appearance")).toEqual(undefined);
     });
 });

--- a/packages/fast-components-react-msft/src/button/button.tsx
+++ b/packages/fast-components-react-msft/src/button/button.tsx
@@ -37,6 +37,10 @@ class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButto
      * Generates class names
      */
     protected generateClassNames(): string {
+        if (!this.props.appearance) {
+            return;
+        }
+
         switch (this.props.appearance) {
             case ButtonAppearance.primary:
                 return super.generateClassNames(get(this.props, "managedClasses.button_primary"));

--- a/packages/fast-components-react-msft/src/button/button.tsx
+++ b/packages/fast-components-react-msft/src/button/button.tsx
@@ -2,14 +2,14 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import { Foundation, HandledProps } from "@microsoft/fast-components-react-base";
-import { IButtonHandledProps, IButtonManagedClasses, IButtonUnhandledProps, Subtype } from "./button.props";
+import { Appearance, IButtonHandledProps, IButtonManagedClasses, IButtonUnhandledProps } from "./button.props";
 import { IManagedClasses, IMSFTButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { Button as BaseButton } from "@microsoft/fast-components-react-base";
 
 /* tslint:disable-next-line */
 class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButtonClassNameContract>,  React.AllHTMLAttributes<HTMLElement>, {}> {
     protected handledProps: HandledProps<IButtonHandledProps & IManagedClasses<IMSFTButtonClassNameContract>> = {
-        subtype: void 0,
+        appearance: void 0,
         children: void 0,
         disabled: void 0,
         href: void 0,
@@ -37,23 +37,22 @@ class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButto
      * Generates class names
      */
     protected generateClassNames(): string {
-        let classLocation: string;
-
-        if (this.props.subtype === Subtype.primary) {
-            classLocation = "managedClasses.button_primary";
-        } else if (this.props.subtype === Subtype.outline) {
-            classLocation = "managedClasses.button_outline";
-        } else if (this.props.subtype === Subtype.lightweight) {
-            classLocation = "managedClasses.button_lightweight";
-        } else if (this.props.subtype === Subtype.justified) {
-            classLocation = "managedClasses.button_justified";
+        switch (this.props.appearance) {
+            case Appearance.primary:
+                return super.generateClassNames(get(this.props, "managedClasses.button_primary"));
+            case Appearance.outline:
+                return super.generateClassNames(get(this.props, "managedClasses.button_outline"));
+            case Appearance.lightweight:
+                return super.generateClassNames(get(this.props, "managedClasses.button_lightweight"));
+            case Appearance.justified:
+                return super.generateClassNames(get(this.props, "managedClasses.button_justified"));
+            default:
+                return null;
         }
-
-        return super.generateClassNames(get(this.props, classLocation));
     }
 
     private generateInnerContent(): React.ReactElement<HTMLSpanElement> | (React.ReactNode | React.ReactNode[]) {
-        if (this.props.subtype === Subtype.lightweight || this.props.subtype === Subtype.justified) {
+        if (this.props.appearance === Appearance.lightweight || this.props.appearance === Appearance.justified) {
             return <span className={get(this.props, "managedClasses.button_span")}>{this.props.children}</span>;
         }
 

--- a/packages/fast-components-react-msft/src/button/button.tsx
+++ b/packages/fast-components-react-msft/src/button/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import { Foundation, HandledProps } from "@microsoft/fast-components-react-base";
-import { Appearance, IButtonHandledProps, IButtonManagedClasses, IButtonUnhandledProps } from "./button.props";
+import { ButtonAppearance, IButtonHandledProps, IButtonManagedClasses, IButtonUnhandledProps } from "./button.props";
 import { IManagedClasses, IMSFTButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { Button as BaseButton } from "@microsoft/fast-components-react-base";
 
@@ -38,13 +38,13 @@ class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButto
      */
     protected generateClassNames(): string {
         switch (this.props.appearance) {
-            case Appearance.primary:
+            case ButtonAppearance.primary:
                 return super.generateClassNames(get(this.props, "managedClasses.button_primary"));
-            case Appearance.outline:
+            case ButtonAppearance.outline:
                 return super.generateClassNames(get(this.props, "managedClasses.button_outline"));
-            case Appearance.lightweight:
+            case ButtonAppearance.lightweight:
                 return super.generateClassNames(get(this.props, "managedClasses.button_lightweight"));
-            case Appearance.justified:
+            case ButtonAppearance.justified:
                 return super.generateClassNames(get(this.props, "managedClasses.button_justified"));
             default:
                 return null;
@@ -52,7 +52,7 @@ class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButto
     }
 
     private generateInnerContent(): React.ReactElement<HTMLSpanElement> | (React.ReactNode | React.ReactNode[]) {
-        if (this.props.appearance === Appearance.lightweight || this.props.appearance === Appearance.justified) {
+        if (this.props.appearance === ButtonAppearance.lightweight || this.props.appearance === ButtonAppearance.justified) {
             return <span className={get(this.props, "managedClasses.button_span")}>{this.props.children}</span>;
         }
 

--- a/packages/fast-components-react-msft/src/button/button.tsx
+++ b/packages/fast-components-react-msft/src/button/button.tsx
@@ -50,8 +50,6 @@ class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButto
                 return super.generateClassNames(get(this.props, "managedClasses.button_lightweight"));
             case ButtonAppearance.justified:
                 return super.generateClassNames(get(this.props, "managedClasses.button_justified"));
-            default:
-                return null;
         }
     }
 

--- a/packages/fast-components-react-msft/src/button/button.tsx
+++ b/packages/fast-components-react-msft/src/button/button.tsx
@@ -2,21 +2,18 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import { Foundation, HandledProps } from "@microsoft/fast-components-react-base";
-import { IButtonHandledProps, IButtonManagedClasses, IButtonUnhandledProps } from "./button.props";
+import { IButtonHandledProps, IButtonManagedClasses, IButtonUnhandledProps, Subtype } from "./button.props";
 import { IManagedClasses, IMSFTButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { Button as BaseButton } from "@microsoft/fast-components-react-base";
 
 /* tslint:disable-next-line */
 class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButtonClassNameContract>,  React.AllHTMLAttributes<HTMLElement>, {}> {
     protected handledProps: HandledProps<IButtonHandledProps & IManagedClasses<IMSFTButtonClassNameContract>> = {
+        subtype: void 0,
         children: void 0,
         disabled: void 0,
         href: void 0,
-        justified: void 0,
-        lightweight: void 0,
         managedClasses: void 0,
-        outline: void 0,
-        primary: void 0
     };
 
     /**
@@ -42,13 +39,13 @@ class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButto
     protected generateClassNames(): string {
         let classLocation: string;
 
-        if (this.props.primary) {
+        if (this.props.subtype === Subtype.primary) {
             classLocation = "managedClasses.button_primary";
-        } else if (this.props.outline) {
+        } else if (this.props.subtype === Subtype.outline) {
             classLocation = "managedClasses.button_outline";
-        } else if (this.props.lightweight) {
+        } else if (this.props.subtype === Subtype.lightweight) {
             classLocation = "managedClasses.button_lightweight";
-        } else if (this.props.justified) {
+        } else if (this.props.subtype === Subtype.justified) {
             classLocation = "managedClasses.button_justified";
         }
 
@@ -56,7 +53,7 @@ class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButto
     }
 
     private generateInnerContent(): React.ReactElement<HTMLSpanElement> | (React.ReactNode | React.ReactNode[]) {
-        if (this.props.lightweight || this.props.justified) {
+        if (this.props.subtype === Subtype.lightweight || this.props.subtype === Subtype.justified) {
             return <span className={get(this.props, "managedClasses.button_span")}>{this.props.children}</span>;
         }
 

--- a/packages/fast-components-react-msft/src/button/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/button/examples.data.tsx
@@ -4,11 +4,11 @@ import { IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import Button from "./index";
 import { IButtonHandledProps as IBaseButtonHandledProps } from "@microsoft/fast-components-react-base";
 import {
+    Appearance,
     ButtonProps,
     IButtonHandledProps,
     IButtonManagedClasses,
-    IButtonUnhandledProps,
-    Subtype
+    IButtonUnhandledProps
 } from "./button.props";
 import schema from "./button.schema.json";
 import Documentation from "./.tmp/documentation";
@@ -27,22 +27,22 @@ export default {
             "data-sketch-symbol": "Button - default"
         },
         {
-            subtype: Subtype.primary,
+            appearance: Appearance.primary,
             children: "Primary (submit) button",
             "data-sketch-symbol": "Button - primary"
         },
         {
-            subtype: Subtype.outline,
+            appearance: Appearance.outline,
             children: "Outline button",
             "data-sketch-symbol": "Button - outline"
         },
         {
-            subtype: Subtype.lightweight,
+            appearance: Appearance.lightweight,
             children: "Lightweight button",
             "data-sketch-symbol": "Button - lightweight"
         },
         {
-            subtype: Subtype.justified,
+            appearance: Appearance.justified,
             children: "Justified button"
         },
         {
@@ -56,25 +56,25 @@ export default {
         },
         {
             disabled: true,
-            subtype: Subtype.primary,
+            appearance: Appearance.primary,
             children: "Primary (submit) button",
             "data-sketch-symbol": "Button - primary disabled"
         },
         {
             disabled: true,
-            subtype: Subtype.outline,
+            appearance: Appearance.outline,
             children: "Outline button",
             "data-sketch-symbol": "Button - outline disabled"
         },
         {
             disabled: true,
-            subtype: Subtype.lightweight,
+            appearance: Appearance.lightweight,
             children: "Lightweight button",
             "data-sketch-symbol": "Button - lightweight disabled"
         },
         {
             disabled: true,
-            subtype: Subtype.justified,
+            appearance: Appearance.justified,
             children: "Justified button"
         },
         {

--- a/packages/fast-components-react-msft/src/button/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/button/examples.data.tsx
@@ -7,7 +7,8 @@ import {
     ButtonProps,
     IButtonHandledProps,
     IButtonManagedClasses,
-    IButtonUnhandledProps
+    IButtonUnhandledProps,
+    Subtype
 } from "./button.props";
 import schema from "./button.schema.json";
 import Documentation from "./.tmp/documentation";
@@ -26,22 +27,22 @@ export default {
             "data-sketch-symbol": "Button - default"
         },
         {
-            primary: true,
+            subtype: Subtype.primary,
             children: "Primary (submit) button",
             "data-sketch-symbol": "Button - primary"
         },
         {
-            outline: true,
+            subtype: Subtype.outline,
             children: "Outline button",
             "data-sketch-symbol": "Button - outline"
         },
         {
-            lightweight: true,
+            subtype: Subtype.lightweight,
             children: "Lightweight button",
             "data-sketch-symbol": "Button - lightweight"
         },
         {
-            justified: true,
+            subtype: Subtype.justified,
             children: "Justified button"
         },
         {
@@ -55,25 +56,25 @@ export default {
         },
         {
             disabled: true,
-            primary: true,
+            subtype: Subtype.primary,
             children: "Primary (submit) button",
             "data-sketch-symbol": "Button - primary disabled"
         },
         {
             disabled: true,
-            outline: true,
+            subtype: Subtype.outline,
             children: "Outline button",
             "data-sketch-symbol": "Button - outline disabled"
         },
         {
             disabled: true,
-            lightweight: true,
+            subtype: Subtype.lightweight,
             children: "Lightweight button",
             "data-sketch-symbol": "Button - lightweight disabled"
         },
         {
             disabled: true,
-            justified: true,
+            subtype: Subtype.justified,
             children: "Justified button"
         },
         {

--- a/packages/fast-components-react-msft/src/button/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/button/examples.data.tsx
@@ -4,7 +4,7 @@ import { IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import Button from "./index";
 import { IButtonHandledProps as IBaseButtonHandledProps } from "@microsoft/fast-components-react-base";
 import {
-    Appearance,
+    ButtonAppearance,
     ButtonProps,
     IButtonHandledProps,
     IButtonManagedClasses,
@@ -27,22 +27,22 @@ export default {
             "data-sketch-symbol": "Button - default"
         },
         {
-            appearance: Appearance.primary,
+            appearance: ButtonAppearance.primary,
             children: "Primary (submit) button",
             "data-sketch-symbol": "Button - primary"
         },
         {
-            appearance: Appearance.outline,
+            appearance: ButtonAppearance.outline,
             children: "Outline button",
             "data-sketch-symbol": "Button - outline"
         },
         {
-            appearance: Appearance.lightweight,
+            appearance: ButtonAppearance.lightweight,
             children: "Lightweight button",
             "data-sketch-symbol": "Button - lightweight"
         },
         {
-            appearance: Appearance.justified,
+            appearance: ButtonAppearance.justified,
             children: "Justified button"
         },
         {
@@ -56,25 +56,25 @@ export default {
         },
         {
             disabled: true,
-            appearance: Appearance.primary,
+            appearance: ButtonAppearance.primary,
             children: "Primary (submit) button",
             "data-sketch-symbol": "Button - primary disabled"
         },
         {
             disabled: true,
-            appearance: Appearance.outline,
+            appearance: ButtonAppearance.outline,
             children: "Outline button",
             "data-sketch-symbol": "Button - outline disabled"
         },
         {
             disabled: true,
-            appearance: Appearance.lightweight,
+            appearance: ButtonAppearance.lightweight,
             children: "Lightweight button",
             "data-sketch-symbol": "Button - lightweight disabled"
         },
         {
             disabled: true,
-            appearance: Appearance.justified,
+            appearance: ButtonAppearance.justified,
             children: "Justified button"
         },
         {


### PR DESCRIPTION
Closes: #702 
 
BREAKING CHANGE: The API for the fast-components-react-msft button has 4 boolean props (justified, lightweight, outline and primary). These values are mutually exclusive and cannot be applied simultaneously. For this reason an enum is a more appropriate approach. This fix removes those booleans and passes a single prop.