### PR TITLE
fix: update disabled action toggle/trigger glyph color

### DIFF
--- a/packages/fast-components-styles-msft/src/action-toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/action-toggle/index.ts
@@ -130,7 +130,7 @@ const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = (
                 fill: primaryRestBackgroundColor,
             },
             "&$actionToggle__disabled $actionToggle_selectedGlyph, &$actionToggle__disabled $actionToggle_unselectedGlyph": {
-                fill: secondaryDisabledColor,
+                fill: outlineDisabledColor,
             },
         },
         actionToggle__justified: {

--- a/packages/fast-components-styles-msft/src/action-trigger/index.ts
+++ b/packages/fast-components-styles-msft/src/action-trigger/index.ts
@@ -125,7 +125,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = (
                 fill: primaryRestBackgroundColor,
             },
             "&$actionTrigger__disabled $actionTrigger_glyph": {
-                fill: secondaryDisabledColor,
+                fill: outlineDisabledColor,
             },
         },
         actionTrigger__justified: {


### PR DESCRIPTION
# Description
Disabled action toggle glyph not dimmed like text, was using wrong color for glyph in css

## Motivation & context
Disabled action toggles don't look right. 
Fixes 1288 - https://github.com/Microsoft/fast-dna/issues/1288

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.
