### PR TITLE
fix(fast-css-editor-react): update the api to accept strings for position

### DIFF
--- a/packages/fast-css-editor-react/app/app.tsx
+++ b/packages/fast-css-editor-react/app/app.tsx
@@ -37,16 +37,16 @@ class App extends React.Component<{}, IAppState> {
             },
             editorExample: {
                 position: PositionValue.absolute,
-                left: 4,
-                top: 12
+                left: "4px",
+                top: "12px"
             },
             positionDetail:{
                 position: PositionValue.static
             },
             positionExample: {
                 position: PositionValue.absolute,
-                left: 1,
-                top: 5
+                left: "1px",
+                top: "5px"
             }
         };
     }

--- a/packages/fast-css-editor-react/app/components/position.spec.tsx
+++ b/packages/fast-css-editor-react/app/components/position.spec.tsx
@@ -14,8 +14,8 @@ const exampleData: ICSSPositionProps = {
 
 const detailData: ICSSPositionProps = {
     position: PositionValue.absolute,
-    top: 5,
-    left: 12,
+    top: "5px",
+    left: "12px",
     /* tslint:disable-next-line */
     onChange: (data: any): void => {}
 };

--- a/packages/fast-css-editor-react/src/editor.schema.json
+++ b/packages/fast-css-editor-react/src/editor.schema.json
@@ -14,20 +14,20 @@
             ]
         },
         "left": {
-            "title": "Left (px)",
-            "type": "number"
+            "title": "Left",
+            "type": "string"
         },
         "right": {
-            "title": "Right (px)",
-            "type": "number"
+            "title": "Right",
+            "type": "string"
         },
         "top": {
-            "title": "Top (px)",
-            "type": "number"
+            "title": "Top",
+            "type": "string"
         },
         "bottom": {
-            "title": "Bottom (px)",
-            "type": "number"
+            "title": "Bottom",
+            "type": "string"
         }
     }
 }

--- a/packages/fast-css-editor-react/src/position/README.md
+++ b/packages/fast-css-editor-react/src/position/README.md
@@ -13,7 +13,7 @@ export class Example extends React.Component {
         this.state = {
             positionValues: {
                 position: "absolute",
-                left: 0
+                left: "0"
             }
         }
     }

--- a/packages/fast-css-editor-react/src/position/index.tsx
+++ b/packages/fast-css-editor-react/src/position/index.tsx
@@ -22,10 +22,10 @@ export interface ILocationsMappedToClassNames {
 
 export interface ICSSPositionProps {
     position?: PositionValue;
-    left?: number;
-    right?: number;
-    top?: number;
-    bottom?: number;
+    left?: string;
+    right?: string;
+    top?: string;
+    bottom?: string;
     onChange?: (positionValues: any) => void;
 }
 
@@ -78,7 +78,7 @@ class CSSPosition extends React.Component<ICSSPositionProps & IManagedClasses<IC
     private renderLocationInput(location: Location): JSX.Element {
         return (
             <input
-                type="number"
+                type="text"
                 className={this.props.managedClasses.cssPosition_input}
                 data-location={location}
                 onChange={this.handleOnChange}
@@ -154,7 +154,7 @@ class CSSPosition extends React.Component<ICSSPositionProps & IManagedClasses<IC
             }
         });
 
-        updatedProps[updatedPropKey] = parseInt(updatedPropValue, 10);
+        updatedProps[updatedPropKey] = updatedPropValue;
 
         return updatedProps;
     }

--- a/packages/fast-css-editor-react/src/position/position.schema.json
+++ b/packages/fast-css-editor-react/src/position/position.schema.json
@@ -14,20 +14,20 @@
             ]
         },
         "left": {
-            "title": "Left (px)",
-            "type": "number"
+            "title": "Left",
+            "type": "string"
         },
         "right": {
-            "title": "Right (px)",
-            "type": "number"
+            "title": "Right",
+            "type": "string"
         },
         "top": {
-            "title": "Top (px)",
-            "type": "number"
+            "title": "Top",
+            "type": "string"
         },
         "bottom": {
-            "title": "Bottom (px)",
-            "type": "number"
+            "title": "Bottom",
+            "type": "string"
         }
     }
 }


### PR DESCRIPTION
Resolves #706

BREAKING CHANGE: The API for the fast-css-editor-react libraries CSSPosition and CSSEditor exports is changing to use strings instead of numbers for the left, right, top and bottom CSS properties. This is a fix needed to map directly to JSS and other CSS systems.

