### PR TITLE
fix: revert "update the T4 type ramp to 28 size and 36 line-height (#1261)"

### DIFF
--- a/packages/fast-components-styles-msft/src/utilities/typography.ts
+++ b/packages/fast-components-styles-msft/src/utilities/typography.ts
@@ -50,8 +50,8 @@ export const typeRamp: TypeRamp = {
         lineHeight: 44,
     },
     t4: {
-        fontSize: 28,
-        lineHeight: 36,
+        fontSize: 24,
+        lineHeight: 32,
     },
     t5: {
         fontSize: 20,


### PR DESCRIPTION
This reverts commit 0698ad11efb32f93f44e383d89d9e64132d5107a.