### PR TITLE
fix: remove margins from components and fix text-field placeholder color in disabled state

### DIFF
--- a/packages/fast-components-react-msft/src/text-field/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/text-field/examples.data.tsx
@@ -36,6 +36,11 @@ export default {
             defaultValue: "Disabled",
         },
         {
+            disabled: true,
+            type: TextFieldType.text,
+            placeholder: "Disabled placeholder",
+        },
+        {
             placeholder: "Enter Password",
             type: TextFieldType.password,
         },

--- a/packages/fast-components-styles-msft/src/divider/index.ts
+++ b/packages/fast-components-styles-msft/src/divider/index.ts
@@ -18,7 +18,7 @@ const styles: ComponentStyles<DividerClassNameContract, DesignSystem> = (
         divider: {
             boxSizing: "content-box",
             height: "0",
-            margin: `0`,
+            margin: "0",
             border: "none",
             borderTop: `1px solid ${normalContrast(
                 designSystem.contrast,

--- a/packages/fast-components-styles-msft/src/divider/index.ts
+++ b/packages/fast-components-styles-msft/src/divider/index.ts
@@ -18,7 +18,7 @@ const styles: ComponentStyles<DividerClassNameContract, DesignSystem> = (
         divider: {
             boxSizing: "content-box",
             height: "0",
-            margin: `${density(designSystem.designUnit * 3)(designSystem)} 0`,
+            margin: `0`,
             border: "none",
             borderTop: `1px solid ${normalContrast(
                 designSystem.contrast,

--- a/packages/fast-components-styles-msft/src/text-field/index.ts
+++ b/packages/fast-components-styles-msft/src/text-field/index.ts
@@ -34,7 +34,7 @@ const styles: ComponentStyles<TextFieldClassNameContract, DesignSystem> = (
             boxSizing: "border-box",
             borderRadius: toPx(designSystem.cornerRadius),
             padding: "10px",
-            margin: `${density(designSystem.designUnit * 3)(designSystem)} 0`,
+            margin: `0`,
             height: density(defaultHeight)(designSystem),
             minHeight: toPx(minHeight),
             maxHeight: toPx(maxHeight),
@@ -52,6 +52,9 @@ const styles: ComponentStyles<TextFieldClassNameContract, DesignSystem> = (
                 ...outlinePattern.disabled,
                 ...typographyPattern.disabled,
                 cursor: "not-allowed",
+                "&::placeholder": {
+                    ...typographyPattern.disabled,
+                },
             },
             "&::placeholder": {
                 color: foregroundNormal,

--- a/packages/fast-components-styles-msft/src/text-field/index.ts
+++ b/packages/fast-components-styles-msft/src/text-field/index.ts
@@ -34,7 +34,7 @@ const styles: ComponentStyles<TextFieldClassNameContract, DesignSystem> = (
             boxSizing: "border-box",
             borderRadius: toPx(designSystem.cornerRadius),
             padding: "10px",
-            margin: `0`,
+            margin: "0",
             height: density(defaultHeight)(designSystem),
             minHeight: toPx(minHeight),
             maxHeight: toPx(maxHeight),


### PR DESCRIPTION
Closes [#1239](https://github.com/Microsoft/fast-dna/issues/1239)

## Description
Removes margin from components and addresses placeholder text color for the disabled state in text-field.

## Motivation & context
Noticed margin and placeholder issue when creating `text action` component.
