### PR TITLE
feat: apply theme background color to examples view

### DIFF
--- a/packages/fast-development-site-react/src/components/site/component-view.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-view.tsx
@@ -33,6 +33,7 @@ const style: ComponentStyles<ComponentViewManagedClasses, DevSiteDesignSystem> =
         width: "100%",
         display: "grid",
         gridTemplateColumns: "1fr 1fr 1fr",
+        backgroundColor: (config: DevSiteDesignSystem): string => config.backgroundColor,
     },
     componentDetailView: {
         overflow: "auto",

--- a/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
@@ -7,7 +7,7 @@ import manageJss, {
     ManagedJSSProps,
 } from "@microsoft/fast-jss-manager-react";
 import { ErrorBoundary, ErrorBoundaryProps } from "../../utilities";
-import { toPx } from "@microsoft/fast-jss-utilities";
+import { contrast, toPx } from "@microsoft/fast-jss-utilities";
 import { Direction } from "@microsoft/fast-application-utilities";
 import devSiteDesignSystemDefaults, { DevSiteDesignSystem } from "../design-system";
 import { ComponentViewTypes } from "./component-view";
@@ -35,19 +35,23 @@ export interface ComponentWrapperProps<T> {
 const checker: string =
     "url('data:image/gif;base64,R0lGODlhEAAQAPABANfX1////yH5BAAAAAAALAAAAAAQABAAAAIfhG+hq4jM3IFLJhoswNly/XkcBpIiVaInlLJr9FZWAQAh/wtYTVAgRGF0YVhNUDw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+Cjx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTM4IDc5LjE1OTgyNCwgMjAxNi8wOS8xNC0wMTowOTowMSAgICAgICAgIj4KIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIvPgogPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KPD94cGFja2V0IGVuZD0iciI/PgH//v38+/r5+Pf29fTz8vHw7+7t7Ovq6ejn5uXk4+Lh4N/e3dzb2tnY19bV1NPS0dDPzs3My8rJyMfGxcTDwsHAv769vLu6ubi3trW0s7KxsK+urayrqqmop6alpKOioaCfnp2cm5qZmJeWlZSTkpGQj46NjIuKiYiHhoWEg4KBgH9+fXx7enl4d3Z1dHNycXBvbm1sa2ppaGdmZWRjYmFgX15dXFtaWVhXVlVUU1JRUE9OTUxLSklIR0ZFRENCQUA/Pj08Ozo5ODc2NTQzMjEwLy4tLCsqKSgnJiUkIyIhIB8eHRwbGhkYFxYVFBMSERAPDg0MCwoJCAcGBQQDAgEAADs=')";
 
-const componentWrapperBorder: string = `${toPx(1)} solid rgb(204, 204, 204)`;
+function componentWrapperBorder(config: DevSiteDesignSystem): string {
+    return `1px solid ${contrast(1.3, "#FFF", config.backgroundColor)}`;
+}
+
 const styles: ComponentStyles<ComponentWrapperManagedClasses, DevSiteDesignSystem> = {
     componentWrapper: {
         display: "block",
         padding: toPx(24),
         borderBottom: componentWrapperBorder,
+        borderRight: componentWrapperBorder,
     },
     componentWrapper__transparent: {
         background: checker,
     },
     componentWrapperExamples: {
-        "&:nth-child(3n + 1), &:nth-child(3n + 2)": {
-            borderRight: componentWrapperBorder,
+        "&:nth-child(3n)": {
+            borderRight: "none",
         },
     },
     componentWrapper__active: {

--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -609,10 +609,18 @@ class Site extends React.Component<
                         />
                     </Row>
                     <div className={this.props.managedClasses.site_canvasContent}>
-                        <ComponentView {...{ viewType: this.state.componentView }}>
-                            {this.renderChildrenBySlot(this, ShellSlot.canvas)}
-                            {this.renderComponentByRoute(route)}
-                        </ComponentView>
+                        <DesignSystemProvider
+                            designSystem={
+                                this.state.componentView === ComponentViewTypes.examples
+                                    ? { backgroundColor: this.state.theme.background }
+                                    : {}
+                            }
+                        >
+                            <ComponentView {...{ viewType: this.state.componentView }}>
+                                {this.renderChildrenBySlot(this, ShellSlot.canvas)}
+                                {this.renderComponentByRoute(route)}
+                            </ComponentView>
+                        </DesignSystemProvider>
                         <Row
                             resizable={true}
                             hidden={!this.state.devToolsView}


### PR DESCRIPTION
This change ensures that the entire canvas is filled with the user-defined background color in the component examples view. It also ensures that component separators are derived from the background color, allowing them to look more consistent across light and dark theme experiences.