### PR TITLE
fix: update focus events on keyboard close of menu

### DIFF
--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -121,10 +121,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
             !this.state.isMenuOpen &&
             !this.props.multiselectable
         ) {
-            const triggerButton: HTMLButtonElement = this.getTriggerButton();
-            if (triggerButton !== null) {
-                triggerButton.focus();
-            }
+            this.focusOnTrigger();
         }
     }
 
@@ -364,13 +361,19 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         if (this.props.disabled || e.defaultPrevented) {
             return;
         }
+
         switch (e.keyCode) {
             case KeyCodes.enter:
             case KeyCodes.space:
+                e.preventDefault();
                 this.toggleMenu(!this.state.isMenuOpen);
+                if (this.state.isMenuOpen && this.props.isMenuOpen !== true) {
+                    this.focusOnTrigger();
+                }
                 break;
             case KeyCodes.escape:
                 this.toggleMenu(false);
+                this.focusOnTrigger();
                 break;
             case KeyCodes.arrowDown:
             case KeyCodes.arrowRight:
@@ -415,7 +418,6 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
                 increment
             );
         }
-
         this.toggleMenu(true);
     };
 
@@ -511,6 +513,16 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
             element instanceof HTMLButtonElement &&
             element.getAttribute("aria-disabled") !== "true"
         );
+    };
+
+    /**
+     * focus on the trigger button
+     */
+    private focusOnTrigger = (): void => {
+        const triggerButton: HTMLButtonElement = this.getTriggerButton();
+        if (triggerButton !== null) {
+            triggerButton.focus();
+        }
     };
 }
 

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -121,7 +121,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
             !this.state.isMenuOpen &&
             !this.props.multiselectable
         ) {
-            this.focusOnTrigger();
+            this.focusTriggerElement();
         }
     }
 
@@ -365,15 +365,17 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         switch (e.keyCode) {
             case KeyCodes.enter:
             case KeyCodes.space:
+                // preventing default here because when we change focus to the trigger the keydown event gets
+                // emitted from the button again which otherwise toggles the menu a second time on a single key press
                 e.preventDefault();
                 this.toggleMenu(!this.state.isMenuOpen);
-                if (this.state.isMenuOpen && this.props.isMenuOpen !== true) {
-                    this.focusOnTrigger();
+                if (this.validateMenuState(!this.state.isMenuOpen) === false) {
+                    this.focusTriggerElement();
                 }
                 break;
             case KeyCodes.escape:
                 this.toggleMenu(false);
-                this.focusOnTrigger();
+                this.focusTriggerElement();
                 break;
             case KeyCodes.arrowDown:
             case KeyCodes.arrowRight:
@@ -518,7 +520,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
     /**
      * focus on the trigger button
      */
-    private focusOnTrigger = (): void => {
+    private focusTriggerElement = (): void => {
         const triggerButton: HTMLButtonElement = this.getTriggerButton();
         if (triggerButton !== null) {
             triggerButton.focus();


### PR DESCRIPTION
Select was focusing on next item rather than select trigger on menu close.  This forces focus back to the trigger.

## Issue type checklist
<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.
