### PR TITLE
fix: update on incorrectly extended prop interfaces

### DIFF
--- a/packages/fast-components-react-base/package.json
+++ b/packages/fast-components-react-base/package.json
@@ -114,6 +114,7 @@
     "react-dom": "^16.3.0"
   },
   "dependencies": {
-    "@microsoft/fast-components-class-name-contracts-base": "^3.0.1"
+    "@microsoft/fast-components-class-name-contracts-base": "^3.0.1",
+    "utility-types": "^2.1.0"
   }
 }

--- a/packages/fast-components-react-base/src/divider/divider.props.ts
+++ b/packages/fast-components-react-base/src/divider/divider.props.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { DividerClassNameContract, ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
+import { Omit } from "utility-types";
 
 /**
  * Divider HTML Roles
@@ -10,7 +11,7 @@ export enum DividerRoles {
 }
 
 export interface DividerManagedClasses extends ManagedClasses<DividerClassNameContract> {}
-export interface DividerUnhandledProps extends React.HTMLAttributes<HTMLHRElement> {}
+export interface DividerUnhandledProps extends Omit<React.HTMLAttributes<HTMLHRElement>, "role"> {}
 export interface DividerHandledProps extends DividerManagedClasses {
     /**
      * The HTML role attribute

--- a/packages/fast-components-react-base/src/image/image.props.ts
+++ b/packages/fast-components-react-base/src/image/image.props.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { ImageClassNameContract, ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
+import { Omit } from "utility-types";
 
-export interface ImageUnhandledProps extends React.HTMLAttributes<HTMLImageElement | HTMLPictureElement> {}
+export interface ImageUnhandledProps extends Omit<React.HTMLAttributes<HTMLImageElement | HTMLPictureElement>, "children"> {}
 export interface ImageManagedClasses extends ManagedClasses<ImageClassNameContract> {}
 export interface ImageHandledProps extends ImageManagedClasses {
     /**

--- a/packages/fast-components-react-base/src/text-field/text-field.props.ts
+++ b/packages/fast-components-react-base/src/text-field/text-field.props.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { ManagedClasses, TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
+import { Omit } from "utility-types";
 
 export enum TextFieldType {
    email = "email",
@@ -12,7 +13,7 @@ export enum TextFieldType {
 }
 
 export interface TextFieldManagedClasses extends ManagedClasses<TextFieldClassNameContract> {}
-export interface TextFieldUnhandledProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export interface TextFieldUnhandledProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {}
 export interface TextFieldHandledProps extends TextFieldManagedClasses {
     /**
      * The disabled state


### PR DESCRIPTION
Several base-component prop interfaces we're incorrectly extended, causing type-errors when values we're applied as react props. EG, react defined "type" as an optional string where FAST defines "type" as an enum - when an enum is applied as a prop, an error is generated claiming that an enum is not assignable to a string type.