### PR TITLE
feat: add common MSFT input field style pattern

### DIFF
--- a/packages/fast-components-styles-msft/src/patterns/input-field.ts
+++ b/packages/fast-components-styles-msft/src/patterns/input-field.ts
@@ -7,6 +7,10 @@ import { DesignSystem } from "src/design-system";
 import { applyFocusVisible, toPx } from "@microsoft/fast-jss-utilities";
 import { foregroundNormal } from "../utilities/colors";
 
+/**
+ * Shared input field styles
+ * @param designSystem
+ */
 export function inputFieldStyles(designSystem: DesignSystem): CSSRules<{}> {
     return {
         ...applyTypeRampConfig("t7"),

--- a/packages/fast-components-styles-msft/src/patterns/input-field.ts
+++ b/packages/fast-components-styles-msft/src/patterns/input-field.ts
@@ -3,13 +3,12 @@ import { fontWeight } from "../utilities/fonts";
 import outlinePattern from "../patterns/outline";
 import typographyPattern from "../patterns/typography";
 import { CSSRules } from "@microsoft/fast-jss-manager";
-import { DesignSystem } from "src/design-system";
+import { DesignSystem } from "../design-system";
 import { applyFocusVisible, toPx } from "@microsoft/fast-jss-utilities";
 import { foregroundNormal } from "../utilities/colors";
 
 /**
  * Shared input field styles
- * @param designSystem
  */
 export function inputFieldStyles(designSystem: DesignSystem): CSSRules<{}> {
     return {

--- a/packages/fast-components-styles-msft/src/patterns/input-field.ts
+++ b/packages/fast-components-styles-msft/src/patterns/input-field.ts
@@ -1,0 +1,39 @@
+import { applyTypeRampConfig } from "../utilities/typography";
+import { fontWeight } from "../utilities/fonts";
+import outlinePattern from "../patterns/outline";
+import typographyPattern from "../patterns/typography";
+import { CSSRules } from "@microsoft/fast-jss-manager";
+import { DesignSystem } from "src/design-system";
+import { applyFocusVisible, toPx } from "@microsoft/fast-jss-utilities";
+import { foregroundNormal } from "../utilities/colors";
+
+export function inputFieldStyles(designSystem: DesignSystem): CSSRules<{}> {
+    return {
+        ...applyTypeRampConfig("t7"),
+        ...outlinePattern.rest,
+        ...typographyPattern.rest,
+        fontFamily: "inherit",
+        fontWeight: fontWeight.normal.toString(),
+        boxSizing: "border-box",
+        borderRadius: toPx(designSystem.cornerRadius),
+        padding: "10px",
+        margin: "0",
+        "&:hover": {
+            ...outlinePattern.hover,
+        },
+        ...applyFocusVisible({
+            ...outlinePattern.focus,
+        }),
+        "&:disabled": {
+            ...outlinePattern.disabled,
+            ...typographyPattern.disabled,
+            cursor: "not-allowed",
+            "&::placeholder": {
+                ...typographyPattern.disabled,
+            },
+        },
+        "&::placeholder": {
+            color: foregroundNormal,
+        },
+    };
+}

--- a/packages/fast-components-styles-msft/src/text-area/index.ts
+++ b/packages/fast-components-styles-msft/src/text-area/index.ts
@@ -1,19 +1,10 @@
-import { applyTypeRampConfig } from "../utilities/typography";
 import { DesignSystem, withDesignSystemDefaults } from "../design-system";
 import { TextAreaClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { applyFocusVisible, toPx } from "@microsoft/fast-jss-utilities";
-import { get } from "lodash-es";
+import { toPx } from "@microsoft/fast-jss-utilities";
 import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
-import { fontWeight } from "../utilities/fonts";
-import {
-    disabledContrast,
-    ensureForegroundNormal,
-    foregroundNormal,
-} from "../utilities/colors";
 import { density } from "../utilities/density";
 import { defaultHeight, maxHeight, minHeight } from "../utilities/height";
-import outlinePattern from "../patterns/outline";
-import typographyPattern from "../patterns/typography";
+import { inputFieldStyles } from "../patterns/input-field";
 
 const styles: ComponentStyles<TextAreaClassNameContract, DesignSystem> = (
     config: DesignSystem
@@ -22,36 +13,11 @@ const styles: ComponentStyles<TextAreaClassNameContract, DesignSystem> = (
 
     return {
         textArea: {
-            ...applyTypeRampConfig("t7"),
-            ...outlinePattern.rest,
-            ...typographyPattern.rest,
-            fontFamily: "inherit",
-            fontWeight: fontWeight.normal.toString(),
-            boxSizing: "border-box",
-            borderRadius: toPx(designSystem.cornerRadius),
-            padding: "10px",
-            margin: "0",
+            ...inputFieldStyles(designSystem),
             height: density(defaultHeight * 2)(designSystem),
             minHeight: toPx(minHeight * 2),
             maxHeight: toPx(maxHeight * 2),
             maxWidth: "100%",
-            "&:hover": {
-                ...outlinePattern.hover,
-            },
-            ...applyFocusVisible({
-                ...outlinePattern.focus,
-            }),
-            "&:disabled": {
-                ...outlinePattern.disabled,
-                ...typographyPattern.disabled,
-                cursor: "not-allowed",
-                "&::placeholder": {
-                    ...typographyPattern.disabled,
-                },
-            },
-            "&::placeholder": {
-                color: foregroundNormal,
-            },
         },
     };
 };

--- a/packages/fast-components-styles-msft/src/text-field/index.ts
+++ b/packages/fast-components-styles-msft/src/text-field/index.ts
@@ -1,15 +1,10 @@
-import { applyTypeRampConfig } from "../utilities/typography";
 import { DesignSystem, withDesignSystemDefaults } from "../design-system";
 import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { applyFocusVisible, toPx } from "@microsoft/fast-jss-utilities";
-import { get } from "lodash-es";
+import { toPx } from "@microsoft/fast-jss-utilities";
 import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
-import { fontWeight } from "../utilities/fonts";
-import { foregroundNormal } from "../utilities/colors";
 import { density } from "../utilities/density";
 import { defaultHeight, maxHeight, minHeight } from "../utilities/height";
-import outlinePattern from "../patterns/outline";
-import typographyPattern from "../patterns/typography";
+import { inputFieldStyles } from "../patterns/input-field";
 
 const styles: ComponentStyles<TextFieldClassNameContract, DesignSystem> = (
     config: DesignSystem
@@ -18,35 +13,10 @@ const styles: ComponentStyles<TextFieldClassNameContract, DesignSystem> = (
 
     return {
         textField: {
-            ...applyTypeRampConfig("t7"),
-            ...outlinePattern.rest,
-            ...typographyPattern.rest,
-            fontFamily: "inherit",
-            fontWeight: fontWeight.normal.toString(),
-            boxSizing: "border-box",
-            borderRadius: toPx(designSystem.cornerRadius),
-            padding: "10px",
-            margin: "0",
+            ...inputFieldStyles(designSystem),
             height: density(defaultHeight)(designSystem),
             minHeight: toPx(minHeight),
             maxHeight: toPx(maxHeight),
-            "&:hover": {
-                ...outlinePattern.hover,
-            },
-            ...applyFocusVisible({
-                ...outlinePattern.focus,
-            }),
-            "&:disabled": {
-                ...outlinePattern.disabled,
-                ...typographyPattern.disabled,
-                cursor: "not-allowed",
-                "&::placeholder": {
-                    ...typographyPattern.disabled,
-                },
-            },
-            "&::placeholder": {
-                color: foregroundNormal,
-            },
         },
     };
 };


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->
Closes [#1374](https://github.com/Microsoft/fast-dna/issues/1374)
# Description

Adds a pattern for the shared MSFT styling of input fields. 
<!--- Describe your changes. -->

## Motivation & context
The same pattern existed in _text area_ and _text field_ and would soon exist in other components (_number field_, etc.) therefore a shared pattern makes sense.

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.
        - Start your description with `add`, `update`, or `remove.`

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->