### PR TITLE
fix: add overflow behavior to dev site pane to ensure all TOC items can be accessed

### DIFF
--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -121,6 +121,7 @@ export interface SiteManagedClasses {
     site_infoBarConfiguration_base: string;
     site_infoBarConfiguration_input: string;
     site_infoBarConfiguration_theme: string;
+    site_pane: string;
     site_paneForm: string;
     site_paneToc: string;
     site_paneTocRow: string;
@@ -209,6 +210,9 @@ const styles: ComponentStyles<SiteManagedClasses, DevSiteDesignSystem> = {
                 return `inset 0 0 0 1 ${config.brandColor}`;
             },
         },
+    },
+    site_pane: {
+        overflowX: "auto",
     },
     site_paneForm: {
         padding: toPx(12),
@@ -575,7 +579,7 @@ class Site extends React.Component<
                     jssStyleSheet={paneStyleSheet}
                     minWidth={200}
                 >
-                    <div>
+                    <div className={this.props.managedClasses.site_pane}>
                         {this.renderPaneCollapseToggle()}
                         {this.renderChildrenBySlot(this, ShellSlot.pane)}
                         <ul className={this.props.managedClasses.site_paneToc}>

--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -212,13 +212,17 @@ const styles: ComponentStyles<SiteManagedClasses, DevSiteDesignSystem> = {
         },
     },
     site_pane: {
-        overflowX: "auto",
+        display: "flex",
+        flexDirection: "column",
+        flexGrow: "1",
+        height: "100%",
     },
     site_paneForm: {
         padding: toPx(12),
     },
     site_paneToc: {
         padding: "0",
+        overflow: "scroll",
     },
     site_paneTocRow: {
         display: "flex",
@@ -238,6 +242,7 @@ const styles: ComponentStyles<SiteManagedClasses, DevSiteDesignSystem> = {
         background: "none",
         padding: toPx(12),
         outline: "0",
+        alignSelf: "flex-start",
     },
     site_paneToggleButtonIcon: {
         height: toPx(16),


### PR DESCRIPTION
<body>
closes #1065 
<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
