### PR TITLE
feat: deprecate responsive type ramp and update ramp to even values

### DIFF
--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -18,7 +18,7 @@ import {
     toPx,
 } from "@microsoft/fast-jss-utilities";
 import { curry, get } from "lodash-es";
-import { applyType } from "../utilities/typography";
+import { applyType, applyTypeRampConfig } from "../utilities/typography";
 import {
     applyMixedColor,
     disabledContrast,
@@ -189,7 +189,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = (
 
     return {
         button: {
-            ...applyType("t7", "vp1"),
+            ...applyTypeRampConfig("t7"),
             boxSizing: "border-box",
             maxWidth: "374px",
             minWidth: "120px",

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -18,7 +18,7 @@ import {
     toPx,
 } from "@microsoft/fast-jss-utilities";
 import { curry, get } from "lodash-es";
-import { applyType, applyTypeRampConfig } from "../utilities/typography";
+import { applyTypeRampConfig } from "../utilities/typography";
 import {
     applyMixedColor,
     disabledContrast,

--- a/packages/fast-components-styles-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-styles-msft/src/call-to-action/index.ts
@@ -66,7 +66,6 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = (
 
     return {
         callToAction: {
-            fontSize: "15px",
             display: "inline-flex",
             maxWidth: "100%",
             border: "2px solid transparent",

--- a/packages/fast-components-styles-msft/src/label/index.ts
+++ b/packages/fast-components-styles-msft/src/label/index.ts
@@ -3,7 +3,7 @@ import { ensureForegroundNormal, ensureNormalContrast } from "../utilities/color
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { LabelClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import { applyType, applyTypeRampConfig } from "../utilities/typography";
+import { applyTypeRampConfig } from "../utilities/typography";
 import { applyScreenReader } from "@microsoft/fast-jss-utilities";
 import { get } from "lodash-es";
 

--- a/packages/fast-components-styles-msft/src/label/index.ts
+++ b/packages/fast-components-styles-msft/src/label/index.ts
@@ -3,13 +3,13 @@ import { ensureForegroundNormal, ensureNormalContrast } from "../utilities/color
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { LabelClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import { applyType } from "../utilities/typography";
+import { applyType, applyTypeRampConfig } from "../utilities/typography";
 import { applyScreenReader } from "@microsoft/fast-jss-utilities";
 import { get } from "lodash-es";
 
 const styles: ComponentStyles<LabelClassNameContract, DesignSystem> = {
     label: {
-        ...applyType("t8", "vp3"),
+        ...applyTypeRampConfig("t7"),
         display: "inline-block",
         color: ensureForegroundNormal,
         padding: "0",

--- a/packages/fast-components-styles-msft/src/text-field/index.ts
+++ b/packages/fast-components-styles-msft/src/text-field/index.ts
@@ -3,7 +3,7 @@ import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manage
 import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { adjustContrast, contrast, toPx } from "@microsoft/fast-jss-utilities";
 import { get } from "lodash-es";
-import { applyType, applyTypeRampConfig } from "../utilities/typography";
+import { applyTypeRampConfig } from "../utilities/typography";
 import { fontWeight } from "../utilities/fonts";
 import {
     disabledContrast,

--- a/packages/fast-components-styles-msft/src/text-field/index.ts
+++ b/packages/fast-components-styles-msft/src/text-field/index.ts
@@ -3,7 +3,7 @@ import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manage
 import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { adjustContrast, contrast, toPx } from "@microsoft/fast-jss-utilities";
 import { get } from "lodash-es";
-import { applyType } from "../utilities/typography";
+import { applyType, applyTypeRampConfig } from "../utilities/typography";
 import { fontWeight } from "../utilities/fonts";
 import {
     disabledContrast,
@@ -43,7 +43,7 @@ const styles: ComponentStyles<TextFieldClassNameContract, DesignSystem> = (
 
     return {
         textField: {
-            ...applyType("t7", "vp1"),
+            ...applyTypeRampConfig("t7"),
             color: ensureForegroundNormal,
             background: ensuresBackgroundNormal,
             fontWeight: fontWeight.light.toString(),

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -14,7 +14,7 @@ import {
     ensureContrast,
     toPx,
 } from "@microsoft/fast-jss-utilities";
-import { typeRamp } from "../utilities/typography";
+import { typeRamp, applyType, applyTypeRampConfig } from "../utilities/typography";
 import { ToggleClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import Chroma from "chroma-js";
 
@@ -58,9 +58,8 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = (
             },
         },
         toggle_label: {
+            ...applyTypeRampConfig("t8"),
             display: "inline-block",
-            fontSize: toPx(typeRamp.t8.vp3.fontSize),
-            lineHeight: toPx(typeRamp.t8.vp3.lineHeight),
             foreground: foregroundColor,
             paddingBottom: "7px",
             float: applyLocalizedProperty("left", "right", direction),

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -14,7 +14,7 @@ import {
     ensureContrast,
     toPx,
 } from "@microsoft/fast-jss-utilities";
-import { typeRamp, applyType, applyTypeRampConfig } from "../utilities/typography";
+import { applyTypeRampConfig, typeRamp } from "../utilities/typography";
 import { ToggleClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import Chroma from "chroma-js";
 

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -14,7 +14,7 @@ import {
     ensureContrast,
     toPx,
 } from "@microsoft/fast-jss-utilities";
-import { applyTypeRampConfig, typeRamp } from "../utilities/typography";
+import { applyTypeRampConfig } from "../utilities/typography";
 import { ToggleClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import Chroma from "chroma-js";
 

--- a/packages/fast-components-styles-msft/src/utilities/typography.ts
+++ b/packages/fast-components-styles-msft/src/utilities/typography.ts
@@ -15,7 +15,7 @@ export interface TypeRampItemConfig {
 /**
  * The type ramp item type
  */
-export type TypeRampItem = Partial<KeyOfToType<Breakpoints, TypeRampItemConfig>>;
+export type TypeRampItem = TypeRampItemConfig;
 
 /**
  * The type ramp which covers all type configurations used
@@ -38,103 +38,61 @@ export interface TypeRamp {
  */
 export const typeRamp: TypeRamp = {
     t1: {
-        vp1: {
-            fontSize: 46,
-            lineHeight: 60,
-        },
-        vp3: {
-            fontSize: 62,
-            lineHeight: 72,
-        },
+        fontSize: 60,
+        lineHeight: 72,
     },
     t2: {
-        vp1: {
-            fontSize: 34,
-            lineHeight: 48,
-        },
-        vp3: {
-            fontSize: 46,
-            lineHeight: 56,
-        },
+        fontSize: 46,
+        lineHeight: 56,
     },
     t3: {
-        vp1: {
-            fontSize: 26,
-            lineHeight: 40,
-        },
-        vp3: {
-            fontSize: 34,
-            lineHeight: 48,
-        },
+        fontSize: 34,
+        lineHeight: 44,
     },
     t4: {
-        vp1: {
-            fontSize: 20,
-            lineHeight: 32,
-        },
-        vp3: {
-            fontSize: 24,
-            lineHeight: 36,
-        },
+        fontSize: 24,
+        lineHeight: 32,
     },
     t5: {
-        vp1: {
-            fontSize: 18,
-            lineHeight: 28,
-        },
-        vp3: {
-            fontSize: 20,
-            lineHeight: 28,
-        },
+        fontSize: 20,
+        lineHeight: 28,
     },
     t6: {
-        vp1: {
-            fontSize: 16,
-            lineHeight: 28,
-        },
-        vp3: {
-            fontSize: 18,
-            lineHeight: 28,
-        },
+        fontSize: 16,
+        lineHeight: 24,
     },
     t7: {
-        vp1: {
-            fontSize: 15,
-            lineHeight: 24,
-        },
+        fontSize: 14,
+        lineHeight: 20,
     },
     t8: {
-        vp1: {
-            fontSize: 12,
-            lineHeight: 20,
-        },
-        vp3: {
-            fontSize: 13,
-            lineHeight: 20,
-        },
+        fontSize: 12,
+        lineHeight: 16,
     },
     t9: {
-        vp1: {
-            fontSize: 10,
-            lineHeight: 20,
-        },
-        vp3: {
-            fontSize: 11,
-            lineHeight: 20,
-        },
+        fontSize: 10,
+        lineHeight: 12,
     },
 };
 
 /**
  * Applies a type ramp config instance based on viewport
+ * @deprecated
  */
 export function applyType(
     typeConfig: keyof TypeRamp,
-    viewport: keyof TypeRampItem
+    viewport?: keyof KeyOfToType<Breakpoints, TypeRampItemConfig>
 ): CSSRules<DesignSystem> {
+    if (viewport) {
+        /* tslint:disable-next-line:no-console */
+        console.warn(
+            "The applyType function has been deprecated. Please use applyTypeRampConfig instead"
+        );
+    }
+
     return {
-        fontSize: toPx(typeRamp[typeConfig][viewport].fontSize),
-        lineHeight: toPx(typeRamp[typeConfig][viewport].lineHeight),
+        fontSize: toPx(typeRamp[typeConfig].fontSize),
+        lineHeight: toPx(typeRamp[typeConfig].lineHeight),
     };
 }
 
@@ -142,15 +100,8 @@ export function applyType(
  * Takes a param of type ramp key (string) and returns a type ramp configuration
  */
 export function applyTypeRampConfig(typeConfig: keyof TypeRamp): CSSRules<DesignSystem> {
-    return Object.keys(typeRamp[typeConfig])
-        .map(
-            (key: keyof TypeRampItem): CSSRules<DesignSystem> => {
-                return {
-                    [applyBreakpoint(key)]: applyType(typeConfig, key),
-                };
-            }
-        )
-        .reduce((accumulator: CSSRules<DesignSystem>, value: CSSRules<DesignSystem>) =>
-            Object.assign({}, accumulator, value)
-        );
+    return {
+        fontSize: toPx(typeRamp[typeConfig].fontSize),
+        lineHeight: toPx(typeRamp[typeConfig].lineHeight),
+    };
 }


### PR DESCRIPTION
<body>
closes #1083
<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
