### PR TITLE
fix: Changing activeID on Tabs component causes type error

### DIFF
--- a/packages/fast-components-react-base/src/tabs/tabs.spec.tsx
+++ b/packages/fast-components-react-base/src/tabs/tabs.spec.tsx
@@ -284,6 +284,35 @@ describe("tabs", (): void => {
         expect(renderedWithChildren.find("Tab").length).toEqual(3);
     });
 
+    test("should handle non existing active id set in props by keeping previous tab active.", () => {
+        const renderedWithChildren: ShallowWrapper = shallow(
+            <Tabs managedClasses={tabsManagedClasses} label={"items"} activeId={id0}>
+                {children}
+            </Tabs>
+        );
+
+        expect(renderedWithChildren.find("Tab").length).toEqual(3);
+
+        const tab1: any = renderedWithChildren.find("Tab").at(0);
+        const tab2: any = renderedWithChildren.find("Tab").at(1);
+
+        expect(tab1.prop("active")).toEqual(true);
+        expect(tab2.prop("active")).toEqual(false);
+
+        const handledProps: TabsHandledProps & TabsManagedClasses = {
+            managedClasses: tabsManagedClasses,
+            children,
+            label: "items",
+            activeId: "nonExistingTabId",
+        };
+
+        const props: TabsProps = { ...handledProps };
+        renderedWithChildren.setProps(props);
+
+        expect(tab1.prop("active")).toEqual(true);
+        expect(tab2.prop("active")).toEqual(false);
+    });
+
     test("should generate an ID if none has been provided", () => {
         const renderedWithChildren: any = shallow(
             <Tabs managedClasses={tabsManagedClasses} label={"items"}>

--- a/packages/fast-components-react-base/src/tabs/tabs.tsx
+++ b/packages/fast-components-react-base/src/tabs/tabs.tsx
@@ -127,9 +127,12 @@ class Tabs extends Foundation<TabsHandledProps, TabsUnhandledProps, TabsState> {
             const items: React.ReactNode[] = React.Children.toArray(this.tabItems());
             const currentItemIndex: number = items.findIndex(this.getCurrentIndexById);
 
-            (Array.from(this.tabListRef.current.children)[
-                currentItemIndex
-            ] as HTMLButtonElement).focus();
+            // Do nothing if current item index is not found
+            if (currentItemIndex !== -1) {
+                (Array.from(this.tabListRef.current.children)[
+                    currentItemIndex
+                ] as HTMLButtonElement).focus();
+            }
         }
     }
 


### PR DESCRIPTION
# Description

Preventing Type Error when active ID is not found among current tabs.

## Motivation & context

https://github.com/Microsoft/fast-dna/issues/1218

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [X] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [X] I have added tests for my changes.
- [X] I have tested my changes.
- [X] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.