### PR TITLE
chore: remove TODO statement check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -42,7 +42,6 @@ plugins:
     config:
       strings:
       - HACK
-      - TODO
   markdownlint:
     enabled: false
 exclude_patterns:


### PR DESCRIPTION
Removing `TODO` from `.codeclimate.yml` plugins will ensure that when found in code it will be ignored and we can put this in code with task and description for work to be done later. 

For details on this [plugin](https://docs.codeclimate.com/docs/fixme) 

closes #586 