### PR TITLE
fix: correct misspelled button enum value

### DIFF
--- a/packages/fast-components-react-msft/src/button/button.schema.json
+++ b/packages/fast-components-react-msft/src/button/button.schema.json
@@ -17,7 +17,7 @@
             "title": "Appearance",
             "type": "string",
             "enum": [
-                "justfied",
+                "justified",
                 "lightweight",
                 "outline",
                 "primary"


### PR DESCRIPTION
<body>
closes #1147 
<footer>
 

For [details on formatting](https://github.com/Microsoft/fast-dna/wiki/pull-request-guidance) pull requests.
