### PR TITLE
feat: add neutral-focus recipe

### DIFF
--- a/packages/fast-components-styles-msft/src/utilities/color/index.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/index.ts
@@ -75,6 +75,11 @@ export {
 } from "./neutral-outline";
 
 /**
+ * Focus colors
+ */
+export { neutralFocus } from "./neutral-focus";
+
+/**
  * Export supporting types
  */
 export { neutralPaletteConfig, accentPaletteConfig } from "./color-constants";

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.spec.ts
@@ -1,0 +1,30 @@
+import { neutralForegroundRest } from "./neutral-foreground";
+import { palette, Palette, PaletteType, Swatch } from "./palette";
+import designSystemDefaults, { DesignSystem } from "../../design-system";
+import { neutralFocus } from "./neutral-focus";
+
+describe("neutralForeground", (): void => {
+    test("should return a string when invoked with an object", (): void => {
+        expect(typeof neutralFocus(designSystemDefaults)).toBe("string");
+    });
+
+    test("should return a function when invoked with a function", (): void => {
+        expect(typeof neutralFocus(() => "#FFF")).toBe("function");
+    });
+
+    test("should operate on default design system if no design system is supplied", (): void => {
+        expect(neutralFocus({} as DesignSystem)).toBe("#101010");
+    });
+
+    test("should always match neutralForegroundRest", (): void => {
+        palette(PaletteType.neutral)(designSystemDefaults)
+            .concat(palette(PaletteType.accent)(designSystemDefaults))
+            .forEach(
+                (swatch: Swatch): void => {
+                    expect(neutralFocus((): Swatch => swatch)({} as DesignSystem)).toBe(
+                        neutralForegroundRest((): Swatch => swatch)({} as DesignSystem)
+                    );
+                }
+            );
+    });
+});

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.spec.ts
@@ -3,7 +3,7 @@ import { palette, Palette, PaletteType, Swatch } from "./palette";
 import designSystemDefaults, { DesignSystem } from "../../design-system";
 import { neutralFocus } from "./neutral-focus";
 
-describe("neutralForeground", (): void => {
+describe("neutralFocus", (): void => {
     test("should return a string when invoked with an object", (): void => {
         expect(typeof neutralFocus(designSystemDefaults)).toBe("string");
     });

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
@@ -1,0 +1,42 @@
+import { memoize } from "lodash-es";
+import { isDarkTheme, palette, Palette, PaletteType, Swatch } from "./palette";
+import { neutralForegroundDark, neutralForegroundLight } from "./neutral-foreground";
+import { ColorRecipe, SwatchResolver } from "./common";
+import {
+    DesignSystem,
+    ensureDesignSystemDefaults,
+    withDesignSystemDefaults,
+} from "../../design-system";
+
+/**
+ * Function to derive neutralFocus from color inputs.
+ */
+const neutralFocusAlgorithm: (designSystem: DesignSystem) => Swatch = memoize(
+    (designSystem: DesignSystem): Swatch => {
+        return isDarkTheme(designSystem)
+            ? neutralForegroundLight(designSystem)
+            : neutralForegroundDark(designSystem);
+    },
+    (designSystem: DesignSystem): string => {
+        return designSystem.backgroundColor;
+    }
+);
+
+export function neutralFocus(designSystem: DesignSystem): Swatch;
+export function neutralFocus(backgroundResolver: SwatchResolver): SwatchResolver;
+export function neutralFocus(arg: any): any {
+    if (typeof arg === "function") {
+        return ensureDesignSystemDefaults(
+            (designSystem: DesignSystem): Swatch => {
+                const backgroundColor: Swatch = arg(designSystem);
+                return neutralFocusAlgorithm(
+                    Object.assign({}, designSystem, {
+                        backgroundColor,
+                    })
+                );
+            }
+        );
+    } else {
+        return neutralFocusAlgorithm(withDesignSystemDefaults(arg));
+    }
+}

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
@@ -1,7 +1,7 @@
 import { memoize } from "lodash-es";
-import { isDarkTheme, palette, Palette, PaletteType, Swatch } from "./palette";
+import { isDarkTheme, Swatch } from "./palette";
 import { neutralForegroundDark, neutralForegroundLight } from "./neutral-foreground";
-import { ColorRecipe, SwatchResolver } from "./common";
+import { SwatchResolver } from "./common";
 import {
     DesignSystem,
     ensureDesignSystemDefaults,


### PR DESCRIPTION
# Description

<!--- Describe your changes. -->
Adds recipe for generating the neutral-focus color

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.
        - Start your description with `add`, `update`, or `remove.`

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->