### PR TITLE
feat: add class name for horizontal overflow items

### DIFF
--- a/packages/fast-components-class-name-contracts-base/src/horizontal-overflow/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/horizontal-overflow/index.ts
@@ -8,9 +8,14 @@ export interface HorizontalOverflowClassNameContract {
     horizontalOverflow?: string;
 
     /**
-     * The overflow items
+     * The overflow items container
      */
     horizontalOverflow_contentRegion?: string;
+
+    /**
+     * The overflow item(s)
+     */
+    horizontalOverflow_item?: string;
 
     /**
      * The next scroll control

--- a/packages/fast-components-react-base/src/horizontal-overflow/examples.data.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/examples.data.tsx
@@ -12,7 +12,8 @@ import { ComponentFactoryExample } from "@microsoft/fast-development-site-react"
 const classes: HorizontalOverflowManagedClasses = {
     managedClasses: {
         horizontalOverflow: "horizontal-overflow",
-        horizontalOverflow_contentRegion: "horizontal-overflow_items",
+        horizontalOverflow_contentRegion: "horizontal-overflow_content",
+        horizontalOverflow_item: "horizontal-overflow_item",
         horizontalOverflow_next: "horizontal-overflow_next",
         horizontalOverflow_previous: "horizontal-overflow_previous",
     },
@@ -157,7 +158,6 @@ const examples: ComponentFactoryExample<HorizontalOverflowHandledProps> = {
     schema: schema as any,
     documentation: <Documentation />,
     detailData: {
-        ...classes,
         children: [
             {
                 id: ButtonSchema.id,
@@ -246,7 +246,7 @@ const examples: ComponentFactoryExample<HorizontalOverflowHandledProps> = {
             children: [...images],
         },
         {
-            ...classes,
+            children: [...images],
         },
     ],
 };

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.node.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.node.spec.tsx
@@ -29,6 +29,7 @@ const imageSet1: JSX.Element[] = [
 const managedClasses: HorizontalOverflowClassNameContract = {
     horizontalOverflow: "horizontal-overflow-class",
     horizontalOverflow_contentRegion: "horizontal-overflow-items-class",
+    horizontalOverflow_item: "horizontal-overflow-item-class",
     horizontalOverflow_next: "horizontal-overflow-next-class",
     horizontalOverflow_previous: "horizontal-overflow-previous-class",
 };
@@ -64,7 +65,7 @@ describe("horizontal overflow server-side", (): void => {
 
         /* tslint:disable:max-line-length */
         expect(renderedWithImagesAndNextAndPrevious).toEqual(
-            '<div class="horizontal-overflow-class" data-reactroot=""><div style="height:0px;position:relative;overflow:hidden"><ul class="horizontal-overflow-items-class" style="position:relative;white-space:nowrap;overflow-x:scroll;padding:0;margin:0"><li style="display:inline-block"><img src="https://placehold.it/200x200?text=1"/></li><li style="display:inline-block"><img src="https://placehold.it/200x200?text=2"/></li><li style="display:inline-block"><img src="https://placehold.it/200x200?text=3"/></li><li style="display:inline-block"><img src="https://placehold.it/200x200?text=4"/></li><li style="display:inline-block"><img src="https://placehold.it/200x200?text=5"/></li><li style="display:inline-block"><img src="https://placehold.it/200x200?text=6"/></li></ul></div><div class="horizontal-overflow-previous-class"><button id="testButtonPrevious" slot="previous">previous</button></div><div class="horizontal-overflow-next-class"><button id="testButtonNext" slot="next">next</button></div></div>'
+            '<div class="horizontal-overflow-class" data-reactroot=""><div style="height:0px;position:relative;overflow:hidden"><ul class="horizontal-overflow-items-class" style="position:relative;white-space:nowrap;overflow-x:scroll;padding:0;margin:0"><li class="horizontal-overflow-item-class" style="display:inline-block"><img src="https://placehold.it/200x200?text=1"/></li><li class="horizontal-overflow-item-class" style="display:inline-block"><img src="https://placehold.it/200x200?text=2"/></li><li class="horizontal-overflow-item-class" style="display:inline-block"><img src="https://placehold.it/200x200?text=3"/></li><li class="horizontal-overflow-item-class" style="display:inline-block"><img src="https://placehold.it/200x200?text=4"/></li><li class="horizontal-overflow-item-class" style="display:inline-block"><img src="https://placehold.it/200x200?text=5"/></li><li class="horizontal-overflow-item-class" style="display:inline-block"><img src="https://placehold.it/200x200?text=6"/></li></ul></div><div class="horizontal-overflow-previous-class"><button id="testButtonPrevious" slot="previous">previous</button></div><div class="horizontal-overflow-next-class"><button id="testButtonNext" slot="next">next</button></div></div>'
         );
         /* tslint:enable:max-line-length */
     });

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -46,6 +46,7 @@ const imageSet2: JSX.Element[] = [
 const managedClasses: HorizontalOverflowClassNameContract = {
     horizontalOverflow: "horizontal-overflow-class",
     horizontalOverflow_contentRegion: "horizontal-overflow-items-class",
+    horizontalOverflow_item: "horizontal-overflow-item",
     horizontalOverflow_next: "horizontal-overflow-next-class",
     horizontalOverflow_previous: "horizontal-overflow-previous-class",
 };
@@ -135,6 +136,21 @@ describe("horizontal overflow", (): void => {
                 .find("img")
                 .prop("id")
         ).toBe(id6);
+    });
+
+    test("should add a style of `display: inline-block` to the list item containing each item", () => {
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses}>
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+
+        expect(
+            rendered
+                .find("li")
+                .at(0)
+                .props().style
+        ).toEqual({ display: "inline-block" });
     });
 
     test("should render a previous button if one is passed as a child with the appropriate slot prop", () => {

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -377,7 +377,18 @@ class HorizontalOverflow extends Foundation<
         return React.Children.map(
             this.withoutSlot([ButtonDirection.previous, ButtonDirection.next]),
             (child: React.ReactNode): React.ReactElement<HTMLLIElement> => {
-                return <li style={{ display: "inline-block" }}>{child}</li>;
+                return (
+                    <li
+                        className={get(
+                            this.props.managedClasses,
+                            "horizontalOverflow_item",
+                            ""
+                        )}
+                        style={{ display: "inline-block" }}
+                    >
+                        {child}
+                    </li>
+                );
             }
         );
     }


### PR DESCRIPTION
closes #1428 

# Description

Adds a className to provide more fine grain control over the list item being render on the wrapper of horizontal overflow children. 

*Note*: If the className is undefined, add style for the list item to ensure it renders with `display: inline-block`

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.
        - Start your description with `add`, `update`, or `remove.`

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->