### PR TITLE
feat: add neutral-foreground states

### DIFF
--- a/packages/fast-components-styles-msft/README.md
+++ b/packages/fast-components-styles-msft/README.md
@@ -63,11 +63,11 @@ The state that the color should be applied to:
 Refers to the *size* of text that the color is designed to work with. [color-contrast](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html) requirements vary depending on both font-size and weight. By default, all utilities target normal text and a contrast ratio of 4.5:1. If a utility name has the "large" keyword at the end, it means it is targeting "large" text and a contrast ratio of 3:1.
 
 Component stylesheets can mix and match these utilities to achieve the component design. For example, a secondary button may use:
--  `neutralForeground` for text color
+-  `neutralForegroundRest` for text color
 -  `neutralFillRest` / `neutralFillHover` / `neutralFillActive` for background colors
 
 A ghost button may use:
--  `neutralForeground` for text color
+-  `neutralForegroundRest` for text color
 -  `neutralFillStealthRest` / `neutralFillStealthHover` / `neutralFillActive` for background colors
 -  `neutralOutlineRest` / `neutralOutlineHover` / `neutralOutlineActive` for border colors
 
@@ -82,7 +82,7 @@ When a color utility is invoked with a `DesignSystem`, that `DesignSystem` is us
 ```JavaScript
 const StyleSheet = {
     button: {
-        color: neutralForeground,
+        color: neutralForegroundRest,
         background: neutralFillRest,
         "&:hover": {
             background: neutralFillHover,
@@ -101,10 +101,10 @@ Color utilities can also be invoked with a callback as their sole argument. When
 ```JavaScript
 const StyleSheet = {
     button: {
-        color: neutralForeground(neutralFillRest),
+        color: neutralForegroundRest(neutralFillRest),
         background: neutralFillRest,
         "&:hover": {
-            color: neutralForeground(() => "#FF0"),
+            color: neutralForegroundRest(() => "#FF0"),
             background: "#FF0",
         },
         "&:active": {

--- a/packages/fast-components-styles-msft/package.json
+++ b/packages/fast-components-styles-msft/package.json
@@ -39,6 +39,10 @@
         "lines": 80
       }
     },
+    "coveragePathIgnorePatterns": [
+        "/node_modules",
+        "./src/utilities/color/index.ts"
+    ],
     "testURL": "http://localhost",
     "transform": {
       "^.+\\.tsx?$": "ts-jest",

--- a/packages/fast-components-styles-msft/src/utilities/color/index.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/index.ts
@@ -1,7 +1,12 @@
 /**
  * Text exports
  */
-export { neutralForeground } from "./neutral-foreground";
+export {
+    neutralForeground,
+    neutralForegroundRest,
+    neutralForegroundHover,
+    neutralForegroundActive,
+} from "./neutral-foreground";
 export { accentForegroundCut, accentForegroundCutLarge } from "./accent-foreground-cut";
 export {
     neutralForegroundHint,

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.ts
@@ -4,7 +4,7 @@ import {
     withDesignSystemDefaults,
 } from "../../design-system";
 import { findSwatchIndex, Palette, palette, PaletteType, Swatch } from "./palette";
-import { neutralForeground } from "./neutral-foreground";
+import { neutralForegroundRest } from "./neutral-foreground";
 import { inRange, memoize } from "lodash-es";
 import { ColorRecipe, contrast, SwatchResolver } from "./common";
 
@@ -18,7 +18,7 @@ const neutralForegroundHintAlgorithm: (
         const neutralPaletteLength: number = neutralPalette.length;
         const neutralForegroundIndex: number = findSwatchIndex(
             PaletteType.neutral,
-            neutralForeground(designSystem)
+            neutralForegroundRest(designSystem)
         )(designSystem);
         const direction: 1 | -1 =
             neutralForegroundIndex <= Math.floor(neutralPaletteLength / 2) ? 1 : -1;

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.spec.ts
@@ -1,30 +1,91 @@
-import { neutralForeground } from "./neutral-foreground";
+import {
+    neutralForeground,
+    neutralForegroundActive,
+    neutralForegroundDark,
+    neutralForegroundDeltaActive,
+    neutralForegroundDeltaHover,
+    neutralForegroundHover,
+    neutralForegroundLight,
+    neutralForegroundRest,
+} from "./neutral-foreground";
+import { palette, Palette, PaletteType, Swatch } from "./palette";
 import designSystemDefaults from "../../design-system";
 
-describe("neutralForeground", (): void => {
+describe("neutralForegroundRest", (): void => {
     test("should return a string when invoked with an object", (): void => {
-        expect(typeof neutralForeground(designSystemDefaults)).toBe("string");
+        expect(typeof neutralForegroundRest(designSystemDefaults)).toBe("string");
+        expect(typeof neutralForegroundHover(designSystemDefaults)).toBe("string");
+        expect(typeof neutralForegroundActive(designSystemDefaults)).toBe("string");
     });
 
     test("should return a function when invoked with a function", (): void => {
-        expect(typeof neutralForeground(() => "#FFF")).toBe("function");
+        expect(typeof neutralForegroundRest(() => "#FFF")).toBe("function");
+        expect(typeof neutralForegroundHover(() => "#FFF")).toBe("function");
+        expect(typeof neutralForegroundActive(() => "#FFF")).toBe("function");
     });
 
     test("should opperate on default design system if no design system is supplied", (): void => {
-        expect(neutralForeground(undefined as any)).toBe("#101010");
-        expect(neutralForeground(() => undefined as any)(undefined as any)).toBe(
-            "#101010"
+        const neutralPalette: Palette = palette(PaletteType.neutral)(
+            designSystemDefaults
         );
-        expect(neutralForeground(() => "#FFF")(undefined as any)).toBe("#101010");
+        expect(neutralForegroundRest(undefined! as any)).toBe(
+            neutralForegroundDark(undefined)
+        );
+        expect(neutralForegroundRest(() => undefined as any)(undefined as any)).toBe(
+            neutralForegroundDark(undefined)
+        );
+        expect(neutralForegroundRest(() => "#FFF")(undefined as any)).toBe(
+            neutralForegroundDark(undefined)
+        );
+
+        expect(neutralForegroundHover(undefined! as any)).toBe(
+            neutralPalette[
+                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
+                    neutralForegroundDeltaHover
+            ]
+        );
+        expect(neutralForegroundHover(() => undefined as any)(undefined as any)).toBe(
+            neutralPalette[
+                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
+                    neutralForegroundDeltaHover
+            ]
+        );
+        expect(neutralForegroundHover(() => "#FFF")(undefined as any)).toBe(
+            neutralPalette[
+                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
+                    neutralForegroundDeltaHover
+            ]
+        );
+
+        expect(neutralForegroundActive(undefined! as any)).toBe(
+            neutralPalette[
+                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
+                    neutralForegroundDeltaActive
+            ]
+        );
+        expect(neutralForegroundActive(() => undefined as any)(undefined as any)).toBe(
+            neutralPalette[
+                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
+                    neutralForegroundDeltaActive
+            ]
+        );
+        expect(neutralForegroundActive(() => "#FFF")(undefined as any)).toBe(
+            neutralPalette[
+                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
+                    neutralForegroundDeltaActive
+            ]
+        );
     });
 
     test("should return #101010 with default design system values", (): void => {
-        expect(neutralForeground(designSystemDefaults)).toBe("#101010");
+        expect(neutralForegroundRest(designSystemDefaults)).toBe(
+            neutralForegroundDark(undefined)
+        );
     });
 
     test("should return #FFF with a dark background", (): void => {
         expect(
-            neutralForeground(
+            neutralForegroundRest(
                 Object.assign({}, designSystemDefaults, {
                     backgroundColor: "#000",
                 })

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.spec.ts
@@ -24,11 +24,11 @@ describe("neutralForeground", (): void => {
         expect(typeof neutralForegroundActive(() => "#FFF")).toBe("function");
     });
 
-    test("should opperate on default design system if no design system is supplied", (): void => {
+    test("should operate on default design system if no design system is supplied", (): void => {
         const neutralPalette: Palette = palette(PaletteType.neutral)(
             designSystemDefaults
         );
-        expect(neutralForegroundRest(undefined! as any)).toBe(
+        expect(neutralForegroundRest(undefined as any)).toBe(
             neutralForegroundDark(undefined)
         );
         expect(neutralForegroundRest(() => undefined as any)(undefined as any)).toBe(

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.spec.ts
@@ -11,7 +11,7 @@ import {
 import { palette, Palette, PaletteType, Swatch } from "./palette";
 import designSystemDefaults from "../../design-system";
 
-describe("neutralForegroundRest", (): void => {
+describe("neutralForeground", (): void => {
     test("should return a string when invoked with an object", (): void => {
         expect(typeof neutralForegroundRest(designSystemDefaults)).toBe("string");
         expect(typeof neutralForegroundHover(designSystemDefaults)).toBe("string");

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.ts
@@ -1,11 +1,20 @@
 import { memoize } from "lodash-es";
-import { isDarkTheme, palette, PaletteType, Swatch } from "./palette";
-import { SwatchResolver } from "./common";
+import { isDarkTheme, palette, Palette, PaletteType, Swatch } from "./palette";
+import {
+    ColorRecipe,
+    StatefulSwatch,
+    StatefulSwatchToColorRecipeFactory,
+    SwatchResolver,
+    SwatchStates,
+} from "./common";
 import {
     DesignSystem,
     ensureDesignSystemDefaults,
     withDesignSystemDefaults,
 } from "../../design-system";
+
+export const neutralForegroundDeltaHover: number = 4;
+export const neutralForegroundDeltaActive: number = 8;
 
 /**
  * Function to derive neutralForeground from color inputs.
@@ -13,11 +22,25 @@ import {
  * the color that has the most contrast against the background. If contrast
  * cannot be retrieved correctly, function returns black.
  */
-const neutralForegroundAlgorithm: SwatchResolver = memoize(
-    (designSystem: DesignSystem): Swatch => {
-        return isDarkTheme(designSystem)
+const neutralForegroundAlgorithm: (
+    designSystem: DesignSystem
+) => StatefulSwatch = memoize(
+    (designSystem: DesignSystem): StatefulSwatch => {
+        const neutralPalette: Palette = palette(PaletteType.neutral)(designSystem);
+        const isDark: boolean = isDarkTheme(designSystem);
+        const direction: 1 | -1 = isDark ? 1 : -1;
+        const restColor: Swatch = isDark
             ? neutralForegroundLight(designSystem)
             : neutralForegroundDark(designSystem);
+        const restIndex: number = neutralPalette.indexOf(restColor);
+        const hoverIndex: number = restIndex + neutralForegroundDeltaHover * direction;
+        const activeIndex: number = restIndex + neutralForegroundDeltaActive * direction;
+
+        return {
+            rest: neutralPalette[restIndex],
+            hover: neutralPalette[hoverIndex],
+            active: neutralPalette[activeIndex],
+        };
     },
     (designSystem: DesignSystem): string => {
         return designSystem.backgroundColor;
@@ -38,14 +61,14 @@ export function neutralForegroundDark(designSystem: DesignSystem): Swatch {
     return palette(PaletteType.neutral)(designSystem)[58];
 }
 
-export function neutralForeground(designSystem: DesignSystem): Swatch;
+export function neutralForeground(designSystem: DesignSystem): StatefulSwatch;
 export function neutralForeground(
-    backgroundResolver: (designSystem: DesignSystem) => Swatch
-): (designSystem: DesignSystem) => Swatch;
+    backgroundResolver: SwatchResolver
+): (designSystem: DesignSystem) => StatefulSwatch;
 export function neutralForeground(arg: any): any {
     if (typeof arg === "function") {
         return ensureDesignSystemDefaults(
-            (designSystem: DesignSystem): Swatch => {
+            (designSystem: DesignSystem): StatefulSwatch => {
                 const backgroundColor: Swatch = arg(designSystem);
                 return neutralForegroundAlgorithm(
                     Object.assign({}, designSystem, {
@@ -58,3 +81,16 @@ export function neutralForeground(arg: any): any {
         return neutralForegroundAlgorithm(withDesignSystemDefaults(arg));
     }
 }
+
+export const neutralForegroundRest: ColorRecipe = StatefulSwatchToColorRecipeFactory(
+    SwatchStates.rest,
+    neutralForeground
+);
+export const neutralForegroundHover: ColorRecipe = StatefulSwatchToColorRecipeFactory(
+    SwatchStates.hover,
+    neutralForeground
+);
+export const neutralForegroundActive: ColorRecipe = StatefulSwatchToColorRecipeFactory(
+    SwatchStates.active,
+    neutralForeground
+);

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -148,6 +148,7 @@ export function findClosestSwatchIndex(
  */
 export const isDarkTheme: DesignSystemResolver<boolean> = memoize(
     (designSystem: DesignSystem): boolean => {
+        const neutralPalette: Palette = palette(PaletteType.neutral)(designSystem);
         try {
             return (
                 chroma.contrast(

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -148,7 +148,6 @@ export function findClosestSwatchIndex(
  */
 export const isDarkTheme: DesignSystemResolver<boolean> = memoize(
     (designSystem: DesignSystem): boolean => {
-        const neutralPalette: Palette = palette(PaletteType.neutral)(designSystem);
         try {
             return (
                 chroma.contrast(


### PR DESCRIPTION
Adds hover and active states to the neutral-foreground recipe

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.
