### PR TITLE
fix: update the t4 type ramp to 28px size and 36px line-height

### DIFF
--- a/packages/fast-components-styles-msft/src/utilities/typography.ts
+++ b/packages/fast-components-styles-msft/src/utilities/typography.ts
@@ -50,8 +50,8 @@ export const typeRamp: TypeRamp = {
         lineHeight: 44,
     },
     t4: {
-        fontSize: 24,
-        lineHeight: 32,
+        fontSize: 28,
+        lineHeight: 36,
     },
     t5: {
         fontSize: 20,


### PR DESCRIPTION
Today, the design system updated the `t4` size of our type ramp. This change aligns the code base with the design system.

# Description

Updated the `t4` type ramp size to `28px` size and `36px` line-height.

## Motivation & context

Today, the design system updated the `t4` ramp size and this change re-aligns the design system and the code base.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.
