### PR TITLE
feat: integrate fast-dna/colors palette generation into msft color utilities

### DIFF
--- a/packages/fast-components-styles-msft/package.json
+++ b/packages/fast-components-styles-msft/package.json
@@ -75,6 +75,7 @@
     "typescript": "^3.0.1"
   },
   "dependencies": {
+    "@microsoft/fast-colors": "^3.1.5",
     "@microsoft/fast-components-class-name-contracts-base": "^3.7.0",
     "@microsoft/fast-components-class-name-contracts-msft": "^3.5.1",
     "@microsoft/fast-jss-manager": "^3.0.10",

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -1,10 +1,11 @@
 import { Direction } from "@microsoft/fast-web-utilities";
 import { withDefaults } from "@microsoft/fast-jss-utilities";
 import {
-    accentPaletteSource,
-    neutralPaletteSource,
+    accentPaletteConfig,
+    neutralPaletteConfig,
     white,
 } from "../utilities/color/color-constants";
+import { ColorPaletteConfig } from "@microsoft/fast-colors";
 
 export interface DesignSystem {
     /**
@@ -17,14 +18,14 @@ export interface DesignSystem {
      * This should be an array of strings representing colors in
      * RGB or HEX format. Color sources should be ordered from light to dark
      */
-    neutralPaletteSource: string[];
+    neutralPaletteConfig: ColorPaletteConfig;
 
     /**
      * The source colors used to create the accent color palette.
      * This should be an array of strings representing colors in
      * RGB or HEX format. Color sources should be ordered from light to dark
      */
-    accentPaletteSource: string[];
+    accentPaletteConfig: ColorPaletteConfig;
 
     /**
      * The brand color used as color accents.
@@ -77,8 +78,8 @@ const designSystemDefaults: DesignSystem = {
     direction: Direction.ltr,
     cornerRadius: 2,
     outlinePatternOutlineWidth: 1,
-    neutralPaletteSource,
-    accentPaletteSource,
+    neutralPaletteConfig,
+    accentPaletteConfig,
 
     // @deprecated
     foregroundColor: "#111",

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -14,16 +14,12 @@ export interface DesignSystem {
     backgroundColor: string;
 
     /**
-     * The source colors used to create the neutral color palette.
-     * This should be an array of strings representing colors in
-     * RGB or HEX format. Color sources should be ordered from light to dark
+     * Configuration object to derive the neutral palette. Expects a ColorPaletteConfig from @microsoft/fast-colors
      */
     neutralPaletteConfig: ColorPaletteConfig;
 
     /**
-     * The source colors used to create the accent color palette.
-     * This should be an array of strings representing colors in
-     * RGB or HEX format. Color sources should be ordered from light to dark
+     * Configuration object to derive the accent palette. Expects a ColorPaletteConfig from @microsoft/fast-colors
      */
     accentPaletteConfig: ColorPaletteConfig;
 

--- a/packages/fast-components-styles-msft/src/utilities/color/accent-foreground-cut.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/accent-foreground-cut.spec.ts
@@ -1,5 +1,6 @@
 import { accentForegroundCut, accentForegroundCutLarge } from "./accent-foreground-cut";
 import designSystemDefaults, { DesignSystem } from "../../design-system";
+import { Swatch } from "./palette";
 
 describe("Cut text", (): void => {
     test("should return white by by default", (): void => {
@@ -7,16 +8,8 @@ describe("Cut text", (): void => {
         expect(accentForegroundCutLarge(undefined as any)).toBe("#FFFFFF");
     });
     test("should return black when background does not meet contrast ratio", (): void => {
-        expect(
-            accentForegroundCut({
-                accentPaletteSource: ["#FFF", "#FFF"],
-            } as DesignSystem)
-        ).toBe("#000000");
-        expect(
-            accentForegroundCutLarge({
-                accentPaletteSource: ["#FFF", "#FFF"],
-            } as DesignSystem)
-        ).toBe("#000000");
+        expect(accentForegroundCut((): Swatch => "#FFF")({} as any)).toBe("#000000");
+        expect(accentForegroundCutLarge((): Swatch => "#FFF")({} as any)).toBe("#000000");
 
         expect(
             accentForegroundCut((designSystem: DesignSystem) => "#FFF")(

--- a/packages/fast-components-styles-msft/src/utilities/color/accent-foreground.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/accent-foreground.spec.ts
@@ -9,6 +9,8 @@ import {
 import designSystemDefaults, { DesignSystem } from "../../design-system";
 import { palette, Palette, PaletteType, Swatch } from "./palette";
 import { contrast } from "./common";
+import { accentPaletteConfig } from "./color-constants";
+import { parseColorHexRGB } from "@microsoft/fast-colors";
 
 describe("accentForeground", (): void => {
     const neutralPalette: Palette = palette(PaletteType.neutral)(designSystemDefaults);
@@ -69,7 +71,11 @@ describe("accentForeground", (): void => {
                             designSystemDefaults,
                             {
                                 backgroundColor: swatch,
-                                accentPaletteSource: ["#FFF", accent, "#000"],
+                                accentPaletteConfig: Object.assign(
+                                    {},
+                                    accentPaletteConfig,
+                                    { baseColor: parseColorHexRGB(swatch) }
+                                ),
                             }
                         );
 

--- a/packages/fast-components-styles-msft/src/utilities/color/accent.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/accent.spec.ts
@@ -1,5 +1,7 @@
 import { accentSwatch } from "./accent";
-import { DesignSystem } from "../../design-system";
+import designSystemDefaults, { DesignSystem } from "../../design-system";
+import { accentPaletteConfig } from "./color-constants";
+import { parseColorHexRGB } from "@microsoft/fast-colors";
 
 describe("accentSwatch", (): void => {
     test("should return #0078D4 by default", (): void => {
@@ -7,9 +9,13 @@ describe("accentSwatch", (): void => {
     });
     test("should return the middle of the accentPaletteSource", (): void => {
         expect(
-            accentSwatch({
-                accentPaletteSource: ["#FFF", "#F2C812", "#000"],
-            } as DesignSystem)
+            accentSwatch(
+                Object.assign({}, designSystemDefaults, {
+                    accentPaletteConfig: Object.assign({}, accentPaletteConfig, {
+                        baseColor: parseColorHexRGB("#F2C812"),
+                    }),
+                })
+            )
         ).toBe("#F2C812");
     });
 });

--- a/packages/fast-components-styles-msft/src/utilities/color/color-constants.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/color-constants.ts
@@ -3,15 +3,21 @@ import { ColorPaletteConfig, parseColorHexRGB } from "@microsoft/fast-colors";
 export const white: string = "#FFFFFF";
 export const black: string = "#000000";
 export const accent: string = "#0078D4";
-export const paletteSteps: number = 63;
+
+export const paletteConstants: Partial<ColorPaletteConfig> = {
+    steps: 63,
+    clipLight: 0,
+    clipDark: 0,
+};
 
 /**
  * Default palette sources
  */
 export const neutralPaletteConfig: ColorPaletteConfig = {
-    steps: paletteSteps,
+    ...paletteConstants,
 };
+
 export const accentPaletteConfig: ColorPaletteConfig = {
+    ...paletteConstants,
     baseColor: parseColorHexRGB(accent),
-    steps: paletteSteps,
 };

--- a/packages/fast-components-styles-msft/src/utilities/color/color-constants.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/color-constants.ts
@@ -3,7 +3,7 @@ import { ColorPaletteConfig, parseColorHexRGB } from "@microsoft/fast-colors";
 export const white: string = "#FFFFFF";
 export const black: string = "#000000";
 export const accent: string = "#0078D4";
-export const paletteSteps: number = 64;
+export const paletteSteps: number = 63;
 
 /**
  * Default palette sources

--- a/packages/fast-components-styles-msft/src/utilities/color/color-constants.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/color-constants.ts
@@ -1,9 +1,17 @@
+import { ColorPaletteConfig, parseColorHexRGB } from "@microsoft/fast-colors";
+
 export const white: string = "#FFFFFF";
 export const black: string = "#000000";
 export const accent: string = "#0078D4";
+export const paletteSteps: number = 64;
 
 /**
  * Default palette sources
  */
-export const neutralPaletteSource: string[] = [white, black];
-export const accentPaletteSource: string[] = [white, accent, black];
+export const neutralPaletteConfig: ColorPaletteConfig = {
+    steps: paletteSteps,
+};
+export const accentPaletteConfig: ColorPaletteConfig = {
+    baseColor: parseColorHexRGB(accent),
+    steps: paletteSteps,
+};

--- a/packages/fast-components-styles-msft/src/utilities/color/index.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/index.ts
@@ -77,5 +77,5 @@ export {
 /**
  * Export supporting types
  */
-export { neutralPaletteSource, accentPaletteSource } from "./color-constants";
+export { neutralPaletteConfig, accentPaletteConfig } from "./color-constants";
 export { palette, PaletteType, Palette } from "./palette";

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -40,6 +40,23 @@ const generatePalette: (config: ColorPaletteConfig) => Palette = memoize(
         //             .mode("rgb")
         //             .colors(63)
         //             .map((color: string) => color.toUpperCase());
+    },
+    (config: ColorPaletteConfig): string => {
+        return Object.keys(config).reduce(
+            (reduced: string, value: keyof ColorPaletteConfig): string => {
+                const configValue: ColorPaletteConfig[keyof ColorPaletteConfig] =
+                    config[value];
+
+                if (typeof configValue === "number") {
+                    return reduced.concat(configValue.toString());
+                } else if (configValue instanceof ColorRGBA64) {
+                    return reduced.concat(configValue.toStringWebRGBA());
+                } else {
+                    return "";
+                }
+            },
+            ""
+        );
     }
 );
 

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -1,4 +1,4 @@
-import { neutralPaletteSource } from "./color-constants";
+import { neutralPaletteConfig } from "./color-constants";
 import {
     DesignSystem,
     DesignSystemResolver,
@@ -8,6 +8,7 @@ import chroma from "chroma-js";
 import { memoize } from "lodash-es";
 import { colorMatches, isValidColor, luminance } from "./common";
 import { neutralForegroundDark, neutralForegroundLight } from "./neutral-foreground";
+import { ColorPalette, ColorPaletteConfig, ColorRGBA64 } from "@microsoft/fast-colors";
 
 /**
  * The named palettes of the MSFT design system
@@ -26,19 +27,19 @@ export type Swatch = string;
  */
 export type Palette = Swatch[];
 
-const generatePalette: (source: string[]) => Palette = memoize(
-    (source: string[]): Palette => {
-        const isValid: boolean = source.every(isValidColor);
-        const sanitizedSource: string[] = isValid ? source : neutralPaletteSource;
-
-        return chroma
-            .scale(sanitizedSource)
-            .mode("rgb")
-            .colors(63)
-            .map((color: string) => color.toUpperCase());
-    },
-    (source: string[]): string => {
-        return Array.isArray(source) ? source.join("") : source;
+const generatePalette: (config: ColorPaletteConfig) => Palette = memoize(
+    (config: ColorPaletteConfig): Palette => {
+        return new ColorPalette(config).palette.map(
+            (color: ColorRGBA64): string => color.toStringHexRGB().toUpperCase()
+        );
+        //         const isValid: boolean = source.every(isValidColor);
+        //         const sanitizedSource: string[] = isValid ? source : neutralPaletteConfig;
+        //
+        //         return chroma
+        //             .scale(sanitizedSource)
+        //             .mode("rgb")
+        //             .colors(63)
+        //             .map((color: string) => color.toUpperCase());
     }
 );
 
@@ -51,19 +52,19 @@ export function palette(
 ): (designSystem: DesignSystem) => Palette {
     return ensureDesignSystemDefaults(
         (designSystem: DesignSystem): Palette => {
-            let source: Palette;
+            let config: ColorPaletteConfig;
 
             switch (paletteType) {
                 case PaletteType.accent:
-                    source = designSystem.accentPaletteSource;
+                    config = designSystem.accentPaletteConfig;
                     break;
                 case PaletteType.neutral:
                 default:
-                    source = designSystem.neutralPaletteSource;
+                    config = designSystem.neutralPaletteConfig;
                     break;
             }
 
-            return generatePalette(source);
+            return generatePalette(config);
         }
     );
 }

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -32,14 +32,6 @@ const generatePalette: (config: ColorPaletteConfig) => Palette = memoize(
         return new ColorPalette(config).palette.map(
             (color: ColorRGBA64): string => color.toStringHexRGB().toUpperCase()
         );
-        //         const isValid: boolean = source.every(isValidColor);
-        //         const sanitizedSource: string[] = isValid ? source : neutralPaletteConfig;
-        //
-        //         return chroma
-        //             .scale(sanitizedSource)
-        //             .mode("rgb")
-        //             .colors(63)
-        //             .map((color: string) => color.toUpperCase());
     },
     (config: ColorPaletteConfig): string => {
         return Object.keys(config).reduce(


### PR DESCRIPTION
# Description

Integrates `@microsoft/fast-colors` palette generation tooling into MSFT style utilities

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.
