### PR TITLE
chore: Update grammar used in unit testing output

### DIFF
--- a/packages/fast-permutator/__tests__/test-schemas/index.js
+++ b/packages/fast-permutator/__tests__/test-schemas/index.js
@@ -288,7 +288,7 @@ describe('Deep reference primitive', function() {
         const schemaData = require('../schemas/primitive/deepRef.schema.json');
         possibleData = permutator(schemaData, refSchemas);
     });
-    it('should the correct number of permutations', function() {
+    it('should generate correct number of permutations', function() {
         expect(possibleData).toHaveLength(2);
     });
 });

--- a/packages/fast-permutator/__tests__/test-utils/index.js
+++ b/packages/fast-permutator/__tests__/test-utils/index.js
@@ -22,7 +22,7 @@ describe('Reference IDs', function() {
             possibleRefs.push(get(schemaData, `${refLocation}['$ref']`));
         }
     });
-    it('should the correct number schema IDs', function() {
+    it('should generate correct number of schema IDs', function() {
         expect(possibleRefs).toHaveLength(2);
     });
     it('should return the correct schema IDs', function() {
@@ -63,7 +63,7 @@ describe('Deep reference IDs', function() {
             possibleRefs.push(get(schemaData, `${refLocation}['$ref']`));
         }
     });
-    it('should the correct number schema IDs', function() {
+    it('should generate correct number of schema IDs', function() {
         expect(possibleRefs).toHaveLength(5);
     });
 });
@@ -99,7 +99,7 @@ describe('Locations of properties', function() {
         possibleAllOf = permutator.getDeepPropLocations(schemaData, 'allOf');
         possibleRequired = permutator.getDeepPropLocations(schemaData, 'required');
     });
-    it('should the correct number of locations', function() {
+    it('should generate correct number of locations', function() {
         expect(possibleRefs).toHaveLength(5);
         expect(possibleAllOf).toHaveLength(2);
         expect(possibleRequired).toHaveLength(2);

--- a/packages/fast-permutator/package.json
+++ b/packages/fast-permutator/package.json
@@ -20,6 +20,7 @@
     "unit-tests": "jest --maxWorkers=4"
   },
   "jest": {
+    "verbose": true,
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {


### PR DESCRIPTION
Fixes unit test grammar and adds verbose option to unit test output, so these are shown when running unit tests.

closes #75 