### PR TITLE
feat(fast-development-site-react): add component example transparency as opt-out

### DIFF
--- a/packages/fast-components-react-base/app/index.tsx
+++ b/packages/fast-components-react-base/app/index.tsx
@@ -53,7 +53,7 @@ formChildOptions = formChildOptions.concat([
 /* tslint:disable */
 function render(): void {
     ReactDOM.render(
-        <Site formChildOptions={formChildOptions}>
+        <Site formChildOptions={formChildOptions} showTransparencyToggle={true}>
             <SiteTitle slot={"title"}>
                 <SiteTitleBrand>FAST</SiteTitleBrand> base component documentation
             </SiteTitle>

--- a/packages/fast-components-react-msft/app/app.tsx
+++ b/packages/fast-components-react-msft/app/app.tsx
@@ -76,6 +76,7 @@ export default class App extends React.Component<{}, IAppState> {
                 onUpdateTheme={this.handleUpdateTheme}
                 themes={this.themes}
                 activeTheme={this.getThemeById(this.state.theme)}
+                showTransparencyToggle={true}
             >
                 <SiteMenu slot={"header"}>
                     <SiteMenuItem>

--- a/packages/fast-development-site-react/app/app.tsx
+++ b/packages/fast-development-site-react/app/app.tsx
@@ -71,6 +71,7 @@ export default class App extends React.Component<{}, IAppState> {
                 themes={themes}
                 onUpdateTheme={this.handleUpdateTheme}
                 showComponentStatus={true}
+                showTransparencyToggle={true}
             >
                 {this.renderSiteTitle()}
                 {this.renderSiteMenu()}

--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -53,6 +53,7 @@ export interface ISiteProps {
     collapsed?: boolean;
     componentBackgroundTransparent?: boolean;
     showComponentStatus?: boolean;
+    showTransparencyToggle?: boolean;
 }
 
 export interface IFormChildOption {
@@ -293,7 +294,8 @@ class Site extends React.Component<ISiteProps & IManagedClasses<ISiteManagedClas
 
     public static defaultProps: Partial<ISiteProps> = {
         locales: ["en", "en-rtl"],
-        showComponentStatus: true
+        showComponentStatus: true,
+        showTransparencyToggle: true
     };
 
     public static getDerivedStateFromProps(props: ISiteProps, state: ISiteState): Partial<ISiteState> | null {
@@ -743,13 +745,7 @@ class Site extends React.Component<ISiteProps & IManagedClasses<ISiteManagedClas
     private renderInfoBarConfiguration(): JSX.Element {
         return (
             <div className={this.props.managedClasses.site_infoBarConfiguration}>
-                <button
-                    aria-pressed={this.state.componentBackgroundTransparent}
-                    onClick={this.handleTransparencyToggleClick}
-                    className={this.props.managedClasses.site_transparencyToggleButton}
-                >
-                    <span dangerouslySetInnerHTML={{__html: glyphTransparency}}/>
-                </button>
+                {this.renderTransparencyToggle()}
                 {this.renderThemeSelect()}
                 <span className={this.props.managedClasses.site_infoBarConfiguration_base}>
                     <select
@@ -771,6 +767,20 @@ class Site extends React.Component<ISiteProps & IManagedClasses<ISiteManagedClas
                 {this.renderStatus()}
             </div>
         );
+    }
+
+    private renderTransparencyToggle(): JSX.Element {
+        if (this.props.showTransparencyToggle) {
+            return (
+                <button
+                    aria-pressed={this.state.componentBackgroundTransparent}
+                    onClick={this.handleTransparencyToggleClick}
+                    className={this.props.managedClasses.site_transparencyToggleButton}
+                >
+                    <span dangerouslySetInnerHTML={{__html: glyphTransparency}}/>
+                </button>
+            );
+        }
     }
 
     private renderStatus(): JSX.Element {


### PR DESCRIPTION
Closes [#621](https://github.com/Microsoft/fast-dna/issues/621)
<body>

<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
