### PR TITLE
fix: apply checkbox `indeterminate` property regardless of "checked" state

### DIFF
--- a/packages/fast-components-react-base/src/checkbox/checkbox.tsx
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.tsx
@@ -136,7 +136,7 @@ class Checkbox extends Foundation<
      * This method should be called after render because it relies on element references.
      */
     private applyIndeterminateState(): void {
-         if (this.props.indeterminate && this.inputRef.current && this.state.checked) {
+         if (this.props.indeterminate && this.inputRef.current) {
             this.inputRef.current.indeterminate = this.props.indeterminate;
         }
     }


### PR DESCRIPTION
As per the issue, we should apply `indeterminate` property irrespective of `checked` state.

Fixes #968 
