### PR TITLE
fix: increase specificity on MSFT styled components which are derived from other MSFT components

### DIFF
--- a/packages/fast-components-styles-msft/src/action-toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/action-toggle/index.ts
@@ -27,6 +27,7 @@ export const actionToggleButtonOverrides: ComponentStyles<
 > = {
     button: {
         maxWidth: "100%",
+        minWidth: "14px",
     },
     button_contentRegion: {
         alignItems: "center",
@@ -43,11 +44,7 @@ const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = (
     const direction: Direction = designSystem.direction;
 
     return {
-        actionToggle: {
-            display: "inline-flex",
-            maxWidth: "100%",
-            minWidth: "14px",
-        },
+        actionToggle: {},
         actionToggle__selected: {},
         actionToggle_selectedGlyph: {
             display: "inline-block",

--- a/packages/fast-components-styles-msft/src/action-trigger/index.ts
+++ b/packages/fast-components-styles-msft/src/action-trigger/index.ts
@@ -27,6 +27,7 @@ export const actionTriggerButtonOverrides: ComponentStyles<
 > = {
     button: {
         maxWidth: "100%",
+        minWidth: "14px",
     },
     button_contentRegion: {
         transition: "all 600ms cubic-bezier(0.19, 1, 0.22, 1)",
@@ -43,11 +44,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = (
     const direction: Direction = designSystem.direction;
 
     return {
-        actionTrigger: {
-            display: "inline-flex",
-            maxWidth: "100%",
-            minWidth: "14px",
-        },
+        actionTrigger: {},
         actionTrigger_glyph: {
             display: "inline-block",
             position: "relative",

--- a/packages/fast-components-styles-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-styles-msft/src/call-to-action/index.ts
@@ -60,12 +60,6 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = (
 
     return {
         callToAction: {
-            display: "inline-flex",
-            maxWidth: "100%",
-            border: "2px solid transparent",
-            lineHeight: "1",
-            textDecoration: "none",
-            whiteSpace: "nowrap",
             transition: "all 0.2s ease-in-out",
             "&:hover": {
                 "& $callToAction_glyph": {

--- a/packages/fast-components-styles-msft/src/heading/index.ts
+++ b/packages/fast-components-styles-msft/src/heading/index.ts
@@ -13,25 +13,32 @@ function applyHeadingStyles(): CSSRules<DesignSystem> {
  * TODO #306: Pull font weight styles when we have an API for font/variable font properties
  */
 const styles: ComponentStyles<HeadingClassNameContract, DesignSystem> = {
-    heading: {},
-    heading__1: {
-        ...applyHeadingStyles(),
+    heading: {
+        "&$heading__1": {
+            ...applyHeadingStyles(),
+        },
+        "&$heading__2": {
+            ...applyHeadingStyles(),
+        },
+        "&$heading__3": {
+            ...applyHeadingStyles(),
+        },
+        "&$heading__4": {
+            ...applyHeadingStyles(),
+        },
+        "&$heading__5": {
+            ...applyHeadingStyles(),
+        },
+        "&$heading__6": {
+            ...applyHeadingStyles(),
+        },
     },
-    heading__2: {
-        ...applyHeadingStyles(),
-    },
-    heading__3: {
-        ...applyHeadingStyles(),
-    },
-    heading__4: {
-        ...applyHeadingStyles(),
-    },
-    heading__5: {
-        ...applyHeadingStyles(),
-    },
-    heading__6: {
-        ...applyHeadingStyles(),
-    },
+    heading__1: {},
+    heading__2: {},
+    heading__3: {},
+    heading__4: {},
+    heading__5: {},
+    heading__6: {},
 };
 
 export default styles;

--- a/packages/fast-components-styles-msft/src/paragraph/index.ts
+++ b/packages/fast-components-styles-msft/src/paragraph/index.ts
@@ -4,16 +4,20 @@ import { ParagraphClassNameContract } from "@microsoft/fast-components-class-nam
 import { fontWeight } from "../utilities/fonts";
 
 const styles: ComponentStyles<ParagraphClassNameContract, DesignSystem> = {
-    paragraph: {},
-    paragraph__1: {
-        fontWeight: `${fontWeight.semilight}`,
+    paragraph: {
+        "&$paragraph__1": {
+            fontWeight: `${fontWeight.semilight}`,
+        },
+        "&$paragraph__2": {
+            fontWeight: `${fontWeight.normal}`,
+        },
+        "&$paragraph__3": {
+            fontWeight: `${fontWeight.normal}`,
+        },
     },
-    paragraph__2: {
-        fontWeight: `${fontWeight.normal}`,
-    },
-    paragraph__3: {
-        fontWeight: `${fontWeight.normal}`,
-    },
+    paragraph__1: {},
+    paragraph__2: {},
+    paragraph__3: {},
 };
 
 export default styles;

--- a/packages/fast-components-styles-msft/src/subheading/index.ts
+++ b/packages/fast-components-styles-msft/src/subheading/index.ts
@@ -3,9 +3,32 @@ import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import { SubheadingClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { fontWeight } from "../utilities/fonts";
 
+function applySubeadingStyles(): CSSRules<DesignSystem> {
+    return {
+        fontWeight: `${fontWeight.normal}`,
+    };
+}
+
 const styles: ComponentStyles<SubheadingClassNameContract, DesignSystem> = {
     subheading: {
-        fontWeight: `${fontWeight.normal}`,
+        "&$subheading__1": {
+            ...applySubeadingStyles(),
+        },
+        "&$subheading__2": {
+            ...applySubeadingStyles(),
+        },
+        "&$subheading__3": {
+            ...applySubeadingStyles(),
+        },
+        "&$subheading__4": {
+            ...applySubeadingStyles(),
+        },
+        "&$subheading__5": {
+            ...applySubeadingStyles(),
+        },
+        "&$subheading__6": {
+            ...applySubeadingStyles(),
+        },
     },
     subheading__1: {},
     subheading__2: {},


### PR DESCRIPTION
closes #1498 
## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.
        - Start your description with `add`, `update`, or `remove.`

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->