### PR TITLE
fix: fixes an issue where objects were returned when strings were selected in the children UI

### DIFF
--- a/packages/fast-form-generator-react/src/form/form-item.children.spec.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.children.spec.tsx
@@ -262,7 +262,18 @@ describe("Children", () => {
                 .find("li")
         ).toHaveLength(1);
 
-        const renderedWithTwoChildren: any = mount(
+        const renderedWithOneChildString: any = mount(
+            <Children {...childrenProps} data={"hello world"} />
+        );
+
+        expect(
+            renderedWithOneChild
+                .find("ul")
+                .at(0)
+                .find("li")
+        ).toHaveLength(1);
+
+        const renderedWithThreeChildren: any = mount(
             <Children
                 {...childrenProps}
                 data={[
@@ -274,16 +285,17 @@ describe("Children", () => {
                         id: "beta 1",
                         props: {},
                     },
+                    "hello world",
                 ]}
             />
         );
 
         expect(
-            renderedWithTwoChildren
+            renderedWithThreeChildren
                 .find("ul")
                 .at(0)
                 .find("li")
-        ).toHaveLength(2);
+        ).toHaveLength(3);
     });
     test("should fire a callback to update the data when an `option` in the `listbox` is clicked", () => {
         const callback: any = jest.fn();
@@ -299,6 +311,28 @@ describe("Children", () => {
         expect(callback).toHaveBeenCalled();
         expect(callback.mock.calls[0][0]).toEqual("locationOfChildren");
         expect(callback.mock.calls[0][1]).toEqual([{ id: "beta 1", props: {} }]);
+    });
+    test("should fire a callback to update the data when a default text `option` in the `listbox` is clicked", () => {
+        const callback: any = jest.fn();
+        const rendered: any = mount(
+            <Children
+                {...childrenProps}
+                defaultChildOptions={["text"]}
+                onChange={callback}
+            />
+        );
+
+        rendered
+            .find("ul")
+            .at(0)
+            .find("li")
+            .at(0)
+            .simulate("click");
+
+        expect(callback).toHaveBeenCalled();
+        expect(callback.mock.calls[0][0]).toEqual("locationOfChildren");
+        expect(Array.isArray(callback.mock.calls[0][1])).toBe(true);
+        expect(typeof callback.mock.calls[0][1][0]).toEqual("string");
     });
     test("should not add a child option to the data when a value has been added to the `input` that is an empty string", () => {
         const callback: any = jest.fn();

--- a/packages/fast-form-generator-react/src/form/form-item.children.tsx
+++ b/packages/fast-form-generator-react/src/form/form-item.children.tsx
@@ -711,7 +711,8 @@ class FormItemChildren extends FormItemBase<
         item: ChildOptionItem
     ): ChildComponent[] {
         const components: ChildComponent[] = [].concat(currentChildren);
-        components.push(this.getChildComponent(item));
+        const isString: boolean = item.schema === reactChildrenStringSchema;
+        components.push(this.getChildComponent(item, isString));
 
         return components;
     }
@@ -737,7 +738,14 @@ class FormItemChildren extends FormItemBase<
                 : [];
     }
 
-    private getChildComponent(item: ChildOptionItem): ChildComponentConfig {
+    private getChildComponent(
+        item: ChildOptionItem,
+        isString?: boolean
+    ): ChildComponentConfig {
+        if (!!isString) {
+            return generateExampleData(item.schema, "");
+        }
+
         return {
             id: item.schema.id,
             props: generateExampleData(item.schema, ""),


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
This allows the addition of strings as children without returning an object, which while valid causes some confusion.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Standardization of the returned object to a simple string.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.
        - Start your description with `add`, `update`, or `remove.`

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->