### PR TITLE
Add new file for cleaning all temporary files

### DIFF
--- a/build/clean-temp-files.js
+++ b/build/clean-temp-files.js
@@ -1,0 +1,53 @@
+/**
+ * Utility for cleaning package locks.
+ * Usage: node build/clean-package-locks.js
+ */
+
+var rimraf = require('rimraf');
+
+// Delete packages package lock files
+rimraf('./packages/**/package-lock.json', (err) => {  
+    if (err) {
+        throw err;
+    }
+
+    console.log("All `package-lock.json` files have been deleted");
+});
+
+// Delete root package lock file
+rimraf('package-lock.json', (err) => {  
+    if (err) {
+        throw err;
+    }
+
+    console.log("The root `package-lock.json` file has been deleted");
+});
+
+// Delete all dist files
+rimraf('./packages/**/dist', (err) => {  
+    if (err) {
+        throw err;
+    }
+
+    console.log("All `./dist` files have been deleted");
+});
+
+
+// Delete all code coverage files
+rimraf('./packages/**/coverage', (err) => {  
+    if (err) {
+        throw err;
+    }
+
+    console.log("All `./coverage` files have been deleted");
+});
+
+
+// Delete all www distribution files
+rimraf('./packages/**/www', (err) => {  
+    if (err) {
+        throw err;
+    }
+
+    console.log("All `./www` files have been deleted");
+});


### PR DESCRIPTION
<body>
When dealing with incompatible node packages it was time-consuming to manually clean using CLI so rather I created an updated script file that can be run to delete all temporary files created during the build process.
<footer>

