### PR TITLE
fix(foundation): ensures that children are never rendered to the root element by unhandledProps

### DIFF
--- a/packages/fast-components-react-base/src/button/button.tsx
+++ b/packages/fast-components-react-base/src/button/button.tsx
@@ -16,7 +16,6 @@ export enum ButtonHTMLTags {
 /* tslint:disable-next-line */
 class Button extends Foundation<IButtonHandledProps & IManagedClasses<IButtonClassNameContract>,  React.AllHTMLAttributes<HTMLElement>, {}> {
     protected handledProps: HandledProps<IButtonHandledProps & IManagedClasses<IButtonClassNameContract>> = {
-        children: void 0,
         disabled: void 0,
         href: void 0,
         managedClasses: void 0

--- a/packages/fast-components-react-base/src/dialog/dialog.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.tsx
@@ -17,7 +17,6 @@ class Dialog extends Foundation<IDialogHandledProps & IManagedClasses<IDialogCla
         describedBy: void 0,
         label: void 0,
         labelledBy: void 0,
-        children: void 0,
         contentWidth: void 0,
         contentHeight: void 0,
         modal: void 0,

--- a/packages/fast-components-react-base/src/foundation/foundation.spec.tsx
+++ b/packages/fast-components-react-base/src/foundation/foundation.spec.tsx
@@ -141,6 +141,7 @@ describe("unhandledProps", () => {
     }
 
     interface IUnhandledProps {
+        children?: React.ReactNode | React.ReactNode[];
         booleanDirty?: boolean;
         stringDirty?: string;
         arrayDirty?: string[];
@@ -161,6 +162,7 @@ describe("unhandledProps", () => {
     };
 
     const dirtyProps: IUnhandledProps = {
+        children: "children",
         booleanDirty: true,
         stringDirty: "string",
         arrayDirty: ["array"],
@@ -201,7 +203,14 @@ describe("unhandledProps", () => {
         expect(unhandledPropsTestComponentClean["unhandledProps"]()).not.toBe(null);
     });
 
+    test("return object should not include children", () => {
+        const unhandledProps: IUnhandledProps = unhandledPropsTestComponentDirty["unhandledProps"]();
+
+        expect(has(unhandledProps, "children")).toBe(false);
+    });
+
     test("return object should contain all property keys passed to props that is not enumerated on handledProps", () => {
+
         const unhandledProps: IUnhandledProps = unhandledPropsTestComponentDirty["unhandledProps"]();
 
         expect(has(unhandledProps, "booleanDirty")).toBe(true);

--- a/packages/fast-components-react-base/src/foundation/foundation.ts
+++ b/packages/fast-components-react-base/src/foundation/foundation.ts
@@ -43,6 +43,11 @@ export type ReferenceResolver = <T>(reference: T) => void;
  */
 class Foundation<H, U, S> extends React.Component<H & U & IFoundationProps, S> {
     /**
+     * The props that should never be passed to the root element by unhandled props
+     */
+    private static defaultHandledProps: string[] = ["children"];
+
+    /**
      * An enumeration of all handled props. All props passed to the component that are not enumerated here will be
      * treated as unhandled props
      */
@@ -102,7 +107,7 @@ class Foundation<H, U, S> extends React.Component<H & U & IFoundationProps, S> {
      */
     protected unhandledProps(): U {
         const unhandledPropKeys: string[] = Object.keys(this.props).filter((key: string) => {
-            return !this.handledProps.hasOwnProperty(key);
+            return !(Foundation.defaultHandledProps.indexOf(key) > -1) && !this.handledProps.hasOwnProperty(key);
         });
 
         return pick(this.props, unhandledPropKeys) as U;

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -21,7 +21,6 @@ export type AnimateScroll = () => void;
 class HorizontalOverflow extends Foundation<HorizontalOverflowProps,  React.AllHTMLAttributes<HTMLDivElement>, IHorizontalOverflowState> {
 
     protected handledProps: HandledProps<IHorizontalOverflowHandledProps & IManagedClasses<IHorizontalOverflowClassNameContract>> = {
-        children: void 0,
         scrollDuration: void 0,
         managedClasses: void 0
     };

--- a/packages/fast-components-react-base/src/hypertext/hypertext.tsx
+++ b/packages/fast-components-react-base/src/hypertext/hypertext.tsx
@@ -9,8 +9,7 @@ import { get } from "lodash-es";
 class Hypertext extends Foundation<IHypertextHandledProps & IManagedClasses<IHypertextClassNameContract>, React.AnchorHTMLAttributes<HTMLAnchorElement>, {}> {
     protected handledProps: HandledProps<IHypertextHandledProps & IManagedClasses<IHypertextClassNameContract>> = {
         href: void 0,
-        managedClasses: void 0,
-        children: void 0
+        managedClasses: void 0
     };
 
     /**

--- a/packages/fast-components-react-base/src/label/label.tsx
+++ b/packages/fast-components-react-base/src/label/label.tsx
@@ -17,7 +17,6 @@ class Label extends Foundation<ILabelHandledProps & IManagedClasses<ILabelClassN
     };
 
     protected handledProps: HandledProps<ILabelHandledProps & IManagedClasses<ILabelClassNameContract>> = {
-        children: void 0,
         hidden: void 0,
         managedClasses: void 0,
         tag: void 0

--- a/packages/fast-components-react-base/src/tabs/tab-panel.tsx
+++ b/packages/fast-components-react-base/src/tabs/tab-panel.tsx
@@ -6,7 +6,6 @@ import { ITabPanelHandledProps, ITabPanelManagedClasses, ITabPanelUnhandledProps
 
 class TabPanel extends Foundation<ITabPanelHandledProps & ITabPanelManagedClasses, ITabPanelUnhandledProps, {}> {
     protected handledProps: HandledProps<ITabPanelHandledProps & IManagedClasses<ITabPanelClassNameContract>> = {
-        children: void 0,
         managedClasses: void 0,
         slot: void 0
     };

--- a/packages/fast-components-react-base/src/tabs/tab.tsx
+++ b/packages/fast-components-react-base/src/tabs/tab.tsx
@@ -6,7 +6,6 @@ import { ITabHandledProps, ITabManagedClasses, ITabUnhandledProps } from "./tab.
 
 class Tab extends Foundation<ITabHandledProps & ITabManagedClasses, ITabUnhandledProps, {}> {
     protected handledProps: HandledProps<ITabHandledProps & IManagedClasses<ITabClassNameContract>> = {
-        children: void 0,
         managedClasses: void 0,
         slot: void 0
     };

--- a/packages/fast-components-react-base/src/tabs/tabs.tsx
+++ b/packages/fast-components-react-base/src/tabs/tabs.tsx
@@ -39,7 +39,6 @@ class Tabs extends Foundation<ITabsHandledProps & ITabsManagedClasses, ITabsUnha
 
     protected handledProps: HandledProps<ITabsHandledProps & IManagedClasses<ITabsClassNameContract>> = {
         activeId: void 0,
-        children: void 0,
         label: void 0,
         managedClasses: void 0,
         onUpdateTab: void 0,

--- a/packages/fast-components-react-msft/src/button/button.tsx
+++ b/packages/fast-components-react-msft/src/button/button.tsx
@@ -10,7 +10,6 @@ import { Button as BaseButton } from "@microsoft/fast-components-react-base";
 class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButtonClassNameContract>,  React.AllHTMLAttributes<HTMLElement>, {}> {
     protected handledProps: HandledProps<IButtonHandledProps & IManagedClasses<IMSFTButtonClassNameContract>> = {
         appearance: void 0,
-        children: void 0,
         disabled: void 0,
         href: void 0,
         managedClasses: void 0,


### PR DESCRIPTION
closes #806 
<body>

<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
