### PR TITLE
fix(fast-web-utilities): fix an issue where getClientRectWithMargin threw an error in EDGE and IE strict modes due to readonly properties

### DIFF
--- a/packages/fast-web-utilities/src/html.ts
+++ b/packages/fast-web-utilities/src/html.ts
@@ -17,7 +17,7 @@ export function getClientRectWithMargin(element: HTMLElement): IClientRectWithMa
 
     const rect: ClientRect = element.getBoundingClientRect();
     const style: CSSStyleDeclaration = window.getComputedStyle(element, null);
-    const clone: any = {
+    const clone: IClientRectWithMargin = {
         width: rect.width,
         height: rect.height,
         top: rect.top,

--- a/packages/fast-web-utilities/src/html.ts
+++ b/packages/fast-web-utilities/src/html.ts
@@ -1,13 +1,30 @@
+export interface IClientRectWithMargin {
+    width: number;
+    height: number;
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+}
+
 /**
  * Gets the client bounding rectangle including any margins of an element.
  */
-export function getClientRectWithMargin(element: HTMLElement): ClientRect | DOMRect {
+export function getClientRectWithMargin(element: HTMLElement): IClientRectWithMargin {
     if (!element) {
         return;
     }
 
-    const clone: any = element.getBoundingClientRect();
+    const rect: ClientRect = element.getBoundingClientRect();
     const style: CSSStyleDeclaration = window.getComputedStyle(element, null);
+    const clone: any = {
+        width: rect.width,
+        height: rect.height,
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+        right: rect.right
+    };
 
     clone.width += convertStylePropertyPixelsToNumber(style, "margin-left");
     clone.width += convertStylePropertyPixelsToNumber(style, "margin-right");


### PR DESCRIPTION
closes #764 
<body>

<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
