### PR TITLE
feat: add focus features to ContextMenu

### DIFF
--- a/packages/fast-components-react-base/src/context-menu/context-menu.props.ts
+++ b/packages/fast-components-react-base/src/context-menu/context-menu.props.ts
@@ -12,6 +12,11 @@ export interface ContextMenuHandledProps extends ContextMenuManagedClasses {
      * The context menu children
      */
     children?: React.ReactNode;
+
+    /**
+     * When true, the context menu will immediately place focus on the appropriate menu-item when the context-menu mounts
+     */
+    enableAutoFocus?: boolean;
 }
 
 export type ContextMenuProps = ContextMenuHandledProps & ContextMenuUnhandledProps;

--- a/packages/fast-components-react-base/src/context-menu/context-menu.spec.tsx
+++ b/packages/fast-components-react-base/src/context-menu/context-menu.spec.tsx
@@ -188,4 +188,40 @@ describe("context menu", (): void => {
         rendered.childAt(0).simulate("keydown", { keyCode: KeyCodes.arrowDown });
         expect(rendered.state("focusIndex")).toBe(5);
     });
+
+    test("should not call focus on mount when enableAutoFocus is false", (): void => {
+        const spy: jest.SpyInstance = jest.spyOn(ContextMenu.prototype, "focus" as any);
+
+        const rendered: any = mount(
+            <ContextMenu enableAutoFocus={false}>
+                <div role="menuitem">two</div>
+                <div role="menuitem">three</div>
+                <div role="menuitem">four</div>
+            </ContextMenu>
+        );
+
+        const defaultRendered: any = mount(
+            <ContextMenu>
+                <div role="menuitem">two</div>
+                <div role="menuitem">three</div>
+                <div role="menuitem">four</div>
+            </ContextMenu>
+        );
+
+        expect(spy).toHaveBeenCalledTimes(0);
+    });
+
+    test("should call focus on mount when enableAutoFocus is true", (): void => {
+        const spy: jest.SpyInstance = jest.spyOn(ContextMenu.prototype, "focus" as any);
+
+        const rendered: any = mount(
+            <ContextMenu enableAutoFocus={true}>
+                <div role="menuitem">two</div>
+                <div role="menuitem">three</div>
+                <div role="menuitem">four</div>
+            </ContextMenu>
+        );
+
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/fast-components-react-base/src/context-menu/context-menu.tsx
+++ b/packages/fast-components-react-base/src/context-menu/context-menu.tsx
@@ -33,6 +33,7 @@ class ContextMenu extends Foundation<
     protected handledProps: HandledProps<ContextMenuHandledProps> = {
         children: void 0,
         managedClasses: void 0,
+        enableAutoFocus: void 0,
     };
 
     private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
@@ -73,6 +74,17 @@ class ContextMenu extends Foundation<
                 focusIndex,
             });
         }
+
+        if (this.props.enableAutoFocus) {
+            this.focus();
+        }
+    }
+
+    /**
+     * Brings focus to the appropriate menu-item
+     */
+    public focus(): void {
+        this.setFocus(this.state.focusIndex === -1 ? 0 : this.state.focusIndex, 1);
     }
 
     /**

--- a/packages/fast-components-react-base/src/context-menu/examples.data.tsx
+++ b/packages/fast-components-react-base/src/context-menu/examples.data.tsx
@@ -55,6 +55,7 @@ const examples: ComponentFactoryExample<ContextMenuProps> = {
     data: [
         {
             ...managedClasses,
+            enableAutoFocus: true,
             children: [
                 {
                     id: "context-menu-item",


### PR DESCRIPTION
# Description
Adds a public function the `ContextMenu` to bring focus to the appropriate menu item. Also adds an opt-in prop (`enableFocusVisible`) to bring focus to invoke the focus method when the component mounts, which is generally desired. Making `enableFocusVisible` false by default ensures we don't change behavior of existing implementations of `ContextMenu`.

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

closes #1398