### PR TITLE
chore: hide density slider

### DIFF
--- a/packages/fast-components-react-msft/app/app.tsx
+++ b/packages/fast-components-react-msft/app/app.tsx
@@ -132,7 +132,10 @@ export default class App extends React.Component<{}, AppState> {
                             height: "100%",
                         }}
                     >
-                        <Label style={{ marginRight: "8px" }}>density</Label>
+                        {/* Re-implement density slider with: https://github.com/Microsoft/fast-dna/issues/1139 */}
+                        <Label style={{ marginRight: "8px", display: "none" }}>
+                            density
+                        </Label>
                         <input
                             type="range"
                             name="density"
@@ -140,6 +143,7 @@ export default class App extends React.Component<{}, AppState> {
                             min="0"
                             max="2"
                             onChange={this.handleDensityUpdate}
+                            style={{ display: "none" }}
                         />
                         <ColorPicker
                             foregroundColor={this.state.foregroundColor}


### PR DESCRIPTION
Hiding density slider for the time being because the experience feels broken