### PR TITLE
chore: commit auto-generated package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     }
   },
   "lint-staged": {
-    "*.{ts,tsx,js}": ["lerna run prettier", "git add ."]
+    "*.{ts,tsx,js}": [
+      "lerna run prettier",
+      "git add ."
+    ]
   },
   "devDependencies": {
     "@types/node": "^9.4.7",


### PR DESCRIPTION
`npm i` generates a different structure than what is in our current repo, so everyone will get a diff when they run `npm i`.