### PR TITLE
fix: remove defaultValue from number field schema and examples

### DIFF
--- a/packages/fast-components-react-base/src/number-field/examples.data.tsx
+++ b/packages/fast-components-react-base/src/number-field/examples.data.tsx
@@ -15,7 +15,7 @@ const classes: NumberFieldManagedClasses = {
     },
 };
 
-const examples: ComponentFactoryExample<NumberFieldHandledProps> = {
+const examples: ComponentFactoryExample<NumberFieldProps> = {
     name: "Number field",
     component: NumberField,
     schema: schema as any,
@@ -26,8 +26,7 @@ const examples: ComponentFactoryExample<NumberFieldHandledProps> = {
         min: 0,
         max: 100,
         step: 10,
-        defaultValue: 0,
-    } as any,
+    },
     data: [
         {
             ...classes,
@@ -44,10 +43,6 @@ const examples: ComponentFactoryExample<NumberFieldHandledProps> = {
         {
             ...classes,
             value: 100,
-        },
-        {
-            ...classes,
-            defaultValue: 100,
         },
         {
             ...classes,
@@ -68,7 +63,7 @@ const examples: ComponentFactoryExample<NumberFieldHandledProps> = {
         {
             ...classes,
             name: "Name",
-        } as any,
+        },
     ],
 };
 

--- a/packages/fast-components-react-base/src/number-field/number-field.schema.json
+++ b/packages/fast-components-react-base/src/number-field/number-field.schema.json
@@ -37,10 +37,6 @@
             "title": "HTML required attribute",
             "type": "boolean"
         },
-        "defaultValue": {
-            "title": "Initial value",
-            "type": "number"
-        },
         "value": {
             "title": "HTML value attribute",
             "type": "number"

--- a/packages/fast-components-react-msft/src/number-field/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/number-field/examples.data.tsx
@@ -14,8 +14,7 @@ export default {
         step: 10,
         min: 0,
         max: 100,
-        defaultValue: 0,
-    } as any,
+    },
     data: [
         {
             step: 0.1,
@@ -28,9 +27,6 @@ export default {
         },
         {
             value: 100,
-        },
-        {
-            defaultValue: 0,
         },
         {
             disabled: true,


### PR DESCRIPTION
# Description
The `defaultValue` attribute for inputs are expected to be string. I noticed that we were typing our examples as "any" in several places to overcome type errors. I think these errors were actually valid. Default value is expected as a string, our examples and schema showed it as a number. I don't believe this is a breaking change as the components actual contract is not changing.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.
        - Start your description with `add`, `update`, or `remove.`

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->