### PR TITLE
feat: add enhancements for auto-suggest

### DIFF
--- a/packages/fast-components-react-base/src/listbox/README.md
+++ b/packages/fast-components-react-base/src/listbox/README.md
@@ -11,7 +11,7 @@ To get results from user interaction with the *listbox* hook up to the "onSelect
 - value: the string value associated with the option
 - displayString: optional, a user friendly version of the value to display in ui.
 
-Use the optional "defaultSelection" prop to provide a string[] of the id's of selected items to the component.
+Use the optional "defaultSelection" prop to provide a string[] of the id's of selected items to the component.  Providing a new value for the defaultSelection prop in uncontrolled  mode after the component has intitially mounted will cause the component to reset its selection and focus accordingly.  "defaultSelection" has no effect in controlled mode ("ie. when the "selectedItems" prop is defined).
 
 Invalid items (ie. that don't have matching non-disabled items with the same id as children of the *listbox*) are removed and in single select mode only the first valid item is relevant.
 

--- a/packages/fast-components-react-base/src/listbox/listbox.props.ts
+++ b/packages/fast-components-react-base/src/listbox/listbox.props.ts
@@ -19,6 +19,11 @@ export interface ListboxHandledProps extends ListboxManagedClasses {
     typeAheadPropertyKey?: string;
 
     /**
+     * Enable type ahead
+     */
+    typeAheadEnabled?: boolean;
+
+    /**
      * Whether this listbox supports multi-selection (default is 'false')
      */
     multiselectable?: boolean;
@@ -43,6 +48,11 @@ export interface ListboxHandledProps extends ListboxManagedClasses {
      * The  onSelectedItemsChanged event handler
      */
     onSelectedItemsChanged?: (selectedItems: ListboxItemProps[]) => void;
+
+    /**
+     * The onItemInvoked event handler
+     */
+    onItemInvoked?: (item: ListboxItemProps) => void;
 
     /**
      * Whether a listitem should automatically get focus when this component is mounted

--- a/packages/fast-components-react-base/src/listbox/listbox.spec.tsx
+++ b/packages/fast-components-react-base/src/listbox/listbox.spec.tsx
@@ -230,13 +230,12 @@ describe("listbox", (): void => {
         expect(rendered.state("focusIndex")).toBe(5);
     });
 
-    test("should move focus to matching items as characters are typed", (): void => {
+    test("typeahead should be disabled when prop is set to false", (): void => {
         const rendered: any = mount(
-            <Listbox>
+            <Listbox typeAheadEnabled={false}>
                 {itemA}
                 {itemB}
                 {itemC}
-                <div>four</div>
             </Listbox>,
             { attachTo: container }
         );
@@ -247,13 +246,7 @@ describe("listbox", (): void => {
         expect(rendered.state("focusIndex")).toBe(0);
 
         rendered.childAt(0).simulate("keydown", { key: "b" });
-        expect(rendered.state("focusIndex")).toBe(1);
-
-        rendered.childAt(0).simulate("keydown", { key: "c" });
-        expect(rendered.state("focusIndex")).toBe(2);
-
-        rendered.childAt(0).simulate("keydown", { key: "d" });
-        expect(rendered.state("focusIndex")).toBe(2);
+        expect(rendered.state("focusIndex")).toBe(0);
     });
 
     test("changing the typeahead property key should work", (): void => {
@@ -725,5 +718,24 @@ describe("listbox", (): void => {
         expect(onSelectedItemsChanged).toHaveBeenCalledTimes(1);
         rendered.childAt(0).simulate("keydown", { keyCode: KeyCodes.arrowDown });
         expect(onSelectedItemsChanged).toHaveBeenCalledTimes(2);
+    });
+
+    test("should call a registered callback after selection invoked", (): void => {
+        const onItemInvoked: any = jest.fn();
+        const rendered: any = mount(
+            <Listbox onItemInvoked={onItemInvoked}>
+                {itemA}
+                {itemB}
+                {itemC}
+            </Listbox>,
+            { attachTo: container }
+        );
+
+        expect(onItemInvoked).toHaveBeenCalledTimes(0);
+        rendered
+            .childAt(0)
+            .childAt(0)
+            .simulate("click");
+        expect(onItemInvoked).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
# Description
In order to support the auto-suggest component listbox required some additional functionality:
- a prop to disable typeAhead functionality
- a prop for a callback when an item is invoked
- a behavior where supplying a new value for the "defaultSelection" prop in uncontrolled mode essentially resets focus and selection.

## Motivation & context
Functionality required to support auto-suggest

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.
