### PR TITLE
fix: style change targeting :link and :visited rather than href

### DIFF
--- a/packages/fast-components-styles-msft/src/hypertext/index.ts
+++ b/packages/fast-components-styles-msft/src/hypertext/index.ts
@@ -13,21 +13,6 @@ function applyHypertextBorder(pixels: number): CSSRules<DesignSystem> {
     };
 }
 
-// const styles: ComponentStyles<HypertextClassNameContract, DesignSystem> = {
-//     hypertext: {
-//         outline: "none",
-//         textDecoration: "none",
-//         color: ensureForegroundNormal,
-//         "&[href]": {
-//             ...applyHypertextBorder(1),
-//             color: ensureBrandNormal,
-//             "&:hover, &:focus": {
-//                 ...applyHypertextBorder(2),
-//             },
-//         },
-//     },
-// };
-
 const styles: ComponentStyles<HypertextClassNameContract, DesignSystem> = {
     hypertext: {
         outline: "none",

--- a/packages/fast-components-styles-msft/src/hypertext/index.ts
+++ b/packages/fast-components-styles-msft/src/hypertext/index.ts
@@ -18,7 +18,6 @@ const styles: ComponentStyles<HypertextClassNameContract, DesignSystem> = {
         outline: "none",
         textDecoration: "none",
         color: ensureForegroundNormal,
-        // remove [href] attribute in favor of link and visited <======
         "&:link, &:visited": {
             ...applyHypertextBorder(1),
             color: ensureBrandNormal,

--- a/packages/fast-components-styles-msft/src/hypertext/index.ts
+++ b/packages/fast-components-styles-msft/src/hypertext/index.ts
@@ -13,12 +13,28 @@ function applyHypertextBorder(pixels: number): CSSRules<DesignSystem> {
     };
 }
 
+// const styles: ComponentStyles<HypertextClassNameContract, DesignSystem> = {
+//     hypertext: {
+//         outline: "none",
+//         textDecoration: "none",
+//         color: ensureForegroundNormal,
+//         "&[href]": {
+//             ...applyHypertextBorder(1),
+//             color: ensureBrandNormal,
+//             "&:hover, &:focus": {
+//                 ...applyHypertextBorder(2),
+//             },
+//         },
+//     },
+// };
+
 const styles: ComponentStyles<HypertextClassNameContract, DesignSystem> = {
     hypertext: {
         outline: "none",
         textDecoration: "none",
         color: ensureForegroundNormal,
-        "&[href]": {
+        // remove [href] attribute in favor of link and visited <======
+        "&:link, &:visited": {
             ...applyHypertextBorder(1),
             color: ensureBrandNormal,
             "&:hover, &:focus": {


### PR DESCRIPTION
Targeting href in the style to apply brand color for hypertext was not working in Edge. Changing the target in the style to be :link and :visited does work in both Edge and Chrome.

closes #883 
