### PR TITLE
fix: update to use esModuleInterop in the TypeScript configuration files

### DIFF
--- a/build/helpers/file-includes-all-subdirectories-as-named-exports.spec.ts
+++ b/build/helpers/file-includes-all-subdirectories-as-named-exports.spec.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import path from "path";
 import { includesAllSubdirectoriesAsNamedExports } from "./file-includes-all-subdirectories-as-named-exports";
 
 describe("file-includes-all-subdirectories-as-named-exports.ts", (): void => {

--- a/build/helpers/file-includes-all-subdirectories-as-named-exports.ts
+++ b/build/helpers/file-includes-all-subdirectories-as-named-exports.ts
@@ -1,5 +1,5 @@
-import * as path from "path";
-import * as fs from "fs";
+import path from "path";
+import fs from "fs";
 import { pascalCase } from "../../packages/fast-web-utilities";
 
 /**

--- a/packages/fast-animation/client/examples/app/app.tsx
+++ b/packages/fast-animation/client/examples/app/app.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import TestPage from "./components/TestPage";
 
 /**

--- a/packages/fast-animation/client/examples/app/components/TestPage.tsx
+++ b/packages/fast-animation/client/examples/app/components/TestPage.tsx
@@ -1,5 +1,5 @@
 /* tslint:disable:no-var-requires */
-import * as React from "react";
+import React from "react";
 const doSvg1: string = require("../assets/images/do-check.svg");
 const easingCurve: string = require("../assets/images/easing-curve.svg");
 const sass: string = require("../assets/styles/test-page.css");

--- a/packages/fast-animation/tsconfig.json
+++ b/packages/fast-animation/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
     "experimentalDecorators": true,
     "jsx": "react",
     "target": "es5",

--- a/packages/fast-application-utilities/tsconfig.json
+++ b/packages/fast-application-utilities/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-breakpoint-tracker-react/README.md
+++ b/packages/fast-breakpoint-tracker-react/README.md
@@ -21,7 +21,7 @@ BreakpointTracker.breakpoints = [0, 800, 1024, 1559];
 
 ## Usage
 ```jsx
-import * as React from "react";
+import React from "react";
 import BreakpointTracker from "@microsoft/fast-breakpoint-tracker-react";
 
 export interface AppProps {}

--- a/packages/fast-breakpoint-tracker-react/src/breakpoint-tracker.spec.tsx
+++ b/packages/fast-breakpoint-tracker-react/src/breakpoint-tracker.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import { configure, mount } from "enzyme";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { Breakpoints, defaultBreakpoints } from "./breakpoints";
 import BreakpointTracker from "./breakpoint-tracker";
 

--- a/packages/fast-breakpoint-tracker-react/src/breakpoint-tracker.tsx
+++ b/packages/fast-breakpoint-tracker-react/src/breakpoint-tracker.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { canUseDOM } from "exenv-es6";
 import { throttle } from "lodash-es";
 import { Breakpoints, defaultBreakpoints, identifyBreakpoint } from "./breakpoints";

--- a/packages/fast-breakpoint-tracker-react/tsconfig.json
+++ b/packages/fast-breakpoint-tracker-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-browser-extensions/tsconfig.json
+++ b/packages/fast-browser-extensions/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
       "emitDecoratorMetadata": true,
+      "esModuleInterop": true,
       "experimentalDecorators": true,
       "jsx": "react",
       "target": "es5",

--- a/packages/fast-colors/src/contrast.spec.ts
+++ b/packages/fast-colors/src/contrast.spec.ts
@@ -1,5 +1,5 @@
 import { adjustContrast, contrast, ensureContrast } from "./contrast";
-import * as Chroma from "chroma-js";
+import Chroma from "chroma-js";
 
 const white: string = "#FFF";
 const black: string = "#000";

--- a/packages/fast-colors/src/luminosity.spec.ts
+++ b/packages/fast-colors/src/luminosity.spec.ts
@@ -1,5 +1,5 @@
 import { luminance, luminanceSwitch } from "./luminosity";
-import * as Chroma from "chroma-js";
+import Chroma from "chroma-js";
 
 describe("luminance", (): void => {
     test("should adjust a color to an approximate luminance value", (): void => {

--- a/packages/fast-colors/tsconfig.json
+++ b/packages/fast-colors/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-components-class-name-contracts-base/tsconfig.json
+++ b/packages/fast-components-class-name-contracts-base/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-components-class-name-contracts-msft/tsconfig.json
+++ b/packages/fast-components-class-name-contracts-msft/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-components-foundation-react/README.md
+++ b/packages/fast-components-foundation-react/README.md
@@ -7,8 +7,8 @@ The foundation component for FAST component packages in React. The default expor
 ## Usage
 ### Basic implementation
 ```jsx
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import Foundation from "@microsoft/fast-components-foundation-react";
 
 class MyComponent extends Foundation {

--- a/packages/fast-components-foundation-react/src/foundation/foundation.spec.tsx
+++ b/packages/fast-components-foundation-react/src/foundation/foundation.spec.tsx
@@ -1,8 +1,8 @@
 /* tslint:disable:max-classes-per-file */
 /* tslint:disable:no-string-literal */
-import * as React from "react";
+import React from "react";
 import Foundation, { HandledProps, ReferenceResolver } from "./foundation";
-import * as ReactTestUtils from "react-dom/test-utils";
+import ReactTestUtils from "react-dom/test-utils";
 import { has, merge } from "lodash-es";
 
 class GetRefTestComponent extends Foundation<{}, {}, {}> {

--- a/packages/fast-components-foundation-react/src/foundation/foundation.ts
+++ b/packages/fast-components-foundation-react/src/foundation/foundation.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { get, isPlainObject, pick, set } from "lodash-es";
 import { FoundationProps } from "./foundation.props";
 

--- a/packages/fast-components-foundation-react/tsconfig.json
+++ b/packages/fast-components-foundation-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-components-react-base/README.md
+++ b/packages/fast-components-react-base/README.md
@@ -9,8 +9,8 @@ Base components are the structural, semantic, and interactive core of a piece of
 An example of using one of the components from the `@microsoft/fast-components-react-base` package:
 
 ```tsx
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { ClassNames, IButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { Button } from "@microsoft/fast-components-react-base";
 

--- a/packages/fast-components-react-base/app/components/react-html-element.tsx
+++ b/packages/fast-components-react-base/app/components/react-html-element.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 export interface ReactHTMLElementProps {
     tag?: string;

--- a/packages/fast-components-react-base/app/index.tsx
+++ b/packages/fast-components-react-base/app/index.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import Site, {
     componentFactory,
     formChildFromExamplesFactory,

--- a/packages/fast-components-react-base/src/breadcrumb/breadcrumb.props.ts
+++ b/packages/fast-components-react-base/src/breadcrumb/breadcrumb.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     BreadcrumbClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/breadcrumb/breadcrumb.spec.tsx
+++ b/packages/fast-components-react-base/src/breadcrumb/breadcrumb.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import Breadcrumb, {
     BreadcrumbClassNameContract,

--- a/packages/fast-components-react-base/src/breadcrumb/breadcrumb.tsx
+++ b/packages/fast-components-react-base/src/breadcrumb/breadcrumb.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { BreadcrumbClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import {

--- a/packages/fast-components-react-base/src/breadcrumb/examples.data.tsx
+++ b/packages/fast-components-react-base/src/breadcrumb/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import schema from "./breadcrumb.schema.json";
 import Breadcrumb, { BreadcrumbManagedClasses, BreadcrumbProps } from "./breadcrumb";

--- a/packages/fast-components-react-base/src/button/button.props.ts
+++ b/packages/fast-components-react-base/src/button/button.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ButtonClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/button/button.spec.tsx
+++ b/packages/fast-components-react-base/src/button/button.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, shallow } from "enzyme";
 import examples from "./examples.data";
 import Button, {

--- a/packages/fast-components-react-base/src/button/button.tsx
+++ b/packages/fast-components-react-base/src/button/button.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { ButtonHandledProps, ButtonUnhandledProps } from "./button.props";

--- a/packages/fast-components-react-base/src/button/examples.data.tsx
+++ b/packages/fast-components-react-base/src/button/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Button, {
     ButtonHandledProps,
     ButtonManagedClasses,

--- a/packages/fast-components-react-base/src/card/card.props.ts
+++ b/packages/fast-components-react-base/src/card/card.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     CardClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/card/card.spec.tsx
+++ b/packages/fast-components-react-base/src/card/card.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, shallow } from "enzyme";
 import examples from "./examples.data";
 import Card, {

--- a/packages/fast-components-react-base/src/card/card.tsx
+++ b/packages/fast-components-react-base/src/card/card.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {

--- a/packages/fast-components-react-base/src/card/examples.data.tsx
+++ b/packages/fast-components-react-base/src/card/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Card, {
     CardHandledProps,
     CardManagedClasses,

--- a/packages/fast-components-react-base/src/checkbox/checkbox.props.ts
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     CheckboxClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/checkbox/checkbox.spec.tsx
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import Checkbox, {

--- a/packages/fast-components-react-base/src/checkbox/checkbox.tsx
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {
     CheckboxHandledProps,

--- a/packages/fast-components-react-base/src/checkbox/examples.data.tsx
+++ b/packages/fast-components-react-base/src/checkbox/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Checkbox, {
     CheckboxHandledProps,
     CheckboxManagedClasses,

--- a/packages/fast-components-react-base/src/context-menu-item/context-menu-item.props.ts
+++ b/packages/fast-components-react-base/src/context-menu-item/context-menu-item.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ContextMenuItemClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/context-menu-item/context-menu-item.spec.tsx
+++ b/packages/fast-components-react-base/src/context-menu-item/context-menu-item.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, shallow } from "enzyme";
 import ContextMenuItem, {
     ContextMenuItemRole,

--- a/packages/fast-components-react-base/src/context-menu-item/context-menu-item.tsx
+++ b/packages/fast-components-react-base/src/context-menu-item/context-menu-item.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { get } from "lodash-es";
 import { ContextMenuItemClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";

--- a/packages/fast-components-react-base/src/context-menu-item/examples.data.tsx
+++ b/packages/fast-components-react-base/src/context-menu-item/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import ContextMenuItem, {
     ContextMenuItemHandledProps,

--- a/packages/fast-components-react-base/src/context-menu/context-menu.props.ts
+++ b/packages/fast-components-react-base/src/context-menu/context-menu.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ContextMenuClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/context-menu/context-menu.spec.tsx
+++ b/packages/fast-components-react-base/src/context-menu/context-menu.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import ContextMenu, { ContextMenuUnhandledProps } from "./context-menu";
 import { KeyCodes } from "@microsoft/fast-web-utilities";

--- a/packages/fast-components-react-base/src/context-menu/context-menu.tsx
+++ b/packages/fast-components-react-base/src/context-menu/context-menu.tsx
@@ -1,4 +1,4 @@
-import * as ReactDOM from "react-dom";
+import ReactDOM from "react-dom";
 import { ContextMenuItemProps, ContextMenuItemRole } from "../context-menu-item";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { ContextMenuClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
@@ -7,7 +7,7 @@ import {
     ContextMenuProps,
     ContextMenuUnhandledProps,
 } from "./context-menu.props";
-import * as React from "react";
+import React from "react";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 import { get, inRange, invert } from "lodash-es";
 import { canUseDOM } from "exenv-es6";

--- a/packages/fast-components-react-base/src/context-menu/examples.data.tsx
+++ b/packages/fast-components-react-base/src/context-menu/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import schema from "./context-menu.schema.json";
 import ContextMenu, { ContextMenuManagedClasses, ContextMenuProps } from "./context-menu";

--- a/packages/fast-components-react-base/src/dialog/dialog.props.ts
+++ b/packages/fast-components-react-base/src/dialog/dialog.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     DialogClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import Dialog, {

--- a/packages/fast-components-react-base/src/dialog/dialog.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {

--- a/packages/fast-components-react-base/src/dialog/examples.data.tsx
+++ b/packages/fast-components-react-base/src/dialog/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Dialog, {
     DialogHandledProps,
     DialogManagedClasses,

--- a/packages/fast-components-react-base/src/divider/divider.props.ts
+++ b/packages/fast-components-react-base/src/divider/divider.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     DividerClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/divider/divider.spec.tsx
+++ b/packages/fast-components-react-base/src/divider/divider.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, shallow } from "enzyme";
 import examples from "./examples.data";
 import Divider, {

--- a/packages/fast-components-react-base/src/divider/divider.tsx
+++ b/packages/fast-components-react-base/src/divider/divider.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {

--- a/packages/fast-components-react-base/src/divider/examples.data.tsx
+++ b/packages/fast-components-react-base/src/divider/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import Divider, {
     DividerHandledProps,

--- a/packages/fast-components-react-base/src/horizontal-overflow/examples.data.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import HorizontalOverflow, {
     HorizontalOverflowHandledProps,
     HorizontalOverflowManagedClasses,

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.node.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.node.spec.tsx
@@ -3,9 +3,9 @@
  */
 import "jsdom-global/register";
 
-import * as React from "react";
-import * as ReactDOMServer from "react-dom/server";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import HorizontalOverflow, {
     HorizontalOverflowClassNameContract,

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.props.ts
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     HorizontalOverflowClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import HorizontalOverflow, {
     ButtonDirection,

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { get } from "lodash-es";
 import { canUseDOM } from "exenv-es6";
 import {

--- a/packages/fast-components-react-base/src/hypertext/examples.data.tsx
+++ b/packages/fast-components-react-base/src/hypertext/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Hypertext, {
     HypertextHandledProps,
     HypertextManagedClasses,

--- a/packages/fast-components-react-base/src/hypertext/hypertext.props.ts
+++ b/packages/fast-components-react-base/src/hypertext/hypertext.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     HypertextClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/hypertext/hypertext.spec.tsx
+++ b/packages/fast-components-react-base/src/hypertext/hypertext.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, shallow } from "enzyme";
 import examples from "./examples.data";
 import Hypertext, {

--- a/packages/fast-components-react-base/src/hypertext/hypertext.tsx
+++ b/packages/fast-components-react-base/src/hypertext/hypertext.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {
     HypertextHandledProps,

--- a/packages/fast-components-react-base/src/image/examples.data.tsx
+++ b/packages/fast-components-react-base/src/image/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Image, {
     ImageHandledProps,
     ImageManagedClasses,

--- a/packages/fast-components-react-base/src/image/image.props.ts
+++ b/packages/fast-components-react-base/src/image/image.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ImageClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/image/image.spec.tsx
+++ b/packages/fast-components-react-base/src/image/image.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, shallow } from "enzyme";
 import examples from "./examples.data";
 import Image, {

--- a/packages/fast-components-react-base/src/image/image.tsx
+++ b/packages/fast-components-react-base/src/image/image.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {

--- a/packages/fast-components-react-base/src/label/examples.data.tsx
+++ b/packages/fast-components-react-base/src/label/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Label, {
     LabelHandledProps,
     LabelManagedClasses,

--- a/packages/fast-components-react-base/src/label/label.props.ts
+++ b/packages/fast-components-react-base/src/label/label.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     LabelClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-base/src/label/label.spec.tsx
+++ b/packages/fast-components-react-base/src/label/label.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, shallow } from "enzyme";
 import examples from "./examples.data";
 import Label, {

--- a/packages/fast-components-react-base/src/label/label.tsx
+++ b/packages/fast-components-react-base/src/label/label.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get, isUndefined } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {

--- a/packages/fast-components-react-base/src/progress/examples.data.tsx
+++ b/packages/fast-components-react-base/src/progress/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Progress, {
     ProgressHandledProps,
     ProgressManagedClasses,

--- a/packages/fast-components-react-base/src/progress/progress.props.ts
+++ b/packages/fast-components-react-base/src/progress/progress.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ManagedClasses,
     ProgressClassNameContract,

--- a/packages/fast-components-react-base/src/progress/progress.spec.tsx
+++ b/packages/fast-components-react-base/src/progress/progress.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import Progress, { ProgressClassNameContract, ProgressType } from "./";
 

--- a/packages/fast-components-react-base/src/progress/progress.tsx
+++ b/packages/fast-components-react-base/src/progress/progress.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {

--- a/packages/fast-components-react-base/src/radio/examples.data.tsx
+++ b/packages/fast-components-react-base/src/radio/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Radio, {
     RadioHandledProps,
     RadioManagedClasses,

--- a/packages/fast-components-react-base/src/radio/radio.props.ts
+++ b/packages/fast-components-react-base/src/radio/radio.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ManagedClasses,
     RadioClassNameContract,

--- a/packages/fast-components-react-base/src/radio/radio.spec.tsx
+++ b/packages/fast-components-react-base/src/radio/radio.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import Radio, { RadioClassNameContract, RadioSlot } from "./radio";

--- a/packages/fast-components-react-base/src/radio/radio.tsx
+++ b/packages/fast-components-react-base/src/radio/radio.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {
     RadioHandledProps,

--- a/packages/fast-components-react-base/src/tabs/examples.data.tsx
+++ b/packages/fast-components-react-base/src/tabs/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     TabClassNameContract,
     TabPanelClassNameContract,

--- a/packages/fast-components-react-base/src/tabs/tab-item.props.ts
+++ b/packages/fast-components-react-base/src/tabs/tab-item.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { TabsSlot } from "./tabs";
 
 export interface TabItemUnhandledProps extends React.AllHTMLAttributes<HTMLElement> {}

--- a/packages/fast-components-react-base/src/tabs/tab-item.tsx
+++ b/packages/fast-components-react-base/src/tabs/tab-item.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { TabItemHandledProps, TabItemUnhandledProps } from "./tab-item.props";
 

--- a/packages/fast-components-react-base/src/tabs/tab-panel.props.ts
+++ b/packages/fast-components-react-base/src/tabs/tab-panel.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ManagedClasses,
     TabPanelClassNameContract,

--- a/packages/fast-components-react-base/src/tabs/tab-panel.tsx
+++ b/packages/fast-components-react-base/src/tabs/tab-panel.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {

--- a/packages/fast-components-react-base/src/tabs/tab.props.ts
+++ b/packages/fast-components-react-base/src/tabs/tab.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ManagedClasses,
     TabClassNameContract,

--- a/packages/fast-components-react-base/src/tabs/tab.tsx
+++ b/packages/fast-components-react-base/src/tabs/tab.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { get } from "lodash-es";
 import {
     ManagedClasses,

--- a/packages/fast-components-react-base/src/tabs/tabs.props.ts
+++ b/packages/fast-components-react-base/src/tabs/tabs.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ManagedClasses,
     TabsClassNameContract,

--- a/packages/fast-components-react-base/src/tabs/tabs.spec.tsx
+++ b/packages/fast-components-react-base/src/tabs/tabs.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import { KeyCodes, Orientation } from "@microsoft/fast-web-utilities";
 import { noop } from "lodash-es";

--- a/packages/fast-components-react-base/src/tabs/tabs.tsx
+++ b/packages/fast-components-react-base/src/tabs/tabs.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { get } from "lodash-es";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 import {

--- a/packages/fast-components-react-base/src/text-field/examples.data.tsx
+++ b/packages/fast-components-react-base/src/text-field/examples.data.tsx
@@ -5,7 +5,7 @@ import TextField, {
     TextFieldUnhandledProps,
 } from "./text-field";
 import schema from "./text-field.schema.json";
-import * as React from "react";
+import React from "react";
 import Documentation from "./.tmp/documentation";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 

--- a/packages/fast-components-react-base/src/text-field/text-field.props.ts
+++ b/packages/fast-components-react-base/src/text-field/text-field.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ManagedClasses,
     TextFieldClassNameContract,

--- a/packages/fast-components-react-base/src/text-field/text-field.spec.tsx
+++ b/packages/fast-components-react-base/src/text-field/text-field.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, render, shallow } from "enzyme";
 import examples from "./examples.data";
 import TextField, {

--- a/packages/fast-components-react-base/src/text-field/text-field.tsx
+++ b/packages/fast-components-react-base/src/text-field/text-field.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {
     TextFieldHandledProps,

--- a/packages/fast-components-react-base/src/toggle/examples.data.tsx
+++ b/packages/fast-components-react-base/src/toggle/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Toggle, {
     ToggleHandledProps,
     ToggleManagedClasses,

--- a/packages/fast-components-react-base/src/toggle/toggle.props.ts
+++ b/packages/fast-components-react-base/src/toggle/toggle.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ManagedClasses,
     ToggleClassNameContract,

--- a/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, shallow } from "enzyme";
 import examples from "./examples.data";
 import Toggle, {

--- a/packages/fast-components-react-base/src/toggle/toggle.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {

--- a/packages/fast-components-react-base/src/typography/examples.data.tsx
+++ b/packages/fast-components-react-base/src/typography/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Typography, {
     TypographyHandledProps,
     TypographyManagedClasses,

--- a/packages/fast-components-react-base/src/typography/typography.props.ts
+++ b/packages/fast-components-react-base/src/typography/typography.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ManagedClasses,
     TypographyClassNameContract,

--- a/packages/fast-components-react-base/src/typography/typography.spec.tsx
+++ b/packages/fast-components-react-base/src/typography/typography.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, shallow } from "enzyme";
 import examples from "./examples.data";
 import Typography, {

--- a/packages/fast-components-react-base/src/typography/typography.tsx
+++ b/packages/fast-components-react-base/src/typography/typography.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {

--- a/packages/fast-components-react-base/tsconfig.json
+++ b/packages/fast-components-react-base/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-components-react-msft/README.md
+++ b/packages/fast-components-react-msft/README.md
@@ -8,8 +8,8 @@ A set of React components which implements the Microsoft styling.
 An example of using one of the components from the `@microsoft/fast-components-react-msft` package:
 
 ```tsx
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { Button, ButtonAppearance } from "@microsoft/fast-components-react-msft";
 
 const root = document.createElement("div");

--- a/packages/fast-components-react-msft/app/app.tsx
+++ b/packages/fast-components-react-msft/app/app.tsx
@@ -24,7 +24,7 @@ import {
     ManagedClasses,
 } from "@microsoft/fast-components-class-name-contracts-base";
 import { glyphBuildingblocks } from "@microsoft/fast-glyphs-msft";
-import * as React from "react";
+import React from "react";
 import { Direction } from "@microsoft/fast-application-utilities";
 import { Foundation, Pattern } from "./examples";
 import { Hypertext } from "../src/hypertext";

--- a/packages/fast-components-react-msft/app/color-picker.tsx
+++ b/packages/fast-components-react-msft/app/color-picker.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, {
     ComponentStyles,
     ManagedClasses,

--- a/packages/fast-components-react-msft/app/components/react-html-element.tsx
+++ b/packages/fast-components-react-msft/app/components/react-html-element.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 export interface ReactHTMLElementProps {
     tag?: string;

--- a/packages/fast-components-react-msft/app/index.tsx
+++ b/packages/fast-components-react-msft/app/index.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import App from "./app";
 
 /**

--- a/packages/fast-components-react-msft/src/action-trigger/action-trigger.props.ts
+++ b/packages/fast-components-react-msft/src/action-trigger/action-trigger.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Omit } from "utility-types";
 import {
     ActionTriggerClassNameContract,

--- a/packages/fast-components-react-msft/src/action-trigger/action-trigger.spec.tsx
+++ b/packages/fast-components-react-msft/src/action-trigger/action-trigger.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16/build";
+import Adapter from "enzyme-adapter-react-16/build";
 import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import MSFTActionTrigger, {

--- a/packages/fast-components-react-msft/src/action-trigger/action-trigger.tsx
+++ b/packages/fast-components-react-msft/src/action-trigger/action-trigger.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { Button, ButtonAppearance } from "../button";

--- a/packages/fast-components-react-msft/src/action-trigger/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/action-trigger/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ActionTrigger, ActionTriggerAppearance, ActionTriggerProps } from "./index";
 import schema from "./action-trigger.schema.json";
 import Documentation from "./.tmp/documentation";

--- a/packages/fast-components-react-msft/src/action-trigger/index.ts
+++ b/packages/fast-components-react-msft/src/action-trigger/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ActionTriggerClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import {

--- a/packages/fast-components-react-msft/src/breadcrumb/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/breadcrumb/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Breadcrumb, BreadcrumbHandledProps } from "./index";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import schema from "@microsoft/fast-components-react-base/dist/breadcrumb/breadcrumb.schema.json";

--- a/packages/fast-components-react-msft/src/breadcrumb/index.ts
+++ b/packages/fast-components-react-msft/src/breadcrumb/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     Breadcrumb as BaseBreadcrumb,
     BreadcrumbClassNameContract,

--- a/packages/fast-components-react-msft/src/button/button.props.ts
+++ b/packages/fast-components-react-msft/src/button/button.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Subtract } from "utility-types";
 import {
     ButtonHandledProps as BaseButtonHandledProps,

--- a/packages/fast-components-react-msft/src/button/button.spec.tsx
+++ b/packages/fast-components-react-msft/src/button/button.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import { ButtonHTMLTags } from "@microsoft/fast-components-react-base";
 import { ButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";

--- a/packages/fast-components-react-msft/src/button/button.tsx
+++ b/packages/fast-components-react-msft/src/button/button.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {

--- a/packages/fast-components-react-msft/src/button/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/button/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { Button, ButtonAppearance, ButtonProps } from "./index";
 import { ButtonHandledProps as BaseButtonHandledProps } from "@microsoft/fast-components-react-base";

--- a/packages/fast-components-react-msft/src/button/index.ts
+++ b/packages/fast-components-react-msft/src/button/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ButtonStyles, DesignSystem } from "@microsoft/fast-components-styles-msft";

--- a/packages/fast-components-react-msft/src/call-to-action/call-to-action.props.ts
+++ b/packages/fast-components-react-msft/src/call-to-action/call-to-action.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Omit, Subtract } from "utility-types";
 import {
     CallToActionClassNameContract,

--- a/packages/fast-components-react-msft/src/call-to-action/call-to-action.spec.tsx
+++ b/packages/fast-components-react-msft/src/call-to-action/call-to-action.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16/build";
+import Adapter from "enzyme-adapter-react-16/build";
 import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import MSFTCallToAction, {

--- a/packages/fast-components-react-msft/src/call-to-action/call-to-action.tsx
+++ b/packages/fast-components-react-msft/src/call-to-action/call-to-action.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { Button, ButtonAppearance } from "../button";
 import {

--- a/packages/fast-components-react-msft/src/call-to-action/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/call-to-action/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { CallToAction, CallToActionAppearance, CallToActionProps } from "./index";
 import schema from "./call-to-action.schema.json";
 import Documentation from "./.tmp/documentation";

--- a/packages/fast-components-react-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-react-msft/src/call-to-action/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { CallToActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { CallToActionStyles, DesignSystem } from "@microsoft/fast-components-styles-msft";

--- a/packages/fast-components-react-msft/src/caption/caption.props.ts
+++ b/packages/fast-components-react-msft/src/caption/caption.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     CaptionClassNameContract,
     ManagedClasses,

--- a/packages/fast-components-react-msft/src/caption/caption.spec.tsx
+++ b/packages/fast-components-react-msft/src/caption/caption.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import MSFTCaption, {

--- a/packages/fast-components-react-msft/src/caption/caption.tsx
+++ b/packages/fast-components-react-msft/src/caption/caption.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { TypographySize, TypographyTag } from "@microsoft/fast-components-react-base";

--- a/packages/fast-components-react-msft/src/caption/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/caption/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Caption, CaptionProps, CaptionSize, CaptionTag } from "./index";
 import schema from "./caption.schema.json";

--- a/packages/fast-components-react-msft/src/caption/index.ts
+++ b/packages/fast-components-react-msft/src/caption/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import MSFTCaption, {
     CaptionHandledProps as MSFTCaptionHandledProps,
     CaptionManagedClasses,

--- a/packages/fast-components-react-msft/src/card/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/card/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Card } from "./index";
 import { CardHandledProps, CardProps, CardTag, CardUnhandledProps } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/card/card.schema.json";

--- a/packages/fast-components-react-msft/src/card/index.ts
+++ b/packages/fast-components-react-msft/src/card/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     Card as BaseCard,
     CardClassNameContract,

--- a/packages/fast-components-react-msft/src/checkbox/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/checkbox/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Checkbox, CheckboxProps, CheckboxSlot } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/checkbox/checkbox.schema.json";

--- a/packages/fast-components-react-msft/src/checkbox/index.ts
+++ b/packages/fast-components-react-msft/src/checkbox/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import {
     Checkbox as BaseCheckbox,

--- a/packages/fast-components-react-msft/src/context-menu-item/context-menu-item.props.ts
+++ b/packages/fast-components-react-msft/src/context-menu-item/context-menu-item.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Subtract } from "utility-types";
 import {
     ContextMenuItemHandledProps as BaseContextMenuItemHandledProps,

--- a/packages/fast-components-react-msft/src/context-menu-item/context-menu-item.spec.tsx
+++ b/packages/fast-components-react-msft/src/context-menu-item/context-menu-item.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import { ContextMenuItemClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import MSFTContextMenuItem from "./context-menu-item";

--- a/packages/fast-components-react-msft/src/context-menu-item/context-menu-item.tsx
+++ b/packages/fast-components-react-msft/src/context-menu-item/context-menu-item.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {
     ContextMenuItemHandledProps,

--- a/packages/fast-components-react-msft/src/context-menu-item/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/context-menu-item/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ContextMenuItem, ContextMenuItemProps } from "./index";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import schema from "@microsoft/fast-components-react-base/dist/context-menu-item/context-menu-item.schema.json";

--- a/packages/fast-components-react-msft/src/context-menu-item/index.ts
+++ b/packages/fast-components-react-msft/src/context-menu-item/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ContextMenuItemRole } from "@microsoft/fast-components-react-base";
 import MSFTContextMenuItem, {
     ContextMenuItemHandledProps as MSFTContextMenuItemHandledProps,

--- a/packages/fast-components-react-msft/src/context-menu/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/context-menu/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ContextMenu, ContextMenuHandledProps } from "./index";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import schema from "@microsoft/fast-components-react-base/dist/context-menu/context-menu.schema.json";

--- a/packages/fast-components-react-msft/src/context-menu/index.ts
+++ b/packages/fast-components-react-msft/src/context-menu/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ContextMenu as BaseContextMenu,
     ContextMenuClassNameContract,

--- a/packages/fast-components-react-msft/src/dialog/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/dialog/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Dialog, DialogProps } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/dialog/dialog.schema.json";

--- a/packages/fast-components-react-msft/src/dialog/index.ts
+++ b/packages/fast-components-react-msft/src/dialog/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     Dialog as BaseDialog,
     DialogClassNameContract,

--- a/packages/fast-components-react-msft/src/divider/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/divider/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Divider, DividerProps, DividerRoles } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/divider/divider.schema.json";

--- a/packages/fast-components-react-msft/src/divider/index.ts
+++ b/packages/fast-components-react-msft/src/divider/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     Divider as BaseDivider,
     DividerClassNameContract,

--- a/packages/fast-components-react-msft/src/flipper/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/flipper/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Flipper, FlipperDirection, FlipperProps } from "./index";
 import schema from "./flipper.schema.json";

--- a/packages/fast-components-react-msft/src/flipper/flipper.props.ts
+++ b/packages/fast-components-react-msft/src/flipper/flipper.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ButtonHandledProps,
     ButtonManagedClasses,

--- a/packages/fast-components-react-msft/src/flipper/flipper.spec.tsx
+++ b/packages/fast-components-react-msft/src/flipper/flipper.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import MSFTFlipper, { FlipperHandledProps, FlipperUnhandledProps } from "./flipper";

--- a/packages/fast-components-react-msft/src/flipper/flipper.tsx
+++ b/packages/fast-components-react-msft/src/flipper/flipper.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { Button, ButtonProps } from "@microsoft/fast-components-react-base";

--- a/packages/fast-components-react-msft/src/flipper/index.ts
+++ b/packages/fast-components-react-msft/src/flipper/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import {
     ButtonHandledProps as BaseButtonHandledProps,

--- a/packages/fast-components-react-msft/src/heading/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/heading/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Heading, HeadingProps, HeadingSize, HeadingTag } from "./index";
 import schema from "./heading.schema.json";

--- a/packages/fast-components-react-msft/src/heading/heading.props.ts
+++ b/packages/fast-components-react-msft/src/heading/heading.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { TypographyUnhandledProps } from "../typography";
 import {
     HeadingClassNameContract,

--- a/packages/fast-components-react-msft/src/heading/heading.spec.tsx
+++ b/packages/fast-components-react-msft/src/heading/heading.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import MSFTHeading, {

--- a/packages/fast-components-react-msft/src/heading/heading.tsx
+++ b/packages/fast-components-react-msft/src/heading/heading.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { TypographySize, TypographyTag } from "@microsoft/fast-components-react-base";

--- a/packages/fast-components-react-msft/src/heading/index.ts
+++ b/packages/fast-components-react-msft/src/heading/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import { HeadingClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import MSFTHeading, {

--- a/packages/fast-components-react-msft/src/hypertext/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/hypertext/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Hypertext, HypertextProps } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/hypertext/hypertext.schema.json";

--- a/packages/fast-components-react-msft/src/hypertext/index.ts
+++ b/packages/fast-components-react-msft/src/hypertext/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     Hypertext as BaseHypertext,
     HypertextClassNameContract,

--- a/packages/fast-components-react-msft/src/image/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/image/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Image, ImageProps, ImageSlot } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/image/image.schema.json";

--- a/packages/fast-components-react-msft/src/image/index.ts
+++ b/packages/fast-components-react-msft/src/image/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import {
     Image as BaseImage,

--- a/packages/fast-components-react-msft/src/label/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/label/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Label, LabelProps, LabelTag } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/label/label.schema.json";

--- a/packages/fast-components-react-msft/src/label/index.ts
+++ b/packages/fast-components-react-msft/src/label/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import {
     Label as BaseLabel,

--- a/packages/fast-components-react-msft/src/metatext/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/metatext/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Metatext, MetatextProps, MetatextTag } from "./index";
 import schema from "./metatext.schema.json";

--- a/packages/fast-components-react-msft/src/metatext/index.ts
+++ b/packages/fast-components-react-msft/src/metatext/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import { MetatextClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import MSFTMetatext, {

--- a/packages/fast-components-react-msft/src/metatext/metatext.props.ts
+++ b/packages/fast-components-react-msft/src/metatext/metatext.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ManagedClasses,
     MetatextClassNameContract,

--- a/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
+++ b/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import MSFTMetatext, {

--- a/packages/fast-components-react-msft/src/metatext/metatext.tsx
+++ b/packages/fast-components-react-msft/src/metatext/metatext.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { TypographySize, TypographyTag } from "@microsoft/fast-components-react-base";

--- a/packages/fast-components-react-msft/src/paragraph/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/paragraph/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Paragraph, ParagraphProps, ParagraphSize } from "./index";
 import schema from "./paragraph.schema.json";

--- a/packages/fast-components-react-msft/src/paragraph/index.ts
+++ b/packages/fast-components-react-msft/src/paragraph/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import { ParagraphClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import MSFTParagraph, {

--- a/packages/fast-components-react-msft/src/paragraph/paragraph.props.ts
+++ b/packages/fast-components-react-msft/src/paragraph/paragraph.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ManagedClasses,
     ParagraphClassNameContract,

--- a/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
+++ b/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import MSFTParagraph, {

--- a/packages/fast-components-react-msft/src/paragraph/paragraph.tsx
+++ b/packages/fast-components-react-msft/src/paragraph/paragraph.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { TypographySize, TypographyTag } from "@microsoft/fast-components-react-base";

--- a/packages/fast-components-react-msft/src/progress/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/progress/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { Progress, ProgressProps } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/progress/progress.schema.json";

--- a/packages/fast-components-react-msft/src/progress/index.ts
+++ b/packages/fast-components-react-msft/src/progress/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ProgressClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { DesignSystem, ProgressStyles } from "@microsoft/fast-components-styles-msft";

--- a/packages/fast-components-react-msft/src/progress/progress.props.ts
+++ b/packages/fast-components-react-msft/src/progress/progress.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ProgressHandledProps as BaseProgressHandledProps,
     ProgressManagedClasses as BaseProgressManagedClasses,

--- a/packages/fast-components-react-msft/src/progress/progress.spec.tsx
+++ b/packages/fast-components-react-msft/src/progress/progress.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, shallow } from "enzyme";
 import examples from "./examples.data";
 import { ProgressClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";

--- a/packages/fast-components-react-msft/src/progress/progress.tsx
+++ b/packages/fast-components-react-msft/src/progress/progress.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { ProgressType } from "@microsoft/fast-components-react-base";

--- a/packages/fast-components-react-msft/src/radio/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/radio/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Radio, RadioProps } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/radio/radio.schema.json";

--- a/packages/fast-components-react-msft/src/radio/index.ts
+++ b/packages/fast-components-react-msft/src/radio/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     Radio as BaseRadio,
     RadioClassNameContract,

--- a/packages/fast-components-react-msft/src/subheading/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/subheading/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Subheading, SubheadingProps, SubheadingSize, SubheadingTag } from "./index";
 import schema from "./subheading.schema.json";

--- a/packages/fast-components-react-msft/src/subheading/index.ts
+++ b/packages/fast-components-react-msft/src/subheading/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import { SubheadingClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import MSFTSubheading, {

--- a/packages/fast-components-react-msft/src/subheading/subheading.props.ts
+++ b/packages/fast-components-react-msft/src/subheading/subheading.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {
     ManagedClasses,
     SubheadingClassNameContract,

--- a/packages/fast-components-react-msft/src/subheading/subheading.spec.tsx
+++ b/packages/fast-components-react-msft/src/subheading/subheading.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import MSFTSubheading, {

--- a/packages/fast-components-react-msft/src/subheading/subheading.tsx
+++ b/packages/fast-components-react-msft/src/subheading/subheading.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { TypographySize, TypographyTag } from "@microsoft/fast-components-react-base";

--- a/packages/fast-components-react-msft/src/text-field/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/text-field/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { TextField, TextFieldProps, TextFieldType } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/text-field/text-field.schema.json";

--- a/packages/fast-components-react-msft/src/text-field/index.ts
+++ b/packages/fast-components-react-msft/src/text-field/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import {
     TextField as BaseTextField,

--- a/packages/fast-components-react-msft/src/toggle/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/toggle/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Toggle, ToggleProps } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/toggle/toggle.schema.json";

--- a/packages/fast-components-react-msft/src/toggle/index.ts
+++ b/packages/fast-components-react-msft/src/toggle/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import {
     Toggle as BaseToggle,

--- a/packages/fast-components-react-msft/src/typography/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/typography/examples.data.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
 import { Typography, TypographyProps, TypographySize, TypographyTag } from "./index";
 import schema from "@microsoft/fast-components-react-base/dist/typography/typography.schema.json";

--- a/packages/fast-components-react-msft/src/typography/index.ts
+++ b/packages/fast-components-react-msft/src/typography/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import {
     Typography as BaseTypography,

--- a/packages/fast-components-react-msft/tsconfig.json
+++ b/packages/fast-components-react-msft/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-components-styles-msft/tsconfig.json
+++ b/packages/fast-components-styles-msft/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-css-editor-react/README.md
+++ b/packages/fast-css-editor-react/README.md
@@ -9,7 +9,7 @@ A set of React components that allows the user to edit CSS properties.
 The default export implements all of the individual components to create a set of form elements that allow for editing of CSS values.
 
 ```jsx
-import * as React from "react";
+import React from "react";
 import CSSEditor from "@microsoft/fast-css-editor-react";
 
 export class Example extends React.Component {

--- a/packages/fast-css-editor-react/app/app.tsx
+++ b/packages/fast-css-editor-react/app/app.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Site, {
     SiteCategory,
     SiteCategoryDocumentation,

--- a/packages/fast-css-editor-react/app/index.tsx
+++ b/packages/fast-css-editor-react/app/index.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import App from "./app";
 
 /**

--- a/packages/fast-css-editor-react/src/editor.spec.tsx
+++ b/packages/fast-css-editor-react/src/editor.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import Editor from "./editor";
 import CSSEditor, { PositionValue, SpacingType } from "./";

--- a/packages/fast-css-editor-react/src/editor.tsx
+++ b/packages/fast-css-editor-react/src/editor.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { omit } from "lodash-es";
 import Foundation, {
     FoundationProps,

--- a/packages/fast-css-editor-react/src/index.ts
+++ b/packages/fast-css-editor-react/src/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import Editor from "./editor";

--- a/packages/fast-css-editor-react/src/position/README.md
+++ b/packages/fast-css-editor-react/src/position/README.md
@@ -3,7 +3,7 @@ The `CSSPosition` component shows the CSS position value as a select, it will al
 
 ## Usage
 ```jsx
-import * as React from "react";
+import React from "react";
 import { CSSPosition } from "@microsoft/fast-css-editor-react";
 
 export class Example extends React.Component {

--- a/packages/fast-css-editor-react/src/position/index.ts
+++ b/packages/fast-css-editor-react/src/position/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import Position from "./position";

--- a/packages/fast-css-editor-react/src/position/position.spec.tsx
+++ b/packages/fast-css-editor-react/src/position/position.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import Position from "./position";
 import { CSSPosition } from "./";

--- a/packages/fast-css-editor-react/src/position/position.tsx
+++ b/packages/fast-css-editor-react/src/position/position.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Foundation, {
     FoundationProps,
     HandledProps,

--- a/packages/fast-css-editor-react/src/spacing/README.md
+++ b/packages/fast-css-editor-react/src/spacing/README.md
@@ -3,7 +3,7 @@ The `CSSSpacing` component shows the CSS spacing (margin and padding) value as f
 
 ## Usage
 ```jsx
-import * as React from "react";
+import React from "react";
 import { CSSSpacing } from "@microsoft/fast-css-editor-react";
 
 export class Example extends React.Component {

--- a/packages/fast-css-editor-react/src/spacing/index.ts
+++ b/packages/fast-css-editor-react/src/spacing/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import Spacing from "./spacing";

--- a/packages/fast-css-editor-react/src/spacing/spacing.spec.tsx
+++ b/packages/fast-css-editor-react/src/spacing/spacing.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import Spacing from "./spacing";
 import { CSSSpacingClassNameContract } from "./spacing.style";

--- a/packages/fast-css-editor-react/src/spacing/spacing.tsx
+++ b/packages/fast-css-editor-react/src/spacing/spacing.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Foundation, {
     FoundationProps,
     HandledProps,

--- a/packages/fast-css-editor-react/tsconfig.json
+++ b/packages/fast-css-editor-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-data-utilities-react/README.md
+++ b/packages/fast-data-utilities-react/README.md
@@ -11,8 +11,8 @@ The `mapDataToComponent` function can be used to map data to a React component. 
 An example of mapping data to a component from the `@microsoft/fast-data-utilities-react` package:
 
 ```jsx
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { Dialog } from "@microsoft/fast-components-react-msft";
 import * as dialogSchema from "@microsoft/fast-components-react-base/dist/dialog/dialog.schema.json";
 import * as headingSchema from "@microsoft/fast-components-react-msft/dist/heading/heading.schema.json";

--- a/packages/fast-data-utilities-react/src/__tests__/components/children.tsx
+++ b/packages/fast-data-utilities-react/src/__tests__/components/children.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 export interface ObjectWithChildren {
     nestedObjectChildren: JSX.Element;

--- a/packages/fast-data-utilities-react/src/__tests__/components/general-example.tsx
+++ b/packages/fast-data-utilities-react/src/__tests__/components/general-example.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 export enum GeneralExampleTags {
     button = "button",

--- a/packages/fast-data-utilities-react/src/__tests__/components/text-field.tsx
+++ b/packages/fast-data-utilities-react/src/__tests__/components/text-field.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 export enum TextFieldTags {
     button = "button",

--- a/packages/fast-data-utilities-react/src/index.ts
+++ b/packages/fast-data-utilities-react/src/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { cloneDeep, get, isPlainObject, set } from "lodash-es";
 import * as tv4 from "tv4";
 

--- a/packages/fast-data-utilities-react/tsconfig.json
+++ b/packages/fast-data-utilities-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-development-site-react/app/app.tsx
+++ b/packages/fast-development-site-react/app/app.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { glyphBuildingblocks } from "@microsoft/fast-glyphs-msft";
 import Site, {
     FormChildOption,

--- a/packages/fast-development-site-react/app/components/button/button.tsx
+++ b/packages/fast-development-site-react/app/components/button/button.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import { DesignSystem } from "../../design-system";

--- a/packages/fast-development-site-react/app/components/paragraph/paragraph.tsx
+++ b/packages/fast-development-site-react/app/components/paragraph/paragraph.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import { DesignSystem } from "../../design-system";

--- a/packages/fast-development-site-react/app/components/span/span.tsx
+++ b/packages/fast-development-site-react/app/components/span/span.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import { DesignSystem } from "../../design-system";

--- a/packages/fast-development-site-react/app/index.tsx
+++ b/packages/fast-development-site-react/app/index.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import App from "./app";
 
 function render(): void {

--- a/packages/fast-development-site-react/src/components/breadcrumb/breadcrumb-item.tsx
+++ b/packages/fast-development-site-react/src/components/breadcrumb/breadcrumb-item.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import { DevSiteDesignSystem } from "../design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";

--- a/packages/fast-development-site-react/src/components/breadcrumb/index.tsx
+++ b/packages/fast-development-site-react/src/components/breadcrumb/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { DevSiteDesignSystem } from "../design-system";
 import manageJss, {
     ComponentStyles,

--- a/packages/fast-development-site-react/src/components/shell/header.tsx
+++ b/packages/fast-development-site-react/src/components/shell/header.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, {
     ComponentStyles,
     ManagedClasses,

--- a/packages/fast-development-site-react/src/components/shell/index.tsx
+++ b/packages/fast-development-site-react/src/components/shell/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentStyles, ManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { DevSiteDesignSystem } from "../design-system";

--- a/packages/fast-development-site-react/src/components/shell/info-bar.tsx
+++ b/packages/fast-development-site-react/src/components/shell/info-bar.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, {
     ComponentStyles,
     ManagedClasses,

--- a/packages/fast-development-site-react/src/components/shell/pane-collapse.tsx
+++ b/packages/fast-development-site-react/src/components/shell/pane-collapse.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, {
     ComponentStyles,
     ManagedClasses,

--- a/packages/fast-development-site-react/src/components/site/action-bar.tsx
+++ b/packages/fast-development-site-react/src/components/site/action-bar.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import devSiteDesignSystemDefaults, { DevSiteDesignSystem } from "../design-system";
 import { Link, withRouter } from "react-router-dom";

--- a/packages/fast-development-site-react/src/components/site/category-documentation.tsx
+++ b/packages/fast-development-site-react/src/components/site/category-documentation.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, {
     ComponentStyles,
     DesignSystemProvider,

--- a/packages/fast-development-site-react/src/components/site/category-icon.tsx
+++ b/packages/fast-development-site-react/src/components/site/category-icon.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 
 export interface SiteCategoryIconProps {

--- a/packages/fast-development-site-react/src/components/site/category-item.tsx
+++ b/packages/fast-development-site-react/src/components/site/category-item.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, {
     ComponentStyles,
     ManagedClasses,

--- a/packages/fast-development-site-react/src/components/site/category-list.tsx
+++ b/packages/fast-development-site-react/src/components/site/category-list.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import { SiteCategoryItemProps } from "./category-item";
 import { SiteCategoryProps } from "./category";

--- a/packages/fast-development-site-react/src/components/site/category.tsx
+++ b/packages/fast-development-site-react/src/components/site/category.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 
 export interface SiteCategoryProps {

--- a/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-view-toggle.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { Link, withRouter } from "react-router-dom";
 import manageJss, {

--- a/packages/fast-development-site-react/src/components/site/component-view.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-view.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Route, Switch, withRouter } from "react-router-dom";
 import { RouteComponentProps } from "react-router";
 import { DevSiteDesignSystem } from "../design-system";

--- a/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
+++ b/packages/fast-development-site-react/src/components/site/component-wrapper.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, {
     ComponentStyles,
     CSSRules,

--- a/packages/fast-development-site-react/src/components/site/configuration-panel.tsx
+++ b/packages/fast-development-site-react/src/components/site/configuration-panel.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import devSiteDesignSystemDefaults, { DevSiteDesignSystem } from "../design-system";
 import Form from "@microsoft/fast-form-generator-react";

--- a/packages/fast-development-site-react/src/components/site/dev-tools-code-preview.tsx
+++ b/packages/fast-development-site-react/src/components/site/dev-tools-code-preview.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Framework } from "./dev-tools";
 import { FormChildOption } from "./";
 import { get, isEmpty, isObject, set, uniqueId } from "lodash-es";

--- a/packages/fast-development-site-react/src/components/site/dev-tools.tsx
+++ b/packages/fast-development-site-react/src/components/site/dev-tools.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import manageJss, {
     ComponentStyles,

--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import SiteTitleBrand from "./title-brand";
 import manageJss, {
     ComponentStyles,

--- a/packages/fast-development-site-react/src/components/site/menu-item.tsx
+++ b/packages/fast-development-site-react/src/components/site/menu-item.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 class SiteMenuItem extends React.Component<{}, {}> {
     public render(): JSX.Element {

--- a/packages/fast-development-site-react/src/components/site/menu.tsx
+++ b/packages/fast-development-site-react/src/components/site/menu.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, {
     ComponentStyles,
     ManagedClasses,

--- a/packages/fast-development-site-react/src/components/site/not-found.tsx
+++ b/packages/fast-development-site-react/src/components/site/not-found.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 class NotFound extends React.Component<{}, {}> {
     public render(): JSX.Element {

--- a/packages/fast-development-site-react/src/components/site/title-brand.tsx
+++ b/packages/fast-development-site-react/src/components/site/title-brand.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJSS, {
     ComponentStyles,
     ManagedClasses,

--- a/packages/fast-development-site-react/src/components/site/title.tsx
+++ b/packages/fast-development-site-react/src/components/site/title.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 export interface SiteTitleProps {
     slot?: string;

--- a/packages/fast-development-site-react/src/components/toc/index.tsx
+++ b/packages/fast-development-site-react/src/components/toc/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { DevSiteDesignSystem } from "../design-system";
 import manageJss, {
     ComponentStyles,

--- a/packages/fast-development-site-react/src/components/toc/toc-item.tsx
+++ b/packages/fast-development-site-react/src/components/toc/toc-item.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import TocMenu from "./toc-menu";
 import devSiteDesignSystemDefaults, { DevSiteDesignSystem } from "../design-system";

--- a/packages/fast-development-site-react/src/components/toc/toc-menu.tsx
+++ b/packages/fast-development-site-react/src/components/toc/toc-menu.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import devSiteDesignSystemDefaults, { DevSiteDesignSystem } from "../design-system";
 import manageJss, {

--- a/packages/fast-development-site-react/src/utilities/component-detail-example-factory.tsx
+++ b/packages/fast-development-site-react/src/utilities/component-detail-example-factory.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentViewSlot, SiteCategoryItem } from "../";
 import { DesignSystemProvider } from "@microsoft/fast-jss-manager-react";
 

--- a/packages/fast-development-site-react/src/utilities/component-documentation-factory.tsx
+++ b/packages/fast-development-site-react/src/utilities/component-documentation-factory.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { SiteCategoryDocumentation } from "../";
 
 export default function componentExampleFactory(

--- a/packages/fast-development-site-react/src/utilities/component-example-factory.tsx
+++ b/packages/fast-development-site-react/src/utilities/component-example-factory.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentViewSlot, SiteCategoryItem } from "../";
 import { DesignSystemProvider } from "@microsoft/fast-jss-manager-react";
 

--- a/packages/fast-development-site-react/src/utilities/component-factory.tsx
+++ b/packages/fast-development-site-react/src/utilities/component-factory.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import componentDetailExampleFactory from "./component-detail-example-factory";
 import componentExampleFactory from "./component-example-factory";
 import componentDocumentationFactory from "./component-documentation-factory";

--- a/packages/fast-development-site-react/src/utilities/error-boundary.tsx
+++ b/packages/fast-development-site-react/src/utilities/error-boundary.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { DevSiteDesignSystem } from "../components/design-system";
 import manageJss, {

--- a/packages/fast-development-site-react/tsconfig.json
+++ b/packages/fast-development-site-react/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "baseUrl": ".",
         "declaration": true,
+        "esModuleInterop": true,
         "experimentalDecorators": true,
         "moduleResolution": "node",
         "outDir": "./dist",

--- a/packages/fast-form-generator-react/app/configs/arrays/index.tsx
+++ b/packages/fast-form-generator-react/app/configs/arrays/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 export interface ArrayObject {
     string: string;
 }

--- a/packages/fast-form-generator-react/app/configs/children/index.tsx
+++ b/packages/fast-form-generator-react/app/configs/children/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 export interface ObjectWithChildren {
     nestedObjectChildren: JSX.Element;
 }

--- a/packages/fast-form-generator-react/app/configs/general/index.tsx
+++ b/packages/fast-form-generator-react/app/configs/general/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Array, { ArrayProps } from "../arrays";
 import Objects, { ObjectsProps } from "../objects";
 import Theme, { ThemeProps } from "../theme";

--- a/packages/fast-form-generator-react/app/configs/objects/index.tsx
+++ b/packages/fast-form-generator-react/app/configs/objects/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 export interface ObjectNoRequired {
     number?: number;
 }

--- a/packages/fast-form-generator-react/app/configs/one-of/index.tsx
+++ b/packages/fast-form-generator-react/app/configs/one-of/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 export interface OneOfProps {
     number?: number;
     string?: string;

--- a/packages/fast-form-generator-react/app/configs/textarea/index.tsx
+++ b/packages/fast-form-generator-react/app/configs/textarea/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 export enum TextareaTags {
     button = "button",
     span = "span",

--- a/packages/fast-form-generator-react/app/configs/theme/index.tsx
+++ b/packages/fast-form-generator-react/app/configs/theme/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 export enum Themes {
     light = "light",
     dark = "dark",

--- a/packages/fast-form-generator-react/app/index.tsx
+++ b/packages/fast-form-generator-react/app/index.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { DesignSystemProvider } from "@microsoft/fast-jss-manager-react";
 import { getExample } from "@microsoft/fast-permutator";
 import { ChildOptionItem } from "@microsoft/fast-data-utilities-react";

--- a/packages/fast-form-generator-react/src/form/form-category.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-category.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
 import FormCategory, { FormCategoryProps } from "./form-category";
 

--- a/packages/fast-form-generator-react/src/form/form-category.tsx
+++ b/packages/fast-form-generator-react/src/form/form-category.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import FormItemCommon from "./form-item";
 import styles from "./form-category.style";
 import { FormCategoryClassNameContract } from "../class-name-contracts/";

--- a/packages/fast-form-generator-react/src/form/form-item.align-horizontal.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.align-horizontal.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import AlignHorizontal from "./form-item.align-horizontal";
 import { FormItemComponentMappingToProperyNamesProps, mappingName } from "./form-item";

--- a/packages/fast-form-generator-react/src/form/form-item.align-horizontal.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.align-horizontal.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FormItemComponentMappingToProperyNamesProps } from "./form-item";
 import styles from "./form-item.align-horizontal.style";
 import { FormItemAlignHorizontalClassNameContract } from "../class-name-contracts/";

--- a/packages/fast-form-generator-react/src/form/form-item.align-vertical.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.align-vertical.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import AlignVertical from "./form-item.align-vertical";
 import { FormItemComponentMappingToProperyNamesProps, mappingName } from "./form-item";

--- a/packages/fast-form-generator-react/src/form/form-item.align-vertical.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.align-vertical.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FormItemComponentMappingToProperyNamesProps } from "./form-item";
 import styles from "./form-item.align-vertical.style";
 import { FormItemAlignVerticalClassNameContract } from "../class-name-contracts/";

--- a/packages/fast-form-generator-react/src/form/form-item.array.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.array.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
 import Array, { FormItemArrayProps } from "./form-item.array";
 

--- a/packages/fast-form-generator-react/src/form/form-item.array.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.array.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { get } from "lodash-es";
 import { canUseDOM } from "exenv-es6";
 import { arrayMove, SortableContainer, SortableElement } from "react-sortable-hoc";

--- a/packages/fast-form-generator-react/src/form/form-item.base.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.base.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import SoftRemove from "./soft-remove";
 import FormItemCommon from "./form-item";
 

--- a/packages/fast-form-generator-react/src/form/form-item.checkbox.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.checkbox.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import FormItemCommon from "./form-item";
 import Checkbox from "./form-item.checkbox";

--- a/packages/fast-form-generator-react/src/form/form-item.checkbox.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.checkbox.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import FormItemCommon from "./form-item";
 import styles from "./form-item.checkbox.style";
 import { FormItemCheckboxClassNameContract } from "../class-name-contracts/";

--- a/packages/fast-form-generator-react/src/form/form-item.children.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.children.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
 import Children, { FormItemChildrenProps } from "./form-item.children";
 

--- a/packages/fast-form-generator-react/src/form/form-item.children.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.children.tsx
@@ -1,5 +1,5 @@
 import { generateExampleData } from "./form-section.utilities";
-import * as React from "react";
+import React from "react";
 import { canUseDOM } from "exenv-es6";
 import { arrayMove, SortableContainer, SortableElement } from "react-sortable-hoc";
 import { get } from "lodash-es";

--- a/packages/fast-form-generator-react/src/form/form-item.file-upload.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.file-upload.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
 import FileUpload from "./form-item.file-upload";
 import { FormItemComponentMappingToProperyNamesProps, mappingName } from "./form-item";

--- a/packages/fast-form-generator-react/src/form/form-item.file-upload.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.file-upload.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { uniqueId } from "lodash-es";
 import { FormItemComponentMappingToProperyNamesProps } from "./form-item";
 

--- a/packages/fast-form-generator-react/src/form/form-item.mapping.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.mapping.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
 import Mapping from "./form-item.mapping";
 import { FormItemComponentMappingToProperyNamesProps, mappingName } from "./form-item";

--- a/packages/fast-form-generator-react/src/form/form-item.mapping.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.mapping.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FormItemComponentMappingToProperyNamesProps, mappingName } from "./form-item";
 import FormItemAlignHorizontal from "./form-item.align-horizontal";
 import FormItemAlignVertical from "./form-item.align-vertical";

--- a/packages/fast-form-generator-react/src/form/form-item.number-field.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.number-field.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import FormItemCommon from "./form-item";
 import NumberField from "./form-item.number-field";

--- a/packages/fast-form-generator-react/src/form/form-item.number-field.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.number-field.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import FormItemCommon from "./form-item";
 import { getStringValue } from "./form-item.utilities";
 import styles from "./form-item.number-field.style";

--- a/packages/fast-form-generator-react/src/form/form-item.select.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.select.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import Select, { FormItemSelectProps } from "./form-item.select";
 

--- a/packages/fast-form-generator-react/src/form/form-item.select.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.select.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import FormItemCommon from "./form-item";
 import styles from "./form-item.select.style";
 import { FormItemSelectClassNameContract } from "../class-name-contracts/";

--- a/packages/fast-form-generator-react/src/form/form-item.textarea.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.textarea.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import Textarea, { FormItemTextareaProps } from "./form-item.textarea";
 

--- a/packages/fast-form-generator-react/src/form/form-item.textarea.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.textarea.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import FormItemCommon from "./form-item";
 import styles from "./form-item.textarea.style";
 import { FormItemTextareaClassNameContract } from "../class-name-contracts/";

--- a/packages/fast-form-generator-react/src/form/form-item.theme.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.theme.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import Theme from "./form-item.theme";
 import { FormItemComponentMappingToProperyNamesProps, mappingName } from "./form-item";

--- a/packages/fast-form-generator-react/src/form/form-item.theme.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.theme.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FormItemComponentMappingToProperyNamesProps } from "./form-item";
 import styles from "./form-item.theme.style";
 import { FormItemThemeClassNameContract } from "../class-name-contracts/";

--- a/packages/fast-form-generator-react/src/form/form-section.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-section.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
 import FormSection from "./form-section";
 import { FormSectionProps } from "./form-section.props";

--- a/packages/fast-form-generator-react/src/form/form-section.tsx
+++ b/packages/fast-form-generator-react/src/form/form-section.tsx
@@ -1,5 +1,5 @@
 import FormItemChildren from "./form-item.children";
-import * as React from "react";
+import React from "react";
 import { ChildOptionItem } from "@microsoft/fast-data-utilities-react";
 import {
     FormCategories,

--- a/packages/fast-form-generator-react/src/form/form-section.utilities.tsx
+++ b/packages/fast-form-generator-react/src/form/form-section.utilities.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { cloneDeep, get, isEqual, mergeWith, set, uniqueId, unset } from "lodash-es";
 import { getExample } from "@microsoft/fast-permutator";
 import tv4 from "tv4";

--- a/packages/fast-form-generator-react/src/form/form.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
 import Form from "./form";
 import { FormProps } from "./form.props";

--- a/packages/fast-form-generator-react/src/form/form.tsx
+++ b/packages/fast-form-generator-react/src/form/form.tsx
@@ -1,5 +1,5 @@
 import FormSection from "./form-section";
-import * as React from "react";
+import React from "react";
 import {
     BreadcrumbItemEventHandler,
     FormProps,

--- a/packages/fast-form-generator-react/src/form/form.utilities.spec.ts
+++ b/packages/fast-form-generator-react/src/form/form.utilities.spec.ts
@@ -15,14 +15,14 @@ import General from "../../app/configs/general";
 import Textarea from "../../app/configs/textarea";
 import OneOf from "../../app/configs/one-of";
 
-import * as alignHorizontalSchema from "../../app/configs/align-horizontal/align-horizontal.schema.json";
-import * as arraysSchema from "../../app/configs/arrays/arrays.schema.json";
-import * as generalSchema from "../../app/configs/general/general.schema.json";
-import * as objectsSchema from "../../app/configs/objects/objects.schema.json";
-import * as oneOfSchema from "../../app/configs/one-of/one-of.schema.json";
-import * as anyOfSchema from "../../app/configs/any-of/any-of.schema.json";
-import * as childrenSchema from "../../app/configs/children/children.schema.json";
-import * as textFieldSchema from "../../app/configs/textarea/textarea.schema.json";
+import alignHorizontalSchema from "../../app/configs/align-horizontal/align-horizontal.schema.json";
+import arraysSchema from "../../app/configs/arrays/arrays.schema.json";
+import generalSchema from "../../app/configs/general/general.schema.json";
+import objectsSchema from "../../app/configs/objects/objects.schema.json";
+import oneOfSchema from "../../app/configs/one-of/one-of.schema.json";
+import anyOfSchema from "../../app/configs/any-of/any-of.schema.json";
+import childrenSchema from "../../app/configs/children/children.schema.json";
+import textFieldSchema from "../../app/configs/textarea/textarea.schema.json";
 import { reactChildrenStringSchema } from "./form-item.children.text";
 
 /**

--- a/packages/fast-form-generator-react/src/form/form.utilities.ts
+++ b/packages/fast-form-generator-react/src/form/form.utilities.ts
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import { clone, cloneDeep, get, isEqual, isPlainObject, mergeWith, set } from "lodash-es";
-import * as tv4 from "tv4";
+import tv4 from "tv4";
 import {
     ChildOptionItem,
     getChildOptionBySchemaId,

--- a/packages/fast-form-generator-react/src/form/soft-remove.tsx
+++ b/packages/fast-form-generator-react/src/form/soft-remove.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 export interface SoftRemoveProps {
     /**

--- a/packages/fast-form-generator-react/src/form/sorting.tsx
+++ b/packages/fast-form-generator-react/src/form/sorting.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 export interface SortableConfig {
     key: string;

--- a/packages/fast-form-generator-react/tsconfig.json
+++ b/packages/fast-form-generator-react/tsconfig.json
@@ -9,6 +9,7 @@
         "target": "ES6",
         "baseUrl": ".",
         "declaration": true,
+        "esModuleInterop": true,
         "jsx": "react",
         "outDir": "./dist",
         "resolveJsonModule": true

--- a/packages/fast-glyphs-msft/tsconfig.json
+++ b/packages/fast-glyphs-msft/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "baseUrl": ".",
         "declaration": true,
+        "esModuleInterop": true,
         "experimentalDecorators": true,
         "moduleResolution": "node",
         "outDir": "./dist",

--- a/packages/fast-jest-snapshots-react/src/index.spec.tsx
+++ b/packages/fast-jest-snapshots-react/src/index.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { generateSnapshots, SnapshotTestSuite } from "./index";
 
 interface TestComponentProps {

--- a/packages/fast-jest-snapshots-react/src/index.ts
+++ b/packages/fast-jest-snapshots-react/src/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import * as renderer from "react-test-renderer";
 
 /**

--- a/packages/fast-jest-snapshots-react/tsconfig.json
+++ b/packages/fast-jest-snapshots-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "commonjs",
         "target": "ES6",

--- a/packages/fast-jss-manager-angular/tsconfig.json
+++ b/packages/fast-jss-manager-angular/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "emitDecoratorMetadata": true,
+        "esModuleInterop": true,
         "experimentalDecorators": true,
         "moduleResolution": "node",
         "module": "ES6",

--- a/packages/fast-jss-manager-react/README.md
+++ b/packages/fast-jss-manager-react/README.md
@@ -9,7 +9,7 @@
 `manageJss` is a HOC that passes as props the generated classes from a given stylesheet. The generated classes are made available on the `managedClasses` prop of the rendered component.
 ```jsx
 // button.jsx
-import * as React from "react";
+import React from "react";
 
 class Button extends React.Component {
     render() {

--- a/packages/fast-jss-manager-react/src/context.ts
+++ b/packages/fast-jss-manager-react/src/context.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 /**
  * Create and export JSSManager consumer/provider components to be used by

--- a/packages/fast-jss-manager-react/src/design-system-provider.spec.tsx
+++ b/packages/fast-jss-manager-react/src/design-system-provider.spec.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
+import React from "react";
 import { DesignSystemProvider } from "./design-system-provider";
 import * as ShallowRenderer from "react-test-renderer/shallow";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow, ShallowWrapper } from "enzyme";
 import { Consumer } from "./context";
 

--- a/packages/fast-jss-manager-react/src/design-system-provider.tsx
+++ b/packages/fast-jss-manager-react/src/design-system-provider.tsx
@@ -4,7 +4,7 @@
  * react contexts. If given a design-language, the JSSManager will make the design-language object available
  * to all JSS rules defined as a function
  */
-import * as React from "react";
+import React from "react";
 import * as propTypes from "prop-types";
 import { Consumer, Provider } from "./context";
 

--- a/packages/fast-jss-manager-react/src/jss-manager.spec.tsx
+++ b/packages/fast-jss-manager-react/src/jss-manager.spec.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
+import React from "react";
 import { JSSManager, mergeClassNames } from "./jss-manager";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import * as ShallowRenderer from "react-test-renderer/shallow";
 import { configure, mount, ReactWrapper, render, shallow } from "enzyme";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 import { jss, stylesheetRegistry } from "./jss";
 import { DesignSystemProvider } from "./design-system-provider";
 import { values } from "lodash-es";

--- a/packages/fast-jss-manager-react/src/jss-manager.tsx
+++ b/packages/fast-jss-manager-react/src/jss-manager.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { jss, stylesheetManager, stylesheetRegistry } from "./jss";
 import SheetManager from "./sheet-manager";
 import { DesignSystem } from "./design-system-provider";

--- a/packages/fast-jss-manager-react/src/manage-jss.spec.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { manageJss } from "./manage-jss";
 import { JSSManager } from "./jss-manager";
 import { jss, stylesheetRegistry } from "./jss";
@@ -8,7 +8,7 @@ import {
 } from "@microsoft/fast-jss-manager";
 import * as ShallowRenderer from "react-test-renderer/shallow";
 import { configure, mount, ReactWrapper, render, shallow } from "enzyme";
-import * as Adapter from "enzyme-adapter-react-16";
+import Adapter from "enzyme-adapter-react-16";
 
 /*
  * Configure Enzyme

--- a/packages/fast-jss-manager-react/src/manage-jss.tsx
+++ b/packages/fast-jss-manager-react/src/manage-jss.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentStyles, ManagedClasses } from "@microsoft/fast-jss-manager";
 import { omit } from "lodash-es";
 import { Consumer } from "./context";

--- a/packages/fast-jss-manager-react/tsconfig.json
+++ b/packages/fast-jss-manager-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-jss-manager/tsconfig.json
+++ b/packages/fast-jss-manager/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-jss-utilities/tsconfig.json
+++ b/packages/fast-jss-utilities/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-layouts-react/app/index.tsx
+++ b/packages/fast-layouts-react/app/index.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { ComponentStyles } from "@microsoft/fast-jss-manager-react";
 import { Canvas } from "../src/canvas";
 import { Container } from "../src/container";

--- a/packages/fast-layouts-react/src/canvas/canvas.props.ts
+++ b/packages/fast-layouts-react/src/canvas/canvas.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { CanvasClassNamesContract } from "./canvas";
 

--- a/packages/fast-layouts-react/src/canvas/canvas.tsx
+++ b/packages/fast-layouts-react/src/canvas/canvas.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { CanvasHandledProps, CanvasProps, CanvasUnhandledProps } from "./canvas.props";
 import manageJss, {
     ComponentStyles,

--- a/packages/fast-layouts-react/src/canvas/index.ts
+++ b/packages/fast-layouts-react/src/canvas/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import {
     Canvas as BaseCanvas,

--- a/packages/fast-layouts-react/src/column/column.props.ts
+++ b/packages/fast-layouts-react/src/column/column.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { GridGutter } from "../grid/grid.props";
 import { ColumnClassNamesContract } from "./column";
 import { ManagedClasses } from "@microsoft/fast-jss-manager-react";

--- a/packages/fast-layouts-react/src/column/column.tsx
+++ b/packages/fast-layouts-react/src/column/column.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, {
     ComponentStyles,
     CSSRules,

--- a/packages/fast-layouts-react/src/column/index.ts
+++ b/packages/fast-layouts-react/src/column/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import {
     Column as BaseColumn,

--- a/packages/fast-layouts-react/src/container/container.props.ts
+++ b/packages/fast-layouts-react/src/container/container.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { ContainerClassNamesContract } from "./container";
 

--- a/packages/fast-layouts-react/src/container/container.tsx
+++ b/packages/fast-layouts-react/src/container/container.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ComponentStyles } from "@microsoft/fast-jss-manager-react";
 import {
     ContainerHandledProps,

--- a/packages/fast-layouts-react/src/container/index.ts
+++ b/packages/fast-layouts-react/src/container/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import {
     Container as BaseContainer,

--- a/packages/fast-layouts-react/src/grid/grid.props.ts
+++ b/packages/fast-layouts-react/src/grid/grid.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { GridClassNamesContract } from "./grid";
 /**

--- a/packages/fast-layouts-react/src/grid/grid.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, {
     ComponentStyles,
     CSSRules,

--- a/packages/fast-layouts-react/src/grid/index.ts
+++ b/packages/fast-layouts-react/src/grid/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import {
     Grid as BaseGrid,

--- a/packages/fast-layouts-react/src/page/index.ts
+++ b/packages/fast-layouts-react/src/page/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import {
     Page as BasePage,

--- a/packages/fast-layouts-react/src/page/page.props.ts
+++ b/packages/fast-layouts-react/src/page/page.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { PageClassNamesContract } from "./page";
 

--- a/packages/fast-layouts-react/src/page/page.tsx
+++ b/packages/fast-layouts-react/src/page/page.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, {
     ComponentStyles,
     ManagedClasses,

--- a/packages/fast-layouts-react/src/pane/index.ts
+++ b/packages/fast-layouts-react/src/pane/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import {
     Pane as BasePane,

--- a/packages/fast-layouts-react/src/pane/pane.props.ts
+++ b/packages/fast-layouts-react/src/pane/pane.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { PaneClassNamesContract } from "./pane";
 

--- a/packages/fast-layouts-react/src/pane/pane.tsx
+++ b/packages/fast-layouts-react/src/pane/pane.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { throttle } from "lodash-es";
 import {
     PaneHandledProps,

--- a/packages/fast-layouts-react/src/row/index.ts
+++ b/packages/fast-layouts-react/src/row/index.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import {
     east,

--- a/packages/fast-layouts-react/src/row/row.props.ts
+++ b/packages/fast-layouts-react/src/row/row.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { RowClassNamesContract } from "./row";
 import { ManagedClasses } from "@microsoft/fast-jss-manager-react";
 

--- a/packages/fast-layouts-react/src/row/row.tsx
+++ b/packages/fast-layouts-react/src/row/row.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { throttle } from "lodash-es";
 import { Canvas } from "../canvas";
 import rafThrottle from "raf-throttle";

--- a/packages/fast-layouts-react/tsconfig.json
+++ b/packages/fast-layouts-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "lib": ["dom", "es6", "es7"],
         "moduleResolution": "node",
         "module": "ES6",

--- a/packages/fast-markdown-msft-react/README.md
+++ b/packages/fast-markdown-msft-react/README.md
@@ -6,7 +6,7 @@ This is a plugin for [markdown-it](https://github.com/markdown-it/markdown-it) a
 
 ## Usage
 ```js
-import * as MarkdownIt from "markdown-it";
+import MarkdownIt from "markdown-it";
 import FASTMarkdownIt from "@microsoft/fast-markdown-msft-react";
 
 const md = new MarkdownIt({

--- a/packages/fast-markdown-msft-react/src/index.spec.ts
+++ b/packages/fast-markdown-msft-react/src/index.spec.ts
@@ -1,4 +1,4 @@
-import * as MarkdownIt from "markdown-it";
+import MarkdownIt from "markdown-it";
 import FASTMarkdownIt from "./index";
 
 const md: any = new MarkdownIt({

--- a/packages/fast-markdown-msft-react/tsconfig.json
+++ b/packages/fast-markdown-msft-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "commonjs",
         "target": "ES6",

--- a/packages/fast-sketch-library/tsconfig.json
+++ b/packages/fast-sketch-library/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "CommonJS",
         "target": "ES6",

--- a/packages/fast-viewer-react/README.md
+++ b/packages/fast-viewer-react/README.md
@@ -10,8 +10,8 @@ This can be used to as a method for previewing a React component(s) or an entire
 An example of using one of the components from the `@microsoft/fast-viewer-msft` package:
 
 ```jsx
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import Viewer from "@microsoft/fast-viewer-msft";
 
 const root = document.createElement("div");
@@ -146,7 +146,7 @@ Using the `ViewerContent` on the route provided to the `Viewer` will allow for t
 
 Example component provided in the "/example-content" route for the `Viewer` impplementation example:
 ```tsx
-import * as React from "react";
+import React from "react";
 import { ViewerContent } from "@microsoft/fast-viewer-msft";
 import MyComponent from "./my-component";
 

--- a/packages/fast-viewer-react/app/components/example.tsx
+++ b/packages/fast-viewer-react/app/components/example.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Foundation from "@microsoft/fast-components-foundation-react";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import manageJss, { ManagedClasses } from "@microsoft/fast-jss-manager-react";

--- a/packages/fast-viewer-react/app/components/links.tsx
+++ b/packages/fast-viewer-react/app/components/links.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 
 export default class Links extends React.Component<{}, {}> {

--- a/packages/fast-viewer-react/app/index.tsx
+++ b/packages/fast-viewer-react/app/index.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { Route, Switch } from "react-router";
 import { BrowserRouter } from "react-router-dom";
 import BasicPage from "./pages/basic-page";

--- a/packages/fast-viewer-react/app/pages/basic-page.tsx
+++ b/packages/fast-viewer-react/app/pages/basic-page.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Links from "../components/links";
 import Viewer from "../../src";
 

--- a/packages/fast-viewer-react/app/pages/basic-page.viewer-content.tsx
+++ b/packages/fast-viewer-react/app/pages/basic-page.viewer-content.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Example from "../components/example";
 
 class BasicPageViewerContent extends React.Component<{}, {}> {

--- a/packages/fast-viewer-react/app/pages/device-page.tsx
+++ b/packages/fast-viewer-react/app/pages/device-page.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Viewer, {
     defaultDevices,
     Device,

--- a/packages/fast-viewer-react/app/pages/device-page.viewer-content.tsx
+++ b/packages/fast-viewer-react/app/pages/device-page.viewer-content.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Example from "../components/example";
 
 class DevicePageViewerContent extends React.Component<{}, {}> {

--- a/packages/fast-viewer-react/app/pages/update-props-page.tsx
+++ b/packages/fast-viewer-react/app/pages/update-props-page.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import components from "../components";
 import Viewer from "../../src";
 import Links from "../components/links";

--- a/packages/fast-viewer-react/app/pages/update-props-page.viewer-content.tsx
+++ b/packages/fast-viewer-react/app/pages/update-props-page.viewer-content.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ViewerContent } from "../../src";
 import components from "../components";
 

--- a/packages/fast-viewer-react/src/rotate/rotate.base.spec.tsx
+++ b/packages/fast-viewer-react/src/rotate/rotate.base.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, render, shallow } from "enzyme";
 import { Orientation, RotateHandledProps } from "./";
 import RotateBase from "./rotate.base";

--- a/packages/fast-viewer-react/src/rotate/rotate.base.tsx
+++ b/packages/fast-viewer-react/src/rotate/rotate.base.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { get } from "lodash-es";
 import { Orientation, RotateHandledProps, RotateUnhandledProps } from "./rotate.props";

--- a/packages/fast-viewer-react/src/rotate/rotate.tsx
+++ b/packages/fast-viewer-react/src/rotate/rotate.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import BaseRotate from "./rotate.base";
 import {
     Orientation,

--- a/packages/fast-viewer-react/src/select-device/select-device.base.spec.tsx
+++ b/packages/fast-viewer-react/src/select-device/select-device.base.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import { SelectDeviceHandledProps } from "./";
 import SelectDeviceBase from "./select-device.base";

--- a/packages/fast-viewer-react/src/select-device/select-device.base.tsx
+++ b/packages/fast-viewer-react/src/select-device/select-device.base.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { SelectDeviceProps } from "./select-device.props";
 import { Device } from "./devices";

--- a/packages/fast-viewer-react/src/select-device/select-device.tsx
+++ b/packages/fast-viewer-react/src/select-device/select-device.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import BaseSelectDevice from "./select-device.base";
 import {
     SelectDeviceHandledProps as BaseSelectDeviceHandledProps,

--- a/packages/fast-viewer-react/src/viewer-content/viewer-content.base.spec.tsx
+++ b/packages/fast-viewer-react/src/viewer-content/viewer-content.base.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import ViewerContentBase from "./viewer-content.base";
 import { ViewerContentHandledProps } from "./";

--- a/packages/fast-viewer-react/src/viewer-content/viewer-content.base.tsx
+++ b/packages/fast-viewer-react/src/viewer-content/viewer-content.base.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {
     ChildOptionItem,

--- a/packages/fast-viewer-react/src/viewer-content/viewer-content.props.ts
+++ b/packages/fast-viewer-react/src/viewer-content/viewer-content.props.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { ChildOptionItem } from "@microsoft/fast-data-utilities-react";
 import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 

--- a/packages/fast-viewer-react/src/viewer-content/viewer-content.tsx
+++ b/packages/fast-viewer-react/src/viewer-content/viewer-content.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import BaseViewerContent from "./viewer-content.base";
 import {
     ViewerContentHandledProps as BaseViewerContentHandledProps,

--- a/packages/fast-viewer-react/src/viewer/viewer.base.spec.tsx
+++ b/packages/fast-viewer-react/src/viewer/viewer.base.spec.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as Adapter from "enzyme-adapter-react-16";
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
 import { ViewerHandledProps } from "./";
 import ViewerBase from "./viewer.base";

--- a/packages/fast-viewer-react/src/viewer/viewer.base.tsx
+++ b/packages/fast-viewer-react/src/viewer/viewer.base.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { get } from "lodash-es";
 import { canUseDOM } from "exenv-es6";

--- a/packages/fast-viewer-react/src/viewer/viewer.tsx
+++ b/packages/fast-viewer-react/src/viewer/viewer.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import BaseViewer from "./viewer.base";
 import {
     ViewerHandledProps as BaseViewerHandledProps,

--- a/packages/fast-viewer-react/tsconfig.json
+++ b/packages/fast-viewer-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/packages/fast-web-utilities/tsconfig.json
+++ b/packages/fast-web-utilities/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "module": "ES6",
         "target": "ES6",


### PR DESCRIPTION
This is a breaking change for some users depending on their Webpack/TypeScript setup, the will need to use esModuleInterop if they are on TypeScript.