### PR TITLE
fix: align checkbox and radio spacing and ensure examples are aligned

### DIFF
--- a/packages/fast-components-react-msft/src/checkbox/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/checkbox/examples.data.tsx
@@ -16,6 +16,7 @@ export default {
             id: "label",
             props: {
                 slot: CheckboxSlot.label,
+                htmlFor: "checkbox",
                 children: "Checkbox",
             },
         },
@@ -27,6 +28,7 @@ export default {
                 id: "label",
                 props: {
                     slot: CheckboxSlot.label,
+                    htmlFor: "checkbox1",
                     children: "Default",
                 },
             },
@@ -38,6 +40,7 @@ export default {
                 id: "label",
                 props: {
                     slot: CheckboxSlot.label,
+                    htmlFor: "checkbox2",
                     children: "Checked (controlled)",
                 },
             },
@@ -49,6 +52,7 @@ export default {
                 id: "label",
                 props: {
                     slot: CheckboxSlot.label,
+                    htmlFor: "checkbox3",
                     children: "Disabled",
                 },
             },
@@ -60,6 +64,7 @@ export default {
                 id: "label",
                 props: {
                     slot: CheckboxSlot.label,
+                    htmlFor: "checkbox4",
                     children: "Indeterminate",
                 },
             },
@@ -72,6 +77,7 @@ export default {
                 id: "label",
                 props: {
                     slot: CheckboxSlot.label,
+                    htmlFor: "checkbox5",
                     children: "Indeterminate checked (controlled)",
                 },
             },

--- a/packages/fast-components-styles-msft/src/checkbox/index.ts
+++ b/packages/fast-components-styles-msft/src/checkbox/index.ts
@@ -129,7 +129,7 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = (
                 backgroundColor
             ),
             ...applyTypeRampConfig("t7"),
-            [applyLocalizedProperty("marginLeft", "marginRight", direction)]: "5px",
+            [applyLocalizedProperty("marginLeft", "marginRight", direction)]: "8px",
         },
         checkbox__disabled: {
             cursor: "not-allowed",

--- a/packages/fast-components-styles-msft/src/radio/index.ts
+++ b/packages/fast-components-styles-msft/src/radio/index.ts
@@ -108,7 +108,7 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = (
             },
         },
         radio_label: {
-            [applyLocalizedProperty("marginLeft", "marginRight", direction)]: "5px",
+            [applyLocalizedProperty("marginLeft", "marginRight", direction)]: "8px",
         },
     };
 };


### PR DESCRIPTION
<body>
closes #1090, closes #1091  
<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
