### PR TITLE
fix: update to disconnect the resize observer on component will unmount

### DIFF
--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -78,6 +78,11 @@ class HorizontalOverflow extends Foundation<
     private overflowEnd: boolean;
 
     /**
+     * Store a reference to a constructed resize observer
+     */
+    private resizeObserver?: ResizeObserverClassDefinition;
+
+    /**
      * Constructor
      */
     constructor(props: HorizontalOverflowProps) {
@@ -167,14 +172,14 @@ class HorizontalOverflow extends Foundation<
             // https://bugzilla.mozilla.org/show_bug.cgi?id=1272409
             // https://bugs.webkit.org/show_bug.cgi?id=157743
             if ((window as WindowWithResizeObserver).ResizeObserver) {
-                const resizeObserver: ResizeObserverClassDefinition = new (window as WindowWithResizeObserver).ResizeObserver(
+                this.resizeObserver = new (window as WindowWithResizeObserver).ResizeObserver(
                     (entries: ResizeObserverEntry[]): void => {
                         if (this.overflow !== this.isOverflow()) {
                             this.handleOverflowChange();
                         }
                     }
                 );
-                resizeObserver.observe(this.horizontalOverflowItemsRef.current);
+                this.resizeObserver.observe(this.horizontalOverflowItemsRef.current);
             }
         }
     }
@@ -189,6 +194,19 @@ class HorizontalOverflow extends Foundation<
                 this.throttledScroll
             );
             window.removeEventListener("resize", this.throttledResize);
+
+            // TODO #1142 https://github.com/Microsoft/fast-dna/issues/1142
+            // Full browser support imminent
+            // Revisit usage once Safari and Firefox adapt
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=1272409
+            // https://bugs.webkit.org/show_bug.cgi?id=157743
+            if (
+                this.resizeObserver &&
+                typeof this.resizeObserver.disconnect === "function"
+            ) {
+                this.resizeObserver.disconnect();
+                this.resizeObserver = null;
+            }
         }
     }
 


### PR DESCRIPTION
# Description
Added a private reference to the resize observer (resizeObserver) in horizontal-overflow. Assign the observer if it is created on component did mount and disconnect it on component will unmount

## Motivation & context
Bugfix for #1515

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.