### PR TITLE
feat: update class-name contracts to be entirely optional

### DIFF
--- a/packages/fast-components-class-name-contracts-base/src/button/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/button/index.ts
@@ -5,5 +5,5 @@ export interface IButtonClassNameContract {
     /**
      * The root of the button component
      */
-    button: string;
+    button?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/checkbox/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/checkbox/index.ts
@@ -5,25 +5,25 @@ export interface ICheckboxClassNameContract {
     /**
      * The root of the checkbox component
      */
-    checkbox: string;
+    checkbox?: string;
 
     /**
      * The disabled state modifier
      */
-    checkbox__disabled: string;
+    checkbox__disabled?: string;
 
     /**
      * The checkbox input element
      */
-    checkbox_input: string;
+    checkbox_input?: string;
 
     /**
      * The label associated with the checkbox
      */
-    checkbox_label: string;
+    checkbox_label?: string;
 
     /**
      * The checkbox state indicator
      */
-    checkbox_stateIndicator: string;
+    checkbox_stateIndicator?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/dialog/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/dialog/index.ts
@@ -5,15 +5,15 @@ export interface IDialogClassNameContract {
     /**
      * The root of the dialog component
      */
-    dialog: string;
+    dialog?: string;
 
     /**
      * The element that overlays the page while the modal is visible
      */
-    dialog_modalOverlay: string;
+    dialog_modalOverlay?: string;
 
     /**
      * The dialog content region
      */
-    dialog_contentRegion: string;
+    dialog_contentRegion?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/divider/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/divider/index.ts
@@ -5,5 +5,5 @@ export interface IDividerClassNameContract {
     /**
      * The root of the divider component
      */
-    divider: string;
+    divider?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/horizontal-overflow/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/horizontal-overflow/index.ts
@@ -5,20 +5,20 @@ export interface IHorizontalOverflowClassNameContract {
     /**
      * The root of the horizontal overflow component
      */
-    horizontalOverflow: string;
+    horizontalOverflow?: string;
 
     /**
      * The overflow items
      */
-    horizontalOverflow_contentRegion: string;
+    horizontalOverflow_contentRegion?: string;
 
     /**
      * The next scroll control
      */
-    horizontalOverflow_next: string;
+    horizontalOverflow_next?: string;
 
     /**
      * The previous scroll control
      */
-    horizontalOverflow_previous: string;
+    horizontalOverflow_previous?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/hypertext/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/hypertext/index.ts
@@ -5,5 +5,5 @@ export interface IHypertextClassNameContract {
     /**
      * The root of the hypertext component
      */
-    hypertext: string;
+    hypertext?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/image/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/image/index.ts
@@ -5,7 +5,7 @@ export interface IImageClassNameContract {
     /**
      * The root of the image component
      */
-    image: string;
+    image?: string;
 
     /**
      * The picture element image modifier

--- a/packages/fast-components-class-name-contracts-base/src/label/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/label/index.ts
@@ -5,10 +5,10 @@ export interface ILabelClassNameContract {
     /**
      * The root of the label component
      */
-    label: string;
+    label?: string;
 
     /**
      * The hidden from assistive technologies modifier
      */
-    label__hidden: string;
+    label__hidden?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/managed-classes.ts
+++ b/packages/fast-components-class-name-contracts-base/src/managed-classes.ts
@@ -2,12 +2,12 @@
  * Class names under a given object keys
  */
  export type ClassNames<T> = {
-    [className in keyof T]: string;
+    [className in keyof T]?: string;
 };
 
 /**
  * The interface for class names passed as props
  */
  export interface IManagedClasses<T> {
-    managedClasses: ClassNames<T>;
+    managedClasses?: ClassNames<T>;
 }

--- a/packages/fast-components-class-name-contracts-base/src/progress/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/progress/index.ts
@@ -5,5 +5,5 @@ export interface IProgressClassNameContract {
     /**
      * The root of the progress component
      */
-    progress: string;
+    progress?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/tabs/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/tabs/index.ts
@@ -5,39 +5,39 @@ export interface ITabsClassNameContract {
     /**
      * The root of the tabs component
      */
-    tabs: string;
+    tabs?: string;
 
     /**
      * The tab panels
      */
-    tabs_tabPanels: string;
+    tabs_tabPanels?: string;
 
     /**
      * The tab list
      */
-    tabs_tabList: string;
+    tabs_tabList?: string;
 }
 
 export interface ITabClassNameContract {
     /**
      * The root of the tab components
      */
-    tab: string;
+    tab?: string;
 
     /**
      * The active tab modifier
      */
-    tab__active: string;
+    tab__active?: string;
 }
 
 export interface ITabPanelClassNameContract {
     /**
      * The root of the tab panel component
      */
-    tabPanel: string;
+    tabPanel?: string;
 
     /**
      * The hidden tab panel modifier
      */
-    tabPanel__hidden: string;
+    tabPanel__hidden?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/text-field/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/text-field/index.ts
@@ -5,5 +5,5 @@ export interface ITextFieldClassNameContract {
     /**
      * The root of the text field
      */
-    textField: string;
+    textField?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/toggle/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/toggle/index.ts
@@ -5,25 +5,25 @@ export interface IToggleClassNameContract {
     /**
      * The root of the toggle component
      */
-    toggle: string;
+    toggle?: string;
 
     /**
      * The toggle label
      */
-    toggle_label: string;
+    toggle_label?: string;
 
     /**
      * The toggle button
      */
-    toggle_toggleButton: string;
+    toggle_toggleButton?: string;
 
     /**
      * The toggle input element
      */
-    toggle_input: string;
+    toggle_input?: string;
 
     /**
      * The toggle state indicator
      */
-    toggle_stateIndicator: string;
+    toggle_stateIndicator?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/typography/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/typography/index.ts
@@ -5,50 +5,50 @@ export interface ITypographyClassNameContract {
     /**
      * The root of the typography component
      */
-    typography: string;
+    typography?: string;
 
     /**
      * The type ramp 1 modifier
      */
-    typography__1: string;
+    typography__1?: string;
 
     /**
      * The type ramp 2 modifier
      */
-    typography__2: string;
+    typography__2?: string;
 
     /**
      * The type ramp 3 modifier
      */
-    typography__3: string;
+    typography__3?: string;
 
     /**
      * The type ramp 4 modifier
      */
-    typography__4: string;
+    typography__4?: string;
 
     /**
      * The type ramp 5 modifier
      */
-    typography__5: string;
+    typography__5?: string;
 
     /**
      * The type ramp 6 modifier
      */
-    typography__6: string;
+    typography__6?: string;
 
     /**
      * The type ramp 7 modifier
      */
-    typography__7: string;
+    typography__7?: string;
 
     /**
      * The type ramp 8 modifier
      */
-    typography__8: string;
+    typography__8?: string;
 
     /**
      * The type ramp 9 modifier
      */
-    typography__9: string;
+    typography__9?: string;
 }

--- a/packages/fast-components-class-name-contracts-msft/src/button/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/button/index.ts
@@ -7,30 +7,30 @@ export interface IMSFTButtonClassNameContract extends IButtonClassNameContract {
     /**
      * The primary appearance modifier
      */
-    button__primary: string;
+    button__primary?: string;
 
     /**
      * The outline appearance modifier
      */
-    button__outline: string;
+    button__outline?: string;
 
     /**
      * The lightweight appearance modifier
      */
-    button__lightweight: string;
+    button__lightweight?: string;
 
     /**
      * The justified appearance modifier
      */
-    button__justified: string;
+    button__justified?: string;
 
     /**
      * The button content region
      */
-    button_contentRegion: string;
+    button_contentRegion?: string;
 
     /**
      * The disabled modifier
      */
-    button__disabled: string;
+    button__disabled?: string;
 }

--- a/packages/fast-components-class-name-contracts-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/call-to-action/index.ts
@@ -5,30 +5,30 @@ export interface ICallToActionClassNameContract {
     /**
      * The root of the call to action component
      */
-    callToAction: string;
+    callToAction?: string;
 
     /**
      * The call to action glyph
      */
-    callToAction_glyph: string;
+    callToAction_glyph?: string;
 
     /**
      * The primary appearance modifier
      */
-    callToAction__primary: string;
+    callToAction__primary?: string;
 
     /**
      * The lightweight appearance modifier
      */
-    callToAction__lightweight: string;
+    callToAction__lightweight?: string;
 
     /**
      * The justified appearance modifier
      */
-    callToAction__justified: string;
+    callToAction__justified?: string;
 
     /**
      * The disabled modifier
      */
-    callToAction__disabled: string;
+    callToAction__disabled?: string;
 }

--- a/packages/fast-components-class-name-contracts-msft/src/caption/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/caption/index.ts
@@ -5,15 +5,15 @@ export interface ICaptionClassNameContract {
     /**
      * The root of the caption component
      */
-    caption: string;
+    caption?: string;
 
     /**
      * The size 1 modifier
      */
-    caption__1: string;
+    caption__1?: string;
 
     /**
      * The size 2 modifier
      */
-    caption__2: string;
+    caption__2?: string;
 }

--- a/packages/fast-components-class-name-contracts-msft/src/flipper/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/flipper/index.ts
@@ -5,20 +5,20 @@ export interface IFlipperClassNameContract {
     /**
      * The root of the flipper component
      */
-    flipper: string;
+    flipper?: string;
 
     /**
      * The flipper glyph
      */
-    flipper_glyph: string;
+    flipper_glyph?: string;
 
     /**
      * The next direction flipper modifier
      */
-    flipper__next: string;
+    flipper__next?: string;
 
     /**
      * The previous direction flipper modifier
      */
-    flipper__previous: string;
+    flipper__previous?: string;
 }

--- a/packages/fast-components-class-name-contracts-msft/src/heading/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/heading/index.ts
@@ -5,35 +5,35 @@ export interface IHeadingClassNameContract {
     /**
      * The root of the heading component
      */
-    heading: string;
+    heading?: string;
 
     /**
      * The size 1 modifier
      */
-    heading__1: string;
+    heading__1?: string;
 
     /**
      * The size 2 modifier
      */
-    heading__2: string;
+    heading__2?: string;
 
     /**
      * The size 3 modifier
      */
-    heading__3: string;
+    heading__3?: string;
 
     /**
      * The size 4 modifier
      */
-    heading__4: string;
+    heading__4?: string;
 
     /**
      * The size 5 modifier
      */
-    heading__5: string;
+    heading__5?: string;
 
     /**
      * The size 6 modifier
      */
-    heading__6: string;
+    heading__6?: string;
 }

--- a/packages/fast-components-class-name-contracts-msft/src/metatext/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/metatext/index.ts
@@ -5,5 +5,5 @@ export interface IMetatextClassNameContract {
     /**
      * The root of the metatext component
      */
-    metatext: string;
+    metatext?: string;
 }

--- a/packages/fast-components-class-name-contracts-msft/src/paragraph/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/paragraph/index.ts
@@ -5,20 +5,20 @@ export interface IParagraphClassNameContract {
     /**
      * The root of the paragraph component
      */
-    paragraph: string;
+    paragraph?: string;
 
     /**
      * The size 1 modifier
      */
-    paragraph__1: string;
+    paragraph__1?: string;
 
     /**
      * The size 2 modifier
      */
-    paragraph__2: string;
+    paragraph__2?: string;
 
     /**
      * The size 3 modifier
      */
-    paragraph__3: string;
+    paragraph__3?: string;
 }

--- a/packages/fast-components-class-name-contracts-msft/src/progress/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/progress/index.ts
@@ -7,50 +7,50 @@ export interface IMSFTProgressClassNameContract extends IProgressClassNameContra
     /**
      * The progress value indicator
      */
-    progress_valueIndicator: string;
+    progress_valueIndicator?: string;
 
     /**
      * The indeterminate progress indicator
      */
-    progress_indicator: string;
+    progress_indicator?: string;
 
     /**
      * The determinate progress value indicator
      */
-    progress_indicator__determinate: string;
+    progress_indicator__determinate?: string;
 
     /**
      * The indeterminate progress indicator
      */
-    progress_dot: string;
+    progress_dot?: string;
 
     /**
      * The indeterminate progress indicator 1 modifier
      */
-    progress_dot__1: string;
+    progress_dot__1?: string;
 
     /**
      * The indeterminate progress indicator 2 modifier
      */
-    progress_dot__2: string;
+    progress_dot__2?: string;
 
     /**
      * The indeterminate progress indicator 3 modifier
      */
-    progress_dot__3: string;
+    progress_dot__3?: string;
 
     /**
      * The indeterminate progress indicator 4 modifier
      */
-    progress_dot__4: string;
+    progress_dot__4?: string;
 
     /**
      * The indeterminate progress indicator 5 modifier
      */
-    progress_dot__5: string;
+    progress_dot__5?: string;
 
     /**
      * The keyframes for the dots animation
      */
-    "@keyframes dots": string;
+    "@keyframes dots"?: string;
 }

--- a/packages/fast-components-class-name-contracts-msft/src/subheading/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/subheading/index.ts
@@ -5,35 +5,35 @@ export interface ISubheadingClassNameContract {
     /**
      * The root of the subheading component
      */
-    subheading: string;
+    subheading?: string;
 
     /**
      * The size 1 modifier
      */
-    subheading__1: string;
+    subheading__1?: string;
 
     /**
      * The size 2 modifier
      */
-    subheading__2: string;
+    subheading__2?: string;
 
     /**
      * The size 3 modifier
      */
-    subheading__3: string;
+    subheading__3?: string;
 
     /**
      * The size 4 modifier
      */
-    subheading__4: string;
+    subheading__4?: string;
 
     /**
      * The size 5 modifier
      */
-    subheading__5: string;
+    subheading__5?: string;
 
     /**
      * The size 6 modifier
      */
-    subheading__6: string;
+    subheading__6?: string;
 }

--- a/packages/fast-components-react-base/src/button/button.spec.tsx
+++ b/packages/fast-components-react-base/src/button/button.spec.tsx
@@ -32,6 +32,14 @@ describe("button", (): void => {
         expect((Button as any).name).toBe(Button.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Button />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: IButtonHandledProps & IButtonManagedClasses = {
             managedClasses

--- a/packages/fast-components-react-base/src/checkbox/checkbox.spec.tsx
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.spec.tsx
@@ -37,6 +37,15 @@ describe("checkbox", (): void => {
         expect((Checkbox as any).name).toBe(Checkbox.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Checkbox />);
+                shallow(<Checkbox disabled={true} />);
+            }
+        ).not.toThrow();
+    });
+
     test("should implement unhandledProps", () => {
         const handledProps: ICheckboxHandledProps & ICheckboxManagedClasses = {
             managedClasses

--- a/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
@@ -34,6 +34,15 @@ describe("dialog", (): void => {
         expect((Dialog as any).name).toBe(Dialog.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Dialog />);
+                shallow(<Dialog modal={true} />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: IDialogHandledProps & IDialogManagedClasses = {
             managedClasses,

--- a/packages/fast-components-react-base/src/divider/divider.spec.tsx
+++ b/packages/fast-components-react-base/src/divider/divider.spec.tsx
@@ -28,6 +28,14 @@ describe("divider", (): void => {
         expect((Divider as any).name).toBe(Divider.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Divider />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: IDividerHandledProps & IDividerManagedClasses = {
             managedClasses

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, mount } from "enzyme";
+import { configure, mount, shallow } from "enzyme";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import HorizontalOverflow, {
     ButtonDirection,
@@ -40,6 +40,14 @@ describe("horizontal overflow snapshot", (): void => {
 describe("horizontal overflow", (): void => {
     test("should have a displayName that matches the component name", () => {
         expect((HorizontalOverflow as any).name).toBe(HorizontalOverflow.displayName);
+    });
+
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<HorizontalOverflow />);
+            }
+        ).not.toThrow();
     });
 
     test("should render a previous button if one is passed as a child with the appropriate slot prop", () => {

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -65,17 +65,23 @@ class HorizontalOverflow extends Foundation<
             >
                 <div style={{height: `${this.state.itemsHeight}px`, position: "relative", overflow: "hidden"}}>
                     <ul
-                        className={this.props.managedClasses.horizontalOverflow_contentRegion}
+                        className={get(this.props, "managedClasses.horizontalOverflow_contentRegion")}
                         style={this.getListStyle()}
                         ref={this.horizontalOverflowItemsRef}
                     >
                         {this.getItems()}
                     </ul>
                 </div>
-                <div className={this.props.managedClasses.horizontalOverflow_previous} onClick={this.handlePreviousClick}>
+                <div
+                    className={get(this.props, "managedClasses.horizontalOverflow_previous")}
+                    onClick={this.handlePreviousClick}
+                >
                     {this.withSlot(ButtonDirection.previous)}
                 </div>
-                <div className={this.props.managedClasses.horizontalOverflow_next} onClick={this.handleNextClick}>
+                <div
+                    className={get(this.props, "managedClasses.horizontalOverflow_next")}
+                    onClick={this.handleNextClick}
+                >
                     {this.withSlot(ButtonDirection.next)}
                 </div>
             </div>

--- a/packages/fast-components-react-base/src/hypertext/hypertext.spec.tsx
+++ b/packages/fast-components-react-base/src/hypertext/hypertext.spec.tsx
@@ -30,6 +30,14 @@ describe("hypertext", (): void => {
         expect((Hypertext as any).name).toBe(Hypertext.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Hypertext />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: IHypertextHandledProps & IHypertextManagedClasses = {
             managedClasses

--- a/packages/fast-components-react-base/src/image/image.spec.tsx
+++ b/packages/fast-components-react-base/src/image/image.spec.tsx
@@ -33,6 +33,19 @@ describe("image", (): void => {
         expect((Image as any).name).toBe(Image.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Image alt="alt" />);
+                shallow(
+                    <Image alt="alt">
+                        <source slot={ImageSlot.source} />
+                    </Image>
+                );
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: IImageHandledProps & IImageManagedClasses = {
             managedClasses,

--- a/packages/fast-components-react-base/src/label/label.spec.tsx
+++ b/packages/fast-components-react-base/src/label/label.spec.tsx
@@ -32,6 +32,15 @@ describe("label", (): void => {
         expect((Label as any).name).toBe(Label.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Label />);
+                shallow(<Label hidden={true} />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: ILabelHandledProps & ILabelManagedClasses = {
             managedClasses,

--- a/packages/fast-components-react-base/src/progress/progress.spec.tsx
+++ b/packages/fast-components-react-base/src/progress/progress.spec.tsx
@@ -26,6 +26,14 @@ describe("progress", (): void => {
         expect((Progress as any).name).toBe(Progress.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Progress />);
+            }
+        ).not.toThrow();
+    });
+
     test("should render a child if one is passed as a child with the appropriate slot prop", () => {
         const progess: any = mount(
             <Progress managedClasses={managedClasses}>

--- a/packages/fast-components-react-base/src/tabs/tabs.spec.tsx
+++ b/packages/fast-components-react-base/src/tabs/tabs.spec.tsx
@@ -143,6 +143,14 @@ describe("tabs", (): void => {
         expect((Tabs as any).name).toBe(Tabs.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Tabs label="label" />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: ITabsHandledProps & ITabsManagedClasses = {
             managedClasses: tabsManagedClasses,
@@ -373,6 +381,15 @@ describe("Tab", (): void => {
     test("should have a displayName that matches the component name", () => {
         expect((Tab as any).name).toBe(Tab.displayName);
     });
+
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Tab slot={TabsSlot.tab} />);
+                shallow(<Tab slot={TabsSlot.tab} aria-selected={true} />);
+            }
+        ).not.toThrow();
+    });
 });
 
 describe("TabItem", (): void => {
@@ -384,5 +401,14 @@ describe("TabItem", (): void => {
 describe("TabPanel", (): void => {
     test("should have a displayName that matches the component name", () => {
         expect((TabPanel as any).name).toBe(TabPanel.displayName);
+    });
+
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<TabPanel slot={TabsSlot.tabPanel} />);
+                shallow(<TabPanel slot={TabsSlot.tabPanel} aria-hidden={true} />);
+            }
+        ).not.toThrow();
     });
 });

--- a/packages/fast-components-react-base/src/tabs/tabs.tsx
+++ b/packages/fast-components-react-base/src/tabs/tabs.tsx
@@ -88,13 +88,13 @@ class Tabs extends Foundation<
                 <div
                     role="tablist"
                     ref={this.tabListRef}
-                    className={this.props.managedClasses.tabs_tabList}
+                    className={get(this.props, "managedClasses.tabs_tabList")}
                     aria-label={this.props.label}
                     aria-orientation={this.props.orientation}
                 >
                     {tabElements}
                 </div>
-                <div className={this.props.managedClasses.tabs_tabPanels}>
+                <div className={get(this.props, "managedClasses.tabs_tabPanels")}>
                     {this.renderTabPanels()}
                 </div>
             </div>

--- a/packages/fast-components-react-base/src/text-field/text-field.spec.tsx
+++ b/packages/fast-components-react-base/src/text-field/text-field.spec.tsx
@@ -31,6 +31,14 @@ describe("text-field", (): void => {
         expect((TextField as any).name).toBe(TextField.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<TextField />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: ITextFieldHandledProps & ITextFieldManagedClasses = {
             managedClasses,

--- a/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
@@ -43,6 +43,22 @@ describe("toggle", (): void => {
         expect((Toggle as any).name).toBe(Toggle.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(
+                    <Toggle
+                        id="id"
+                        selectedString="selectedString"
+                        unselectedString="selectedString"
+                        statusLabelId="statusLabelId"
+                        labelId="labelId"
+                    />
+                );
+            }
+        ).not.toThrow();
+    });
+
     test("should implement unhandledProps", () => {
         const unhandledProps: IToggleUnhandledProps = {
             "data-my-custom-attribute": true

--- a/packages/fast-components-react-base/src/typography/typography.spec.tsx
+++ b/packages/fast-components-react-base/src/typography/typography.spec.tsx
@@ -9,6 +9,7 @@ import Typography, {
     ITypographyHandledProps,
     ITypographyManagedClasses,
     ITypographyUnhandledProps,
+    TypeLevel,
     TypographyProps,
     TypographyTag
 } from "./typography";
@@ -37,6 +38,15 @@ describe("typography", (): void => {
 
     test("should have a displayName that matches the component name", () => {
         expect((Typography as any).name).toBe(Typography.displayName);
+    });
+
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Typography />);
+                shallow(<Typography typeLevel={TypeLevel._1} />);
+            }
+        ).not.toThrow();
     });
 
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {

--- a/packages/fast-components-react-base/src/typography/typography.spec.tsx
+++ b/packages/fast-components-react-base/src/typography/typography.spec.tsx
@@ -9,8 +9,8 @@ import Typography, {
     ITypographyHandledProps,
     ITypographyManagedClasses,
     ITypographyUnhandledProps,
-    TypeLevel,
     TypographyProps,
+    TypographySize,
     TypographyTag
 } from "./typography";
 
@@ -44,7 +44,7 @@ describe("typography", (): void => {
         expect(
             () => {
                 shallow(<Typography />);
-                shallow(<Typography typeLevel={TypeLevel._1} />);
+                shallow(<Typography size={TypographySize._1} />);
             }
         ).not.toThrow();
     });

--- a/packages/fast-components-react-msft/src/button/button.spec.tsx
+++ b/packages/fast-components-react-msft/src/button/button.spec.tsx
@@ -51,6 +51,18 @@ describe("button", (): void => {
         expect((MSFTButton as any).name).toBe(MSFTButton.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<MSFTButton />);
+                shallow(<MSFTButton appearance={ButtonAppearance.justified} />);
+                shallow(<MSFTButton appearance={ButtonAppearance.outline} />);
+                shallow(<MSFTButton appearance={ButtonAppearance.lightweight} />);
+                shallow(<MSFTButton appearance={ButtonAppearance.primary} />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: IButtonHandledProps = {
             href

--- a/packages/fast-components-react-msft/src/call-to-action/call-to-action.spec.tsx
+++ b/packages/fast-components-react-msft/src/call-to-action/call-to-action.spec.tsx
@@ -39,6 +39,18 @@ describe("call to action", (): void => {
         expect((MSFTCallToAction as any).name).toBe(MSFTCallToAction.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<MSFTCallToAction />);
+                shallow(<MSFTCallToAction disabled={true} />);
+                shallow(<MSFTCallToAction appearance={CallToActionAppearance.primary} />);
+                shallow(<MSFTCallToAction appearance={CallToActionAppearance.lightweight} />);
+                shallow(<MSFTCallToAction appearance={CallToActionAppearance.justified} />);
+            }
+        ).not.toThrow();
+    });
+
     test("should implement unhandledProps", () => {
         const handledProps: ICallToActionProps & ICallToActionManagedClasses = {
             managedClasses,

--- a/packages/fast-components-react-msft/src/caption/caption.spec.tsx
+++ b/packages/fast-components-react-msft/src/caption/caption.spec.tsx
@@ -27,6 +27,14 @@ describe("caption", (): void => {
         expect((MSFTCaption as any).name).toBe(MSFTCaption.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<MSFTCaption />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: ICaptionHandledProps = {
             tag: CaptionTag.p,

--- a/packages/fast-components-react-msft/src/flipper/flipper.spec.tsx
+++ b/packages/fast-components-react-msft/src/flipper/flipper.spec.tsx
@@ -25,6 +25,14 @@ describe("flipper", (): void => {
         expect((MSFTFlipper as any).name).toBe(MSFTFlipper.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<MSFTFlipper />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: IFlipperHandledProps = {
             visibleToAssistiveTechnologies: false

--- a/packages/fast-components-react-msft/src/flipper/flipper.tsx
+++ b/packages/fast-components-react-msft/src/flipper/flipper.tsx
@@ -31,10 +31,9 @@ class Flipper extends Foundation<
             <Button
                 {...this.unhandledProps()}
                 {...this.coerceButtonProps()}
-                managedClasses={null}
                 className={this.generateClassNames()}
             >
-                <span className={this.props.managedClasses.flipper_glyph}>{this.props.children}</span>
+                <span className={get(this.props, "managedClasses.flipper_glyph")}>{this.props.children}</span>
             </Button>
         );
     }
@@ -43,7 +42,7 @@ class Flipper extends Foundation<
      * Generates class names based on props
      */
     protected generateClassNames(): string {
-        const classes: string = this.props.managedClasses[`flipper__${this.props.direction || FlipperDirection.next}`];
+        const classes: string = get(this.props, `managedClasses.flipper__${this.props.direction || FlipperDirection.next}`);
 
         return super.generateClassNames(`${get(this.props, "managedClasses.flipper")} ${classes}`);
     }

--- a/packages/fast-components-react-msft/src/heading/heading.spec.tsx
+++ b/packages/fast-components-react-msft/src/heading/heading.spec.tsx
@@ -28,6 +28,15 @@ describe("heading", (): void => {
         expect((MSFTHeading as any).name).toBe(MSFTHeading.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<MSFTHeading tag={HeadingTag.h1} />);
+                shallow(<MSFTHeading tag={HeadingTag.h1} level={HeadingLevel._1} />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: IHeadingHandledProps = {
             tag: HeadingTag.h1,

--- a/packages/fast-components-react-msft/src/heading/heading.spec.tsx
+++ b/packages/fast-components-react-msft/src/heading/heading.spec.tsx
@@ -32,7 +32,7 @@ describe("heading", (): void => {
         expect(
             () => {
                 shallow(<MSFTHeading tag={HeadingTag.h1} />);
-                shallow(<MSFTHeading tag={HeadingTag.h1} level={HeadingLevel._1} />);
+                shallow(<MSFTHeading tag={HeadingTag.h1} size={HeadingSize._1} />);
             }
         ).not.toThrow();
     });

--- a/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
+++ b/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
@@ -26,6 +26,14 @@ describe("metatext", (): void => {
         expect((MSFTMetatext as any).name).toBe(MSFTMetatext.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Metatext />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: IMetatextHandledProps = {
             tag: MetatextTag.p

--- a/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
+++ b/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
@@ -29,7 +29,7 @@ describe("metatext", (): void => {
     test("should not throw if managedClasses are not provided", () => {
         expect(
             () => {
-                shallow(<Metatext />);
+                shallow(<MSFTMetatext />);
             }
         ).not.toThrow();
     });

--- a/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
+++ b/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
@@ -26,6 +26,15 @@ describe("paragraph", (): void => {
         expect((MSFTParagraph as any).name).toBe(MSFTParagraph.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<Paragraph />);
+                shallow(<Paragraph level={ParagraphLevel._1} />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
         const handledProps: IParagraphHandledProps = {
             size: ParagraphLevel._1

--- a/packages/fast-components-react-msft/src/progress/progress.spec.tsx
+++ b/packages/fast-components-react-msft/src/progress/progress.spec.tsx
@@ -4,7 +4,7 @@ import { configure, shallow } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import { IProgressClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import {
+import MSFTProgress, {
     IMSFTProgressClassNameContract,
     IMSFTProgressHandledProps,
     IMSFTProgressManagedClasses,
@@ -18,4 +18,14 @@ configure({adapter: new Adapter()});
 
 describe("progress snapshots", (): void => {
     generateSnapshots(examples);
+});
+
+describe("progress", (): void => {
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<MSFTProgress />);
+            }
+        ).not.toThrow();
+    });
 });

--- a/packages/fast-components-react-msft/src/progress/progress.tsx
+++ b/packages/fast-components-react-msft/src/progress/progress.tsx
@@ -41,9 +41,6 @@ class Progress extends Foundation<
      * Renders the component
      */
     public render(): React.ReactElement<HTMLDivElement> {
-        /* tslint:disable-next-line */
-        const className: string = `${this.props.managedClasses.progress_indicator} ${this.props.managedClasses.progress_indicator__determinate}`;
-
         return (
             <BaseProgress
                 {...this.unhandledProps()}
@@ -54,17 +51,17 @@ class Progress extends Foundation<
                 maxValue={this.props.maxValue}
             >
                 <div
-                    className={className}
+                    className={this.progressIndicatorClasses()}
                     slot={ProgressType.determinate}
                 >
                     <div
-                        className={this.props.managedClasses.progress_valueIndicator}
+                        className={get(this.props, "managedClasses.progress_valueIndicator")}
                         style={{width: `${this.props.value}%`}}
                     />
                 </div>
                 <div
                     slot={ProgressType.indeterminate}
-                    className={this.props.managedClasses.progress_indicator}
+                    className={get(this.props, "managedClasses.progress_indicator")}
                 >
                     {this.renderIndeterminateItems()}
                 </div>
@@ -72,10 +69,18 @@ class Progress extends Foundation<
         );
     }
 
+    private progressIndicatorClasses(): string {
+        return [
+            get(this.props, "managedClasses.progress_indicator"),
+            get(this.props, "managedClasses.progress_indicator__determinate")
+        ].join(" ");
+    }
+
     private renderIndeterminateItems(): JSX.Element[] {
         return new Array(Progress.indicatorDotCount).fill(undefined).map((item: undefined, index: number) => {
-            let className: string = this.props.managedClasses.progress_dot;
-            className = `${className} ${this.props.managedClasses[`progress_dot__${index + 1}`]}`;
+            let className: string = get(this.props, "managedClasses.progress_dot");
+            className = `${className} ${get(this.props, `managedClasses.progress_dot__${index + 1}`)}`;
+
             return (
                 <span
                     className={className}

--- a/packages/fast-components-react-msft/src/subheading/subheading.spec.tsx
+++ b/packages/fast-components-react-msft/src/subheading/subheading.spec.tsx
@@ -26,6 +26,15 @@ describe("subheading", (): void => {
         expect((MSFTSubheading as any).name).toBe(MSFTSubheading.displayName);
     });
 
+    test("should not throw if managedClasses are not provided", () => {
+        expect(
+            () => {
+                shallow(<MSFTSubheading />);
+                shallow(<MSFTSubheading level={SubheadingLevel._1} />);
+            }
+        ).not.toThrow();
+    });
+
     test("should return a valid object which includes all props that are not enumerated as handledProps", (): void => {
         const handledProps: ISubheadingHandledProps = {
             tag: SubheadingTag.h1,

--- a/packages/fast-layouts-react/src/container/container.tsx
+++ b/packages/fast-layouts-react/src/container/container.tsx
@@ -4,8 +4,8 @@ import { ContainerProps } from "./container.props";
 import Foundation, { IFoundationProps } from "../foundation";
 
 export interface IContainerClassNamesContract {
-    "@global": string;
-    container: string;
+    "@global"?: string;
+    container?: string;
 }
 
 const styles: ComponentStyles<IContainerClassNamesContract, undefined> = {

--- a/packages/fast-layouts-react/src/grid/grid.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.tsx
@@ -7,7 +7,7 @@ import Foundation, { IFoundationProps } from "../foundation";
 import Column from "../column";
 
 export interface IGridClassNamesContract {
-    grid: string;
+    grid?: string;
 }
 
 const styles: ComponentStyles<IGridClassNamesContract, undefined> = {

--- a/packages/fast-layouts-react/src/page/page.tsx
+++ b/packages/fast-layouts-react/src/page/page.tsx
@@ -4,8 +4,8 @@ import { IPageHandledProps, PageProps } from "./page.props";
 import Foundation, { IFoundationProps } from "../foundation";
 
 export interface IPageClassNamesContract {
-    "@global": string;
-    page: string;
+    "@global"?: string;
+    page?: string;
 }
 
 const styles: ComponentStyles<IPageClassNamesContract, undefined> = {

--- a/packages/fast-layouts-react/src/pane/pane.tsx
+++ b/packages/fast-layouts-react/src/pane/pane.tsx
@@ -30,12 +30,12 @@ export interface IPaneState {
 }
 
 export interface IPaneClassNamesContract {
-    pane: string;
-    pane_resizeHandle: string;
-    pane__resizeWest: string;
-    pane__resizeEast: string;
-    pane__overlay: string;
-    pane__hidden: string;
+    pane?: string;
+    pane_resizeHandle?: string;
+    pane__resizeWest?: string;
+    pane__resizeEast?: string;
+    pane__overlay?: string;
+    pane__hidden?: string;
 }
 
 const paneStyleSheet: ComponentStyles<IPaneClassNamesContract, undefined> = {

--- a/packages/fast-layouts-react/src/row/row.tsx
+++ b/packages/fast-layouts-react/src/row/row.tsx
@@ -35,13 +35,13 @@ export interface IRowState {
 }
 
 export interface IRowClassNamesContract {
-    row: string;
-    row__fill: string;
-    row_resizeHandle: string;
-    row__resizeNorth: string;
-    row__resizeSouth: string;
-    row__overlay: string;
-    row__hidden: string;
+    row?: string;
+    row__fill?: string;
+    row_resizeHandle?: string;
+    row__resizeNorth?: string;
+    row__resizeSouth?: string;
+    row__overlay?: string;
+    row__hidden?: string;
 }
 
 const rowStyleSheet: ComponentStyles<IRowClassNamesContract, undefined> = {


### PR DESCRIPTION
The managedClasses prop will be optional, as well as all properties of a class-name contract. It will be up to developer-discretion if class-names are required for their specific implementation.

closes #951