### PR TITLE
fix(fast-components-react-base): update peer dependency version for `fast-web-utilities`

### DIFF
--- a/packages/fast-components-react-base/package.json
+++ b/packages/fast-components-react-base/package.json
@@ -104,7 +104,7 @@
   },
   "peerDependencies": {
     "@microsoft/fast-application-utilities": "^1.9.2",
-    "@microsoft/fast-web-utilities": "^1.9.2",
+    "@microsoft/fast-web-utilities": "^2.2.0",
     "exenv-es6": "^1.0.0",
     "lodash-es": "^4.0.0",
     "raf-throttle": "^2.0.3",


### PR DESCRIPTION
<body>
Tab component expects enum which doesn't exist in referenced peer dependency version. Anyone who has v1.9.2 will get compile errors.
<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
