### PR TITLE
feat: update JSSManager context API

### DIFF
--- a/packages/fast-components-react-msft/app/color-picker.tsx
+++ b/packages/fast-components-react-msft/app/color-picker.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem } from "@microsoft/fast-components-styles-msft";
 
 export interface IColorConfig {

--- a/packages/fast-components-react-msft/app/color-picker.tsx
+++ b/packages/fast-components-react-msft/app/color-picker.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem } from "@microsoft/fast-components-styles-msft";
 
 export interface IColorConfig {

--- a/packages/fast-components-react-msft/app/color-picker.tsx
+++ b/packages/fast-components-react-msft/app/color-picker.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem } from "@microsoft/fast-components-styles-msft";
 
 export interface IColorConfig {

--- a/packages/fast-components-react-msft/src/button/button.spec.tsx
+++ b/packages/fast-components-react-msft/src/button/button.spec.tsx
@@ -58,7 +58,7 @@ describe("button", (): void => {
         ).not.toThrow();
     });
 
-    test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
+    test("should accept unhandledProps", () => {
         const handledProps: IButtonHandledProps = {
             href
         };
@@ -69,115 +69,57 @@ describe("button", (): void => {
 
         const props: ButtonProps = {...handledProps, ...unhandledProps};
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Button {...props}/>
         );
 
-        const button: any = rendered.first().shallow();
-
-        expect(button.prop("aria-hidden")).toEqual(true);
+        expect(rendered.find("a").prop("aria-hidden")).toEqual(true);
     });
 
     /* tslint:disable-next-line */
     test("should apply a 'primary' html class when appearance is primary", () => {
-        const props: ButtonProps = {
-            appearance: ButtonAppearance.primary
-        };
-
-        const rendered: any = shallow(
-            <Button {...props}/>
+        const rendered: any = mount(
+            <Button appearance={ButtonAppearance.primary}/>
         );
 
-        const button: any = rendered.first().shallow();
-        // Get the expected className value from the list of generated managed classes
-        const expectedClassName: string = button.instance().props.managedClasses.button__primary;
-
-        expect(button.instance().props.appearance).toEqual(ButtonAppearance.primary);
-        // Generated managedClass should be passed to className
-        expect(button.prop("className")).toBe(expectedClassName);
+        expect(rendered.find("button").prop("className")).toContain("button__primary");
     });
 
     /* tslint:disable-next-line */
     test("should apply an 'outline' html class when appearance is outline", () => {
-        const props: IButtonHandledProps = {
-            appearance: ButtonAppearance.outline
-        };
-
-        const rendered: any = shallow(
-            <Button {...props}/>
+        const rendered: any = mount(
+            <Button appearance={ButtonAppearance.outline}/>
         );
 
-        const button: any = rendered.first().shallow();
-        // Get the expected className value from the list of generated managed classes
-        const expectedClassName: string = button.instance().props.managedClasses.button__outline;
-
-        expect(button.instance().props.appearance).toEqual(ButtonAppearance.outline);
-        // Generated managedClass should be passed to className
-        expect(button.prop("className")).toBe(expectedClassName);
+        expect(rendered.find("button").prop("className")).toContain("button__outline");
     });
 
     /* tslint:disable-next-line */
     test("should apply a 'lightweight' html class when appearance is lightweight", () => {
-        const props: IButtonHandledProps = {
-            appearance: ButtonAppearance.lightweight
-        };
-
-        const rendered: any = shallow(
-            <Button {...props}/>
+        const rendered: any = mount(
+            <Button appearance={ButtonAppearance.lightweight}/>
         );
 
-        const button: any = rendered.first().shallow();
-        // Get the expected className value from the list of generated managed classes
-        const expectedClassName: string = button.instance().props.managedClasses.button__lightweight;
-
-        expect(button.instance().props.appearance).toEqual(ButtonAppearance.lightweight);
-        // Generated managedClass should be passed to className
-        expect(button.prop("className")).toBe(expectedClassName);
+        expect(rendered.find("button").prop("className")).toContain("button__lightweight");
     });
 
-    /* tslint:disable-next-line */
     test("should apply a 'justified' html class when appearance is justified", () => {
-        const props: IButtonHandledProps = {
-            appearance: ButtonAppearance.justified
-        };
-
-        const rendered: any = shallow(
-            <Button {...props}/>
+        const rendered: any = mount(
+            <Button appearance={ButtonAppearance.justified}/>
         );
 
-        const button: any = rendered.first().shallow();
-        // Get the expected className value from the list of generated managed classes
-        const expectedClassName: string = button.instance().props.managedClasses.button__justified;
-
-        expect(button.instance().props.appearance).toEqual(ButtonAppearance.justified);
-        // Generated managedClass should be passed to className
-        expect(button.prop("className")).toBe(expectedClassName);
+        expect(rendered.find("button").prop("className")).toContain("button__justified");
     });
 
     test("should set a custom class name when passed", () => {
         const customClassNameString: string = "customClassName";
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Button className={customClassNameString} />
         );
 
-        const button: any = rendered.first().shallow();
-
-        expect(button.prop("className")).toEqual(customClassNameString);
+        expect(rendered.find("button").prop("className")).toContain(customClassNameString);
     });
 
-    test("should set a custom class name and 'justified' class name when appearance is justified and a custom class is passed", () => {
-        const customClassNameString: string = "customClassName";
-        const rendered: any = shallow(
-            <Button appearance={ButtonAppearance.justified} className={customClassNameString} />
-        );
-
-        const button: any = rendered.first().shallow();
-        const expectedClassName: string = `${button.instance().props.managedClasses.button__justified} ${customClassNameString}`;
-
-        expect(button.prop("className")).toEqual(expectedClassName);
-    });
-
-    /* tslint:disable-next-line */
     test("should add a child element with the slot prop set to 'before' into the before slot location", () => {
         const props: IButtonHandledProps = {
             appearance: ButtonAppearance.lightweight,
@@ -186,14 +128,13 @@ describe("button", (): void => {
         };
 
         const rendered: any = mount(
-            <Button {...props} />
+            <MSFTButton {...props} />
         );
 
         expect(rendered.instance().props.children[1].props.slot).toBe("before");
         expect(rendered.find("div.slotBefore").length).toBe(1);
     });
 
-    /* tslint:disable-next-line */
     test("should add a child element with the slot prop set to 'after' into the after slot location", () => {
         const props: IButtonHandledProps = {
             appearance: ButtonAppearance.lightweight,
@@ -202,7 +143,7 @@ describe("button", (): void => {
         };
 
         const rendered: any = mount(
-            <Button {...props} />
+            <MSFTButton {...props} />
         );
 
         expect(rendered.instance().props.children[1].props.slot).toBe("after");

--- a/packages/fast-components-react-msft/src/button/index.ts
+++ b/packages/fast-components-react-msft/src/button/index.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ButtonStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import MSFTButton, {
     ButtonAppearance,
@@ -21,7 +21,7 @@ const Button = manageJss(ButtonStyles)(MSFTButton);
 type Button = InstanceType<typeof Button>;
 
 interface IButtonHandledProps extends Subtract<IMSFTButtonHandledProps, IButtonManagedClasses> {}
-type ButtonProps = JSSManagerProps<MSFTButtonProps, IButtonClassNameContract, IDesignSystem>;
+type ButtonProps = ManagedJSSProps<MSFTButtonProps, IButtonClassNameContract, IDesignSystem>;
 
 export {
     Button,

--- a/packages/fast-components-react-msft/src/button/index.ts
+++ b/packages/fast-components-react-msft/src/button/index.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ButtonStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import MSFTButton, {
     ButtonAppearance,
@@ -18,7 +18,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Button = manageJss(ButtonStyles)(MSFTButton);
-type Button = InstanceType<typeof Button>;
+type Button = typeof Button;
 
 interface IButtonHandledProps extends Subtract<IMSFTButtonHandledProps, IButtonManagedClasses> {}
 type ButtonProps = ManagedJSSProps<MSFTButtonProps, IButtonClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/call-to-action/__snapshots__/call-to-action.spec.tsx.snap
+++ b/packages/fast-components-react-msft/src/call-to-action/__snapshots__/call-to-action.spec.tsx.snap
@@ -2,17 +2,17 @@
 
 exports[`call to action snapshot Call to action: 0 1`] = `
 <a
-  className="button-0-1-20 button__primary-0-1-21 callToAction-0-1-7 callToAction__primary-0-1-9"
+  className="button-0-1-7 button__primary-0-1-8 callToAction-0-1-1 callToAction__primary-0-1-3"
   data-sketch-symbol="Call to action - primary"
   href="https://www.microsoft.com/en-us/"
 >
   <span
-    className="button_contentRegion-0-1-25"
+    className="button_contentRegion-0-1-12"
   >
     Primary call to action
   </span>
   <div
-    className="callToAction_glyph-0-1-8"
+    className="callToAction_glyph-0-1-2"
     dangerouslySetInnerHTML={
       Object {
         "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"-4014.4 1616.998 4.4 8\\">
@@ -29,17 +29,17 @@ exports[`call to action snapshot Call to action: 0 1`] = `
 
 exports[`call to action snapshot Call to action: 1 1`] = `
 <a
-  className="button-0-1-46 button__lightweight-0-1-49 callToAction-0-1-33 callToAction__lightweight-0-1-36"
+  className="button-0-1-20 button__lightweight-0-1-23 callToAction-0-1-14 callToAction__lightweight-0-1-17"
   data-sketch-symbol="Call to action - lightweight"
   href="https://www.microsoft.com/en-us/"
 >
   <span
-    className="button_contentRegion-0-1-51"
+    className="button_contentRegion-0-1-25"
   >
     Lightweight call to action
   </span>
   <div
-    className="callToAction_glyph-0-1-34"
+    className="callToAction_glyph-0-1-15"
     dangerouslySetInnerHTML={
       Object {
         "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"-4014.4 1616.998 4.4 8\\">
@@ -56,17 +56,17 @@ exports[`call to action snapshot Call to action: 1 1`] = `
 
 exports[`call to action snapshot Call to action: 2 1`] = `
 <a
-  className="button-0-1-72 button__justified-0-1-76 callToAction-0-1-59 callToAction__justified-0-1-63"
+  className="button-0-1-33 button__justified-0-1-37 callToAction-0-1-27 callToAction__justified-0-1-31"
   data-sketch-symbol="Call to action - justified"
   href="https://www.microsoft.com/en-us/"
 >
   <span
-    className="button_contentRegion-0-1-77"
+    className="button_contentRegion-0-1-38"
   >
     Secondary call to action
   </span>
   <div
-    className="callToAction_glyph-0-1-60"
+    className="callToAction_glyph-0-1-28"
     dangerouslySetInnerHTML={
       Object {
         "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"-4014.4 1616.998 4.4 8\\">

--- a/packages/fast-components-react-msft/src/call-to-action/call-to-action.spec.tsx
+++ b/packages/fast-components-react-msft/src/call-to-action/call-to-action.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
 import * as Adapter from "enzyme-adapter-react-16/build";
-import { configure, shallow } from "enzyme";
+import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTCallToAction, {
@@ -52,7 +52,7 @@ describe("call to action", (): void => {
     });
 
     test("should implement unhandledProps", () => {
-        const handledProps: ICallToActionProps & ICallToActionManagedClasses = {
+        const handledProps: ICallToActionHandledProps & ICallToActionManagedClasses = {
             managedClasses,
             href,
             children: "text"
@@ -64,7 +64,7 @@ describe("call to action", (): void => {
 
         const props: CallToActionProps = {...handledProps, ...unhandledProps};
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <CallToAction {...props} />
         );
 
@@ -77,18 +77,11 @@ describe("call to action", (): void => {
             appearance: CallToActionAppearance.primary
         };
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <CallToAction {...props}/>
         );
 
-        const callToAction: any = rendered.first().shallow();
-        // Get the expected className value from the list of generated managed classes
-        const expectedClassName: string = callToAction.instance().props.managedClasses.callToAction__primary;
-        const rootClassName: string = callToAction.instance().props.managedClasses.callToAction;
-
-        expect(callToAction.instance().props.appearance).toEqual(CallToActionAppearance.primary);
-        // Generated managedClass should be passed to className
-        expect(callToAction.prop("className")).toBe(`${rootClassName} ${expectedClassName}`);
+        expect(rendered.find("button").prop("className")).toContain("callToAction__primary");
     });
 
     // tslint:disable-next-line:max-line-length
@@ -97,18 +90,11 @@ describe("call to action", (): void => {
             appearance: CallToActionAppearance.lightweight
         };
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <CallToAction {...props}/>
         );
 
-        const callToAction: any = rendered.first().shallow();
-        // Get the expected className value from the list of generated managed classes
-        const expectedClassName: string = callToAction.instance().props.managedClasses.callToAction__lightweight;
-        const rootClassName: string = callToAction.instance().props.managedClasses.callToAction;
-
-        expect(callToAction.instance().props.appearance).toEqual(CallToActionAppearance.lightweight);
-        // Generated managedClass should be passed to className
-        expect(callToAction.prop("className")).toBe(`${rootClassName} ${expectedClassName}`);
+        expect(rendered.find("button").prop("className")).toContain("callToAction__lightweight");
     });
 
     // tslint:disable-next-line:max-line-length
@@ -117,18 +103,11 @@ describe("call to action", (): void => {
             appearance: CallToActionAppearance.justified
         };
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <CallToAction {...props}/>
         );
 
-        const callToAction: any = rendered.first().shallow();
-        // Get the expected className value from the list of generated managed classes
-        const expectedClassName: string = callToAction.instance().props.managedClasses.callToAction__justified;
-        const rootClassName: string = callToAction.instance().props.managedClasses.callToAction;
-
-        expect(callToAction.instance().props.appearance).toEqual(CallToActionAppearance.justified);
-        // Generated managedClass should be passed to className
-        expect(callToAction.prop("className")).toBe(`${rootClassName} ${expectedClassName}`);
+        expect(rendered.find("button").prop("className")).toContain("callToAction__justified");
     });
 
     // tslint:disable-next-line:max-line-length
@@ -137,17 +116,11 @@ describe("call to action", (): void => {
             disabled: true
         };
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <CallToAction {...props}/>
         );
 
-        const callToAction: any = rendered.first().shallow();
-        // Get the expected className value from the list of generated managed classes
-        const expectedClassName: string = callToAction.instance().props.managedClasses.callToAction__disabled;
-        const rootClassName: string = callToAction.instance().props.managedClasses.callToAction;
-
-        // Generated managedClass should be passed to className
-        expect(callToAction.prop("className")).toBe(`${rootClassName} ${expectedClassName}`);
+        expect(rendered.find("button").prop("className")).toContain("callToAction__disabled");
     });
 
     // tslint:disable-next-line:max-line-length
@@ -156,34 +129,20 @@ describe("call to action", (): void => {
             appearance: CallToActionAppearance.primary
         };
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <CallToAction className={"custom-class-name"} {...props}/>
         );
 
-        const callToAction: any = rendered.first().shallow();
-        // Get the expected className value from the list of generated managed classes
-        const expectedClassName: string = callToAction.instance().props.managedClasses.callToAction__primary;
-        const rootClassName: string = callToAction.instance().props.managedClasses.callToAction;
-        const customClassName: string = "custom-class-name";
-
-        expect(callToAction.instance().props.appearance).toEqual(CallToActionAppearance.primary);
-        // Generated managedClass should be passed to className
-        expect(callToAction.prop("className")).toBe(`${rootClassName} ${expectedClassName} ${customClassName}`);
+        expect(rendered.find("button").prop("className")).toContain("custom-class-name");
+        expect(rendered.find("button").prop("className")).toContain("callToAction__primary");
     });
 
     // tslint:disable-next-line:max-line-length
-    test("should set a custom class name and root class name when a custom class name is passed", () => {
-
-        const rendered: any = shallow(
+    test("should apply a custom class-name", () => {
+        const rendered: any = mount(
             <CallToAction className={"custom-class-name"} />
         );
 
-        const callToAction: any = rendered.first().shallow();
-        // Get the expected className value from the list of generated managed classes
-        const rootClassName: string = callToAction.instance().props.managedClasses.callToAction;
-        const customClassName: string = "custom-class-name";
-
-        // Generated managedClass should be passed to className
-        expect(callToAction.prop("className")).toBe(`${rootClassName} ${customClassName}`);
+        expect(rendered.find("button").prop("className")).toContain("custom-class-name");
     });
 });

--- a/packages/fast-components-react-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-react-msft/src/call-to-action/index.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ICallToActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { CallToActionStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import MSFTCallToAction, {
     CallToActionAppearance,
@@ -17,7 +17,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const CallToAction = manageJss(CallToActionStyles)(MSFTCallToAction);
-type CallToAction = InstanceType<typeof CallToAction>;
+type CallToAction = typeof CallToAction;
 
 interface ICallToActionHandledProps extends Subtract<IMSFTCallToActionHandledProps, ICallToActionManagedClasses> {}
 type CallToActionProps = ManagedJSSProps<MSFTCallToActionProps, ICallToActionClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-react-msft/src/call-to-action/index.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ICallToActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { CallToActionStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import MSFTCallToAction, {
     CallToActionAppearance,
@@ -20,7 +20,7 @@ const CallToAction = manageJss(CallToActionStyles)(MSFTCallToAction);
 type CallToAction = InstanceType<typeof CallToAction>;
 
 interface ICallToActionHandledProps extends Subtract<IMSFTCallToActionHandledProps, ICallToActionManagedClasses> {}
-type CallToActionProps = JSSManagerProps<MSFTCallToActionProps, ICallToActionClassNameContract, IDesignSystem>;
+type CallToActionProps = ManagedJSSProps<MSFTCallToActionProps, ICallToActionClassNameContract, IDesignSystem>;
 
 export {
     CallToAction,

--- a/packages/fast-components-react-msft/src/caption/caption.spec.tsx
+++ b/packages/fast-components-react-msft/src/caption/caption.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, shallow, mount } from "enzyme";
+import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTCaption, {

--- a/packages/fast-components-react-msft/src/caption/caption.spec.tsx
+++ b/packages/fast-components-react-msft/src/caption/caption.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, shallow } from "enzyme";
+import { configure, shallow, mount } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTCaption, {
@@ -35,7 +35,7 @@ describe("caption", (): void => {
         ).not.toThrow();
     });
 
-    test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
+    test("should accept unhandledProps", () => {
         const handledProps: ICaptionHandledProps = {
             tag: CaptionTag.p,
             size: CaptionSize._1
@@ -47,30 +47,26 @@ describe("caption", (): void => {
 
         const props: ICaptionHandledProps & ICaptionUnhandledProps = {...handledProps, ...unhandledProps};
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Caption {...props} />
         );
 
-        const caption: any = rendered.first().shallow();
-
-        expect(caption.prop("aria-hidden")).toEqual(true);
+        expect(rendered.find(handledProps.tag).prop("aria-hidden")).toEqual(true);
     });
 
     test("should render a default `tag` of `CaptionTag.p` if no `tag` prop is passed", () => {
-        const rendered: any = shallow(
-            <Caption />
+        const rendered: any = mount(
+            <MSFTCaption />
         );
-        const caption: any = rendered.first().shallow();
 
-        expect(caption.instance().props.tag).toEqual(CaptionTag.p);
+        expect(rendered.prop("tag")).toEqual(CaptionTag.p);
     });
 
     test("should render the correct `size` when `size` prop is passed", () => {
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Caption size={CaptionSize._2} />
         );
-        const caption: any = rendered.first().shallow();
 
-        expect(caption.instance().props.size).toEqual(CaptionSize._2);
+        expect(rendered.find("p").prop("className")).toContain("caption__2");
     });
 });

--- a/packages/fast-components-react-msft/src/caption/index.ts
+++ b/packages/fast-components-react-msft/src/caption/index.ts
@@ -8,7 +8,7 @@ import MSFTCaption, {
     ICaptionUnhandledProps
 } from "./caption";
 import { ICaptionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { CaptionStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -18,7 +18,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Caption = manageJss(CaptionStyles)(MSFTCaption);
-type Caption = InstanceType<typeof Caption>;
+type Caption = typeof Caption;
 
 interface ICaptionHandledProps extends Subtract<IMSFTCaptionHandledProps, ICaptionManagedClasses> {}
 type CaptionProps = ManagedJSSProps<MSFTCaptionProps, ICaptionClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/caption/index.ts
+++ b/packages/fast-components-react-msft/src/caption/index.ts
@@ -8,7 +8,7 @@ import MSFTCaption, {
     ICaptionUnhandledProps
 } from "./caption";
 import { ICaptionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { CaptionStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -21,7 +21,7 @@ const Caption = manageJss(CaptionStyles)(MSFTCaption);
 type Caption = InstanceType<typeof Caption>;
 
 interface ICaptionHandledProps extends Subtract<IMSFTCaptionHandledProps, ICaptionManagedClasses> {}
-type CaptionProps = JSSManagerProps<MSFTCaptionProps, ICaptionClassNameContract, IDesignSystem>;
+type CaptionProps = ManagedJSSProps<MSFTCaptionProps, ICaptionClassNameContract, IDesignSystem>;
 
 export {
     Caption,

--- a/packages/fast-components-react-msft/src/card/index.ts
+++ b/packages/fast-components-react-msft/src/card/index.ts
@@ -8,16 +8,16 @@ import {
     ICardManagedClasses,
     ICardUnhandledProps
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { CardStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
 /*tslint:disable-next-line:typedef */
 const Card = manageJss(CardStyles)(BaseCard);
-type Card = InstanceType<typeof Card>;
+type Card = typeof Card;
 
 interface ICardHandledProps extends Subtract<IBaseCardHandledProps, ICardManagedClasses> {}
-type CardProps = JSSManagerProps<BaseCardProps, ICardClassNameContract, IDesignSystem>;
+type CardProps = ManagedJSSProps<BaseCardProps, ICardClassNameContract, IDesignSystem>;
 
 export {
     Card,

--- a/packages/fast-components-react-msft/src/checkbox/__snapshots__/checkbox.spec.ts.snap
+++ b/packages/fast-components-react-msft/src/checkbox/__snapshots__/checkbox.spec.ts.snap
@@ -2,6 +2,28 @@
 
 exports[`checkbox snapshots Checkbox: 0 1`] = `
 <label
+  className="checkbox-0-1-1"
+>
+  <input
+    checked={false}
+    className="checkbox_input-0-1-2"
+    disabled={null}
+    onChange={[Function]}
+    type="checkbox"
+  />
+  <span
+    className="checkbox_stateIndicator-0-1-3"
+  />
+  <span
+    className="checkbox_label-0-1-4"
+  >
+    Default
+  </span>
+</label>
+`;
+
+exports[`checkbox snapshots Checkbox: 1 1`] = `
+<div
   className="checkbox-0-1-6"
 >
   <input
@@ -17,19 +39,41 @@ exports[`checkbox snapshots Checkbox: 0 1`] = `
   <span
     className="checkbox_label-0-1-9"
   >
-    Default
+    div tag
+  </span>
+</div>
+`;
+
+exports[`checkbox snapshots Checkbox: 2 1`] = `
+<label
+  className="checkbox-0-1-11"
+>
+  <input
+    checked={true}
+    className="checkbox_input-0-1-12"
+    disabled={null}
+    onChange={[Function]}
+    type="checkbox"
+  />
+  <span
+    className="checkbox_stateIndicator-0-1-13"
+  />
+  <span
+    className="checkbox_label-0-1-14"
+  >
+    Checked (controlled)
   </span>
 </label>
 `;
 
-exports[`checkbox snapshots Checkbox: 1 1`] = `
-<div
-  className="checkbox-0-1-16"
+exports[`checkbox snapshots Checkbox: 3 1`] = `
+<label
+  className="checkbox-0-1-16 checkbox__disabled-0-1-20"
 >
   <input
     checked={false}
     className="checkbox_input-0-1-17"
-    disabled={null}
+    disabled={true}
     onChange={[Function]}
     type="checkbox"
   />
@@ -39,12 +83,34 @@ exports[`checkbox snapshots Checkbox: 1 1`] = `
   <span
     className="checkbox_label-0-1-19"
   >
-    div tag
+    Disabled
   </span>
-</div>
+</label>
 `;
 
-exports[`checkbox snapshots Checkbox: 2 1`] = `
+exports[`checkbox snapshots Checkbox: 4 1`] = `
+<label
+  className="checkbox-0-1-21"
+>
+  <input
+    checked={false}
+    className="checkbox_input-0-1-22"
+    disabled={null}
+    onChange={[Function]}
+    type="checkbox"
+  />
+  <span
+    className="checkbox_stateIndicator-0-1-23"
+  />
+  <span
+    className="checkbox_label-0-1-24"
+  >
+    Indeterminate
+  </span>
+</label>
+`;
+
+exports[`checkbox snapshots Checkbox: 5 1`] = `
 <label
   className="checkbox-0-1-26"
 >
@@ -60,72 +126,6 @@ exports[`checkbox snapshots Checkbox: 2 1`] = `
   />
   <span
     className="checkbox_label-0-1-29"
-  >
-    Checked (controlled)
-  </span>
-</label>
-`;
-
-exports[`checkbox snapshots Checkbox: 3 1`] = `
-<label
-  className="checkbox-0-1-36 checkbox__disabled-0-1-40"
->
-  <input
-    checked={false}
-    className="checkbox_input-0-1-37"
-    disabled={true}
-    onChange={[Function]}
-    type="checkbox"
-  />
-  <span
-    className="checkbox_stateIndicator-0-1-38"
-  />
-  <span
-    className="checkbox_label-0-1-39"
-  >
-    Disabled
-  </span>
-</label>
-`;
-
-exports[`checkbox snapshots Checkbox: 4 1`] = `
-<label
-  className="checkbox-0-1-46"
->
-  <input
-    checked={false}
-    className="checkbox_input-0-1-47"
-    disabled={null}
-    onChange={[Function]}
-    type="checkbox"
-  />
-  <span
-    className="checkbox_stateIndicator-0-1-48"
-  />
-  <span
-    className="checkbox_label-0-1-49"
-  >
-    Indeterminate
-  </span>
-</label>
-`;
-
-exports[`checkbox snapshots Checkbox: 5 1`] = `
-<label
-  className="checkbox-0-1-56"
->
-  <input
-    checked={true}
-    className="checkbox_input-0-1-57"
-    disabled={null}
-    onChange={[Function]}
-    type="checkbox"
-  />
-  <span
-    className="checkbox_stateIndicator-0-1-58"
-  />
-  <span
-    className="checkbox_label-0-1-59"
   >
     Indeterminate checked (controlled)
   </span>

--- a/packages/fast-components-react-msft/src/checkbox/index.ts
+++ b/packages/fast-components-react-msft/src/checkbox/index.ts
@@ -8,7 +8,7 @@ import {
     ICheckboxManagedClasses,
     ICheckboxUnhandledProps
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { CheckboxStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -21,7 +21,7 @@ const Checkbox = manageJss(CheckboxStyles)(BaseCheckbox);
 type Checkbox = InstanceType<typeof Checkbox>;
 
 interface ICheckboxHandledProps extends Subtract<IMSFTCheckboxHandledProps, ICheckboxManagedClasses> {}
-type CheckboxProps = JSSManagerProps<MSFTCheckboxProps, ICheckboxClassNameContract, IDesignSystem>;
+type CheckboxProps = ManagedJSSProps<MSFTCheckboxProps, ICheckboxClassNameContract, IDesignSystem>;
 
 export {
     Checkbox,

--- a/packages/fast-components-react-msft/src/checkbox/index.ts
+++ b/packages/fast-components-react-msft/src/checkbox/index.ts
@@ -8,7 +8,7 @@ import {
     ICheckboxManagedClasses,
     ICheckboxUnhandledProps
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { CheckboxStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -18,7 +18,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Checkbox = manageJss(CheckboxStyles)(BaseCheckbox);
-type Checkbox = InstanceType<typeof Checkbox>;
+type Checkbox = typeof Checkbox;
 
 interface ICheckboxHandledProps extends Subtract<IMSFTCheckboxHandledProps, ICheckboxManagedClasses> {}
 type CheckboxProps = ManagedJSSProps<MSFTCheckboxProps, ICheckboxClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/dialog/__snapshots__/dialog.spec.ts.snap
+++ b/packages/fast-components-react-msft/src/dialog/__snapshots__/dialog.spec.ts.snap
@@ -3,13 +3,13 @@
 exports[`dialog snapshots Dialog: 0 1`] = `
 <div
   aria-hidden={true}
-  className="dialog-0-1-4"
+  className="dialog-0-1-1"
 >
   <div
     aria-describedby={undefined}
     aria-label={undefined}
     aria-labelledby={undefined}
-    className="dialog_contentRegion-0-1-6"
+    className="dialog_contentRegion-0-1-3"
     role="dialog"
     style={
       Object {
@@ -25,10 +25,10 @@ exports[`dialog snapshots Dialog: 0 1`] = `
 exports[`dialog snapshots Dialog: 1 1`] = `
 <div
   aria-hidden={true}
-  className="dialog-0-1-10"
+  className="dialog-0-1-4"
 >
   <div
-    className="dialog_modalOverlay-0-1-11"
+    className="dialog_modalOverlay-0-1-5"
     onClick={[Function]}
     role="presentation"
     tabIndex={-1}
@@ -37,7 +37,7 @@ exports[`dialog snapshots Dialog: 1 1`] = `
     aria-describedby={undefined}
     aria-label={undefined}
     aria-labelledby={undefined}
-    className="dialog_contentRegion-0-1-12"
+    className="dialog_contentRegion-0-1-6"
     role="dialog"
     style={
       Object {

--- a/packages/fast-components-react-msft/src/dialog/index.ts
+++ b/packages/fast-components-react-msft/src/dialog/index.ts
@@ -7,7 +7,7 @@ import {
     IDialogManagedClasses,
     IDialogUnhandledProps
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { DialogStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -17,7 +17,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Dialog = manageJss(DialogStyles)(BaseDialog);
-type Dialog = InstanceType<typeof Dialog>;
+type Dialog = typeof Dialog;
 
 interface IDialogHandledProps extends Subtract<IBaseDialogHandledProps, IDialogManagedClasses> {}
 type DialogProps = ManagedJSSProps<BaseDialogProps, IDialogClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/dialog/index.ts
+++ b/packages/fast-components-react-msft/src/dialog/index.ts
@@ -7,7 +7,7 @@ import {
     IDialogManagedClasses,
     IDialogUnhandledProps
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { DialogStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -20,7 +20,7 @@ const Dialog = manageJss(DialogStyles)(BaseDialog);
 type Dialog = InstanceType<typeof Dialog>;
 
 interface IDialogHandledProps extends Subtract<IBaseDialogHandledProps, IDialogManagedClasses> {}
-type DialogProps = JSSManagerProps<BaseDialogProps, IDialogClassNameContract, IDesignSystem>;
+type DialogProps = ManagedJSSProps<BaseDialogProps, IDialogClassNameContract, IDesignSystem>;
 
 export {
     Dialog,

--- a/packages/fast-components-react-msft/src/divider/__snapshots__/divider.spec.ts.snap
+++ b/packages/fast-components-react-msft/src/divider/__snapshots__/divider.spec.ts.snap
@@ -2,20 +2,20 @@
 
 exports[`divider snapshots Divider: 0 1`] = `
 <hr
-  className="divider-0-1-2"
+  className="divider-0-1-1"
   data-sketch-symbol="Divider"
 />
 `;
 
 exports[`divider snapshots Divider: 1 1`] = `
 <hr
-  className="divider-0-1-4"
+  className="divider-0-1-2"
   role="presentation"
 />
 `;
 
 exports[`divider snapshots Divider: 2 1`] = `
 <hr
-  className="divider-0-1-6"
+  className="divider-0-1-3"
 />
 `;

--- a/packages/fast-components-react-msft/src/divider/index.ts
+++ b/packages/fast-components-react-msft/src/divider/index.ts
@@ -8,7 +8,7 @@ import {
     IDividerManagedClasses,
     IDividerUnhandledProps
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { DividerStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -21,7 +21,7 @@ const Divider =  manageJss(DividerStyles)(BaseDivider);
 type Divider = InstanceType<typeof Divider>;
 
 interface IDividerHandledProps extends Subtract<IBaseDividerHandledProps, IDividerManagedClasses> {}
-type DividerProps = JSSManagerProps<BaseDividerProps, IDividerClassNameContract, IDesignSystem>;
+type DividerProps = ManagedJSSProps<BaseDividerProps, IDividerClassNameContract, IDesignSystem>;
 
 export {
     Divider,

--- a/packages/fast-components-react-msft/src/divider/index.ts
+++ b/packages/fast-components-react-msft/src/divider/index.ts
@@ -8,7 +8,7 @@ import {
     IDividerManagedClasses,
     IDividerUnhandledProps
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { DividerStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -18,7 +18,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Divider =  manageJss(DividerStyles)(BaseDivider);
-type Divider = InstanceType<typeof Divider>;
+type Divider = typeof Divider;
 
 interface IDividerHandledProps extends Subtract<IBaseDividerHandledProps, IDividerManagedClasses> {}
 type DividerProps = ManagedJSSProps<BaseDividerProps, IDividerClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/flipper/__snapshots__/flipper.spec.tsx.snap
+++ b/packages/fast-components-react-msft/src/flipper/__snapshots__/flipper.spec.tsx.snap
@@ -3,8 +3,22 @@
 exports[`flipper snapshots Flipper: 0 1`] = `
 <button
   aria-hidden={true}
-  className="flipper-0-1-5 flipper__next-0-1-7"
+  className="flipper-0-1-1 flipper__next-0-1-3"
   data-sketch-symbol="Flipper - default"
+  href={null}
+  tabIndex={-1}
+>
+  <span
+    className="flipper_glyph-0-1-2"
+  />
+</button>
+`;
+
+exports[`flipper snapshots Flipper: 1 1`] = `
+<button
+  aria-hidden={true}
+  className="flipper-0-1-5 flipper__previous-0-1-8"
+  direction="previous"
   href={null}
   tabIndex={-1}
 >
@@ -14,32 +28,18 @@ exports[`flipper snapshots Flipper: 0 1`] = `
 </button>
 `;
 
-exports[`flipper snapshots Flipper: 1 1`] = `
-<button
-  aria-hidden={true}
-  className="flipper-0-1-13 flipper__previous-0-1-16"
-  direction="previous"
-  href={null}
-  tabIndex={-1}
->
-  <span
-    className="flipper_glyph-0-1-14"
-  />
-</button>
-`;
-
 exports[`flipper snapshots Flipper: 2 1`] = `
 <button
   aria-hidden={true}
   aria-label="See next"
-  className="flipper-0-1-21 flipper__next-0-1-23"
+  className="flipper-0-1-9 flipper__next-0-1-11"
   direction="next"
   href={null}
   tabIndex={-1}
   visible={true}
 >
   <span
-    className="flipper_glyph-0-1-22"
+    className="flipper_glyph-0-1-10"
   />
 </button>
 `;
@@ -48,14 +48,14 @@ exports[`flipper snapshots Flipper: 3 1`] = `
 <button
   aria-hidden={true}
   aria-label="See previous"
-  className="flipper-0-1-29 flipper__previous-0-1-32"
+  className="flipper-0-1-13 flipper__previous-0-1-16"
   direction="previous"
   href={null}
   tabIndex={-1}
   visible={true}
 >
   <span
-    className="flipper_glyph-0-1-30"
+    className="flipper_glyph-0-1-14"
   />
 </button>
 `;

--- a/packages/fast-components-react-msft/src/flipper/flipper.spec.tsx
+++ b/packages/fast-components-react-msft/src/flipper/flipper.spec.tsx
@@ -101,7 +101,7 @@ describe("flipper", (): void => {
 
         const flipper: any = rendered.first().first();
 
-        expect(flipper.props("label")).toBe("Test aria-label");
+        expect(rendered.prop("label")).toBe("Test aria-label");
         expect(rendered.exists(`[aria-label="${props.label}"]`)).toBe(true);
     });
 });

--- a/packages/fast-components-react-msft/src/flipper/flipper.spec.tsx
+++ b/packages/fast-components-react-msft/src/flipper/flipper.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, shallow } from "enzyme";
+import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTFlipper, {
@@ -44,13 +44,11 @@ describe("flipper", (): void => {
 
         const props: IFlipperHandledProps & IFlipperUnhandledProps = {...handledProps, ...unhandledProps};
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Flipper {...props} />
         );
 
-        const flipper: any = rendered.first().shallow();
-
-        expect(flipper.prop("aria-labelledby")).toEqual("foo");
+        expect(rendered.find("button").props()["aria-labelledby"]).toEqual("foo");
     });
 
     test("should set an attribute of `tabindex` to -1 if `visibility` prop is false", () => {
@@ -58,13 +56,11 @@ describe("flipper", (): void => {
             visibleToAssistiveTechnologies: false
         };
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Flipper {...props} />
         );
 
-        const flipper: any = rendered.first().shallow();
-
-        expect(flipper.prop("tabIndex")).toEqual(-1);
+        expect(rendered.find("button").props().tabIndex).toEqual(-1);
     });
 
     test("should set an attribute of `aria-hidden` to true if `visibility` prop is false", () => {
@@ -72,13 +68,11 @@ describe("flipper", (): void => {
             visibleToAssistiveTechnologies: false
         };
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Flipper {...props} />
         );
 
-        const flipper: any = rendered.first().shallow();
-
-        expect(flipper.prop("aria-hidden")).toEqual(true);
+        expect(rendered.find("button").props()["aria-hidden"]).toEqual(true);
     });
 
     test("should not set an attribute of `aria-label` if no label is passed", () => {
@@ -86,11 +80,11 @@ describe("flipper", (): void => {
             visibleToAssistiveTechnologies: false
         };
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Flipper {...props} />
         );
 
-        const flipper: any = rendered.first().shallow();
+        const flipper: any = rendered.first().first();
 
         expect(flipper.prop("aria-label")).toBe(undefined);
     });
@@ -101,13 +95,13 @@ describe("flipper", (): void => {
             label: "Test aria-label"
         };
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Flipper {...props} />
         );
 
-        const flipper: any = rendered.first().shallow();
+        const flipper: any = rendered.first().first();
 
-        expect(flipper.instance().props.label).toBe("Test aria-label");
-        expect(flipper.prop("aria-label")).toBe("Test aria-label");
+        expect(flipper.props("label")).toBe("Test aria-label");
+        expect(rendered.exists(`[aria-label="${props.label}"]`)).toBe(true);
     });
 });

--- a/packages/fast-components-react-msft/src/flipper/index.ts
+++ b/packages/fast-components-react-msft/src/flipper/index.ts
@@ -5,7 +5,7 @@ import {
     IButtonUnhandledProps
 } from "@microsoft/fast-components-react-base";
 import { IFlipperClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { FlipperStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import MSFTFlipper, {
     FlipperDirection,
@@ -22,7 +22,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Flipper = manageJss(FlipperStyles)(MSFTFlipper);
-type Flipper = InstanceType<typeof Flipper>;
+type Flipper = typeof Flipper;
 
 interface IFlipperHandledProps extends Subtract<IMSFTFlipperHandledProps, IFlipperManagedClasses> {}
 type FlipperProps = ManagedJSSProps<MSFTFlipperProps, IFlipperClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/flipper/index.ts
+++ b/packages/fast-components-react-msft/src/flipper/index.ts
@@ -5,7 +5,7 @@ import {
     IButtonUnhandledProps
 } from "@microsoft/fast-components-react-base";
 import { IFlipperClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { FlipperStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import MSFTFlipper, {
     FlipperDirection,
@@ -25,7 +25,7 @@ const Flipper = manageJss(FlipperStyles)(MSFTFlipper);
 type Flipper = InstanceType<typeof Flipper>;
 
 interface IFlipperHandledProps extends Subtract<IMSFTFlipperHandledProps, IFlipperManagedClasses> {}
-type FlipperProps = JSSManagerProps<MSFTFlipperProps, IFlipperClassNameContract, IDesignSystem>;
+type FlipperProps = ManagedJSSProps<MSFTFlipperProps, IFlipperClassNameContract, IDesignSystem>;
 
 export {
     Flipper,

--- a/packages/fast-components-react-msft/src/heading/heading.spec.tsx
+++ b/packages/fast-components-react-msft/src/heading/heading.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, shallow } from "enzyme";
+import { configure, shallow, mount } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTHeading, {
@@ -37,7 +37,7 @@ describe("heading", (): void => {
         ).not.toThrow();
     });
 
-    test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
+    test("should accept unhandledProps", () => {
         const handledProps: IHeadingHandledProps = {
             tag: HeadingTag.h1,
             size: HeadingSize._1
@@ -49,21 +49,18 @@ describe("heading", (): void => {
 
         const props: IHeadingHandledProps & IHeadingUnhandledProps = {...handledProps, ...unhandledProps};
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Heading {...props} />
         );
 
-        const heading: any = rendered.first().shallow();
-
-        expect(heading.prop("aria-hidden")).toEqual(true);
+        expect(rendered.find(handledProps.tag).prop("aria-hidden")).toEqual(true);
     });
 
     test("should render the correct `tag` when `tag` prop is passed", () => {
-        const rendered: any = shallow(
-            <Heading tag={HeadingTag.h3} />
+        const rendered: any = mount(
+            <MSFTHeading tag={HeadingTag.h3} />
         );
-        const heading: any = rendered.first().shallow();
 
-        expect(heading.instance().props.tag).toEqual(HeadingTag.h3);
+        expect(rendered.exists(HeadingTag.h3)).toBe(true);
     });
 });

--- a/packages/fast-components-react-msft/src/heading/heading.spec.tsx
+++ b/packages/fast-components-react-msft/src/heading/heading.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, shallow, mount } from "enzyme";
+import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTHeading, {

--- a/packages/fast-components-react-msft/src/heading/index.ts
+++ b/packages/fast-components-react-msft/src/heading/index.ts
@@ -10,7 +10,7 @@ import MSFTHeading, {
     IHeadingManagedClasses,
     IHeadingUnhandledProps
 } from "./heading";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { HeadingStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -23,7 +23,7 @@ const Heading = manageJss(HeadingStyles)(MSFTHeading);
 type Heading = InstanceType<typeof Heading>;
 
 interface IHeadingHandledProps extends Subtract<IMSFTHeadingHandledProps, IHeadingManagedClasses> {}
-type HeadingProps = JSSManagerProps<MSFTHeadingProps, IHeadingClassNameContract, IDesignSystem>;
+type HeadingProps = ManagedJSSProps<MSFTHeadingProps, IHeadingClassNameContract, IDesignSystem>;
 
 export {
     HeadingAlignBaseline,

--- a/packages/fast-components-react-msft/src/heading/index.ts
+++ b/packages/fast-components-react-msft/src/heading/index.ts
@@ -10,7 +10,7 @@ import MSFTHeading, {
     IHeadingManagedClasses,
     IHeadingUnhandledProps
 } from "./heading";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { HeadingStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -20,7 +20,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Heading = manageJss(HeadingStyles)(MSFTHeading);
-type Heading = InstanceType<typeof Heading>;
+type Heading = typeof Heading;
 
 interface IHeadingHandledProps extends Subtract<IMSFTHeadingHandledProps, IHeadingManagedClasses> {}
 type HeadingProps = ManagedJSSProps<MSFTHeadingProps, IHeadingClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/hypertext/index.ts
+++ b/packages/fast-components-react-msft/src/hypertext/index.ts
@@ -7,7 +7,7 @@ import {
     IHypertextManagedClasses,
     IHypertextUnhandledProps
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { HypertextStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -17,7 +17,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Hypertext = manageJss(HypertextStyles)(BaseHypertext);
-type Hypertext = InstanceType<typeof Hypertext>;
+type Hypertext = typeof Hypertext;
 
 interface IHypertextHandledProps extends Subtract<IBaseHypertextHandledProps, IHypertextManagedClasses> {}
 type HypertextProps = ManagedJSSProps<BaseHypertextProps, IHypertextClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/hypertext/index.ts
+++ b/packages/fast-components-react-msft/src/hypertext/index.ts
@@ -7,7 +7,7 @@ import {
     IHypertextManagedClasses,
     IHypertextUnhandledProps
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { HypertextStyles, IDesignSystem } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -20,7 +20,7 @@ const Hypertext = manageJss(HypertextStyles)(BaseHypertext);
 type Hypertext = InstanceType<typeof Hypertext>;
 
 interface IHypertextHandledProps extends Subtract<IBaseHypertextHandledProps, IHypertextManagedClasses> {}
-type HypertextProps = JSSManagerProps<BaseHypertextProps, IHypertextClassNameContract, IDesignSystem>;
+type HypertextProps = ManagedJSSProps<BaseHypertextProps, IHypertextClassNameContract, IDesignSystem>;
 
 export {
     Hypertext,

--- a/packages/fast-components-react-msft/src/image/index.ts
+++ b/packages/fast-components-react-msft/src/image/index.ts
@@ -9,7 +9,7 @@ import {
     ImageProps as IBaseImageProps,
     ImageSlot
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, ImageStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -19,7 +19,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Image = manageJss(ImageStyles)(BaseImage);
-type Image = InstanceType<typeof Image>;
+type Image = typeof Image;
 
 interface IImageHandledProps extends Subtract<IBaseImageHandledProps, IImageManagedClasses> {}
 type ImageProps = ManagedJSSProps<IBaseImageProps, IImageClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/image/index.ts
+++ b/packages/fast-components-react-msft/src/image/index.ts
@@ -9,7 +9,7 @@ import {
     ImageProps as IBaseImageProps,
     ImageSlot
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, ImageStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -22,7 +22,7 @@ const Image = manageJss(ImageStyles)(BaseImage);
 type Image = InstanceType<typeof Image>;
 
 interface IImageHandledProps extends Subtract<IBaseImageHandledProps, IImageManagedClasses> {}
-type ImageProps = JSSManagerProps<IBaseImageProps, IImageClassNameContract, IDesignSystem>;
+type ImageProps = ManagedJSSProps<IBaseImageProps, IImageClassNameContract, IDesignSystem>;
 
 export {
     IImageClassNameContract,

--- a/packages/fast-components-react-msft/src/label/index.ts
+++ b/packages/fast-components-react-msft/src/label/index.ts
@@ -9,7 +9,7 @@ import {
     LabelProps as BaseLabelProps,
     LabelTag
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, LabelStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -22,7 +22,7 @@ const Label = manageJss(LabelStyles)(BaseLabel);
 type Label = InstanceType<typeof Label>;
 
 interface ILabelHandledProps extends Subtract<IBaseLabelHandledProps, ILabelManagedClasses> {}
-type LabelProps = JSSManagerProps<BaseLabelProps, ILabelClassNameContract, IDesignSystem>;
+type LabelProps = ManagedJSSProps<BaseLabelProps, ILabelClassNameContract, IDesignSystem>;
 
 export {
     ILabelClassNameContract,

--- a/packages/fast-components-react-msft/src/label/index.ts
+++ b/packages/fast-components-react-msft/src/label/index.ts
@@ -9,7 +9,7 @@ import {
     LabelProps as BaseLabelProps,
     LabelTag
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, LabelStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -19,7 +19,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Label = manageJss(LabelStyles)(BaseLabel);
-type Label = InstanceType<typeof Label>;
+type Label = typeof Label;
 
 interface ILabelHandledProps extends Subtract<IBaseLabelHandledProps, ILabelManagedClasses> {}
 type LabelProps = ManagedJSSProps<BaseLabelProps, ILabelClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/metatext/__snapshots__/metatext.spec.tsx.snap
+++ b/packages/fast-components-react-msft/src/metatext/__snapshots__/metatext.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`metatext snapshots Metatext: 0 1`] = `
 <span
-  className="typography-0-1-3 typography__7-0-1-10 metatext-0-1-2"
+  className="typography-0-1-2 typography__7-0-1-9 metatext-0-1-1"
 >
   Metatext test string
 </span>
@@ -10,7 +10,7 @@ exports[`metatext snapshots Metatext: 0 1`] = `
 
 exports[`metatext snapshots Metatext: 1 1`] = `
 <p
-  className="typography-0-1-15 typography__7-0-1-22 metatext-0-1-14"
+  className="typography-0-1-13 typography__7-0-1-20 metatext-0-1-12"
   data-sketch-symbol="Metatext"
 >
   Metatext test string
@@ -19,7 +19,7 @@ exports[`metatext snapshots Metatext: 1 1`] = `
 
 exports[`metatext snapshots Metatext: 2 1`] = `
 <span
-  className="typography-0-1-27 typography__7-0-1-34 metatext-0-1-26"
+  className="typography-0-1-24 typography__7-0-1-31 metatext-0-1-23"
 >
   Metatext test string
 </span>

--- a/packages/fast-components-react-msft/src/metatext/index.ts
+++ b/packages/fast-components-react-msft/src/metatext/index.ts
@@ -8,7 +8,7 @@ import MSFTMetatext, {
     MetatextProps as MSFTMetatextProps,
     MetatextTag
 } from "./metatext";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, MetatextStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -18,7 +18,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Metatext = manageJss(MetatextStyles)(MSFTMetatext);
-type Metatext = InstanceType<typeof Metatext>;
+type Metatext = typeof Metatext;
 
 interface IMetatextHandledProps extends Subtract<IMSFTMetatextHandledProps, IMetatextManagedClasses> {}
 type MetatextProps = ManagedJSSProps<MSFTMetatextProps, IMetatextClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/metatext/index.ts
+++ b/packages/fast-components-react-msft/src/metatext/index.ts
@@ -8,7 +8,7 @@ import MSFTMetatext, {
     MetatextProps as MSFTMetatextProps,
     MetatextTag
 } from "./metatext";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, MetatextStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -21,7 +21,7 @@ const Metatext = manageJss(MetatextStyles)(MSFTMetatext);
 type Metatext = InstanceType<typeof Metatext>;
 
 interface IMetatextHandledProps extends Subtract<IMSFTMetatextHandledProps, IMetatextManagedClasses> {}
-type MetatextProps = JSSManagerProps<MSFTMetatextProps, IMetatextClassNameContract, IDesignSystem>;
+type MetatextProps = ManagedJSSProps<MSFTMetatextProps, IMetatextClassNameContract, IDesignSystem>;
 
 export {
     Metatext,

--- a/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
+++ b/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, shallow, mount } from "enzyme";
+import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTMetatext, {

--- a/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
+++ b/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, shallow } from "enzyme";
+import { configure, shallow, mount } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTMetatext, {
@@ -34,7 +34,7 @@ describe("metatext", (): void => {
         ).not.toThrow();
     });
 
-    test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
+    test("should accept unhandledProps", () => {
         const handledProps: IMetatextHandledProps = {
             tag: MetatextTag.p
         };
@@ -45,21 +45,18 @@ describe("metatext", (): void => {
 
         const props: IMetatextHandledProps & IMetatextUnhandledProps = {...handledProps, ...unhandledProps};
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Metatext {...props} />
         );
 
-        const paragraph: any = rendered.first().shallow();
-
-        expect(paragraph.prop("aria-hidden")).toEqual(true);
+        expect(rendered.find(MetatextTag.p).prop("aria-hidden")).toEqual(true);
     });
 
     test("should render the correct `tag` when `tag` prop is passed", () => {
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Metatext tag={MetatextTag.p} />
         );
-        const paragraph: any = rendered.first().shallow();
 
-        expect(paragraph.instance().props.tag).toEqual(MetatextTag.p);
+        expect(rendered.exists(MetatextTag.p)).toBe(true);
     });
 });

--- a/packages/fast-components-react-msft/src/paragraph/index.ts
+++ b/packages/fast-components-react-msft/src/paragraph/index.ts
@@ -8,7 +8,7 @@ import MSFTParagraph, {
     ParagraphProps as MSFTParagraphProps,
     ParagraphSize
 } from "./paragraph";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, ParagraphStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -18,7 +18,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Paragraph = manageJss(ParagraphStyles)(MSFTParagraph);
-type Paragraph = InstanceType<typeof Paragraph>;
+type Paragraph = typeof Paragraph;
 
 interface IParagraphHandledProps extends Subtract<IMSFTParagraphHandledProps, IParagraphManagedClasses> {}
 type ParagraphProps = ManagedJSSProps<MSFTParagraphProps, IParagraphClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/paragraph/index.ts
+++ b/packages/fast-components-react-msft/src/paragraph/index.ts
@@ -8,7 +8,7 @@ import MSFTParagraph, {
     ParagraphProps as MSFTParagraphProps,
     ParagraphSize
 } from "./paragraph";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, ParagraphStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -21,7 +21,7 @@ const Paragraph = manageJss(ParagraphStyles)(MSFTParagraph);
 type Paragraph = InstanceType<typeof Paragraph>;
 
 interface IParagraphHandledProps extends Subtract<IMSFTParagraphHandledProps, IParagraphManagedClasses> {}
-type ParagraphProps = JSSManagerProps<MSFTParagraphProps, IParagraphClassNameContract, IDesignSystem>;
+type ParagraphProps = ManagedJSSProps<MSFTParagraphProps, IParagraphClassNameContract, IDesignSystem>;
 
 export {
     Paragraph,

--- a/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
+++ b/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, shallow } from "enzyme";
+import { configure, shallow, mount } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTParagraph, {
@@ -46,30 +46,26 @@ describe("paragraph", (): void => {
 
         const props: IParagraphHandledProps & IParagraphUnhandledProps = {...handledProps, ...unhandledProps};
 
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Paragraph {...props} />
         );
 
-        const paragraph: any = rendered.first().shallow();
-
-        expect(paragraph.prop("aria-hidden")).toEqual(true);
+        expect(rendered.exists("[aria-hidden]")).toEqual(true);
     });
 
     test("should render the correct `size` when `size` prop is passed", () => {
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Paragraph size={ParagraphSize._2} />
         );
-        const paragraph: any = rendered.first().shallow();
 
-        expect(paragraph.instance().props.size).toEqual(ParagraphSize._2);
+        expect(rendered.find("p").prop("className")).toContain("paragraph__2");
     });
 
     test("should render a default `size` of `ParagraphSize._3` if no `size` prop is passed", () => {
-        const rendered: any = shallow(
+        const rendered: any = mount(
             <Paragraph />
         );
-        const paragraph: any = rendered.first().shallow();
 
-        expect(paragraph.instance().props.size).toEqual(ParagraphSize._3);
+        expect(rendered.find("p").prop("className")).toContain("paragraph__3");
     });
 });

--- a/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
+++ b/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
@@ -63,9 +63,9 @@ describe("paragraph", (): void => {
 
     test("should render a default `size` of `ParagraphSize._3` if no `size` prop is passed", () => {
         const rendered: any = mount(
-            <Paragraph />
+            <MSFTParagraph />
         );
 
-        expect(rendered.find("p").prop("className")).toContain("paragraph__3");
+        expect(rendered.prop("size")).toBe(ParagraphSize._3);
     });
 });

--- a/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
+++ b/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, shallow, mount } from "enzyme";
+import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTParagraph, {

--- a/packages/fast-components-react-msft/src/progress/__snapshots__/progress.spec.tsx.snap
+++ b/packages/fast-components-react-msft/src/progress/__snapshots__/progress.spec.tsx.snap
@@ -5,15 +5,15 @@ exports[`progress snapshots Progress: 0 1`] = `
   aria-valuemax={100}
   aria-valuemin={0}
   aria-valuenow={50}
-  className="progress-0-1-11"
+  className="progress-0-1-1"
   role="progressbar"
 >
   <div
-    className="progress_indicator-0-1-13 progress_indicator__determinate-0-1-14"
+    className="progress_indicator-0-1-3 progress_indicator__determinate-0-1-4"
     slot="determinate"
   >
     <div
-      className="progress_valueIndicator-0-1-12"
+      className="progress_valueIndicator-0-1-2"
       style={
         Object {
           "width": "50%",
@@ -29,27 +29,27 @@ exports[`progress snapshots Progress: 1 1`] = `
   aria-valuemax={100}
   aria-valuemin={0}
   aria-valuenow={undefined}
-  className="progress-0-1-31"
+  className="progress-0-1-11"
   role="progressbar"
 >
   <div
-    className="progress_indicator-0-1-33"
+    className="progress_indicator-0-1-13"
     slot="indeterminate"
   >
     <span
-      className="progress_dot-0-1-35 progress_dot__1-0-1-36"
+      className="progress_dot-0-1-15 progress_dot__1-0-1-16"
     />
     <span
-      className="progress_dot-0-1-35 progress_dot__2-0-1-37"
+      className="progress_dot-0-1-15 progress_dot__2-0-1-17"
     />
     <span
-      className="progress_dot-0-1-35 progress_dot__3-0-1-38"
+      className="progress_dot-0-1-15 progress_dot__3-0-1-18"
     />
     <span
-      className="progress_dot-0-1-35 progress_dot__4-0-1-39"
+      className="progress_dot-0-1-15 progress_dot__4-0-1-19"
     />
     <span
-      className="progress_dot-0-1-35 progress_dot__5-0-1-40"
+      className="progress_dot-0-1-15 progress_dot__5-0-1-20"
     />
   </div>
 </div>

--- a/packages/fast-components-react-msft/src/progress/index.ts
+++ b/packages/fast-components-react-msft/src/progress/index.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IProgressClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, ProgressStyles } from "@microsoft/fast-components-styles-msft";
 import MSFTProgress, {
     IProgressHandledProps as IMSFTProgressHandledProps,
@@ -18,7 +18,7 @@ const Progress = manageJss(ProgressStyles)(MSFTProgress);
 type Progress = InstanceType<typeof Progress>;
 
 interface IProgressHandledProps extends Subtract<IMSFTProgressHandledProps, IProgressManagedClasses> {}
-type ProgressProps = JSSManagerProps<MSFTProgressProps, IProgressClassNameContract, IDesignSystem>;
+type ProgressProps = ManagedJSSProps<MSFTProgressProps, IProgressClassNameContract, IDesignSystem>;
 
 export {
     Progress,

--- a/packages/fast-components-react-msft/src/progress/index.ts
+++ b/packages/fast-components-react-msft/src/progress/index.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IProgressClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, ProgressStyles } from "@microsoft/fast-components-styles-msft";
 import MSFTProgress, {
     IProgressHandledProps as IMSFTProgressHandledProps,
@@ -15,7 +15,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Progress = manageJss(ProgressStyles)(MSFTProgress);
-type Progress = InstanceType<typeof Progress>;
+type Progress = typeof Progress;
 
 interface IProgressHandledProps extends Subtract<IMSFTProgressHandledProps, IProgressManagedClasses> {}
 type ProgressProps = ManagedJSSProps<MSFTProgressProps, IProgressClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/subheading/index.ts
+++ b/packages/fast-components-react-msft/src/subheading/index.ts
@@ -10,7 +10,7 @@ import MSFTSubheading, {
     SubheadingTag
 
 } from "./subheading";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, SubheadingStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -20,7 +20,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Subheading = manageJss(SubheadingStyles)(MSFTSubheading);
-type Subheading = InstanceType<typeof MSFTSubheading>;
+type Subheading = typeof MSFTSubheading;
 
 interface ISubheadingHandledProps extends Subtract<IMSFTSubheadingHandledProps, ISubheadingManagedClasses> {}
 type SubheadingProps = ManagedJSSProps<MSFTSubheadingProps, ISubheadingClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/subheading/index.ts
+++ b/packages/fast-components-react-msft/src/subheading/index.ts
@@ -10,7 +10,7 @@ import MSFTSubheading, {
     SubheadingTag
 
 } from "./subheading";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, SubheadingStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -23,7 +23,7 @@ const Subheading = manageJss(SubheadingStyles)(MSFTSubheading);
 type Subheading = InstanceType<typeof MSFTSubheading>;
 
 interface ISubheadingHandledProps extends Subtract<IMSFTSubheadingHandledProps, ISubheadingManagedClasses> {}
-type SubheadingProps = JSSManagerProps<MSFTSubheadingProps, ISubheadingClassNameContract, IDesignSystem>;
+type SubheadingProps = ManagedJSSProps<MSFTSubheadingProps, ISubheadingClassNameContract, IDesignSystem>;
 
 export {
     Subheading,

--- a/packages/fast-components-react-msft/src/subheading/subheading.spec.tsx
+++ b/packages/fast-components-react-msft/src/subheading/subheading.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, shallow, mount } from "enzyme";
+import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTSubheading, {

--- a/packages/fast-components-react-msft/src/subheading/subheading.spec.tsx
+++ b/packages/fast-components-react-msft/src/subheading/subheading.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Adapter from "enzyme-adapter-react-16";
-import { configure, shallow } from "enzyme";
+import { configure, shallow, mount } from "enzyme";
 import examples from "./examples.data";
 import { generateSnapshots } from "@microsoft/fast-jest-snapshots-react";
 import MSFTSubheading, {
@@ -35,7 +35,7 @@ describe("subheading", (): void => {
         ).not.toThrow();
     });
 
-    test("should return a valid object which includes all props that are not enumerated as handledProps", (): void => {
+    test("should accept unhandledProps", (): void => {
         const handledProps: ISubheadingHandledProps = {
             tag: SubheadingTag.h1,
             size: SubheadingSize._1
@@ -47,32 +47,26 @@ describe("subheading", (): void => {
 
         const props: ISubheadingHandledProps & ISubheadingUnhandledProps = {...handledProps, ...unhandledProps};
 
-        const rendered: any = shallow(
-            <Subheading {...props} />
+        const rendered: any = mount(
+            <MSFTSubheading {...props} />
         );
 
-        const subheading: any = rendered.first().shallow();
-
-        expect(subheading.prop("aria-hidden")).toEqual(true);
+        expect(rendered.find(SubheadingTag.h1).prop("aria-hidden")).toEqual(true);
     });
 
     test("should render the correct `tag` when `tag` prop is passed in", (): void => {
         const rendered: any = shallow(
-            <Subheading tag={SubheadingTag.h4} />
+            <MSFTSubheading tag={SubheadingTag.h4} />
         );
 
-        const subheading: any = rendered.first().shallow();
-
-        expect(subheading.instance().props.tag).toEqual(SubheadingTag.h4);
+        expect(rendered.prop("tag")).toBe(SubheadingTag.h4);
     });
 
     test("should render default size if none is specified", (): void => {
-        const rendered: any = shallow(
-            <Subheading />
+        const rendered: any = mount(
+            <MSFTSubheading />
         );
 
-        const subheading: any = rendered.first().shallow();
-
-        expect(subheading.instance().props.size).toEqual(SubheadingSize._1);
+        expect(rendered.prop("size")).toBe(SubheadingSize._1);
     });
 });

--- a/packages/fast-components-react-msft/src/text-field/__snapshots__/text-field.spec.ts.snap
+++ b/packages/fast-components-react-msft/src/text-field/__snapshots__/text-field.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`text-field snapshots Text field: 0 1`] = `
 <input
-  className="textField-0-1-2"
+  className="textField-0-1-1"
   disabled={null}
   placeholder="Placeholder"
   type="text"
@@ -11,7 +11,7 @@ exports[`text-field snapshots Text field: 0 1`] = `
 
 exports[`text-field snapshots Text field: 1 1`] = `
 <input
-  className="textField-0-1-4"
+  className="textField-0-1-2"
   defaultValue="name@email.com"
   disabled={null}
   placeholder={null}
@@ -21,7 +21,7 @@ exports[`text-field snapshots Text field: 1 1`] = `
 
 exports[`text-field snapshots Text field: 2 1`] = `
 <input
-  className="textField-0-1-6"
+  className="textField-0-1-3"
   defaultValue="12345"
   disabled={null}
   placeholder={null}
@@ -31,7 +31,7 @@ exports[`text-field snapshots Text field: 2 1`] = `
 
 exports[`text-field snapshots Text field: 3 1`] = `
 <input
-  className="textField-0-1-8"
+  className="textField-0-1-4"
   defaultValue="(201) 867-5309"
   disabled={null}
   placeholder={null}
@@ -41,7 +41,7 @@ exports[`text-field snapshots Text field: 3 1`] = `
 
 exports[`text-field snapshots Text field: 4 1`] = `
 <input
-  className="textField-0-1-10"
+  className="textField-0-1-5"
   defaultValue="Disabled"
   disabled={true}
   placeholder={null}
@@ -51,7 +51,7 @@ exports[`text-field snapshots Text field: 4 1`] = `
 
 exports[`text-field snapshots Text field: 5 1`] = `
 <input
-  className="textField-0-1-12"
+  className="textField-0-1-6"
   disabled={null}
   placeholder="Enter Password"
   type="password"

--- a/packages/fast-components-react-msft/src/text-field/index.ts
+++ b/packages/fast-components-react-msft/src/text-field/index.ts
@@ -9,7 +9,7 @@ import {
     TextFieldProps as BaseTextFieldProps,
     TextFieldType
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, TextFieldStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -19,7 +19,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const TextField = manageJss(TextFieldStyles)(BaseTextField);
-type TextField = InstanceType<typeof TextField>;
+type TextField = typeof TextField;
 
 interface ITextFieldHandledProps extends Subtract<IBaseTextFieldHandledProps, ITextFieldManagedClasses> {}
 type TextFieldProps = ManagedJSSProps<BaseTextFieldProps, ITextFieldClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/text-field/index.ts
+++ b/packages/fast-components-react-msft/src/text-field/index.ts
@@ -9,7 +9,7 @@ import {
     TextFieldProps as BaseTextFieldProps,
     TextFieldType
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, TextFieldStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -22,7 +22,7 @@ const TextField = manageJss(TextFieldStyles)(BaseTextField);
 type TextField = InstanceType<typeof TextField>;
 
 interface ITextFieldHandledProps extends Subtract<IBaseTextFieldHandledProps, ITextFieldManagedClasses> {}
-type TextFieldProps = JSSManagerProps<BaseTextFieldProps, ITextFieldClassNameContract, IDesignSystem>;
+type TextFieldProps = ManagedJSSProps<BaseTextFieldProps, ITextFieldClassNameContract, IDesignSystem>;
 
 export {
     ITextFieldClassNameContract,

--- a/packages/fast-components-react-msft/src/toggle/__snapshots__/toggle.spec.ts.snap
+++ b/packages/fast-components-react-msft/src/toggle/__snapshots__/toggle.spec.ts.snap
@@ -3,23 +3,23 @@
 exports[`toggle snapshots Toggle: 0 1`] = `
 <div
   aria-disabled={null}
-  className="toggle-0-1-6"
+  className="toggle-0-1-1"
   data-sketch-symbol="Toggle (on)"
 >
   <label
-    className="toggle_label-0-1-7"
+    className="toggle_label-0-1-2"
     htmlFor="toggle01"
     id="label01"
   >
     Toggle label default on
   </label>
   <div
-    className="toggle_toggleButton-0-1-8"
+    className="toggle_toggleButton-0-1-3"
   >
     <input
       aria-describedby="span01"
       checked={true}
-      className="toggle_input-0-1-10"
+      className="toggle_input-0-1-5"
       disabled={false}
       id="toggle01"
       onChange={[Function]}
@@ -27,7 +27,7 @@ exports[`toggle snapshots Toggle: 0 1`] = `
       value="On"
     />
     <span
-      className="toggle_stateIndicator-0-1-9"
+      className="toggle_stateIndicator-0-1-4"
     />
   </div>
   <span
@@ -41,23 +41,23 @@ exports[`toggle snapshots Toggle: 0 1`] = `
 exports[`toggle snapshots Toggle: 1 1`] = `
 <div
   aria-disabled={null}
-  className="toggle-0-1-16"
+  className="toggle-0-1-6"
   data-sketch-symbol="Toggle (off)"
 >
   <label
-    className="toggle_label-0-1-17"
+    className="toggle_label-0-1-7"
     htmlFor="toggle02"
     id="label02"
   >
     Toggle label default off
   </label>
   <div
-    className="toggle_toggleButton-0-1-18"
+    className="toggle_toggleButton-0-1-8"
   >
     <input
       aria-describedby="span02"
       checked={false}
-      className="toggle_input-0-1-20"
+      className="toggle_input-0-1-10"
       disabled={false}
       id="toggle02"
       onChange={[Function]}
@@ -65,7 +65,7 @@ exports[`toggle snapshots Toggle: 1 1`] = `
       value="Off"
     />
     <span
-      className="toggle_stateIndicator-0-1-19"
+      className="toggle_stateIndicator-0-1-9"
     />
   </div>
   <span
@@ -79,23 +79,23 @@ exports[`toggle snapshots Toggle: 1 1`] = `
 exports[`toggle snapshots Toggle: 2 1`] = `
 <div
   aria-disabled={true}
-  className="toggle-0-1-26"
+  className="toggle-0-1-11"
   data-sketch-symbol="Toggle disabled (on)"
 >
   <label
-    className="toggle_label-0-1-27"
+    className="toggle_label-0-1-12"
     htmlFor="toggle03"
     id="label03"
   >
     Toggle label disabled on
   </label>
   <div
-    className="toggle_toggleButton-0-1-28"
+    className="toggle_toggleButton-0-1-13"
   >
     <input
       aria-describedby="span03"
       checked={true}
-      className="toggle_input-0-1-30"
+      className="toggle_input-0-1-15"
       disabled={true}
       id="toggle03"
       onChange={[Function]}
@@ -103,7 +103,7 @@ exports[`toggle snapshots Toggle: 2 1`] = `
       value="On"
     />
     <span
-      className="toggle_stateIndicator-0-1-29"
+      className="toggle_stateIndicator-0-1-14"
     />
   </div>
   <span
@@ -117,23 +117,23 @@ exports[`toggle snapshots Toggle: 2 1`] = `
 exports[`toggle snapshots Toggle: 3 1`] = `
 <div
   aria-disabled={true}
-  className="toggle-0-1-36"
+  className="toggle-0-1-16"
   data-sketch-symbol="Toggle disabled (off)"
 >
   <label
-    className="toggle_label-0-1-37"
+    className="toggle_label-0-1-17"
     htmlFor="toggle04"
     id="label04"
   >
     Toggle label disabled off
   </label>
   <div
-    className="toggle_toggleButton-0-1-38"
+    className="toggle_toggleButton-0-1-18"
   >
     <input
       aria-describedby="span04"
       checked={false}
-      className="toggle_input-0-1-40"
+      className="toggle_input-0-1-20"
       disabled={true}
       id="toggle04"
       onChange={[Function]}
@@ -141,7 +141,7 @@ exports[`toggle snapshots Toggle: 3 1`] = `
       value="Off"
     />
     <span
-      className="toggle_stateIndicator-0-1-39"
+      className="toggle_stateIndicator-0-1-19"
     />
   </div>
   <span

--- a/packages/fast-components-react-msft/src/toggle/index.ts
+++ b/packages/fast-components-react-msft/src/toggle/index.ts
@@ -8,7 +8,7 @@ import {
     Toggle as BaseToggle,
     ToggleProps as BaseToggleProps
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, ToggleStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -21,7 +21,7 @@ const Toggle = manageJss(ToggleStyles)(BaseToggle);
 type Toggle = InstanceType<typeof Toggle>;
 
 interface IToggleHandledProps extends Subtract<IBaseToggleHandledProps, IToggleManagedClasses> {}
-type ToggleProps = JSSManagerProps<BaseToggleProps, IToggleClassNameContract, IDesignSystem>;
+type ToggleProps = ManagedJSSProps<BaseToggleProps, IToggleClassNameContract, IDesignSystem>;
 
 export {
     Toggle,

--- a/packages/fast-components-react-msft/src/toggle/index.ts
+++ b/packages/fast-components-react-msft/src/toggle/index.ts
@@ -8,7 +8,7 @@ import {
     Toggle as BaseToggle,
     ToggleProps as BaseToggleProps
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, ToggleStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -18,7 +18,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Toggle = manageJss(ToggleStyles)(BaseToggle);
-type Toggle = InstanceType<typeof Toggle>;
+type Toggle = typeof Toggle;
 
 interface IToggleHandledProps extends Subtract<IBaseToggleHandledProps, IToggleManagedClasses> {}
 type ToggleProps = ManagedJSSProps<BaseToggleProps, IToggleClassNameContract, IDesignSystem>;

--- a/packages/fast-components-react-msft/src/typography/index.ts
+++ b/packages/fast-components-react-msft/src/typography/index.ts
@@ -10,7 +10,7 @@ import {
     TypographySize,
     TypographyTag
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IJSSManagerProps, JSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, TypographyStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -23,7 +23,7 @@ const Typography = manageJss(TypographyStyles)(BaseTypography);
 type Typography = InstanceType<typeof Typography>;
 
 interface ITypographyHandledProps extends Subtract<IBaseTypographyHandledProps, ITypographyManagedClasses> {}
-type TypographyProps = JSSManagerProps<BaseTypographyProps, ITypographyClassNameContract, IDesignSystem>;
+type TypographyProps = ManagedJSSProps<BaseTypographyProps, ITypographyClassNameContract, IDesignSystem>;
 
 export {
     ITypographyClassNameContract,

--- a/packages/fast-components-react-msft/src/typography/index.ts
+++ b/packages/fast-components-react-msft/src/typography/index.ts
@@ -10,7 +10,7 @@ import {
     TypographySize,
     TypographyTag
 } from "@microsoft/fast-components-react-base";
-import manageJss, { IManagedJSSProps, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDesignSystem, TypographyStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
 
@@ -20,7 +20,7 @@ import { Subtract } from "utility-types";
  */
 /* tslint:disable-next-line:typedef */
 const Typography = manageJss(TypographyStyles)(BaseTypography);
-type Typography = InstanceType<typeof Typography>;
+type Typography = typeof Typography;
 
 interface ITypographyHandledProps extends Subtract<IBaseTypographyHandledProps, ITypographyManagedClasses> {}
 type TypographyProps = ManagedJSSProps<BaseTypographyProps, ITypographyClassNameContract, IDesignSystem>;

--- a/packages/fast-css-editor-react/src/position/index.tsx
+++ b/packages/fast-css-editor-react/src/position/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import style, { ICSSPositionClassNameContract } from "./position.style";
 
 export enum PositionValue {

--- a/packages/fast-css-editor-react/src/position/index.tsx
+++ b/packages/fast-css-editor-react/src/position/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import style, { ICSSPositionClassNameContract } from "./position.style";
 
 export enum PositionValue {

--- a/packages/fast-development-site-react/app/components/button/button.tsx
+++ b/packages/fast-development-site-react/app/components/button/button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ComponentStyles, ICSSRules } from "@microsoft/fast-jss-manager";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import { IDesignSystem } from "../../design-system";

--- a/packages/fast-development-site-react/app/components/button/button.tsx
+++ b/packages/fast-development-site-react/app/components/button/button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ComponentStyles, ICSSRules } from "@microsoft/fast-jss-manager";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import { IDesignSystem } from "../../design-system";

--- a/packages/fast-development-site-react/app/components/paragraph/paragraph.tsx
+++ b/packages/fast-development-site-react/app/components/paragraph/paragraph.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ComponentStyles, ICSSRules } from "@microsoft/fast-jss-manager";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import { IDesignSystem } from "../../design-system";

--- a/packages/fast-development-site-react/app/components/paragraph/paragraph.tsx
+++ b/packages/fast-development-site-react/app/components/paragraph/paragraph.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ComponentStyles, ICSSRules } from "@microsoft/fast-jss-manager";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import { IDesignSystem } from "../../design-system";

--- a/packages/fast-development-site-react/src/components/breadcrumb/breadcrumb-item.tsx
+++ b/packages/fast-development-site-react/src/components/breadcrumb/breadcrumb-item.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 import { IDevSiteDesignSystem } from "../design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 export interface IBreadcrumbItemProps {
     to: string;

--- a/packages/fast-development-site-react/src/components/breadcrumb/breadcrumb-item.tsx
+++ b/packages/fast-development-site-react/src/components/breadcrumb/breadcrumb-item.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 import { IDevSiteDesignSystem } from "../design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 
 export interface IBreadcrumbItemProps {
     to: string;

--- a/packages/fast-development-site-react/src/components/breadcrumb/breadcrumb-item.tsx
+++ b/packages/fast-development-site-react/src/components/breadcrumb/breadcrumb-item.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 import { IDevSiteDesignSystem } from "../design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 export interface IBreadcrumbItemProps {
     to: string;

--- a/packages/fast-development-site-react/src/components/breadcrumb/index.tsx
+++ b/packages/fast-development-site-react/src/components/breadcrumb/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IDevSiteDesignSystem } from "../design-system";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import BreadcrumbItem from "./breadcrumb-item";
 
 /* tslint:disable-next-line */

--- a/packages/fast-development-site-react/src/components/breadcrumb/index.tsx
+++ b/packages/fast-development-site-react/src/components/breadcrumb/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IDevSiteDesignSystem } from "../design-system";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import BreadcrumbItem from "./breadcrumb-item";
 
 /* tslint:disable-next-line */

--- a/packages/fast-development-site-react/src/components/breadcrumb/index.tsx
+++ b/packages/fast-development-site-react/src/components/breadcrumb/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IDevSiteDesignSystem } from "../design-system";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import BreadcrumbItem from "./breadcrumb-item";
 
 /* tslint:disable-next-line */

--- a/packages/fast-development-site-react/src/components/shell/header.tsx
+++ b/packages/fast-development-site-react/src/components/shell/header.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 import { IRowManagedClasses, Pane, Row } from "@microsoft/fast-layouts-react";

--- a/packages/fast-development-site-react/src/components/shell/header.tsx
+++ b/packages/fast-development-site-react/src/components/shell/header.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 import { IRowManagedClasses, Pane, Row } from "@microsoft/fast-layouts-react";

--- a/packages/fast-development-site-react/src/components/shell/header.tsx
+++ b/packages/fast-development-site-react/src/components/shell/header.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 import { IRowManagedClasses, Pane, Row } from "@microsoft/fast-layouts-react";

--- a/packages/fast-development-site-react/src/components/shell/info-bar.tsx
+++ b/packages/fast-development-site-react/src/components/shell/info-bar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/shell/info-bar.tsx
+++ b/packages/fast-development-site-react/src/components/shell/info-bar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/shell/info-bar.tsx
+++ b/packages/fast-development-site-react/src/components/shell/info-bar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/shell/pane-collapse.tsx
+++ b/packages/fast-development-site-react/src/components/shell/pane-collapse.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/shell/pane-collapse.tsx
+++ b/packages/fast-development-site-react/src/components/shell/pane-collapse.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/shell/pane-collapse.tsx
+++ b/packages/fast-development-site-react/src/components/shell/pane-collapse.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/site/action-bar.tsx
+++ b/packages/fast-development-site-react/src/components/site/action-bar.tsx
@@ -6,7 +6,7 @@ import { RouteComponentProps } from "react-router";
 import { ComponentViewTypes } from "./component-view";
 import { glyphBuildingblocks, glyphExamples, glyphPage } from "@microsoft/fast-glyphs-msft";
 import ComponentViewToggle from "./component-view-toggle";
-import manageJss, { ComponentStyles, ICSSRules, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ICSSRules, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 export enum ActionEnum {
     configure = "configure",

--- a/packages/fast-development-site-react/src/components/site/action-bar.tsx
+++ b/packages/fast-development-site-react/src/components/site/action-bar.tsx
@@ -6,7 +6,7 @@ import { RouteComponentProps } from "react-router";
 import { ComponentViewTypes } from "./component-view";
 import { glyphBuildingblocks, glyphExamples, glyphPage } from "@microsoft/fast-glyphs-msft";
 import ComponentViewToggle from "./component-view-toggle";
-import manageJss, { ComponentStyles, ICSSRules, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ICSSRules, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 
 export enum ActionEnum {
     configure = "configure",

--- a/packages/fast-development-site-react/src/components/site/action-bar.tsx
+++ b/packages/fast-development-site-react/src/components/site/action-bar.tsx
@@ -6,7 +6,7 @@ import { RouteComponentProps } from "react-router";
 import { ComponentViewTypes } from "./component-view";
 import { glyphBuildingblocks, glyphExamples, glyphPage } from "@microsoft/fast-glyphs-msft";
 import ComponentViewToggle from "./component-view-toggle";
-import manageJss, { ComponentStyles, ICSSRules, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ICSSRules, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 export enum ActionEnum {
     configure = "configure",

--- a/packages/fast-development-site-react/src/components/site/category-documentation.tsx
+++ b/packages/fast-development-site-react/src/components/site/category-documentation.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, DesignSystemProvider, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, DesignSystemProvider, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/site/category-documentation.tsx
+++ b/packages/fast-development-site-react/src/components/site/category-documentation.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, DesignSystemProvider, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, DesignSystemProvider, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/site/category-documentation.tsx
+++ b/packages/fast-development-site-react/src/components/site/category-documentation.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, DesignSystemProvider, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, DesignSystemProvider, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/site/category-item.tsx
+++ b/packages/fast-development-site-react/src/components/site/category-item.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { DesignSystemProvider } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";

--- a/packages/fast-development-site-react/src/components/site/category-item.tsx
+++ b/packages/fast-development-site-react/src/components/site/category-item.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { DesignSystemProvider } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";

--- a/packages/fast-development-site-react/src/components/site/category-item.tsx
+++ b/packages/fast-development-site-react/src/components/site/category-item.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { DesignSystemProvider } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";

--- a/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { Link, withRouter } from "react-router-dom";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
 
 export interface IComponentViewToggleClassNameContract {

--- a/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { Link, withRouter } from "react-router-dom";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
 
 export interface IComponentViewToggleClassNameContract {

--- a/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { Link, withRouter } from "react-router-dom";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
 
 export interface IComponentViewToggleClassNameContract {

--- a/packages/fast-development-site-react/src/components/site/component-view.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-view.tsx
@@ -3,7 +3,7 @@ import { Route, Switch, withRouter } from "react-router-dom";
 import { RouteComponentProps } from "react-router";
 import { IDevSiteDesignSystem } from "../design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 
 /**
  * Describes the possible views for a component

--- a/packages/fast-development-site-react/src/components/site/component-view.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-view.tsx
@@ -3,7 +3,7 @@ import { Route, Switch, withRouter } from "react-router-dom";
 import { RouteComponentProps } from "react-router";
 import { IDevSiteDesignSystem } from "../design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 /**
  * Describes the possible views for a component

--- a/packages/fast-development-site-react/src/components/site/component-view.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-view.tsx
@@ -3,7 +3,7 @@ import { Route, Switch, withRouter } from "react-router-dom";
 import { RouteComponentProps } from "react-router";
 import { IDevSiteDesignSystem } from "../design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 /**
  * Describes the possible views for a component

--- a/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
@@ -3,7 +3,7 @@ import manageJss, {
     ComponentStyles,
     DesignSystemProvider,
     ICSSRules,
-    IJSSManagerProps,
+    IManagedJSSProps,
     IManagedClasses
 } from "@microsoft/fast-jss-manager-react";
 import { ErrorBoundary, IErrorBoundaryProps } from "../../utilities";

--- a/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
@@ -3,7 +3,7 @@ import manageJss, {
     ComponentStyles,
     DesignSystemProvider,
     ICSSRules,
-    IManagedJSSProps,
+    ManagedJSSProps,
     IManagedClasses
 } from "@microsoft/fast-jss-manager-react";
 import { ErrorBoundary, IErrorBoundaryProps } from "../../utilities";

--- a/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
@@ -3,8 +3,8 @@ import manageJss, {
     ComponentStyles,
     DesignSystemProvider,
     ICSSRules,
-    ManagedJSSProps,
-    IManagedClasses
+    IManagedClasses,
+    ManagedJSSProps
 } from "@microsoft/fast-jss-manager-react";
 import { ErrorBoundary, IErrorBoundaryProps } from "../../utilities";
 import { toPx } from "@microsoft/fast-jss-utilities";

--- a/packages/fast-development-site-react/src/components/site/configuration-panel.tsx
+++ b/packages/fast-development-site-react/src/components/site/configuration-panel.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
 import Form from "@microsoft/fast-form-generator-react";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 export enum TabType {
     presets = "Presets"

--- a/packages/fast-development-site-react/src/components/site/configuration-panel.tsx
+++ b/packages/fast-development-site-react/src/components/site/configuration-panel.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
 import Form from "@microsoft/fast-form-generator-react";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 export enum TabType {
     presets = "Presets"

--- a/packages/fast-development-site-react/src/components/site/configuration-panel.tsx
+++ b/packages/fast-development-site-react/src/components/site/configuration-panel.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
 import Form from "@microsoft/fast-form-generator-react";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 
 export enum TabType {
     presets = "Presets"

--- a/packages/fast-development-site-react/src/components/site/dev-tools.tsx
+++ b/packages/fast-development-site-react/src/components/site/dev-tools.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDevSiteDesignSystem } from "../design-system";
 import CodePreview from "./dev-tools-code-preview";
 import { IFormChildOption } from "./";

--- a/packages/fast-development-site-react/src/components/site/dev-tools.tsx
+++ b/packages/fast-development-site-react/src/components/site/dev-tools.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { IDevSiteDesignSystem } from "../design-system";
 import CodePreview from "./dev-tools-code-preview";
 import { IFormChildOption } from "./";

--- a/packages/fast-development-site-react/src/components/site/dev-tools.tsx
+++ b/packages/fast-development-site-react/src/components/site/dev-tools.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { IDevSiteDesignSystem } from "../design-system";
 import CodePreview from "./dev-tools-code-preview";
 import { IFormChildOption } from "./";

--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -1,6 +1,6 @@
 import Toc, { TocItem } from "../toc";
 import * as React from "react";
-import manageJss, { ComponentStyles, DesignSystemProvider, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, DesignSystemProvider, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { glyphBuildingblocks, glyphGlobalnavbutton, glyphTransparency } from "@microsoft/fast-glyphs-msft";
 import { mapDataToComponent } from "@microsoft/fast-form-generator-react";
 import { uniqueId } from "lodash-es";

--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -1,6 +1,6 @@
 import Toc, { TocItem } from "../toc";
 import * as React from "react";
-import manageJss, { ComponentStyles, DesignSystemProvider, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, DesignSystemProvider, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { glyphBuildingblocks, glyphGlobalnavbutton, glyphTransparency } from "@microsoft/fast-glyphs-msft";
 import { mapDataToComponent } from "@microsoft/fast-form-generator-react";
 import { uniqueId } from "lodash-es";

--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -1,6 +1,6 @@
+import SiteTitleBrand from "./title-brand";
 import Toc, { TocItem } from "../toc";
-import * as React from "react";
-import manageJss, { ComponentStyles, DesignSystemProvider, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, DesignSystemProvider, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { glyphBuildingblocks, glyphGlobalnavbutton, glyphTransparency } from "@microsoft/fast-glyphs-msft";
 import { mapDataToComponent } from "@microsoft/fast-form-generator-react";
 import { uniqueId } from "lodash-es";
@@ -11,7 +11,7 @@ import { ellipsis, localizeSpacing, toPx } from "@microsoft/fast-jss-utilities";
 import ComponentWrapper from "./component-wrapper";
 import CategoryList from "./category-list";
 import SiteTitle from "./title";
-import SiteTitleBrand from "./title-brand";
+import * as React from "react";
 import SiteMenu from "./menu";
 import SiteMenuItem from "./menu-item";
 import SiteCategory, { Status } from "./category";

--- a/packages/fast-development-site-react/src/components/site/menu.tsx
+++ b/packages/fast-development-site-react/src/components/site/menu.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/site/menu.tsx
+++ b/packages/fast-development-site-react/src/components/site/menu.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/site/menu.tsx
+++ b/packages/fast-development-site-react/src/components/site/menu.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../design-system";
 

--- a/packages/fast-development-site-react/src/components/site/title-brand.tsx
+++ b/packages/fast-development-site-react/src/components/site/title-brand.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJSS, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJSS, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { IDevSiteDesignSystem } from "../design-system";
 
 export interface ISiteTitleBrandedManagedClasses {

--- a/packages/fast-development-site-react/src/components/site/title-brand.tsx
+++ b/packages/fast-development-site-react/src/components/site/title-brand.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJSS, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJSS, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IDevSiteDesignSystem } from "../design-system";
 
 export interface ISiteTitleBrandedManagedClasses {

--- a/packages/fast-development-site-react/src/components/site/title-brand.tsx
+++ b/packages/fast-development-site-react/src/components/site/title-brand.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJSS, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJSS, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { IDevSiteDesignSystem } from "../design-system";
 
 export interface ISiteTitleBrandedManagedClasses {

--- a/packages/fast-development-site-react/src/components/toc/index.tsx
+++ b/packages/fast-development-site-react/src/components/toc/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IDevSiteDesignSystem } from "../design-system";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import TocItem from "./toc-item";
 import TocMenu from "./toc-menu";

--- a/packages/fast-development-site-react/src/components/toc/index.tsx
+++ b/packages/fast-development-site-react/src/components/toc/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IDevSiteDesignSystem } from "../design-system";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import TocItem from "./toc-item";
 import TocMenu from "./toc-menu";

--- a/packages/fast-development-site-react/src/components/toc/index.tsx
+++ b/packages/fast-development-site-react/src/components/toc/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { IDevSiteDesignSystem } from "../design-system";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import TocItem from "./toc-item";
 import TocMenu from "./toc-menu";

--- a/packages/fast-development-site-react/src/components/toc/toc-item.tsx
+++ b/packages/fast-development-site-react/src/components/toc/toc-item.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import TocMenu from "./toc-menu";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 
 export interface ITocItemProps {
     to?: string;

--- a/packages/fast-development-site-react/src/components/toc/toc-item.tsx
+++ b/packages/fast-development-site-react/src/components/toc/toc-item.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import TocMenu from "./toc-menu";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 export interface ITocItemProps {
     to?: string;

--- a/packages/fast-development-site-react/src/components/toc/toc-item.tsx
+++ b/packages/fast-development-site-react/src/components/toc/toc-item.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import TocMenu from "./toc-menu";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 export interface ITocItemProps {
     to?: string;

--- a/packages/fast-development-site-react/src/components/toc/toc-menu.tsx
+++ b/packages/fast-development-site-react/src/components/toc/toc-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import Toc from "./";
 

--- a/packages/fast-development-site-react/src/components/toc/toc-menu.tsx
+++ b/packages/fast-development-site-react/src/components/toc/toc-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import Toc from "./";
 

--- a/packages/fast-development-site-react/src/components/toc/toc-menu.tsx
+++ b/packages/fast-development-site-react/src/components/toc/toc-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 import devSiteDesignSystemDefaults, { IDevSiteDesignSystem } from "../design-system";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import Toc from "./";
 

--- a/packages/fast-development-site-react/src/utilities/error-boundary.tsx
+++ b/packages/fast-development-site-react/src/utilities/error-boundary.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../../src/components/design-system";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 /* tslint:disable:no-empty-interface */
 export interface IErrorBoundaryProps {}

--- a/packages/fast-development-site-react/src/utilities/error-boundary.tsx
+++ b/packages/fast-development-site-react/src/utilities/error-boundary.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../../src/components/design-system";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 
 /* tslint:disable:no-empty-interface */
 export interface IErrorBoundaryProps {}

--- a/packages/fast-development-site-react/src/utilities/error-boundary.tsx
+++ b/packages/fast-development-site-react/src/utilities/error-boundary.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { IDevSiteDesignSystem } from "../../src/components/design-system";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 
 /* tslint:disable:no-empty-interface */
 export interface IErrorBoundaryProps {}

--- a/packages/fast-form-generator-react/src/form/form-category.tsx
+++ b/packages/fast-form-generator-react/src/form/form-category.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import IFormItemCommon from "./form-item";
 import styles from "./form-category.style";
 import { IFormCategoryClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form-category.tsx
+++ b/packages/fast-form-generator-react/src/form/form-category.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import IFormItemCommon from "./form-item";
 import styles from "./form-category.style";
 import { IFormCategoryClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form-item.align-horizontal.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.align-horizontal.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { IFormItemComponentMappingToProperyNamesProps } from "./form-item";
 import styles from "./form-item.align-horizontal.style";
 import { IFormItemAlignHorizontalClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import { Direction } from "@microsoft/fast-jss-utilities";
 

--- a/packages/fast-form-generator-react/src/form/form-item.align-horizontal.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.align-horizontal.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { IFormItemComponentMappingToProperyNamesProps } from "./form-item";
 import styles from "./form-item.align-horizontal.style";
 import { IFormItemAlignHorizontalClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import { Direction } from "@microsoft/fast-jss-utilities";
 

--- a/packages/fast-form-generator-react/src/form/form-item.align-vertical.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.align-vertical.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { IFormItemComponentMappingToProperyNamesProps } from "./form-item";
 import styles from "./form-item.align-vertical.style";
 import { IFormItemAlignVerticalClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form-item.align-vertical.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.align-vertical.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { IFormItemComponentMappingToProperyNamesProps } from "./form-item";
 import styles from "./form-item.align-vertical.style";
 import { IFormItemAlignVerticalClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form-item.array.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.array.tsx
@@ -11,7 +11,7 @@ import { isRootLocation } from "./form.utilities";
 import { getArrayLinks } from "./form-item.array.utilities";
 import styles from "./form-item.array.style";
 import { IFormItemArrayClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 export enum ItemConstraints {

--- a/packages/fast-form-generator-react/src/form/form-item.array.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.array.tsx
@@ -11,7 +11,7 @@ import { isRootLocation } from "./form.utilities";
 import { getArrayLinks } from "./form-item.array.utilities";
 import styles from "./form-item.array.style";
 import { IFormItemArrayClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 export enum ItemConstraints {

--- a/packages/fast-form-generator-react/src/form/form-item.checkbox.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.checkbox.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import IFormItemCommon from "./form-item";
 import styles from "./form-item.checkbox.style";
 import { IFormItemCheckboxClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form-item.checkbox.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.checkbox.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import IFormItemCommon from "./form-item";
 import styles from "./form-item.checkbox.style";
 import { IFormItemCheckboxClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form-item.children.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.children.tsx
@@ -11,7 +11,7 @@ import { DataOnChange, IChildOptionItem } from "./form.props";
 import { reactChildrenStringSchema } from "./form-item.children.text";
 import styles from "./form-item.children.style";
 import { IFormItemChildrenClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 export interface IChildComponentData {

--- a/packages/fast-form-generator-react/src/form/form-item.children.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.children.tsx
@@ -11,7 +11,7 @@ import { DataOnChange, IChildOptionItem } from "./form.props";
 import { reactChildrenStringSchema } from "./form-item.children.text";
 import styles from "./form-item.children.style";
 import { IFormItemChildrenClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 export interface IChildComponentData {

--- a/packages/fast-form-generator-react/src/form/form-item.number-field.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.number-field.tsx
@@ -3,7 +3,7 @@ import IFormItemCommon from "./form-item";
 import { getStringValue } from "./form-item.utilities";
 import styles from "./form-item.number-field.style";
 import { IFormItemNumberFieldClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 export interface IFormItemNumberFieldProps extends IFormItemCommon {

--- a/packages/fast-form-generator-react/src/form/form-item.number-field.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.number-field.tsx
@@ -3,7 +3,7 @@ import IFormItemCommon from "./form-item";
 import { getStringValue } from "./form-item.utilities";
 import styles from "./form-item.number-field.style";
 import { IFormItemNumberFieldClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 export interface IFormItemNumberFieldProps extends IFormItemCommon {

--- a/packages/fast-form-generator-react/src/form/form-item.select.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.select.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import IFormItemCommon from "./form-item";
 import styles from "./form-item.select.style";
 import { IFormItemSelectClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form-item.select.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.select.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import IFormItemCommon from "./form-item";
 import styles from "./form-item.select.style";
 import { IFormItemSelectClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form-item.textarea.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import IFormItemCommon from "./form-item";
 import styles from "./form-item.textarea.style";
 import { IFormItemTextareaClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 export interface IFormItemTextareaProps extends IFormItemCommon {

--- a/packages/fast-form-generator-react/src/form/form-item.textarea.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import IFormItemCommon from "./form-item";
 import styles from "./form-item.textarea.style";
 import { IFormItemTextareaClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 export interface IFormItemTextareaProps extends IFormItemCommon {

--- a/packages/fast-form-generator-react/src/form/form-item.theme.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.theme.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { IFormItemComponentMappingToProperyNamesProps } from "./form-item";
 import styles from "./form-item.theme.style";
 import { IFormItemThemeClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form-item.theme.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.theme.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { IFormItemComponentMappingToProperyNamesProps } from "./form-item";
 import styles from "./form-item.theme.style";
 import { IFormItemThemeClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form-section.tsx
+++ b/packages/fast-form-generator-react/src/form/form-section.tsx
@@ -50,7 +50,7 @@ import {
 } from "./form-section.utilities";
 import styles from "./form-section.style";
 import { IFormSectionClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form-section.tsx
+++ b/packages/fast-form-generator-react/src/form/form-section.tsx
@@ -50,7 +50,7 @@ import {
 } from "./form-section.utilities";
 import styles from "./form-section.style";
 import { IFormSectionClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form.tsx
+++ b/packages/fast-form-generator-react/src/form/form.tsx
@@ -22,7 +22,7 @@ import {
 } from "./form-item.children";
 import styles from "./form.style";
 import { IFormClassNameContract } from "../class-name-contracts/";
-import manageJss, { IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form.tsx
+++ b/packages/fast-form-generator-react/src/form/form.tsx
@@ -22,7 +22,7 @@ import {
 } from "./form-item.children";
 import styles from "./form.style";
 import { IFormClassNameContract } from "../class-name-contracts/";
-import manageJss, { IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 
 /**

--- a/packages/fast-jss-manager-react/package.json
+++ b/packages/fast-jss-manager-react/package.json
@@ -66,29 +66,23 @@
     "babel-preset-react": "^6.24.1",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "hoist-non-react-statics": "^2.5.0",
     "jest": "^22.3.0",
     "jss": "^9.8.0",
     "jss-preset-default": "^4.3.0",
     "lodash-es": "^4.0.0",
-    "prop-types": "^15.6.1",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-test-renderer": "^16.2.0",
     "ts-jest": "^22.0.4",
     "tslint": "^5.9.1",
     "typescript": "^3.0.1",
-    "utility-types": "^2.1.0",
     "watch": "^1.0.2"
   },
   "peerDependencies": {
-    "hoist-non-react-statics": "^2.5.0",
     "jss": "^9.8.0",
     "jss-preset-default": "^4.3.0",
     "lodash-es": "^4.0.0",
-    "prop-types": "^15.0.0",
-    "react": "^16.3.0",
-    "utility-types": "^2.1.0"
+    "react": "^16.3.0"
   },
   "dependencies": {
     "@microsoft/fast-jss-manager": "^2.2.0"

--- a/packages/fast-jss-manager-react/package.json
+++ b/packages/fast-jss-manager-react/package.json
@@ -78,6 +78,7 @@
     "ts-jest": "^22.0.4",
     "tslint": "^5.9.1",
     "typescript": "^3.0.1",
+    "utility-types": "^2.1.0",
     "watch": "^1.0.2"
   },
   "peerDependencies": {
@@ -86,7 +87,8 @@
     "jss-preset-default": "^4.3.0",
     "lodash-es": "^4.0.0",
     "prop-types": "^15.0.0",
-    "react": "^16.3.0"
+    "react": "^16.3.0",
+    "utility-types": "^2.1.0"
   },
   "dependencies": {
     "@microsoft/fast-jss-manager": "^2.2.0"

--- a/packages/fast-jss-manager-react/src/context.ts
+++ b/packages/fast-jss-manager-react/src/context.ts
@@ -1,0 +1,9 @@
+import * as React from "react";
+import { IDesignSystemProviderProps } from "./design-system-provider";
+
+const { Provider, Consumer }: {
+    Provider: React.Provider<IDesignSystemProviderProps<any>>,
+    Consumer: React.Consumer<IDesignSystemProviderProps<any>>
+} = React.createContext<IDesignSystemProviderProps<any>>({ designSystem: {} });
+
+export { Provider, Consumer };

--- a/packages/fast-jss-manager-react/src/context.ts
+++ b/packages/fast-jss-manager-react/src/context.ts
@@ -1,9 +1,12 @@
 import * as React from "react";
-import { IDesignSystemProviderProps } from "./design-system-provider";
 
+/**
+ * Create and export JSSManager consumer/provider components to be used by
+ * the manageJss HOC and DesignSystemProvider
+ */
 const { Provider, Consumer }: {
-    Provider: React.Provider<IDesignSystemProviderProps<any>>,
-    Consumer: React.Consumer<IDesignSystemProviderProps<any>>
-} = React.createContext<IDesignSystemProviderProps<any>>({ designSystem: {} });
+    Provider: React.Provider<unknown>,
+    Consumer: React.Consumer<unknown>
+} = React.createContext<unknown>({});
 
 export { Provider, Consumer };

--- a/packages/fast-jss-manager-react/src/design-system-provider.spec.tsx
+++ b/packages/fast-jss-manager-react/src/design-system-provider.spec.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import DesignSystemProvider from "./design-system-provider";
+import * as ShallowRenderer from "react-test-renderer/shallow";
+import * as Adapter from "enzyme-adapter-react-16";
+import { configure, mount, shallow, ShallowWrapper } from "enzyme";
+import { Consumer } from "./context";
+
+configure({adapter: new Adapter()});
+
+describe("DesignSystemProvider", (): void => {
+    test("should render children", (): void => {
+        const text: string = "aRrAyS sTaRt At OnE";
+        const children: React.ReactNode = <p>{text}</p>;
+        const provider: ShallowWrapper = mount(
+            <DesignSystemProvider
+                designSystem={{}}
+            >
+                <p>{text}</p>
+            </DesignSystemProvider>
+        );
+
+        expect(provider.find("p").text()).toBe(text);
+    });
+
+    test("should not throw when not provided props", (): void => {
+        expect(() => {
+            return shallow(React.createElement(DesignSystemProvider));
+        }).not.toThrow();
+    });
+
+    test("should provide the design system to a consumer", (): void => {
+        function render(value: {success: boolean}): string {
+            return value.success.toString();
+        }
+
+        const tree: ShallowWrapper = mount(
+            <DesignSystemProvider designSystem={{success: true}}>
+                <Consumer>
+                    {render}
+                </Consumer>
+            </DesignSystemProvider>
+        );
+
+        expect(tree.text()).toBe(true.toString());
+    });
+
+    test("should override nested context values", (): void => {
+        function render(value: {success: string}): string {
+            return value.success;
+        }
+
+        const tree: ShallowWrapper = mount(
+            <DesignSystemProvider designSystem={{success: "unsuccessfull"}}>
+                <DesignSystemProvider designSystem={{success: "successful"}}>
+                    <Consumer>
+                        {render}
+                    </Consumer>
+                </DesignSystemProvider>
+            </DesignSystemProvider>
+        );
+
+        expect(tree.text()).toBe("successful");
+    });
+
+    test("should allow partial updates to context values", (): void => {
+        function render(value: { a: string, b: string }): string {
+            return `${value.a}, ${value.b}`;
+        }
+
+        const tree: ShallowWrapper = mount(
+            <DesignSystemProvider designSystem={{a: "a", b: "b"}}>
+                <DesignSystemProvider designSystem={{a: "A"}}>
+                    <Consumer>
+                        {render}
+                    </Consumer>
+                </DesignSystemProvider>
+            </DesignSystemProvider>
+        );
+
+        expect(tree.text()).toBe("A, b");
+    });
+});

--- a/packages/fast-jss-manager-react/src/design-system-provider.spec.tsx
+++ b/packages/fast-jss-manager-react/src/design-system-provider.spec.tsx
@@ -63,20 +63,29 @@ describe("DesignSystemProvider", (): void => {
     });
 
     test("should allow partial updates to context values", (): void => {
+        const renderOne: any = jest.fn();
+        const renderTwo: any = jest.fn();
+
         function render(value: { a: string, b: string }): string {
             return `${value.a}, ${value.b}`;
         }
 
         const tree: ShallowWrapper = mount(
             <DesignSystemProvider designSystem={{a: "a", b: "b"}}>
+                <Consumer>
+                    {renderOne}
+                </Consumer>
                 <DesignSystemProvider designSystem={{a: "A"}}>
                     <Consumer>
-                        {render}
+                        {renderTwo}
                     </Consumer>
                 </DesignSystemProvider>
             </DesignSystemProvider>
         );
 
-        expect(tree.text()).toBe("A, b");
+        expect(renderOne.mock.calls).toHaveLength(1);
+        expect(renderOne.mock.calls[0][0]).toEqual({a: "a", b: "b"});
+        expect(renderTwo.mock.calls).toHaveLength(1);
+        expect(renderTwo.mock.calls[0][0]).toEqual({a: "A", b: "b"});
     });
 });

--- a/packages/fast-jss-manager-react/src/design-system-provider.spec.tsx
+++ b/packages/fast-jss-manager-react/src/design-system-provider.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import DesignSystemProvider from "./design-system-provider";
+import { DesignSystemProvider } from "./design-system-provider";
 import * as ShallowRenderer from "react-test-renderer/shallow";
 import * as Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow, ShallowWrapper } from "enzyme";

--- a/packages/fast-jss-manager-react/src/design-system-provider.tsx
+++ b/packages/fast-jss-manager-react/src/design-system-provider.tsx
@@ -8,12 +8,13 @@ import * as React from "react";
 import * as propTypes from "prop-types";
 import { Consumer, Provider } from "./context";
 
+export type IDesignSystem<T> = T extends {[key: string]: unknown} ? T : never;
 /**
  * Describes the props that the DesignSystemProvider uses. It accepts a single prop "designSystem"
  * that gets exposed to all downstream components of the DesignSystemProvider
  */
 export interface IDesignSystemProviderProps<T> {
-    designSystem: T extends {[key: string]: unknown} ? T : never;
+    designSystem: IDesignSystem<T>;
 }
 
 class DesignSystemProvider<T> extends React.Component<IDesignSystemProviderProps<T>, {}> {

--- a/packages/fast-jss-manager-react/src/design-system-provider.tsx
+++ b/packages/fast-jss-manager-react/src/design-system-provider.tsx
@@ -17,7 +17,7 @@ export interface IDesignSystemProviderProps<T> {
     designSystem: IDesignSystem<T>;
 }
 
-class DesignSystemProvider<T> extends React.Component<IDesignSystemProviderProps<T>, {}> {
+export class DesignSystemProvider<T> extends React.Component<IDesignSystemProviderProps<T>, {}> {
     public render(): React.ReactNode {
         return (
             <Consumer>
@@ -34,5 +34,3 @@ class DesignSystemProvider<T> extends React.Component<IDesignSystemProviderProps
         );
     }
 }
-
-export default DesignSystemProvider;

--- a/packages/fast-jss-manager-react/src/design-system-provider.tsx
+++ b/packages/fast-jss-manager-react/src/design-system-provider.tsx
@@ -6,35 +6,31 @@
  */
 import * as React from "react";
 import * as propTypes from "prop-types";
+import { Consumer, Provider } from "./context";
 
 /**
  * Describes the props that the DesignSystemProvider uses. It accepts a single prop "designSystem"
  * that gets exposed to all downstream components of the DesignSystemProvider
  */
 export interface IDesignSystemProviderProps<T> {
-    designSystem?: T;
+    designSystem: T extends {[key: string]: unknown} ? T : never;
 }
 
 class DesignSystemProvider<T> extends React.Component<IDesignSystemProviderProps<T>, {}> {
-    // TODO: How can we type these to be generics but also static properties
-    public static contextTypes: any = {
-        designSystem: propTypes.any
-    };
-
-    public static childContextTypes: any = {
-        designSystem: propTypes.any
-    };
-
-    public getChildContext(): IDesignSystemProviderProps<T> {
-        const designSystem: T = this.props.designSystem;
-        const contextualDesignSystem: T = this.context.designSystem;
-        const context: T = Object.assign({}, contextualDesignSystem, designSystem);
-
-        return { designSystem: context };
+    public render(): React.ReactNode {
+        return (
+            <Consumer>
+                {this.renderProvider}
+            </Consumer>
+        );
     }
 
-    public render(): React.ReactNode {
-        return this.props.children;
+    private renderProvider = (designSystem: T): React.ReactNode => {
+        return (
+            <Provider value={Object.assign({}, designSystem, this.props.designSystem)}>
+                {this.props.children}
+            </Provider>
+        );
     }
 }
 

--- a/packages/fast-jss-manager-react/src/index.ts
+++ b/packages/fast-jss-manager-react/src/index.ts
@@ -1,7 +1,8 @@
-import manageJss from "./manage-jss";
-import DesignSystemProvider from "./design-system-provider";
+import { manageJss } from "./manage-jss";
 
 export default manageJss;
-export { DesignSystemProvider };
-export * from "./manage-jss";
+export { DesignSystemProvider, IDesignSystemProviderProps } from "./design-system-provider";
+export { stylesheetRegistry, jss } from "./jss";
+export { ManagedJSSProps } from "./jss-manager";
 export * from "./design-system-provider";
+export * from "@microsoft/fast-jss-manager";

--- a/packages/fast-jss-manager-react/src/jss-manager.spec.tsx
+++ b/packages/fast-jss-manager-react/src/jss-manager.spec.tsx
@@ -1,0 +1,216 @@
+import * as React from "react";
+import { JSSManager } from "./jss-manager";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
+import * as ShallowRenderer from "react-test-renderer/shallow";
+import { configure, mount, ReactWrapper, render, shallow } from "enzyme";
+import * as Adapter from "enzyme-adapter-react-16";
+import { jss, stylesheetRegistry } from "./jss";
+import { DesignSystemProvider } from "./design-system-provider";
+
+configure({adapter: new Adapter()});
+
+class SimpleComponent extends React.Component<any, any> {
+    public render(): boolean {
+        return true;
+    }
+}
+
+/**
+ * JSS stylesheet with only static values for CSS properties
+ */
+const staticStyles: ComponentStyles<any, any> = {
+    staticStyleClass: {
+        color: "red"
+    }
+};
+
+/**
+ * JSS stylesheet with dynamic values for CSS properties
+ */
+const dynamicStyles: ComponentStyles<any, any> = {
+    dynamicStylesClass: {
+        background: (): string => {
+            return "blue";
+        }
+    }
+};
+
+/**
+ * JSS stylesheet defined as a function
+ */
+const stylesheetResolver: ComponentStyles<any, any> = (config: any): any => {
+    return {
+        resolvedStylesClass: {
+            background: "green",
+            color: (): string => {
+                return "yellow";
+            }
+        }
+    };
+};
+
+/**
+ * JSS stylesheet with static and dynamic values for CSS properties
+ */
+const staticAndDynamicStyles: ComponentStyles<any, any> = {
+    staticAndDynamicStylesClass: { ...staticStyles.staticStyleClass, ...dynamicStyles.dynamicStylesClass }
+};
+
+describe("The JSSManager", (): void => {
+    interface ITestDesignSystem {
+        color: string;
+    }
+
+    function renderChild(): string {
+        return "children";
+    }
+
+    // JSS doesn't export their StyleSheet class, so we can compile a stylesheet and
+    // access it's constructor to get a reference to the StyleSheet class.
+    const StyleSheet: any = jss.createStyleSheet({}).constructor;
+
+    const stylesheet: any = {
+        class: {
+            color: (config: ITestDesignSystem): string => {
+                return config.color;
+            }
+        }
+    };
+
+    const testDesignSystem: ITestDesignSystem = {
+        color: "red"
+    };
+
+    function functionStyleSheet(config: ITestDesignSystem): any {
+        return {
+            class: {
+                color: config.color
+            }
+        };
+    }
+
+    test("should not throw when no stylesheet is provided", (): void => {
+        expect((): void => {
+            mount(
+                <JSSManager render={renderChild} />
+            );
+        }).not.toThrow();
+    });
+
+    test("should compile a stylesheet when mounting", (): void => {
+        const objectStylesheetComponent: ReactWrapper = mount(
+            <JSSManager
+                render={renderChild}
+                designSystem={testDesignSystem}
+                styles={stylesheet}
+            />
+        );
+
+        const functionStylesheetComponent: ReactWrapper = mount(
+            <JSSManager
+                render={renderChild}
+                styles={functionStyleSheet}
+                designSystem={testDesignSystem}
+            />
+        );
+
+        expect(objectStylesheetComponent.state("styleSheet")).toBeInstanceOf(StyleSheet);
+        expect(objectStylesheetComponent.state("styleSheet").attached).toBe(true);
+
+        expect(functionStylesheetComponent.state("styleSheet")).toBeInstanceOf(StyleSheet);
+        expect(functionStylesheetComponent.state("styleSheet").attached).toBe(true);
+    });
+
+    test("should update an object stylesheet when the design-system changes", (): void => {
+        const objectStylesheetComponent: ReactWrapper = mount(
+            <JSSManager
+                designSystem={{color: "blue"}}
+                styles={stylesheet}
+                render={renderChild}
+            />
+        );
+
+        const functionStylesheetComponent: ReactWrapper = mount(
+            <JSSManager
+                designSystem={{color: "blue"}}
+                styles={functionStyleSheet}
+                render={renderChild}
+            />
+        );
+
+        const mock: any = jest.fn();
+
+        objectStylesheetComponent.state("styleSheet").update = mock;
+        objectStylesheetComponent.setProps({designSystem: testDesignSystem});
+
+        expect(mock.mock.calls).toHaveLength(1);
+        expect(mock.mock.calls[0][0]).toEqual(testDesignSystem);
+
+        const functionSheet: any = functionStylesheetComponent.state("styleSheet");
+        functionStylesheetComponent.setProps({designSystem: testDesignSystem});
+
+        // Function stylesheets must be completely re-generated when the design-system changes,
+        // so check identity
+        expect(functionStylesheetComponent.state("styleSheet")).not.toBe(functionSheet);
+    });
+
+    test("should remove stylesheets when unmounting" , (): void => {
+        const objectStylesheetComponent: ReactWrapper = mount(
+            <JSSManager
+                designSystem={{color: "red"}}
+                styles={stylesheet}
+                render={renderChild}
+            />
+        );
+
+        const functionStylesheetComponent: ReactWrapper = mount(
+            <JSSManager
+                designSystem={{color: "red"}}
+                styles={stylesheet}
+                render={renderChild}
+            />
+        );
+
+        const objectSheet: any = objectStylesheetComponent.state("styleSheet");
+        const functionSheet: any = functionStylesheetComponent.state("styleSheet");
+
+        expect(objectSheet.attached).toBe(true);
+        expect(functionSheet.attached).toBe(true);
+
+        objectStylesheetComponent.unmount();
+        functionStylesheetComponent.unmount();
+
+        expect(objectSheet.attached).toBe(false);
+        expect(functionSheet.attached).toBe(false);
+    });
+
+    xtest("should create a new stylesheet when stylesheet props are changed", () => {
+        const Component: any = manageJss(staticAndDynamicStyles)(SimpleComponent);
+        const rendered: any = shallow(
+            <Component jssStyleSheet={{dynamicStylesClass: { margin: "0" }}} />,
+            { context: {designSystem: true} }
+        );
+
+        const styleSheet: any = rendered.state("styleSheet");
+
+        rendered.setProps({jssStyleSheet: {dynamicStylesClass: { margin: "1px" }}});
+
+        expect(styleSheet.attached).toBe(false);
+        expect(rendered.state("styleSheet").attached).toBe(true);
+    });
+
+    test("should store all stylesheets in the registry", (): void => {
+        stylesheetRegistry.reset();
+        expect(stylesheetRegistry.registry.length).toBe(0);
+
+        const rendered: any = shallow(
+            <JSSManager
+                styles={stylesheet}
+                designSystem={testDesignSystem}
+                render={renderChild}
+            />
+        );
+
+        expect(stylesheetRegistry.registry.length).toBe(1);
+    });
+});

--- a/packages/fast-jss-manager-react/src/jss-manager.spec.tsx
+++ b/packages/fast-jss-manager-react/src/jss-manager.spec.tsx
@@ -97,6 +97,19 @@ describe("The JSSManager", (): void => {
         }).not.toThrow();
     });
 
+    test("should not throw when no stylesheet is provided and design system is changed", (): void => {
+        const rendered: ReactWrapper = mount(
+            <JSSManager
+                designSystem={testDesignSystem}
+                render={renderChild}
+            />
+        );
+
+        expect((): void => {
+            rendered.setProps({designSystem: {color: "blue"}});
+        }).not.toThrow();
+    });
+
     test("should compile a stylesheet when mounting", (): void => {
         const objectStylesheetComponent: ReactWrapper = mount(
             <JSSManager
@@ -184,19 +197,20 @@ describe("The JSSManager", (): void => {
         expect(functionSheet.attached).toBe(false);
     });
 
-    xtest("should create a new stylesheet when stylesheet props are changed", () => {
-        const Component: any = manageJss(staticAndDynamicStyles)(SimpleComponent);
+    test("should create a new stylesheet when stylesheet props are changed", () => {
         const rendered: any = shallow(
-            <Component jssStyleSheet={{dynamicStylesClass: { margin: "0" }}} />,
-            { context: {designSystem: true} }
+            <JSSManager
+                styles={stylesheet}
+                designSystem={testDesignSystem}
+                render={renderChild}
+            />
         );
 
-        const styleSheet: any = rendered.state("styleSheet");
+        const sheet: any = rendered.state("styleSheet");
 
-        rendered.setProps({jssStyleSheet: {dynamicStylesClass: { margin: "1px" }}});
+        rendered.setProps({jssStyleSheet: { class: { color: "blue" } }});
 
-        expect(styleSheet.attached).toBe(false);
-        expect(rendered.state("styleSheet").attached).toBe(true);
+        expect(rendered.state("styleSheet")).not.toBe(sheet);
     });
 
     test("should store all stylesheets in the registry", (): void => {

--- a/packages/fast-jss-manager-react/src/jss-manager.tsx
+++ b/packages/fast-jss-manager-react/src/jss-manager.tsx
@@ -57,7 +57,7 @@ Pick<
  * The JSSManger. This class manages JSSStyleSheet compilation and passes generated class-names
  * down to child component
  */
-export class JSSManager<T, S, C> extends React.Component<IJSSManagerProps<S, C>, IJSSManagerState> {
+export class JSSManager<S, C> extends React.Component<IJSSManagerProps<S, C>, IJSSManagerState> {
     /**
      * The style manager is responsible for attaching and detaching style elements when
      * components mount and un-mount

--- a/packages/fast-jss-manager-react/src/jss-manager.tsx
+++ b/packages/fast-jss-manager-react/src/jss-manager.tsx
@@ -72,11 +72,11 @@ export class JSSManager<T, S, C> extends React.Component<IJSSManagerProps<S, C>,
         if (Boolean(props.styles)) {
             state.styleSheet = this.createStyleSheet();
             state.styleSheet.attach();
-        }
 
-        // It appears we need to update the stylesheet for any style properties defined as functions
-        // to work.
-        state.styleSheet.update(props.designSystem);
+            // It appears we need to update the stylesheet for any style properties defined as functions
+            // to work.
+            state.styleSheet.update(props.designSystem);
+        }
 
         this.state = state;
     }
@@ -89,7 +89,6 @@ export class JSSManager<T, S, C> extends React.Component<IJSSManagerProps<S, C>,
         } else if (!isEqual(this.props.designSystem, prevProps.designSystem)) {
             this.updateStyleSheet();
         }
-
     }
 
     public componentWillUnmount(): void {

--- a/packages/fast-jss-manager-react/src/jss-manager.tsx
+++ b/packages/fast-jss-manager-react/src/jss-manager.tsx
@@ -1,0 +1,182 @@
+import * as React from "react";
+import { jss, stylesheetManager, stylesheetRegistry } from "./jss";
+import { SheetsManager } from "jss";
+import { IDesignSystem } from "./design-system-provider";
+import { ClassNames, ComponentStyles, ComponentStyleSheet, IManagedClasses } from "@microsoft/fast-jss-manager";
+import { isEqual, merge } from "lodash-es";
+import { Consumer } from "./context";
+
+/**
+ * State interface for JSS manager
+ */
+export interface IJSSManagerState {
+    /**
+     * Stores a JSS stylesheet containing all config-driven styles rules for a component
+     */
+    styleSheet?: any;
+}
+
+/**
+ * Describes an interface for adjusting a styled component
+ * per component instance
+ */
+export interface IJSSManagedComponentProps<S, C> {
+    jssStyleSheet?: Partial<ComponentStyles<S, C>>;
+}
+
+export interface IJSSManagerProps<S, C> extends IJSSManagedComponentProps<S, C> {
+    /**
+     * The styles for the JSS manager to compile
+     */
+    styles?: ComponentStyles<S, C>;
+
+    /**
+     * The design-system to compile the styles with
+     */
+    designSystem?: C;
+
+    /**
+     * Render the child component
+     */
+    render: (managedClasses: ClassNames<S> ) => React.ReactNode;
+}
+
+/**
+ * Prop typing for the JSSManager
+ */
+export type ManagedJSSProps<T, S, C> =
+Pick<
+    T,
+    Exclude<
+        keyof T,
+        keyof IManagedClasses<C>
+    >
+> & IJSSManagedComponentProps<S, C>;
+
+/**
+ * The JSSManger. This class manages JSSStyleSheet compilation and passes generated class-names
+ * down to child component
+ */
+export class JSSManager<T, S, C> extends React.Component<IJSSManagerProps<S, C>, IJSSManagerState> {
+    /**
+     * The style manager is responsible for attaching and detaching style elements when
+     * components mount and un-mount
+     */
+    private static stylesheetManager: SheetsManager = stylesheetManager;
+
+    constructor(props: IJSSManagerProps<S, C>) {
+        super(props);
+
+        const state: IJSSManagerState = {};
+
+        if (Boolean(props.styles)) {
+            state.styleSheet = this.createStyleSheet();
+            state.styleSheet.attach();
+        }
+
+        // It appears we need to update the stylesheet for any style properties defined as functions
+        // to work.
+        state.styleSheet.update(props.designSystem);
+
+        this.state = state;
+    }
+
+    public componentDidUpdate(prevProps: IJSSManagerProps<S, C>, prevState: IJSSManagerState): void {
+        // If we have new style assignments, we always need to reset the stylesheet from scratch
+        // else, if the designSystem has changed, update the stylesheet with new design system values
+        if (this.props.jssStyleSheet !== prevProps.jssStyleSheet) {
+            this.resetStyleSheet();
+        } else if (!isEqual(this.props.designSystem, prevProps.designSystem)) {
+            this.updateStyleSheet();
+        }
+
+    }
+
+    public componentWillUnmount(): void {
+        this.removeStyleSheet();
+    }
+
+    public render(): React.ReactNode {
+        return this.props.render(this.classNames());
+    }
+
+    /**
+     * Updates a dynamic stylesheet with context
+     */
+    public updateStyleSheet(): void {
+        if (!Boolean(this.state.styleSheet)) {
+            return;
+        }
+
+        if (typeof this.props.styles === "function") {
+            this.resetStyleSheet();
+        } else {
+            this.state.styleSheet.update(
+                this.props.designSystem
+            );
+        }
+    }
+
+    /**
+     * Remove a JSS stylesheet
+     */
+    private removeStyleSheet(): void {
+        if (this.hasStyleSheet()) {
+            this.state.styleSheet.detach();
+            stylesheetRegistry.remove(this.state.styleSheet);
+            jss.removeStyleSheet(this.state.styleSheet);
+        }
+    }
+
+    /**
+     * Reset a JSS stylesheet relative to current props
+     */
+    private resetStyleSheet(): void {
+        this.removeStyleSheet();
+        this.setState(
+            (previousState: IJSSManagerState, props: IJSSManagerProps<S, C>): Partial<IJSSManagerState> => {
+                return {
+                    styleSheet: this.hasStyleSheet() ? this.createStyleSheet() : null
+                };
+            }, (): void => {
+                if (this.hasStyleSheet()) {
+                    this.state.styleSheet.attach().update(this.props.designSystem);
+                }
+            });
+    }
+
+    /**
+     * Creates a JSS stylesheet from the dynamic portion of an associated style object and any style object passed
+     * as props
+     */
+    private createStyleSheet(): any {
+        const stylesheet: ComponentStyleSheet<S, C> = typeof this.props.styles === "function"
+            ? this.props.styles(this.props.designSystem)
+            : this.props.styles;
+
+        const jssSheet: any =  jss.createStyleSheet(
+            merge({}, stylesheet, this.props.jssStyleSheet),
+            { link: true }
+        );
+
+        stylesheetRegistry.add(jssSheet);
+
+        return jssSheet;
+    }
+
+    /**
+     * Checks to see if this component has an associated dynamic stylesheet
+     */
+    private hasStyleSheet(): boolean {
+        return Boolean(this.props.styles || this.props.jssStyleSheet);
+    }
+
+    /**
+     * returns the compiled classes
+     */
+    private classNames(): ClassNames<S> {
+        return this.hasStyleSheet()
+        ? this.state.styleSheet.classes
+        : {};
+    }
+}

--- a/packages/fast-jss-manager-react/src/jss.ts
+++ b/packages/fast-jss-manager-react/src/jss.ts
@@ -5,5 +5,4 @@ const jss: JSS = create(presets());
 const stylesheetManager: SheetsManager = new SheetsManager();
 const stylesheetRegistry: SheetsRegistry = new SheetsRegistry();
 
-export default jss;
-export { stylesheetManager, stylesheetRegistry };
+export { jss, stylesheetManager, stylesheetRegistry };

--- a/packages/fast-jss-manager-react/src/manage-jss.spec.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.spec.tsx
@@ -1,5 +1,9 @@
 import * as React from "react";
-import manageJss from "./manage-jss";
+import manageJss, {
+    cleanLowerOrderComponentProps,
+    IJSSManagerProps,
+    JSSManager
+} from "./manage-jss";
 import { stylesheetRegistry } from "./jss";
 import { ComponentStyles, ComponentStyleSheetResolver } from "@microsoft/fast-jss-manager";
 import * as ShallowRenderer from "react-test-renderer/shallow";
@@ -62,28 +66,46 @@ const staticAndDynamicStyles: ComponentStyles<any, any> = {
 };
 
 describe("The return value of manageJss", (): void => {
-    test("should return a higher order function", (): void => {
+    test("should return a  function", (): void => {
          expect(typeof manageJss()).toBe("function");
     });
 
-    test("should return a higher order function that returns a higher-order component", (): void => {
+    test("should return a function that returns react stateless component", (): void => {
+        const hoc: React.SFC<{}> = manageJss()(SimpleComponent);
 
-        expect(manageJss()(SimpleComponent).prototype.isReactComponent).toEqual({});
+        expect(typeof hoc).toEqual("function");
+
+        // Should expect a single prop argument
+        expect(hoc.length).toBe(1);
+    });
+});
+
+describe("cleanLowerOrderComponentProps", (): void => {
+    test("should filter out jssStyleSheet and managedClasses", (): void => {
+        const props: any = {
+            managedClasses: {},
+            jssStyleSheet: {},
+            foobar: "success"
+        };
+
+        const result: any = cleanLowerOrderComponentProps(props);
+        expect(result.managedClasses).toBe(undefined);
+        expect(result.jssStyleSheet).toBe(undefined);
+        expect(result.foobar).toBe("success");
     });
 });
 
 describe("The higher-order component", (): void => {
-
-    test("should return a different component when called twice with the same component", (): void => {
+    xtest("should return a different component when called twice with the same component", (): void => {
         expect(manageJss()(SimpleComponent)).not.toBe(manageJss()(SimpleComponent));
     });
 
-    test("should share a stylesheet manager between instances", (): void => {
+    xtest("should share a stylesheet manager between instances", (): void => {
         const key: string = "stylesheetManager";
         expect( manageJss()(SimpleComponent)[key]).toBe(manageJss()(SimpleComponent)[key]);
     });
 
-    test("should not share static styles across component instances", (): void => {
+    xtest("should not share static styles across component instances", (): void => {
         const renderers: ShallowRenderer[] = [
             new ShallowRenderer(),
             new ShallowRenderer()
@@ -98,7 +120,7 @@ describe("The higher-order component", (): void => {
         expect(Component["stylesheetManager"].sheets.length).toBe(expected);
     });
     // tslint:disable-next-line
-    test("should not share the static portion or the dynamic portion of a stylesheets across component instances", (): void => {
+    xtest("should not share the static portion or the dynamic portion of a stylesheets across component instances", (): void => {
         const renderers: ShallowRenderer[] = [
             new ShallowRenderer(),
             new ShallowRenderer()
@@ -113,7 +135,7 @@ describe("The higher-order component", (): void => {
         expect(Component["stylesheetManager"].sheets.length).toBe(expected);
     });
 
-    test("should update the stylesheet when context changes", (): void => {
+    xtest("should update the stylesheet when context changes", (): void => {
         const Component: any = manageJss(staticAndDynamicStyles)(SimpleComponent);
         const mock: any = jest.fn();
         const rendered: any = shallow(
@@ -128,7 +150,7 @@ describe("The higher-order component", (): void => {
         expect(mock.mock.calls.length).toBe(1);
     });
 
-    test("should remove stylesheets when unmounting" , (): void => {
+    xtest("should remove stylesheets when unmounting" , (): void => {
         const Component: any = manageJss(staticAndDynamicStyles)(SimpleComponent);
         const rendered: any = shallow(
             <Component />,
@@ -142,7 +164,7 @@ describe("The higher-order component", (): void => {
         expect(styleSheet.attached).toBe(false);
     });
 
-    test("should create a new stylesheet when stylesheet props are changed", () => {
+    xtest("should create a new stylesheet when stylesheet props are changed", () => {
         const Component: any = manageJss(staticAndDynamicStyles)(SimpleComponent);
         const rendered: any = shallow(
             <Component jssStyleSheet={{dynamicStylesClass: { margin: "0" }}} />,
@@ -157,7 +179,7 @@ describe("The higher-order component", (): void => {
         expect(rendered.state("styleSheet").attached).toBe(true);
     });
 
-    test("should accept a function as a stylesheet", () => {
+    xtest("should accept a function as a stylesheet", () => {
         const Component: any = manageJss(stylesheetResolver)(SimpleComponent);
         const rendered: any = shallow(
             <Component />
@@ -169,7 +191,7 @@ describe("The higher-order component", (): void => {
         expect(styleSheet.classes.resolvedStylesClass).not.toBe(undefined);
     });
 
-    test("should store all stylesheets in the registry", (): void => {
+    xtest("should store all stylesheets in the registry", (): void => {
         stylesheetRegistry.reset();
         expect(stylesheetRegistry.registry.length).toBe(0);
 

--- a/packages/fast-jss-manager-react/src/manage-jss.spec.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.spec.tsx
@@ -31,6 +31,22 @@ describe("manageJss", (): void => {
         // Should expect a single prop argument
         expect(hoc.length).toBe(1);
     });
+
+    test("should render a provided component", (): void => {
+        const Hoc: React.SFC<{}> = manageJss()(SimpleComponent);
+
+        const rendered: ReactWrapper = mount(<Hoc />);
+
+        expect(rendered.exists("SimpleComponent")).toBe(true);
+    });
+
+    test("should render a JSSManager component", (): void => {
+        const Hoc: React.SFC<{}> = manageJss()(SimpleComponent);
+
+        const rendered: ReactWrapper = mount(<Hoc />);
+
+        expect(rendered.exists("JSSManager")).toBe(true);
+    });
 });
 
 describe("cleanLowerOrderComponentProps", (): void => {

--- a/packages/fast-jss-manager-react/src/manage-jss.spec.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.spec.tsx
@@ -1,10 +1,7 @@
 import * as React from "react";
-import manageJss, {
-    cleanLowerOrderComponentProps,
-    IJSSManagerProps,
-    JSSManager
-} from "./manage-jss";
-import jss, { stylesheetRegistry } from "./jss";
+import { cleanLowerOrderComponentProps, manageJss } from "./manage-jss";
+import { IJSSManagerProps, JSSManager } from "./jss-manager";
+import { jss, stylesheetRegistry } from "./jss";
 import { ComponentStyles, ComponentStyleSheetResolver } from "@microsoft/fast-jss-manager";
 import * as ShallowRenderer from "react-test-renderer/shallow";
 import { configure, mount, ReactWrapper, render, shallow } from "enzyme";
@@ -15,55 +12,11 @@ import * as Adapter from "enzyme-adapter-react-16";
  */
 configure({adapter: new Adapter()});
 
-// Disable "no-string-literal" so we can access private members easily
-/* tslint:disable:no-string-literal */
-
 class SimpleComponent extends React.Component<any, any> {
     public render(): boolean {
         return true;
     }
 }
-
-/**
- * JSS stylesheet with only static values for CSS properties
- */
-const staticStyles: ComponentStyles<any, any> = {
-    staticStyleClass: {
-        color: "red"
-    }
-};
-
-/**
- * JSS stylesheet with dynamic values for CSS properties
- */
-const dynamicStyles: ComponentStyles<any, any> = {
-    dynamicStylesClass: {
-        background: (): string => {
-            return "blue";
-        }
-    }
-};
-
-/**
- * JSS stylesheet defined as a function
- */
-const stylesheetResolver: ComponentStyles<any, any> = (config: any): any => {
-    return {
-        resolvedStylesClass: {
-            background: "green",
-            color: (): string => {
-                return "yellow";
-            }
-        }
-    };
-};
-
-/**
- * JSS stylesheet with static and dynamic values for CSS properties
- */
-const staticAndDynamicStyles: ComponentStyles<any, any> = {
-    staticAndDynamicStylesClass: { ...staticStyles.staticStyleClass, ...dynamicStyles.dynamicStylesClass }
-};
 
 describe("manageJss", (): void => {
     test("should return a  function", (): void => {
@@ -89,140 +42,7 @@ describe("cleanLowerOrderComponentProps", (): void => {
         };
 
         const result: any = cleanLowerOrderComponentProps(props);
-        expect(result.managedClasses).toBe(undefined);
         expect(result.jssStyleSheet).toBe(undefined);
         expect(result.foobar).toBe("success");
-    });
-});
-
-describe("The JSSManager", (): void => {
-    function renderChild(): string {
-        return "children";
-    }
-
-    // JSS doesn't export their StyleSheet class, so we can compile a stylesheet and
-    // access it's constructor to get a reference to the StyleSheet class.
-    const StyleSheet: any = jss.createStyleSheet({}).constructor;
-
-    test("should not throw when no stylesheet is provided", (): void => {
-
-        expect((): void => {
-            mount(
-                <JSSManager render={renderChild} />
-            );
-        }).not.toThrow();
-    });
-
-    test("should compile a stylesheet when mounting", (): void => {
-        const tree: ReactWrapper = mount(
-            <JSSManager
-                render={renderChild}
-                styles={{ className: { color: "red" } }}
-            />
-        );
-
-        expect(tree.state("styleSheet")).toBeInstanceOf(StyleSheet);
-    });
-
-    xtest("should return a different component when called twice with the same component", (): void => {
-        expect(manageJss()(SimpleComponent)).not.toBe(manageJss()(SimpleComponent));
-    });
-
-    xtest("should not share static styles across component instances", (): void => {
-        const renderers: ShallowRenderer[] = [
-            new ShallowRenderer(),
-            new ShallowRenderer()
-        ];
-        const Component: any = manageJss(staticStyles)(SimpleComponent);
-        const expected: number = 0;
-
-        renderers.forEach((renderer: ShallowRenderer) => {
-            renderer.render(<Component />);
-        });
-
-        expect(Component["stylesheetManager"].sheets.length).toBe(expected);
-    });
-    // tslint:disable-next-line
-    xtest("should not share the static portion or the dynamic portion of a stylesheets across component instances", (): void => {
-        const renderers: ShallowRenderer[] = [
-            new ShallowRenderer(),
-            new ShallowRenderer()
-        ];
-        const Component: any = manageJss(staticAndDynamicStyles)(SimpleComponent);
-        const expected: number = 0;
-
-        renderers.forEach((renderer: ShallowRenderer) => {
-            renderer.render(<Component />);
-        });
-
-        expect(Component["stylesheetManager"].sheets.length).toBe(expected);
-    });
-
-    xtest("should update the stylesheet when context changes", (): void => {
-        const Component: any = manageJss(staticAndDynamicStyles)(SimpleComponent);
-        const mock: any = jest.fn();
-        const rendered: any = shallow(
-            <Component />,
-            { context: {designSystem: true} }
-        );
-        rendered.instance().updateStyleSheet = mock;
-
-        // Change context
-        rendered.setContext({designSystem: false});
-
-        expect(mock.mock.calls.length).toBe(1);
-    });
-
-    xtest("should remove stylesheets when unmounting" , (): void => {
-        const Component: any = manageJss(staticAndDynamicStyles)(SimpleComponent);
-        const rendered: any = shallow(
-            <Component />,
-            { context: {designSystem: true} }
-        );
-        const styleSheet: any = rendered.state("styleSheet");
-        expect(styleSheet.attached).toBe(true);
-
-        rendered.unmount();
-
-        expect(styleSheet.attached).toBe(false);
-    });
-
-    xtest("should create a new stylesheet when stylesheet props are changed", () => {
-        const Component: any = manageJss(staticAndDynamicStyles)(SimpleComponent);
-        const rendered: any = shallow(
-            <Component jssStyleSheet={{dynamicStylesClass: { margin: "0" }}} />,
-            { context: {designSystem: true} }
-        );
-
-        const styleSheet: any = rendered.state("styleSheet");
-
-        rendered.setProps({jssStyleSheet: {dynamicStylesClass: { margin: "1px" }}});
-
-        expect(styleSheet.attached).toBe(false);
-        expect(rendered.state("styleSheet").attached).toBe(true);
-    });
-
-    xtest("should accept a function as a stylesheet", () => {
-        const Component: any = manageJss(stylesheetResolver)(SimpleComponent);
-        const rendered: any = shallow(
-            <Component />
-        );
-
-        const styleSheet: any = rendered.state("styleSheet");
-
-        expect(styleSheet.attached).toBe(true);
-        expect(styleSheet.classes.resolvedStylesClass).not.toBe(undefined);
-    });
-
-    xtest("should store all stylesheets in the registry", (): void => {
-        stylesheetRegistry.reset();
-        expect(stylesheetRegistry.registry.length).toBe(0);
-
-        const Component: any = manageJss(staticAndDynamicStyles)(SimpleComponent);
-        const rendered: any = shallow(
-            <Component />
-        );
-
-        expect(stylesheetRegistry.registry.length).toBe(1);
     });
 });

--- a/packages/fast-jss-manager-react/src/manage-jss.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.tsx
@@ -30,21 +30,21 @@ export interface IJSSManagerState {
 /**
  * JSS Manager props
  */
-export interface IJSSManagerProps<S, C> {
+export interface IManagedJSSProps<S, C> {
     jssStyleSheet?: Partial<ComponentStyles<S, C>>;
 }
 
 /**
  * Prop typing for the JSSManager
  */
-export type JSSManagerProps<T, S, C> =
+export type ManagedJSSProps<T, S, C> =
 Pick<
     T,
     Exclude<
         keyof T,
         keyof IManagedClasses<C>
     >
-> & IJSSManagerProps<S, C>;
+> & IManagedJSSProps<S, C>;
 
 /**
  * Main entry into the style manager. This function accepts a JSS style object and returns a
@@ -61,8 +61,8 @@ function manageJss<S, C>(
 ) => React.SFC<{}> {
     return function<T>(
         Component: React.ComponentType<T & IManagedClasses<S>>
-    ): React.SFC<JSSManagerProps<T, S, C>> {
-        return (props: JSSManagerProps<T, S, C>): React.ReactElement<{}> => {
+    ): React.SFC<ManagedJSSProps<T, S, C>> {
+        return (props: ManagedJSSProps<T, S, C>): React.ReactElement<{}> => {
             function render(designSystem: C): React.ReactNode {
                 return "JSSManager goes here";
             }
@@ -80,13 +80,13 @@ function manageJss<S, C>(
 //     styles?: ComponentStyles<S, C>
 // ): <T>(
 //     Component: React.ComponentType<T & IManagedClasses<S>>
-// ) => React.ComponentClass<JSSManagerProps<T, S, C>> {
+// ) => React.ComponentClass<ManagedJSSProps<T, S, C>> {
 //     return function<T>(
 //         Component: React.ComponentType<T & IManagedClasses<S>>
-//     ): React.ComponentClass<JSSManagerProps<T, S, C>> {
+//     ): React.ComponentClass<ManagedJSSProps<T, S, C>> {
 
 //         // Define the manager higher-order component inside of the return method of the higher-order function.
-//         class JSSManager extends React.Component<JSSManagerProps<T, S, C>, IJSSManagerState> {
+//         class JSSManager extends React.Component<ManagedJSSProps<T, S, C>, IJSSManagerState> {
 //             // TODO: figure out if there is a better way to type this object
 //             public static contextTypes: any = {
 //                 designSystem: propTypes.any
@@ -98,7 +98,7 @@ function manageJss<S, C>(
 //              */
 //             private static stylesheetManager: SheetsManager = stylesheetManager;
 
-//             constructor(props: JSSManagerProps<T, S, C>) {
+//             constructor(props: ManagedJSSProps<T, S, C>) {
 //                 super(props);
 
 //                 const state: IJSSManagerState = {};
@@ -134,13 +134,13 @@ function manageJss<S, C>(
 //                 }
 //             }
 
-//             public componentWillUpdate(nextProps: JSSManagerProps<T, S, C>, nextState: IJSSManagerState, nextContext: any): void {
+//             public componentWillUpdate(nextProps: ManagedJSSProps<T, S, C>, nextState: IJSSManagerState, nextContext: any): void {
 //                 if (!isEqual(this.context, nextContext)) {
 //                     this.updateStyleSheet(nextContext);
 //                 }
 //             }
 
-//             public componentDidUpdate(prevProps: JSSManagerProps<T, S, C>, prevState: IJSSManagerState): void {
+//             public componentDidUpdate(prevProps: ManagedJSSProps<T, S, C>, prevState: IJSSManagerState): void {
 //                 if (this.props.jssStyleSheet !== prevProps.jssStyleSheet) {
 //                     this.resetStyleSheet();
 //                 }
@@ -182,7 +182,7 @@ function manageJss<S, C>(
 //              */
 //             private resetStyleSheet(): any {
 //                 this.removeStyleSheet();
-//                 this.setState((previousState: IJSSManagerState, props: JSSManagerProps<T, S, C>): Partial<IJSSManagerState> => {
+//                 this.setState((previousState: IJSSManagerState, props: ManagedJSSProps<T, S, C>): Partial<IJSSManagerState> => {
 //                     return {
 //                         styleSheet: this.hasStyleSheet() ? this.createStyleSheet() : null
 //                     };

--- a/packages/fast-jss-manager-react/src/manage-jss.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.tsx
@@ -64,7 +64,6 @@ Pick<
     >
 > & IInstanceStyleSheet<S, C>;
 
-
 export function cleanLowerOrderComponentProps<T, S, C>(props: ManagedJSSProps<T, S, C>): T {
     // TODO: We can make this more performant, running into type issues so leaving as is for now.
     return pick(props, Object.keys(props).filter((key: string) => {
@@ -128,172 +127,172 @@ function manageJss<S, C>(
     };
 }
 
-function BLARG<S, C>(
-    styles?: ComponentStyles<S, C>
-): <T>(
-    Component: React.ComponentType<T & IManagedClasses<S>>
-) => React.ComponentClass<ManagedJSSProps<T, S, C>> {
-    return function<T>(
-        Component: React.ComponentType<T & IManagedClasses<S>>
-    ): React.ComponentClass<ManagedJSSProps<T, S, C>> {
+// function BLARG<S, C>(
+//     styles?: ComponentStyles<S, C>
+// ): <T>(
+//     Component: React.ComponentType<T & IManagedClasses<S>>
+// ) => React.ComponentClass<ManagedJSSProps<T, S, C>> {
+//     return function<T>(
+//         Component: React.ComponentType<T & IManagedClasses<S>>
+//     ): React.ComponentClass<ManagedJSSProps<T, S, C>> {
 
-        // Define the manager higher-order component inside of the return method of the higher-order function.
-        class JSSManager extends React.Component<ManagedJSSProps<T, S, C>, IJSSManagerState> {
-            // TODO: figure out if there is a better way to type this object
-            public static contextTypes: any = {
-                designSystem: propTypes.any
-            };
+//         // Define the manager higher-order component inside of the return method of the higher-order function.
+//         class JSSManager extends React.Component<ManagedJSSProps<T, S, C>, IJSSManagerState> {
+//             // TODO: figure out if there is a better way to type this object
+//             public static contextTypes: any = {
+//                 designSystem: propTypes.any
+//             };
 
-            /**
-             * The style manager is responsible for attaching and detaching style elements when
-             * components mount and un-mount
-             */
-            private static stylesheetManager: SheetsManager = stylesheetManager;
+//             /**
+//              * The style manager is responsible for attaching and detaching style elements when
+//              * components mount and un-mount
+//              */
+//             private static stylesheetManager: SheetsManager = stylesheetManager;
 
-            constructor(props: ManagedJSSProps<T, S, C>) {
-                super(props);
+//             constructor(props: ManagedJSSProps<T, S, C>) {
+//                 super(props);
 
-                const state: IJSSManagerState = {};
+//                 const state: IJSSManagerState = {};
 
-                if (Boolean(styles)) {
-                    state.styleSheet = this.createStyleSheet();
-                }
+//                 if (Boolean(styles)) {
+//                     state.styleSheet = this.createStyleSheet();
+//                 }
 
-                this.state = state;
-            }
+//                 this.state = state;
+//             }
 
-            /**
-             * Updates a dynamic stylesheet with context
-             */
-            public updateStyleSheet(nextContext?: any): void {
-                if (!Boolean(this.state.styleSheet)) {
-                    return;
-                }
+//             /**
+//              * Updates a dynamic stylesheet with context
+//              */
+//             public updateStyleSheet(nextContext?: any): void {
+//                 if (!Boolean(this.state.styleSheet)) {
+//                     return;
+//                 }
 
-                if (typeof styles === "function") {
-                    this.resetStyleSheet();
-                } else {
-                    this.state.styleSheet.update(nextContext && nextContext.designSystem ? nextContext.designSystem : this.designSystem);
-                }
-            }
+//                 if (typeof styles === "function") {
+//                     this.resetStyleSheet();
+//                 } else {
+//                     this.state.styleSheet.update(nextContext && nextContext.designSystem ? nextContext.designSystem : this.designSystem);
+//                 }
+//             }
 
-            public componentWillMount(): void {
-                if (Boolean(this.state.styleSheet)) {
-                    // It appears we need to update the stylesheet for any style properties defined as functions
-                    // to work.
-                    this.state.styleSheet.attach();
-                    this.updateStyleSheet();
-                }
-            }
+//             public componentWillMount(): void {
+//                 if (Boolean(this.state.styleSheet)) {
+//                     // It appears we need to update the stylesheet for any style properties defined as functions
+//                     // to work.
+//                     this.state.styleSheet.attach();
+//                     this.updateStyleSheet();
+//                 }
+//             }
 
-            public componentWillUpdate(nextProps: ManagedJSSProps<T, S, C>, nextState: IJSSManagerState, nextContext: any): void {
-                if (!isEqual(this.context, nextContext)) {
-                    this.updateStyleSheet(nextContext);
-                }
-            }
+//             public componentWillUpdate(nextProps: ManagedJSSProps<T, S, C>, nextState: IJSSManagerState, nextContext: any): void {
+//                 if (!isEqual(this.context, nextContext)) {
+//                     this.updateStyleSheet(nextContext);
+//                 }
+//             }
 
-            public componentDidUpdate(prevProps: ManagedJSSProps<T, S, C>, prevState: IJSSManagerState): void {
-                if (this.props.jssStyleSheet !== prevProps.jssStyleSheet) {
-                    this.resetStyleSheet();
-                }
-            }
+//             public componentDidUpdate(prevProps: ManagedJSSProps<T, S, C>, prevState: IJSSManagerState): void {
+//                 if (this.props.jssStyleSheet !== prevProps.jssStyleSheet) {
+//                     this.resetStyleSheet();
+//                 }
+//             }
 
-            public componentWillUnmount(): void {
-                this.removeStyleSheet();
-            }
+//             public componentWillUnmount(): void {
+//                 this.removeStyleSheet();
+//             }
 
-            public render(): React.ReactNode {
-                return (
-                    <Component
-                        {...omit(this.props, ["jssStyleSheet"])}
-                        managedClasses={this.getClassNames()}
-                    />
-                );
-            }
+//             public render(): React.ReactNode {
+//                 return (
+//                     <Component
+//                         {...omit(this.props, ["jssStyleSheet"])}
+//                         managedClasses={this.getClassNames()}
+//                     />
+//                 );
+//             }
 
-            /**
-             * Get the design-system context to update the stylesheet with
-             */
-            private get designSystem(): any {
-                return this.context && this.context.designSystem ? this.context.designSystem : {};
-            }
+//             /**
+//              * Get the design-system context to update the stylesheet with
+//              */
+//             private get designSystem(): any {
+//                 return this.context && this.context.designSystem ? this.context.designSystem : {};
+//             }
 
-            /**
-             * Remove a JSS stylesheet
-             */
-            private removeStyleSheet(): void {
-                if (this.hasStyleSheet()) {
-                    this.state.styleSheet.detach();
-                    stylesheetRegistry.remove(this.state.styleSheet);
-                    jss.removeStyleSheet(this.state.styleSheet);
-                }
-            }
+//             /**
+//              * Remove a JSS stylesheet
+//              */
+//             private removeStyleSheet(): void {
+//                 if (this.hasStyleSheet()) {
+//                     this.state.styleSheet.detach();
+//                     stylesheetRegistry.remove(this.state.styleSheet);
+//                     jss.removeStyleSheet(this.state.styleSheet);
+//                 }
+//             }
 
-            /**
-             * Reset a JSS stylesheet relative to current props
-             */
-            private resetStyleSheet(): any {
-                this.removeStyleSheet();
-                this.setState((previousState: IJSSManagerState, props: ManagedJSSProps<T, S, C>): Partial<IJSSManagerState> => {
-                    return {
-                        styleSheet: this.hasStyleSheet() ? this.createStyleSheet() : null
-                    };
-                }, (): void => {
-                    if (this.hasStyleSheet()) {
-                        this.state.styleSheet.attach().update(this.designSystem);
-                    }
-                });
-            }
+//             /**
+//              * Reset a JSS stylesheet relative to current props
+//              */
+//             private resetStyleSheet(): any {
+//                 this.removeStyleSheet();
+//                 this.setState((previousState: IJSSManagerState, props: ManagedJSSProps<T, S, C>): Partial<IJSSManagerState> => {
+//                     return {
+//                         styleSheet: this.hasStyleSheet() ? this.createStyleSheet() : null
+//                     };
+//                 }, (): void => {
+//                     if (this.hasStyleSheet()) {
+//                         this.state.styleSheet.attach().update(this.designSystem);
+//                     }
+//                 });
+//             }
 
-            /**
-             * Creates a JSS stylesheet from the dynamic portion of an associated style object and any style object passed
-             * as props
-             */
-            private createStyleSheet(): any {
-                const stylesheet: ComponentStyleSheet<S, C> = typeof styles === "function"
-                    ? styles(this.designSystem)
-                    : styles;
+//             /**
+//              * Creates a JSS stylesheet from the dynamic portion of an associated style object and any style object passed
+//              * as props
+//              */
+//             private createStyleSheet(): any {
+//                 const stylesheet: ComponentStyleSheet<S, C> = typeof styles === "function"
+//                     ? styles(this.designSystem)
+//                     : styles;
 
-                const jssSheet: any =  jss.createStyleSheet(
-                    merge({}, stylesheet, this.props.jssStyleSheet),
-                    { link: true }
-                );
+//                 const jssSheet: any =  jss.createStyleSheet(
+//                     merge({}, stylesheet, this.props.jssStyleSheet),
+//                     { link: true }
+//                 );
 
-                stylesheetRegistry.add(jssSheet);
+//                 stylesheetRegistry.add(jssSheet);
 
-                return jssSheet;
-            }
+//                 return jssSheet;
+//             }
 
-            /**
-             * Checks to see if this component has an associated dynamic stylesheet
-             */
-            private hasStyleSheet(): boolean {
-                return Boolean(styles || this.props.jssStyleSheet);
-            }
+//             /**
+//              * Checks to see if this component has an associated dynamic stylesheet
+//              */
+//             private hasStyleSheet(): boolean {
+//                 return Boolean(styles || this.props.jssStyleSheet);
+//             }
 
-            /**
-             * Merges static and dynamic stylesheet classnames into one object
-             */
-            private getClassNames(): ClassNames<S> {
-                const classNames: Partial<ClassNames<S>> = {};
+//             /**
+//              * Merges static and dynamic stylesheet classnames into one object
+//              */
+//             private getClassNames(): ClassNames<S> {
+//                 const classNames: Partial<ClassNames<S>> = {};
 
-                if (this.hasStyleSheet()) {
-                    for (const key in this.state.styleSheet.classes) {
-                        if (this.state.styleSheet.classes.hasOwnProperty(key)) {
-                            classNames[key] = typeof classNames[key] !== "undefined"
-                                ? `${classNames[key]} ${this.state.styleSheet.classes[key]}`
-                                : this.state.styleSheet.classes[key];
-                        }
-                    }
-                }
+//                 if (this.hasStyleSheet()) {
+//                     for (const key in this.state.styleSheet.classes) {
+//                         if (this.state.styleSheet.classes.hasOwnProperty(key)) {
+//                             classNames[key] = typeof classNames[key] !== "undefined"
+//                                 ? `${classNames[key]} ${this.state.styleSheet.classes[key]}`
+//                                 : this.state.styleSheet.classes[key];
+//                         }
+//                     }
+//                 }
 
-                return classNames as ClassNames<S>;
-            }
-        }
+//                 return classNames as ClassNames<S>;
+//             }
+//         }
 
-        return hoistNonReactStatics(JSSManager, Component);
-    };
-}
+//         return hoistNonReactStatics(JSSManager, Component);
+//     };
+// }
 
 /**
  * The JSSManger. This class manages JSSStyleSheet compilation and passes generated class-names

--- a/packages/fast-jss-manager-react/src/manage-jss.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.tsx
@@ -1,17 +1,29 @@
 import * as React from "react";
 import { ClassNames, ComponentStyles, IManagedClasses } from "@microsoft/fast-jss-manager";
-import { pick } from "lodash-es";
+import { omit } from "lodash-es";
 import { Consumer } from "./context";
-import { JSSManager, ManagedJSSProps } from "./jss-manager";
+import { IJSSManagedComponentProps, JSSManager, ManagedJSSProps } from "./jss-manager";
+
+/**
+ * The prop name that must be passed to the JSSManager and not the managed component
+ */
+const jssManagerProp: keyof IJSSManagedComponentProps<any, any> = "jssStyleSheet";
+
+/**
+ * Determines if component prop object contains props
+ * that need to be handed to the JSSManager
+ */
+function containsJssManagerProps<T, S, C>(props: T | ManagedJSSProps<T, S, C>): props is ManagedJSSProps<T, S, C> {
+    return props.hasOwnProperty(jssManagerProp);
+}
 
 /**
  * Removes props handled by the JSSManager from a prop object
  */
 export function cleanLowerOrderComponentProps<T, S, C>(props: ManagedJSSProps<T, S, C>): T {
-    // TODO: We can make this more performant, running into type issues so leaving as is for now.
-    return pick(props, Object.keys(props).filter((key: string) => {
-        return key !== "jssStyleSheet" && key !== "managedClasses";
-    })) as T;
+    return containsJssManagerProps(props)
+        ? omit(props, [jssManagerProp] ) as T
+        : props;
 }
 
 /**

--- a/packages/fast-jss-manager-react/src/manage-jss.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.tsx
@@ -49,6 +49,9 @@ Pick<
  * Main entry into the style manager. This function accepts a JSS style object and returns a
  * higher order component. That higher-order component can then be used to compose a component
  * with styles managed
+ * @param S - The stylesheet class-name contract
+ * @param C - The stylesheet configuration object
+ * @param T - The component prop interface
  */
 function manageJss<S, C>(
     styles?: ComponentStyles<S, C>

--- a/packages/fast-jss-manager-react/src/manage-jss.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.tsx
@@ -10,6 +10,7 @@ import { IDesignSystemProviderProps } from "./design-system-provider";
 import * as propTypes from "prop-types";
 import { ClassNames, ComponentStyles, ComponentStyleSheet, IManagedClasses } from "@microsoft/fast-jss-manager";
 import { isEqual, merge, omit } from "lodash-es";
+import { Consumer } from "./context";
 
 // hoist-non-react-statics does not seem to be a properly formatted ES6 module, so we need to require it instead
 // TODO https://github.com/Microsoft/fast-dna/issues/512
@@ -50,175 +51,197 @@ Pick<
  * higher order component. That higher-order component can then be used to compose a component
  * with styles managed
  * @param S - The stylesheet class-name contract
- * @param C - The stylesheet configuration object
+ * @param C - The stylesheet design-system configuration object
  * @param T - The component prop interface
  */
 function manageJss<S, C>(
     styles?: ComponentStyles<S, C>
 ): <T>(
     Component: React.ComponentType<T & IManagedClasses<S>>
-) => React.ComponentClass<JSSManagerProps<T, S, C>> {
+) => React.SFC<{}> {
     return function<T>(
         Component: React.ComponentType<T & IManagedClasses<S>>
-    ): React.ComponentClass<JSSManagerProps<T, S, C>> {
-
-        // Define the manager higher-order component inside of the return method of the higher-order function.
-        class JSSManager extends React.Component<JSSManagerProps<T, S, C>, IJSSManagerState> {
-            // TODO: figure out if there is a better way to type this object
-            public static contextTypes: any = {
-                designSystem: propTypes.any
-            };
-
-            /**
-             * The style manager is responsible for attaching and detaching style elements when
-             * components mount and un-mount
-             */
-            private static stylesheetManager: SheetsManager = stylesheetManager;
-
-            constructor(props: JSSManagerProps<T, S, C>) {
-                super(props);
-
-                const state: IJSSManagerState = {};
-
-                if (Boolean(styles)) {
-                    state.styleSheet = this.createStyleSheet();
-                }
-
-                this.state = state;
+    ): React.SFC<JSSManagerProps<T, S, C>> {
+        return (props: JSSManagerProps<T, S, C>): React.ReactElement<{}> => {
+            function render(designSystem: C): React.ReactNode {
+                return "JSSManager goes here";
             }
 
-            /**
-             * Updates a dynamic stylesheet with context
-             */
-            public updateStyleSheet(nextContext?: any): void {
-                if (!Boolean(this.state.styleSheet)) {
-                    return;
-                }
-
-                if (typeof styles === "function") {
-                    this.resetStyleSheet();
-                } else {
-                    this.state.styleSheet.update(nextContext && nextContext.designSystem ? nextContext.designSystem : this.designSystem);
-                }
-            }
-
-            public componentWillMount(): void {
-                if (Boolean(this.state.styleSheet)) {
-                    // It appears we need to update the stylesheet for any style properties defined as functions
-                    // to work.
-                    this.state.styleSheet.attach();
-                    this.updateStyleSheet();
-                }
-            }
-
-            public componentWillUpdate(nextProps: JSSManagerProps<T, S, C>, nextState: IJSSManagerState, nextContext: any): void {
-                if (!isEqual(this.context, nextContext)) {
-                    this.updateStyleSheet(nextContext);
-                }
-            }
-
-            public componentDidUpdate(prevProps: JSSManagerProps<T, S, C>, prevState: IJSSManagerState): void {
-                if (this.props.jssStyleSheet !== prevProps.jssStyleSheet) {
-                    this.resetStyleSheet();
-                }
-            }
-
-            public componentWillUnmount(): void {
-                this.removeStyleSheet();
-            }
-
-            public render(): React.ReactNode {
-                return (
-                    <Component
-                        {...omit(this.props, ["jssStyleSheet"])}
-                        managedClasses={this.getClassNames()}
-                    />
-                );
-            }
-
-            /**
-             * Get the design-system context to update the stylesheet with
-             */
-            private get designSystem(): any {
-                return this.context && this.context.designSystem ? this.context.designSystem : {};
-            }
-
-            /**
-             * Remove a JSS stylesheet
-             */
-            private removeStyleSheet(): void {
-                if (this.hasStyleSheet()) {
-                    this.state.styleSheet.detach();
-                    stylesheetRegistry.remove(this.state.styleSheet);
-                    jss.removeStyleSheet(this.state.styleSheet);
-                }
-            }
-
-            /**
-             * Reset a JSS stylesheet relative to current props
-             */
-            private resetStyleSheet(): any {
-                this.removeStyleSheet();
-                this.setState((previousState: IJSSManagerState, props: JSSManagerProps<T, S, C>): Partial<IJSSManagerState> => {
-                    return {
-                        styleSheet: this.hasStyleSheet() ? this.createStyleSheet() : null
-                    };
-                }, (): void => {
-                    if (this.hasStyleSheet()) {
-                        this.state.styleSheet.attach().update(this.designSystem);
-                    }
-                });
-            }
-
-            /**
-             * Creates a JSS stylesheet from the dynamic portion of an associated style object and any style object passed
-             * as props
-             */
-            private createStyleSheet(): any {
-                const stylesheet: ComponentStyleSheet<S, C> = typeof styles === "function"
-                    ? styles(this.designSystem)
-                    : styles;
-
-                const jssSheet: any =  jss.createStyleSheet(
-                    merge({}, stylesheet, this.props.jssStyleSheet),
-                    { link: true }
-                );
-
-                stylesheetRegistry.add(jssSheet);
-
-                return jssSheet;
-            }
-
-            /**
-             * Checks to see if this component has an associated dynamic stylesheet
-             */
-            private hasStyleSheet(): boolean {
-                return Boolean(styles || this.props.jssStyleSheet);
-            }
-
-            /**
-             * Merges static and dynamic stylesheet classnames into one object
-             */
-            private getClassNames(): ClassNames<S> {
-                const classNames: Partial<ClassNames<S>> = {};
-
-                if (this.hasStyleSheet()) {
-                    for (const key in this.state.styleSheet.classes) {
-                        if (this.state.styleSheet.classes.hasOwnProperty(key)) {
-                            classNames[key] = typeof classNames[key] !== "undefined"
-                                ? `${classNames[key]} ${this.state.styleSheet.classes[key]}`
-                                : this.state.styleSheet.classes[key];
-                        }
-                    }
-                }
-
-                return classNames as ClassNames<S>;
-            }
-        }
-
-        return hoistNonReactStatics(JSSManager, Component);
+            return (
+                <Consumer>
+                    {render}
+                </Consumer>
+            );
+        };
     };
 }
+
+// function manageJss<S, C>(
+//     styles?: ComponentStyles<S, C>
+// ): <T>(
+//     Component: React.ComponentType<T & IManagedClasses<S>>
+// ) => React.ComponentClass<JSSManagerProps<T, S, C>> {
+//     return function<T>(
+//         Component: React.ComponentType<T & IManagedClasses<S>>
+//     ): React.ComponentClass<JSSManagerProps<T, S, C>> {
+
+//         // Define the manager higher-order component inside of the return method of the higher-order function.
+//         class JSSManager extends React.Component<JSSManagerProps<T, S, C>, IJSSManagerState> {
+//             // TODO: figure out if there is a better way to type this object
+//             public static contextTypes: any = {
+//                 designSystem: propTypes.any
+//             };
+
+//             /**
+//              * The style manager is responsible for attaching and detaching style elements when
+//              * components mount and un-mount
+//              */
+//             private static stylesheetManager: SheetsManager = stylesheetManager;
+
+//             constructor(props: JSSManagerProps<T, S, C>) {
+//                 super(props);
+
+//                 const state: IJSSManagerState = {};
+
+//                 if (Boolean(styles)) {
+//                     state.styleSheet = this.createStyleSheet();
+//                 }
+
+//                 this.state = state;
+//             }
+
+//             /**
+//              * Updates a dynamic stylesheet with context
+//              */
+//             public updateStyleSheet(nextContext?: any): void {
+//                 if (!Boolean(this.state.styleSheet)) {
+//                     return;
+//                 }
+
+//                 if (typeof styles === "function") {
+//                     this.resetStyleSheet();
+//                 } else {
+//                     this.state.styleSheet.update(nextContext && nextContext.designSystem ? nextContext.designSystem : this.designSystem);
+//                 }
+//             }
+
+//             public componentWillMount(): void {
+//                 if (Boolean(this.state.styleSheet)) {
+//                     // It appears we need to update the stylesheet for any style properties defined as functions
+//                     // to work.
+//                     this.state.styleSheet.attach();
+//                     this.updateStyleSheet();
+//                 }
+//             }
+
+//             public componentWillUpdate(nextProps: JSSManagerProps<T, S, C>, nextState: IJSSManagerState, nextContext: any): void {
+//                 if (!isEqual(this.context, nextContext)) {
+//                     this.updateStyleSheet(nextContext);
+//                 }
+//             }
+
+//             public componentDidUpdate(prevProps: JSSManagerProps<T, S, C>, prevState: IJSSManagerState): void {
+//                 if (this.props.jssStyleSheet !== prevProps.jssStyleSheet) {
+//                     this.resetStyleSheet();
+//                 }
+//             }
+
+//             public componentWillUnmount(): void {
+//                 this.removeStyleSheet();
+//             }
+
+//             public render(): React.ReactNode {
+//                 return (
+//                     <Component
+//                         {...omit(this.props, ["jssStyleSheet"])}
+//                         managedClasses={this.getClassNames()}
+//                     />
+//                 );
+//             }
+
+//             /**
+//              * Get the design-system context to update the stylesheet with
+//              */
+//             private get designSystem(): any {
+//                 return this.context && this.context.designSystem ? this.context.designSystem : {};
+//             }
+
+//             /**
+//              * Remove a JSS stylesheet
+//              */
+//             private removeStyleSheet(): void {
+//                 if (this.hasStyleSheet()) {
+//                     this.state.styleSheet.detach();
+//                     stylesheetRegistry.remove(this.state.styleSheet);
+//                     jss.removeStyleSheet(this.state.styleSheet);
+//                 }
+//             }
+
+//             /**
+//              * Reset a JSS stylesheet relative to current props
+//              */
+//             private resetStyleSheet(): any {
+//                 this.removeStyleSheet();
+//                 this.setState((previousState: IJSSManagerState, props: JSSManagerProps<T, S, C>): Partial<IJSSManagerState> => {
+//                     return {
+//                         styleSheet: this.hasStyleSheet() ? this.createStyleSheet() : null
+//                     };
+//                 }, (): void => {
+//                     if (this.hasStyleSheet()) {
+//                         this.state.styleSheet.attach().update(this.designSystem);
+//                     }
+//                 });
+//             }
+
+//             /**
+//              * Creates a JSS stylesheet from the dynamic portion of an associated style object and any style object passed
+//              * as props
+//              */
+//             private createStyleSheet(): any {
+//                 const stylesheet: ComponentStyleSheet<S, C> = typeof styles === "function"
+//                     ? styles(this.designSystem)
+//                     : styles;
+
+//                 const jssSheet: any =  jss.createStyleSheet(
+//                     merge({}, stylesheet, this.props.jssStyleSheet),
+//                     { link: true }
+//                 );
+
+//                 stylesheetRegistry.add(jssSheet);
+
+//                 return jssSheet;
+//             }
+
+//             /**
+//              * Checks to see if this component has an associated dynamic stylesheet
+//              */
+//             private hasStyleSheet(): boolean {
+//                 return Boolean(styles || this.props.jssStyleSheet);
+//             }
+
+//             /**
+//              * Merges static and dynamic stylesheet classnames into one object
+//              */
+//             private getClassNames(): ClassNames<S> {
+//                 const classNames: Partial<ClassNames<S>> = {};
+
+//                 if (this.hasStyleSheet()) {
+//                     for (const key in this.state.styleSheet.classes) {
+//                         if (this.state.styleSheet.classes.hasOwnProperty(key)) {
+//                             classNames[key] = typeof classNames[key] !== "undefined"
+//                                 ? `${classNames[key]} ${this.state.styleSheet.classes[key]}`
+//                                 : this.state.styleSheet.classes[key];
+//                         }
+//                     }
+//                 }
+
+//                 return classNames as ClassNames<S>;
+//             }
+//         }
+
+//         return hoistNonReactStatics(JSSManager, Component);
+//     };
+// }
 
 export default manageJss;
 export * from "@microsoft/fast-jss-manager";

--- a/packages/fast-jss-manager-react/src/manage-jss.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.tsx
@@ -29,6 +29,7 @@ export interface IJSSManagerState {
 
 /**
  * JSS Manager props
+ * TODO: Delete this - we should just use ManagedJSSProps
  */
 export interface IManagedJSSProps<S, C> {
     jssStyleSheet?: Partial<ComponentStyles<S, C>>;
@@ -44,7 +45,7 @@ Pick<
         keyof T,
         keyof IManagedClasses<C>
     >
-> & IManagedJSSProps<S, C>;
+> & { jssStyleSheet?: Partial<ComponentStyles<S, C>> };
 
 /**
  * Main entry into the style manager. This function accepts a JSS style object and returns a

--- a/packages/fast-jss-manager-react/src/manage-jss.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.tsx
@@ -83,11 +83,11 @@ function manageJss<S, C>(
     styles?: ComponentStyles<S, C>
 ): <T>(
     Component: React.ComponentType<T & IManagedClasses<S>>
-) => React.SFC<{}> {
+) => React.SFC<ManagedJSSProps<T, S, C>> {
     return function<T>(
         Component: React.ComponentType<T & IManagedClasses<S>>
     ): React.SFC<ManagedJSSProps<T, S, C>> {
-        return (props: ManagedJSSProps<T, S, C>): React.ReactElement<{}> => {
+        return (props: ManagedJSSProps<T, S, C>): React.ReactElement<React.Consumer<unknown>> => {
             /**
              * Define the render prop of the JSSManager. generated class-names are passed into
              * this function and provided to the wrapped component

--- a/packages/fast-jss-manager-react/src/manage-jss.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.tsx
@@ -1,69 +1,12 @@
-/**
- * manageJss is a higher-order function that returns a higher-order component.
- * The HOC that is returned is responsible for managing JSS stylesheets for components
- * registered with manageJss.
- */
 import * as React from "react";
-import jss, { stylesheetManager, stylesheetRegistry } from "./jss";
-import { SheetsManager, StyleSheet } from "jss";
-import { IDesignSystem } from "./design-system-provider";
-import * as propTypes from "prop-types";
-import { ClassNames, ComponentStyles, ComponentStyleSheet, IManagedClasses } from "@microsoft/fast-jss-manager";
-import { isEqual, merge, omit, pick } from "lodash-es";
+import { ClassNames, ComponentStyles, IManagedClasses } from "@microsoft/fast-jss-manager";
+import { pick } from "lodash-es";
 import { Consumer } from "./context";
-
-// hoist-non-react-statics does not seem to be a properly formatted ES6 module, so we need to require it instead
-// TODO https://github.com/Microsoft/fast-dna/issues/512
-/* tslint:disable-next-line */
-const hoistNonReactStatics: any = require("hoist-non-react-statics");
+import { JSSManager, ManagedJSSProps } from "./jss-manager";
 
 /**
- * State interface for JSS manager
+ * Removes props handled by the JSSManager from a prop object
  */
-export interface IJSSManagerState {
-    /**
-     * Stores a JSS stylesheet containing all config-driven styles rules for a component
-     */
-    styleSheet?: any;
-}
-
-/**
- * Describes an interface for adjusting a styled component
- * per component instance
- */
-export interface IInstanceStyleSheet<S, C> {
-    jssStyleSheet?: Partial<ComponentStyles<S, C>>;
-}
-
-export interface IJSSManagerProps<S, C> extends IInstanceStyleSheet<S, C> {
-    /**
-     * The styles for the JSS manager to compile
-     */
-    styles?: ComponentStyles<S, C>;
-
-    /**
-     * The design-system to compile the styles with
-     */
-    designSystem?: C;
-
-    /**
-     * Render the child component
-     */
-    render: (managedClasses: ClassNames<S> ) => React.ReactNode;
-}
-
-/**
- * Prop typing for the JSSManager
- */
-export type ManagedJSSProps<T, S, C> =
-Pick<
-    T,
-    Exclude<
-        keyof T,
-        keyof IManagedClasses<C>
-    >
-> & IInstanceStyleSheet<S, C>;
-
 export function cleanLowerOrderComponentProps<T, S, C>(props: ManagedJSSProps<T, S, C>): T {
     // TODO: We can make this more performant, running into type issues so leaving as is for now.
     return pick(props, Object.keys(props).filter((key: string) => {
@@ -77,19 +20,21 @@ export function cleanLowerOrderComponentProps<T, S, C>(props: ManagedJSSProps<T,
  * with styles managed
  * @param S - The stylesheet class-name contract
  * @param C - The stylesheet design-system configuration object
- * @param T - The component prop interface
  */
 function manageJss<S, C>(
     styles?: ComponentStyles<S, C>
 ): <T>(
     Component: React.ComponentType<T & IManagedClasses<S>>
 ) => React.SFC<ManagedJSSProps<T, S, C>> {
+    /*
+     * @param T - The component prop interface
+     */
     return function<T>(
         Component: React.ComponentType<T & IManagedClasses<S>>
     ): React.SFC<ManagedJSSProps<T, S, C>> {
         return (props: ManagedJSSProps<T, S, C>): React.ReactElement<React.Consumer<unknown>> => {
             /**
-             * Define the render prop of the JSSManager. generated class-names are passed into
+             * Define the render prop of the JSSManager. Generated class-names are passed into
              * this function and provided to the wrapped component
              */
             function renderLowerOrderComponent(
@@ -112,7 +57,7 @@ function manageJss<S, C>(
                     <JSSManager
                         styles={styles}
                         designSystem={designSystem}
-                        jssStyleSheet={props.jssStyleSheet || null}
+                        jssStyleSheet={props.jssStyleSheet}
                         render={renderLowerOrderComponent}
                     />
                 );
@@ -127,317 +72,4 @@ function manageJss<S, C>(
     };
 }
 
-// function BLARG<S, C>(
-//     styles?: ComponentStyles<S, C>
-// ): <T>(
-//     Component: React.ComponentType<T & IManagedClasses<S>>
-// ) => React.ComponentClass<ManagedJSSProps<T, S, C>> {
-//     return function<T>(
-//         Component: React.ComponentType<T & IManagedClasses<S>>
-//     ): React.ComponentClass<ManagedJSSProps<T, S, C>> {
-
-//         // Define the manager higher-order component inside of the return method of the higher-order function.
-//         class JSSManager extends React.Component<ManagedJSSProps<T, S, C>, IJSSManagerState> {
-//             // TODO: figure out if there is a better way to type this object
-//             public static contextTypes: any = {
-//                 designSystem: propTypes.any
-//             };
-
-//             /**
-//              * The style manager is responsible for attaching and detaching style elements when
-//              * components mount and un-mount
-//              */
-//             private static stylesheetManager: SheetsManager = stylesheetManager;
-
-//             constructor(props: ManagedJSSProps<T, S, C>) {
-//                 super(props);
-
-//                 const state: IJSSManagerState = {};
-
-//                 if (Boolean(styles)) {
-//                     state.styleSheet = this.createStyleSheet();
-//                 }
-
-//                 this.state = state;
-//             }
-
-//             /**
-//              * Updates a dynamic stylesheet with context
-//              */
-//             public updateStyleSheet(nextContext?: any): void {
-//                 if (!Boolean(this.state.styleSheet)) {
-//                     return;
-//                 }
-
-//                 if (typeof styles === "function") {
-//                     this.resetStyleSheet();
-//                 } else {
-//                     this.state.styleSheet.update(nextContext && nextContext.designSystem ? nextContext.designSystem : this.designSystem);
-//                 }
-//             }
-
-//             public componentWillMount(): void {
-//                 if (Boolean(this.state.styleSheet)) {
-//                     // It appears we need to update the stylesheet for any style properties defined as functions
-//                     // to work.
-//                     this.state.styleSheet.attach();
-//                     this.updateStyleSheet();
-//                 }
-//             }
-
-//             public componentWillUpdate(nextProps: ManagedJSSProps<T, S, C>, nextState: IJSSManagerState, nextContext: any): void {
-//                 if (!isEqual(this.context, nextContext)) {
-//                     this.updateStyleSheet(nextContext);
-//                 }
-//             }
-
-//             public componentDidUpdate(prevProps: ManagedJSSProps<T, S, C>, prevState: IJSSManagerState): void {
-//                 if (this.props.jssStyleSheet !== prevProps.jssStyleSheet) {
-//                     this.resetStyleSheet();
-//                 }
-//             }
-
-//             public componentWillUnmount(): void {
-//                 this.removeStyleSheet();
-//             }
-
-//             public render(): React.ReactNode {
-//                 return (
-//                     <Component
-//                         {...omit(this.props, ["jssStyleSheet"])}
-//                         managedClasses={this.getClassNames()}
-//                     />
-//                 );
-//             }
-
-//             /**
-//              * Get the design-system context to update the stylesheet with
-//              */
-//             private get designSystem(): any {
-//                 return this.context && this.context.designSystem ? this.context.designSystem : {};
-//             }
-
-//             /**
-//              * Remove a JSS stylesheet
-//              */
-//             private removeStyleSheet(): void {
-//                 if (this.hasStyleSheet()) {
-//                     this.state.styleSheet.detach();
-//                     stylesheetRegistry.remove(this.state.styleSheet);
-//                     jss.removeStyleSheet(this.state.styleSheet);
-//                 }
-//             }
-
-//             /**
-//              * Reset a JSS stylesheet relative to current props
-//              */
-//             private resetStyleSheet(): any {
-//                 this.removeStyleSheet();
-//                 this.setState((previousState: IJSSManagerState, props: ManagedJSSProps<T, S, C>): Partial<IJSSManagerState> => {
-//                     return {
-//                         styleSheet: this.hasStyleSheet() ? this.createStyleSheet() : null
-//                     };
-//                 }, (): void => {
-//                     if (this.hasStyleSheet()) {
-//                         this.state.styleSheet.attach().update(this.designSystem);
-//                     }
-//                 });
-//             }
-
-//             /**
-//              * Creates a JSS stylesheet from the dynamic portion of an associated style object and any style object passed
-//              * as props
-//              */
-//             private createStyleSheet(): any {
-//                 const stylesheet: ComponentStyleSheet<S, C> = typeof styles === "function"
-//                     ? styles(this.designSystem)
-//                     : styles;
-
-//                 const jssSheet: any =  jss.createStyleSheet(
-//                     merge({}, stylesheet, this.props.jssStyleSheet),
-//                     { link: true }
-//                 );
-
-//                 stylesheetRegistry.add(jssSheet);
-
-//                 return jssSheet;
-//             }
-
-//             /**
-//              * Checks to see if this component has an associated dynamic stylesheet
-//              */
-//             private hasStyleSheet(): boolean {
-//                 return Boolean(styles || this.props.jssStyleSheet);
-//             }
-
-//             /**
-//              * Merges static and dynamic stylesheet classnames into one object
-//              */
-//             private getClassNames(): ClassNames<S> {
-//                 const classNames: Partial<ClassNames<S>> = {};
-
-//                 if (this.hasStyleSheet()) {
-//                     for (const key in this.state.styleSheet.classes) {
-//                         if (this.state.styleSheet.classes.hasOwnProperty(key)) {
-//                             classNames[key] = typeof classNames[key] !== "undefined"
-//                                 ? `${classNames[key]} ${this.state.styleSheet.classes[key]}`
-//                                 : this.state.styleSheet.classes[key];
-//                         }
-//                     }
-//                 }
-
-//                 return classNames as ClassNames<S>;
-//             }
-//         }
-
-//         return hoistNonReactStatics(JSSManager, Component);
-//     };
-// }
-
-/**
- * The JSSManger. This class manages JSSStyleSheet compilation and passes generated class-names
- * down to child component
- */
-// TODO: remove tslint disable when BLARG is deleted
-/* tslint:disable-next-line */
-export class JSSManager<T, S, C> extends React.Component<IJSSManagerProps<S, C>, IJSSManagerState> {
-    /**
-     * The style manager is responsible for attaching and detaching style elements when
-     * components mount and un-mount
-     */
-    private static stylesheetManager: SheetsManager = stylesheetManager;
-
-    constructor(props: IJSSManagerProps<S, C>) {
-        super(props);
-
-        const state: IJSSManagerState = {};
-
-        if (Boolean(props.styles)) {
-            state.styleSheet = this.createStyleSheet();
-            state.styleSheet.attach();
-        }
-
-        // It appears we need to update the stylesheet for any style properties defined as functions
-        // to work.
-        state.styleSheet.update(props.designSystem);
-
-        this.state = state;
-    }
-
-    public componentDidUpdate(prevProps: IJSSManagerProps<S, C>, prevState: IJSSManagerState): void {
-        // If we have new style assignments, we always need to reset the stylesheet from scratch
-        // else, if the designSystem has changed, update the stylesheet with new design system values
-        if (this.props.jssStyleSheet !== prevProps.jssStyleSheet) {
-            this.resetStyleSheet();
-        } else if (!isEqual(this.props.designSystem, prevProps.designSystem)) {
-            this.updateStyleSheet();
-        }
-
-    }
-
-    public componentWillUnmount(): void {
-        this.removeStyleSheet();
-    }
-
-    public render(): React.ReactNode {
-        return this.props.render(this.classNames());
-    }
-
-    /**
-     * Updates a dynamic stylesheet with context
-     */
-    public updateStyleSheet(): void {
-        if (!Boolean(this.state.styleSheet)) {
-            return;
-        }
-
-        if (typeof this.props.styles === "function") {
-            this.resetStyleSheet();
-        } else {
-            this.state.styleSheet.update(
-                this.props.designSystem
-            );
-        }
-    }
-
-    /**
-     * Remove a JSS stylesheet
-     */
-    private removeStyleSheet(): void {
-        if (this.hasStyleSheet()) {
-            this.state.styleSheet.detach();
-            stylesheetRegistry.remove(this.state.styleSheet);
-            jss.removeStyleSheet(this.state.styleSheet);
-        }
-    }
-
-    /**
-     * Reset a JSS stylesheet relative to current props
-     */
-    private resetStyleSheet(): any {
-        this.removeStyleSheet();
-        this.setState(
-            (previousState: IJSSManagerState, props: IJSSManagerProps<S, C>): Partial<IJSSManagerState> => {
-                return {
-                    styleSheet: this.hasStyleSheet() ? this.createStyleSheet() : null
-                };
-            }, (): void => {
-                if (this.hasStyleSheet()) {
-                    this.state.styleSheet.attach().update(this.props.designSystem);
-                }
-            });
-    }
-
-    /**
-     * Creates a JSS stylesheet from the dynamic portion of an associated style object and any style object passed
-     * as props
-     */
-    private createStyleSheet(): any {
-        const stylesheet: ComponentStyleSheet<S, C> = typeof this.props.styles === "function"
-            ? this.props.styles(this.props.designSystem)
-            : this.props.styles;
-
-        const jssSheet: any =  jss.createStyleSheet(
-            merge({}, stylesheet, this.props.jssStyleSheet),
-            { link: true }
-        );
-
-        stylesheetRegistry.add(jssSheet);
-
-        return jssSheet;
-    }
-
-    /**
-     * Checks to see if this component has an associated dynamic stylesheet
-     */
-    private hasStyleSheet(): boolean {
-        return Boolean(this.props.styles || this.props.jssStyleSheet);
-    }
-
-    /**
-     * returns the compiled classes
-     */
-    private classNames(): ClassNames<S> {
-        return this.hasStyleSheet()
-        ? this.state.styleSheet.classes
-        : {};
-        // const classNames: Partial<ClassNames<S>> = {};
-
-        // TODO we probably don't need to do this
-        // if (this.hasStyleSheet()) {
-        //     for (const key in this.state.styleSheet.classes) {
-        //         if (this.state.styleSheet.classes.hasOwnProperty(key)) {
-        //             classNames[key] = typeof classNames[key] !== "undefined"
-        //                 ? `${classNames[key]} ${this.state.styleSheet.classes[key]}`
-        //                 : this.state.styleSheet.classes[key];
-        //         }
-        //     }
-        // }
-
-        // return classNames as ClassNames<S>;
-    }
-}
-
-export default manageJss;
-export * from "@microsoft/fast-jss-manager";
-export { stylesheetRegistry };
+export { manageJss };

--- a/packages/fast-jss-manager-react/src/manage-jss.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.tsx
@@ -39,12 +39,12 @@ export interface IJSSManagerProps<S, C> extends IInstanceStyleSheet<S, C> {
     /**
      * The styles for the JSS manager to compile
      */
-    styles: ComponentStyles<S, C>;
+    styles?: ComponentStyles<S, C>;
 
     /**
      * The design-system to compile the styles with
      */
-    designSystem: C;
+    designSystem?: C;
 
     /**
      * Render the child component
@@ -64,15 +64,6 @@ Pick<
     >
 > & IInstanceStyleSheet<S, C>;
 
-/**
- * The JSSManger. This class manages JSSStyleSheet compilation and passes generated class-names
- * down to child component
- */
-export class JSSManager<T, S, C> extends React.Component<IJSSManagerProps<S, C>, IJSSManagerState> {
-    public render(): React.ReactNode {
-        return this.props.children;
-    }
-}
 
 export function cleanLowerOrderComponentProps<T, S, C>(props: ManagedJSSProps<T, S, C>): T {
     // TODO: We can make this more performant, running into type issues so leaving as is for now.
@@ -137,172 +128,316 @@ function manageJss<S, C>(
     };
 }
 
-// function manageJss<S, C>(
-//     styles?: ComponentStyles<S, C>
-// ): <T>(
-//     Component: React.ComponentType<T & IManagedClasses<S>>
-// ) => React.ComponentClass<ManagedJSSProps<T, S, C>> {
-//     return function<T>(
-//         Component: React.ComponentType<T & IManagedClasses<S>>
-//     ): React.ComponentClass<ManagedJSSProps<T, S, C>> {
+function BLARG<S, C>(
+    styles?: ComponentStyles<S, C>
+): <T>(
+    Component: React.ComponentType<T & IManagedClasses<S>>
+) => React.ComponentClass<ManagedJSSProps<T, S, C>> {
+    return function<T>(
+        Component: React.ComponentType<T & IManagedClasses<S>>
+    ): React.ComponentClass<ManagedJSSProps<T, S, C>> {
 
-//         // Define the manager higher-order component inside of the return method of the higher-order function.
-//         class JSSManager extends React.Component<ManagedJSSProps<T, S, C>, IJSSManagerState> {
-//             // TODO: figure out if there is a better way to type this object
-//             public static contextTypes: any = {
-//                 designSystem: propTypes.any
-//             };
+        // Define the manager higher-order component inside of the return method of the higher-order function.
+        class JSSManager extends React.Component<ManagedJSSProps<T, S, C>, IJSSManagerState> {
+            // TODO: figure out if there is a better way to type this object
+            public static contextTypes: any = {
+                designSystem: propTypes.any
+            };
 
-//             /**
-//              * The style manager is responsible for attaching and detaching style elements when
-//              * components mount and un-mount
-//              */
-//             private static stylesheetManager: SheetsManager = stylesheetManager;
+            /**
+             * The style manager is responsible for attaching and detaching style elements when
+             * components mount and un-mount
+             */
+            private static stylesheetManager: SheetsManager = stylesheetManager;
 
-//             constructor(props: ManagedJSSProps<T, S, C>) {
-//                 super(props);
+            constructor(props: ManagedJSSProps<T, S, C>) {
+                super(props);
 
-//                 const state: IJSSManagerState = {};
+                const state: IJSSManagerState = {};
 
-//                 if (Boolean(styles)) {
-//                     state.styleSheet = this.createStyleSheet();
-//                 }
+                if (Boolean(styles)) {
+                    state.styleSheet = this.createStyleSheet();
+                }
 
-//                 this.state = state;
-//             }
+                this.state = state;
+            }
 
-//             /**
-//              * Updates a dynamic stylesheet with context
-//              */
-//             public updateStyleSheet(nextContext?: any): void {
-//                 if (!Boolean(this.state.styleSheet)) {
-//                     return;
-//                 }
+            /**
+             * Updates a dynamic stylesheet with context
+             */
+            public updateStyleSheet(nextContext?: any): void {
+                if (!Boolean(this.state.styleSheet)) {
+                    return;
+                }
 
-//                 if (typeof styles === "function") {
-//                     this.resetStyleSheet();
-//                 } else {
-//                     this.state.styleSheet.update(nextContext && nextContext.designSystem ? nextContext.designSystem : this.designSystem);
-//                 }
-//             }
+                if (typeof styles === "function") {
+                    this.resetStyleSheet();
+                } else {
+                    this.state.styleSheet.update(nextContext && nextContext.designSystem ? nextContext.designSystem : this.designSystem);
+                }
+            }
 
-//             public componentWillMount(): void {
-//                 if (Boolean(this.state.styleSheet)) {
-//                     // It appears we need to update the stylesheet for any style properties defined as functions
-//                     // to work.
-//                     this.state.styleSheet.attach();
-//                     this.updateStyleSheet();
-//                 }
-//             }
+            public componentWillMount(): void {
+                if (Boolean(this.state.styleSheet)) {
+                    // It appears we need to update the stylesheet for any style properties defined as functions
+                    // to work.
+                    this.state.styleSheet.attach();
+                    this.updateStyleSheet();
+                }
+            }
 
-//             public componentWillUpdate(nextProps: ManagedJSSProps<T, S, C>, nextState: IJSSManagerState, nextContext: any): void {
-//                 if (!isEqual(this.context, nextContext)) {
-//                     this.updateStyleSheet(nextContext);
-//                 }
-//             }
+            public componentWillUpdate(nextProps: ManagedJSSProps<T, S, C>, nextState: IJSSManagerState, nextContext: any): void {
+                if (!isEqual(this.context, nextContext)) {
+                    this.updateStyleSheet(nextContext);
+                }
+            }
 
-//             public componentDidUpdate(prevProps: ManagedJSSProps<T, S, C>, prevState: IJSSManagerState): void {
-//                 if (this.props.jssStyleSheet !== prevProps.jssStyleSheet) {
-//                     this.resetStyleSheet();
-//                 }
-//             }
+            public componentDidUpdate(prevProps: ManagedJSSProps<T, S, C>, prevState: IJSSManagerState): void {
+                if (this.props.jssStyleSheet !== prevProps.jssStyleSheet) {
+                    this.resetStyleSheet();
+                }
+            }
 
-//             public componentWillUnmount(): void {
-//                 this.removeStyleSheet();
-//             }
+            public componentWillUnmount(): void {
+                this.removeStyleSheet();
+            }
 
-//             public render(): React.ReactNode {
-//                 return (
-//                     <Component
-//                         {...omit(this.props, ["jssStyleSheet"])}
-//                         managedClasses={this.getClassNames()}
-//                     />
-//                 );
-//             }
+            public render(): React.ReactNode {
+                return (
+                    <Component
+                        {...omit(this.props, ["jssStyleSheet"])}
+                        managedClasses={this.getClassNames()}
+                    />
+                );
+            }
 
-//             /**
-//              * Get the design-system context to update the stylesheet with
-//              */
-//             private get designSystem(): any {
-//                 return this.context && this.context.designSystem ? this.context.designSystem : {};
-//             }
+            /**
+             * Get the design-system context to update the stylesheet with
+             */
+            private get designSystem(): any {
+                return this.context && this.context.designSystem ? this.context.designSystem : {};
+            }
 
-//             /**
-//              * Remove a JSS stylesheet
-//              */
-//             private removeStyleSheet(): void {
-//                 if (this.hasStyleSheet()) {
-//                     this.state.styleSheet.detach();
-//                     stylesheetRegistry.remove(this.state.styleSheet);
-//                     jss.removeStyleSheet(this.state.styleSheet);
-//                 }
-//             }
+            /**
+             * Remove a JSS stylesheet
+             */
+            private removeStyleSheet(): void {
+                if (this.hasStyleSheet()) {
+                    this.state.styleSheet.detach();
+                    stylesheetRegistry.remove(this.state.styleSheet);
+                    jss.removeStyleSheet(this.state.styleSheet);
+                }
+            }
 
-//             /**
-//              * Reset a JSS stylesheet relative to current props
-//              */
-//             private resetStyleSheet(): any {
-//                 this.removeStyleSheet();
-//                 this.setState((previousState: IJSSManagerState, props: ManagedJSSProps<T, S, C>): Partial<IJSSManagerState> => {
-//                     return {
-//                         styleSheet: this.hasStyleSheet() ? this.createStyleSheet() : null
-//                     };
-//                 }, (): void => {
-//                     if (this.hasStyleSheet()) {
-//                         this.state.styleSheet.attach().update(this.designSystem);
-//                     }
-//                 });
-//             }
+            /**
+             * Reset a JSS stylesheet relative to current props
+             */
+            private resetStyleSheet(): any {
+                this.removeStyleSheet();
+                this.setState((previousState: IJSSManagerState, props: ManagedJSSProps<T, S, C>): Partial<IJSSManagerState> => {
+                    return {
+                        styleSheet: this.hasStyleSheet() ? this.createStyleSheet() : null
+                    };
+                }, (): void => {
+                    if (this.hasStyleSheet()) {
+                        this.state.styleSheet.attach().update(this.designSystem);
+                    }
+                });
+            }
 
-//             /**
-//              * Creates a JSS stylesheet from the dynamic portion of an associated style object and any style object passed
-//              * as props
-//              */
-//             private createStyleSheet(): any {
-//                 const stylesheet: ComponentStyleSheet<S, C> = typeof styles === "function"
-//                     ? styles(this.designSystem)
-//                     : styles;
+            /**
+             * Creates a JSS stylesheet from the dynamic portion of an associated style object and any style object passed
+             * as props
+             */
+            private createStyleSheet(): any {
+                const stylesheet: ComponentStyleSheet<S, C> = typeof styles === "function"
+                    ? styles(this.designSystem)
+                    : styles;
 
-//                 const jssSheet: any =  jss.createStyleSheet(
-//                     merge({}, stylesheet, this.props.jssStyleSheet),
-//                     { link: true }
-//                 );
+                const jssSheet: any =  jss.createStyleSheet(
+                    merge({}, stylesheet, this.props.jssStyleSheet),
+                    { link: true }
+                );
 
-//                 stylesheetRegistry.add(jssSheet);
+                stylesheetRegistry.add(jssSheet);
 
-//                 return jssSheet;
-//             }
+                return jssSheet;
+            }
 
-//             /**
-//              * Checks to see if this component has an associated dynamic stylesheet
-//              */
-//             private hasStyleSheet(): boolean {
-//                 return Boolean(styles || this.props.jssStyleSheet);
-//             }
+            /**
+             * Checks to see if this component has an associated dynamic stylesheet
+             */
+            private hasStyleSheet(): boolean {
+                return Boolean(styles || this.props.jssStyleSheet);
+            }
 
-//             /**
-//              * Merges static and dynamic stylesheet classnames into one object
-//              */
-//             private getClassNames(): ClassNames<S> {
-//                 const classNames: Partial<ClassNames<S>> = {};
+            /**
+             * Merges static and dynamic stylesheet classnames into one object
+             */
+            private getClassNames(): ClassNames<S> {
+                const classNames: Partial<ClassNames<S>> = {};
 
-//                 if (this.hasStyleSheet()) {
-//                     for (const key in this.state.styleSheet.classes) {
-//                         if (this.state.styleSheet.classes.hasOwnProperty(key)) {
-//                             classNames[key] = typeof classNames[key] !== "undefined"
-//                                 ? `${classNames[key]} ${this.state.styleSheet.classes[key]}`
-//                                 : this.state.styleSheet.classes[key];
-//                         }
-//                     }
-//                 }
+                if (this.hasStyleSheet()) {
+                    for (const key in this.state.styleSheet.classes) {
+                        if (this.state.styleSheet.classes.hasOwnProperty(key)) {
+                            classNames[key] = typeof classNames[key] !== "undefined"
+                                ? `${classNames[key]} ${this.state.styleSheet.classes[key]}`
+                                : this.state.styleSheet.classes[key];
+                        }
+                    }
+                }
 
-//                 return classNames as ClassNames<S>;
-//             }
-//         }
+                return classNames as ClassNames<S>;
+            }
+        }
 
-//         return hoistNonReactStatics(JSSManager, Component);
-//     };
-// }
+        return hoistNonReactStatics(JSSManager, Component);
+    };
+}
+
+/**
+ * The JSSManger. This class manages JSSStyleSheet compilation and passes generated class-names
+ * down to child component
+ */
+// TODO: remove tslint disable when BLARG is deleted
+/* tslint:disable-next-line */
+export class JSSManager<T, S, C> extends React.Component<IJSSManagerProps<S, C>, IJSSManagerState> {
+    /**
+     * The style manager is responsible for attaching and detaching style elements when
+     * components mount and un-mount
+     */
+    private static stylesheetManager: SheetsManager = stylesheetManager;
+
+    constructor(props: IJSSManagerProps<S, C>) {
+        super(props);
+
+        const state: IJSSManagerState = {};
+
+        if (Boolean(props.styles)) {
+            state.styleSheet = this.createStyleSheet();
+            state.styleSheet.attach();
+        }
+
+        this.state = state;
+
+        // It appears we need to update the stylesheet for any style properties defined as functions
+        // to work.
+        this.updateStyleSheet();
+    }
+
+    public componentDidUpdate(prevProps: IJSSManagerProps<S, C>, prevState: IJSSManagerState): void {
+        // If we have new style assignments, we always need to reset the stylesheet from scratch
+        // else, if the designSystem has changed, update the stylesheet with new design system values
+        if (this.props.jssStyleSheet !== prevProps.jssStyleSheet) {
+            this.resetStyleSheet();
+        } else if (!isEqual(this.props.designSystem, prevProps.designSystem)) {
+            this.updateStyleSheet();
+        }
+
+    }
+
+    public componentWillUnmount(): void {
+        this.removeStyleSheet();
+    }
+
+    public render(): React.ReactNode {
+        return this.props.render(this.classNames());
+    }
+
+    /**
+     * Updates a dynamic stylesheet with context
+     */
+    public updateStyleSheet(): void {
+        if (!Boolean(this.state.styleSheet)) {
+            return;
+        }
+
+        if (typeof this.props.styles === "function") {
+            this.resetStyleSheet();
+        } else {
+            this.state.styleSheet.update(
+                this.props.designSystem
+            );
+        }
+    }
+
+    /**
+     * Remove a JSS stylesheet
+     */
+    private removeStyleSheet(): void {
+        if (this.hasStyleSheet()) {
+            this.state.styleSheet.detach();
+            stylesheetRegistry.remove(this.state.styleSheet);
+            jss.removeStyleSheet(this.state.styleSheet);
+        }
+    }
+
+    /**
+     * Reset a JSS stylesheet relative to current props
+     */
+    private resetStyleSheet(): any {
+        this.removeStyleSheet();
+        this.setState(
+            (previousState: IJSSManagerState, props: IJSSManagerProps<S, C>): Partial<IJSSManagerState> => {
+                return {
+                    styleSheet: this.hasStyleSheet() ? this.createStyleSheet() : null
+                };
+            }, (): void => {
+                if (this.hasStyleSheet()) {
+                    this.state.styleSheet.attach().update(this.props.designSystem);
+                }
+            });
+    }
+
+    /**
+     * Creates a JSS stylesheet from the dynamic portion of an associated style object and any style object passed
+     * as props
+     */
+    private createStyleSheet(): any {
+        const stylesheet: ComponentStyleSheet<S, C> = typeof this.props.styles === "function"
+            ? this.props.styles(this.props.designSystem)
+            : this.props.styles;
+
+        const jssSheet: any =  jss.createStyleSheet(
+            merge({}, stylesheet, this.props.jssStyleSheet),
+            { link: true }
+        );
+
+        stylesheetRegistry.add(jssSheet);
+
+        return jssSheet;
+    }
+
+    /**
+     * Checks to see if this component has an associated dynamic stylesheet
+     */
+    private hasStyleSheet(): boolean {
+        return Boolean(this.props.styles || this.props.jssStyleSheet);
+    }
+
+    /**
+     * returns the compiled classes
+     */
+    private classNames(): ClassNames<S> {
+        return this.hasStyleSheet()
+        ? this.state.styleSheet.classes
+        : {};
+        // const classNames: Partial<ClassNames<S>> = {};
+
+        // TODO we probably don't need to do this
+        // if (this.hasStyleSheet()) {
+        //     for (const key in this.state.styleSheet.classes) {
+        //         if (this.state.styleSheet.classes.hasOwnProperty(key)) {
+        //             classNames[key] = typeof classNames[key] !== "undefined"
+        //                 ? `${classNames[key]} ${this.state.styleSheet.classes[key]}`
+        //                 : this.state.styleSheet.classes[key];
+        //         }
+        //     }
+        // }
+
+        // return classNames as ClassNames<S>;
+    }
+}
 
 export default manageJss;
 export * from "@microsoft/fast-jss-manager";

--- a/packages/fast-jss-manager-react/src/manage-jss.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.tsx
@@ -317,11 +317,11 @@ export class JSSManager<T, S, C> extends React.Component<IJSSManagerProps<S, C>,
             state.styleSheet.attach();
         }
 
-        this.state = state;
-
         // It appears we need to update the stylesheet for any style properties defined as functions
         // to work.
-        this.updateStyleSheet();
+        state.styleSheet.update(props.designSystem);
+
+        this.state = state;
     }
 
     public componentDidUpdate(prevProps: IJSSManagerProps<S, C>, prevState: IJSSManagerState): void {

--- a/packages/fast-layouts-react/src/canvas/canvas.tsx
+++ b/packages/fast-layouts-react/src/canvas/canvas.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { CanvasProps, ICanvasHandledProps } from "./canvas.props";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 
 export interface ICanvasClassNamesContract {

--- a/packages/fast-layouts-react/src/canvas/canvas.tsx
+++ b/packages/fast-layouts-react/src/canvas/canvas.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { CanvasProps, ICanvasHandledProps } from "./canvas.props";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 
 export interface ICanvasClassNamesContract {

--- a/packages/fast-layouts-react/src/canvas/canvas.tsx
+++ b/packages/fast-layouts-react/src/canvas/canvas.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { CanvasProps, ICanvasHandledProps } from "./canvas.props";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 
 export interface ICanvasClassNamesContract {

--- a/packages/fast-layouts-react/src/column/column.tsx
+++ b/packages/fast-layouts-react/src/column/column.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ICSSRules, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ICSSRules, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import BreakpointTracker from "../utilities/breakpoint-tracker";
 import { Breakpoint, getValueByBreakpoint, identifyBreakpoint } from "../utilities/breakpoints";
 import { canUseDOM, canUseViewport } from "exenv-es6";

--- a/packages/fast-layouts-react/src/column/column.tsx
+++ b/packages/fast-layouts-react/src/column/column.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ICSSRules, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ICSSRules, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import BreakpointTracker from "../utilities/breakpoint-tracker";
 import { Breakpoint, getValueByBreakpoint, identifyBreakpoint } from "../utilities/breakpoints";
 import { canUseDOM, canUseViewport } from "exenv-es6";

--- a/packages/fast-layouts-react/src/column/column.tsx
+++ b/packages/fast-layouts-react/src/column/column.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ICSSRules, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ICSSRules, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import BreakpointTracker from "../utilities/breakpoint-tracker";
 import { Breakpoint, getValueByBreakpoint, identifyBreakpoint } from "../utilities/breakpoints";
 import { canUseDOM, canUseViewport } from "exenv-es6";

--- a/packages/fast-layouts-react/src/container/container.tsx
+++ b/packages/fast-layouts-react/src/container/container.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ContainerProps } from "./container.props";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 

--- a/packages/fast-layouts-react/src/container/container.tsx
+++ b/packages/fast-layouts-react/src/container/container.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ContainerProps } from "./container.props";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 

--- a/packages/fast-layouts-react/src/grid/grid.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ICSSRules, IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ICSSRules, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import BreakpointTracker from "../utilities/breakpoint-tracker";
 import { getValueByBreakpoint } from "../utilities/breakpoints";
 import { GridAlignment, GridProps, GridTag, IGridHandledProps } from "./grid.props";

--- a/packages/fast-layouts-react/src/grid/grid.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ICSSRules, IJSSManagerProps } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ICSSRules, IManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import BreakpointTracker from "../utilities/breakpoint-tracker";
 import { getValueByBreakpoint } from "../utilities/breakpoints";
 import { GridAlignment, GridProps, GridTag, IGridHandledProps } from "./grid.props";

--- a/packages/fast-layouts-react/src/page/page.tsx
+++ b/packages/fast-layouts-react/src/page/page.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { IPageHandledProps, PageProps } from "./page.props";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 

--- a/packages/fast-layouts-react/src/page/page.tsx
+++ b/packages/fast-layouts-react/src/page/page.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { IPageHandledProps, PageProps } from "./page.props";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 

--- a/packages/fast-layouts-react/src/page/page.tsx
+++ b/packages/fast-layouts-react/src/page/page.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { IPageHandledProps, PageProps } from "./page.props";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 

--- a/packages/fast-layouts-react/src/pane/pane.tsx
+++ b/packages/fast-layouts-react/src/pane/pane.tsx
@@ -4,7 +4,7 @@ import { IPaneHandledProps, PaneProps, PaneResizeDirection } from "./pane.props"
 import { west } from "../row";
 import rafThrottle from "raf-throttle";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 import { canUseDOM } from "exenv-es6";
 import { joinClasses } from "../utilities";

--- a/packages/fast-layouts-react/src/pane/pane.tsx
+++ b/packages/fast-layouts-react/src/pane/pane.tsx
@@ -4,7 +4,7 @@ import { IPaneHandledProps, PaneProps, PaneResizeDirection } from "./pane.props"
 import { west } from "../row";
 import rafThrottle from "raf-throttle";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 import { canUseDOM } from "exenv-es6";
 import { joinClasses } from "../utilities";

--- a/packages/fast-layouts-react/src/pane/pane.tsx
+++ b/packages/fast-layouts-react/src/pane/pane.tsx
@@ -4,7 +4,7 @@ import { IPaneHandledProps, PaneProps, PaneResizeDirection } from "./pane.props"
 import { west } from "../row";
 import rafThrottle from "raf-throttle";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 import { canUseDOM } from "exenv-es6";
 import { joinClasses } from "../utilities";

--- a/packages/fast-layouts-react/src/row/row.tsx
+++ b/packages/fast-layouts-react/src/row/row.tsx
@@ -4,7 +4,7 @@ import Canvas from "../canvas";
 import rafThrottle from "raf-throttle";
 import { IRowHandledProps, RowProps, RowResizeDirection } from "./row.props";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IJSSManagerProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 import { canUseDOM } from "exenv-es6";
 import { joinClasses } from "../utilities";

--- a/packages/fast-layouts-react/src/row/row.tsx
+++ b/packages/fast-layouts-react/src/row/row.tsx
@@ -4,7 +4,7 @@ import Canvas from "../canvas";
 import rafThrottle from "raf-throttle";
 import { IRowHandledProps, RowProps, RowResizeDirection } from "./row.props";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, IManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 import { canUseDOM } from "exenv-es6";
 import { joinClasses } from "../utilities";

--- a/packages/fast-layouts-react/src/row/row.tsx
+++ b/packages/fast-layouts-react/src/row/row.tsx
@@ -4,7 +4,7 @@ import Canvas from "../canvas";
 import rafThrottle from "raf-throttle";
 import { IRowHandledProps, RowProps, RowResizeDirection } from "./row.props";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import manageJss, { ComponentStyles, ManagedJSSProps, IManagedClasses } from "@microsoft/fast-jss-manager-react";
+import manageJss, { ComponentStyles, IManagedClasses, ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import Foundation, { HandledProps, IFoundationProps } from "@microsoft/fast-components-foundation-react";
 import { canUseDOM } from "exenv-es6";
 import { joinClasses } from "../utilities";


### PR DESCRIPTION
Updates JSSManager to use React 16.3 context API and removes deprecated life-cycle hooks.

closes #856 #258 #175 #142