### PR TITLE
fix: replace lodash reference in MSFT component styles with lodash-es

### DIFF
--- a/packages/fast-components-styles-msft/src/progress/index.ts
+++ b/packages/fast-components-styles-msft/src/progress/index.ts
@@ -2,7 +2,7 @@ import designSystemDefaults, { DesignSystem, withDesignSystemDefaults } from "..
 import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
 import { ProgressClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { ensureBrandNormal, largeContrast } from "../utilities/colors";
-import { get } from "lodash";
+import { get } from "lodash-es";
 import { toPx } from "@microsoft/fast-jss-utilities";
 
 const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = (


### PR DESCRIPTION
<body>
closes #1001 
<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
