### PR TITLE
chore: small fix to text wrap in toc for doc site

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -526,6 +526,9 @@ ul.toc-headings li a {
     outline: none;
     cursor: default;
     border: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 ul.toc-headings li a:hover {


### PR DESCRIPTION
# Pull request

## Description

This small fix adds new CSS properties to for table of contents on the doc site. These properties prevent the line from wrapping onto the next line and adds an ellipsis.

## Motivation & context

Some long TOC items were wrapping onto the next item making it unreadable. This fix forces the text to stay on one line and get an ellipsis when it is cut off.

## Issue type checklist

<!--- What type of change are you submitting? Check the boxes that apply: -->

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A non-breaking change which fixes an issue, link to the issue above.
- [ ] **New feature**: A non-breaking change that adds functionality.
- [ ] **Breaking change**: A fix or feature that will cause current functionality to change.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) set for this project.