### PR TITLE
chore: fix the flipper examples to use the correct property name

### DIFF
--- a/packages/fast-components-react-msft/src/flipper/__snapshots__/flipper.spec.tsx.snap
+++ b/packages/fast-components-react-msft/src/flipper/__snapshots__/flipper.spec.tsx.snap
@@ -30,13 +30,10 @@ exports[`flipper snapshots Flipper: 1 1`] = `
 
 exports[`flipper snapshots Flipper: 2 1`] = `
 <button
-  aria-hidden={true}
   aria-label="See next"
   className="flipper-0-1-9 flipper__next-0-1-11"
   direction="next"
   href={null}
-  tabIndex={-1}
-  visible={true}
 >
   <span
     className="flipper_glyph-0-1-10"
@@ -46,13 +43,10 @@ exports[`flipper snapshots Flipper: 2 1`] = `
 
 exports[`flipper snapshots Flipper: 3 1`] = `
 <button
-  aria-hidden={true}
   aria-label="See previous"
   className="flipper-0-1-13 flipper__previous-0-1-16"
   direction="previous"
   href={null}
-  tabIndex={-1}
-  visible={true}
 >
   <span
     className="flipper_glyph-0-1-14"

--- a/packages/fast-components-react-msft/src/flipper/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/flipper/examples.data.tsx
@@ -21,12 +21,12 @@ export default {
         },
         {
             direction: FlipperDirection.next,
-            visible: true,
+            visibleToAssistiveTechnologies: true,
             label: "See next"
         },
         {
             direction: FlipperDirection.previous,
-            visible: true,
+            visibleToAssistiveTechnologies: true,
             label: "See previous"
         }
     ]


### PR DESCRIPTION
Clean up chore for the flipper examples.