### PR TITLE
fix(acrylic): sets background property to undefined instead of null to prevent error due to jss expectations

### DIFF
--- a/packages/fast-jss-utilities/src/acrylic.ts
+++ b/packages/fast-jss-utilities/src/acrylic.ts
@@ -41,7 +41,7 @@ export function applyAcrylic<T>(config: IAcrylicConfig): ICSSRules<T> {
         ...styles,
         "&::before": {
             content: "\"\"",
-            background: config.textureImage ? `url(${config.textureImage}) repeat` : null,
+            background: config.textureImage ? `url(${config.textureImage}) repeat` : undefined,
             position: "absolute",
             top: "0",
             bottom: "0",


### PR DESCRIPTION
<body>
closes #801 
<footer>
