### PR TITLE
fix(docs): update link for contributors to find good first issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ This [GitHub Wiki](https://github.com/Microsoft/fast-dna/wiki) includes guidance
 * Ask for help [on Stack Overflow](https://stackoverflow.com/questions/tagged/fast-dna)
 * Join the community [on Discord](https://discord.gg/FcSNfg4)
 * Submit [requests / issues](https://github.com/Microsoft/fast-dna/issues/new/choose)
-* Contributors [find issues to work on](https://github.com/Microsoft/fast-dna/labels/contribute%20%3A%20good%20first%20issue)
+* Contributors [find issues to work on](https://github.com/Microsoft/fast-dna/labels/good%20first%20issue)


### PR DESCRIPTION
The link was incorrect on "good first issue". 