### PR TITLE
fix(button): add missing super of generateClassNames method when appearance prop is not set

### DIFF
--- a/packages/fast-components-react-msft/src/button/button.spec.tsx
+++ b/packages/fast-components-react-msft/src/button/button.spec.tsx
@@ -24,7 +24,7 @@ describe("button snapshots", (): void => {
 });
 
 describe("button", (): void => {
-    const Component: React.ComponentClass<IButtonHandledProps> = examples.component;
+    const Component: React.ComponentClass<IButtonHandledProps & IButtonUnhandledProps> = examples.component;
 
     const href: string = "https://www.microsoft.com";
 
@@ -124,13 +124,26 @@ describe("button", (): void => {
         expect(button.prop("className")).toBe(expectedClassName);
     });
 
-    test("should not set a className when appearance prop is not passed", () => {
+    test("should set a custom className when passed", () => {
+        const customClassNameString: string = "customClassName";
         const rendered: any = shallow(
-            <Component />
+            <Component className={customClassNameString} />
         );
 
         const button: any = rendered.first().shallow();
 
-        expect(button.prop("className")).toEqual(undefined);
+        expect(button.prop("className")).toEqual(customClassNameString);
+    });
+
+    test("should set a custom className to be when appearance prop and className are both passed", () => {
+        const customClassNameString: string = "customClassName";
+        const rendered: any = shallow(
+            <Component appearance={ButtonAppearance.justified} className={customClassNameString} />
+        );
+
+        const button: any = rendered.first().shallow();
+        const expectedClassName: string = `${button.instance().props.managedClasses.button_justified} ${customClassNameString}`;
+
+        expect(button.prop("className")).toEqual(expectedClassName);
     });
 });

--- a/packages/fast-components-react-msft/src/button/button.tsx
+++ b/packages/fast-components-react-msft/src/button/button.tsx
@@ -37,7 +37,7 @@ class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButto
      */
     protected generateClassNames(): string {
         if (!this.props.appearance) {
-            return;
+            return super.generateClassNames();
         }
 
         switch (this.props.appearance) {

--- a/packages/fast-components-react-msft/src/button/button.tsx
+++ b/packages/fast-components-react-msft/src/button/button.tsx
@@ -36,10 +36,6 @@ class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButto
      * Generates class names
      */
     protected generateClassNames(): string {
-        if (!this.props.appearance) {
-            return super.generateClassNames();
-        }
-
         switch (this.props.appearance) {
             case ButtonAppearance.primary:
                 return super.generateClassNames(get(this.props, "managedClasses.button_primary"));
@@ -49,6 +45,8 @@ class Button extends Foundation<IButtonHandledProps & IManagedClasses<IMSFTButto
                 return super.generateClassNames(get(this.props, "managedClasses.button_lightweight"));
             case ButtonAppearance.justified:
                 return super.generateClassNames(get(this.props, "managedClasses.button_justified"));
+            default:
+                return super.generateClassNames();
         }
     }
 


### PR DESCRIPTION
<body>
fixes #879 
<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
