### PR TITLE
fix: reverting change to export es6 from fast-animation

### DIFF
--- a/packages/fast-animation/lib/tsconfig.json
+++ b/packages/fast-animation/lib/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
-    "module": "ES6",
+    "module": "CommonJS",
     "target": "ES6",
     "baseUrl": ".",
     "declaration": true,


### PR DESCRIPTION
#825