### PR TITLE
fix: give components unique display names

### DIFF
--- a/build/helpers/file-includes-all-subdirectories-as-named-exports.ts
+++ b/build/helpers/file-includes-all-subdirectories-as-named-exports.ts
@@ -3,9 +3,9 @@ import fs from "fs";
 import { pascalCase } from "../../packages/fast-web-utilities";
 
 /**
- * Verifies all components in source directory are exported
+ * Verifies all components in source directory are exported, directories listed in "excludes" parameter are ignored
  */
-export function includesAllSubdirectoriesAsNamedExports(indexFile: string): boolean {
+export function includesAllSubdirectoriesAsNamedExports(indexFile: string, excludes?: string[]): boolean {
     // Get the folders in the indexFile directory to compare to export listing
     const directoryPath: string = path.dirname(indexFile);
     const components: string[] = fs.readdirSync(directoryPath)
@@ -15,7 +15,7 @@ export function includesAllSubdirectoriesAsNamedExports(indexFile: string): bool
 
     // Get listing of all exports and compare against folder listings
     const foundExports: any = Object.keys(require(path.resolve(__dirname, indexFile)));
-    const missingExports: string[] = components.filter((component: string) => !foundExports.includes(component));
+    const missingExports: string[] = components.filter((component: string) => !foundExports.includes(component) && excludes.indexOf(component) !== -1);
 
     if (missingExports.length === 0) {
         return true;

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
@@ -4,6 +4,7 @@ import { configure, mount, render, shallow } from "enzyme";
 import AutoSuggest, { AutoSuggestUnhandledProps } from "./auto-suggest";
 import ListboxItem from "../listbox-item";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -16,7 +17,9 @@ const itemC: JSX.Element = <ListboxItem id="c" value="c" />;
 
 describe("auto suggest", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((AutoSuggest as any).name).toBe(AutoSuggest.displayName);
+        expect(`${DisplayNamePrefix}${(AutoSuggest as any).name}`).toBe(
+            AutoSuggest.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {
@@ -117,7 +120,7 @@ describe("auto suggest", (): void => {
 
         rendered
             .find({ id: "a" })
-            .find("ListboxItem")
+            .find(ListboxItem.displayName)
             .simulate("keydown", { keyCode: KeyCodes.arrowDown });
         input = rendered.find("input");
         expect(input.prop("aria-owns")).toEqual("listboxId");
@@ -151,7 +154,7 @@ describe("auto suggest", (): void => {
 
         rendered
             .find({ id: "a" })
-            .find("ListboxItem")
+            .find(ListboxItem.displayName)
             .simulate("keydown", { keyCode: KeyCodes.arrowDown });
         input = rendered.find("input");
         expect(input.prop("aria-owns")).toEqual("listboxId");
@@ -182,7 +185,7 @@ describe("auto suggest", (): void => {
 
         rendered
             .find({ id: "a" })
-            .find("ListboxItem")
+            .find(ListboxItem.displayName)
             .simulate("keydown", { keyCode: KeyCodes.arrowDown });
         input = rendered.find("input");
         expect(input.prop("aria-activedescendant")).toEqual("b");
@@ -228,19 +231,19 @@ describe("auto suggest", (): void => {
         expect(rendered.state("value")).toEqual("a");
         rendered
             .find({ id: "a" })
-            .find("ListboxItem")
+            .find(ListboxItem.displayName)
             .simulate("keydown", { keyCode: KeyCodes.arrowDown });
         expect(document.activeElement.id).toBe("b");
         expect(rendered.state("value")).toEqual("b");
         rendered
             .find({ id: "b" })
-            .find("ListboxItem")
+            .find(ListboxItem.displayName)
             .simulate("keydown", { keyCode: KeyCodes.arrowDown });
         expect(document.activeElement.id).toBe("c");
         expect(rendered.state("value")).toEqual("c");
         rendered
             .find({ id: "c" })
-            .find("ListboxItem")
+            .find(ListboxItem.displayName)
             .simulate("keydown", { keyCode: KeyCodes.arrowDown });
         expect(document.activeElement.id).toBe("");
         expect(rendered.state("value")).toEqual("c");
@@ -249,19 +252,19 @@ describe("auto suggest", (): void => {
         expect(rendered.state("value")).toEqual("c");
         rendered
             .find({ id: "c" })
-            .find("ListboxItem")
+            .find(ListboxItem.displayName)
             .simulate("keydown", { keyCode: KeyCodes.arrowUp });
         expect(document.activeElement.id).toBe("b");
         expect(rendered.state("value")).toEqual("b");
         rendered
             .find({ id: "b" })
-            .find("ListboxItem")
+            .find(ListboxItem.displayName)
             .simulate("keydown", { keyCode: KeyCodes.arrowUp });
         expect(document.activeElement.id).toBe("a");
         expect(rendered.state("value")).toEqual("a");
         rendered
             .find({ id: "a" })
-            .find("ListboxItem")
+            .find(ListboxItem.displayName)
             .simulate("keydown", { keyCode: KeyCodes.arrowUp });
         expect(document.activeElement.id).toBe("");
         expect(rendered.state("value")).toEqual("a");
@@ -312,7 +315,7 @@ describe("auto suggest", (): void => {
         input.simulate("keydown", { keyCode: KeyCodes.arrowDown });
         rendered
             .find({ id: "a" })
-            .find("ListboxItem")
+            .find(ListboxItem.displayName)
             .simulate("keydown", { keyCode: KeyCodes.enter });
         expect(onInvoked).toHaveBeenCalledTimes(1);
 

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
@@ -12,6 +12,7 @@ import { ListboxItemProps } from "../listbox-item";
 import Listbox from "../listbox";
 import TextField, { TextFieldType } from "../text-field";
 import { AutoSuggestContext, AutoSuggestContextType } from "./auto-suggest-context";
+import { DisplayNamePrefix } from "../utilities";
 
 export interface AutoSuggestState {
     value: string;
@@ -24,7 +25,7 @@ class AutoSuggest extends Foundation<
     AutoSuggestUnhandledProps,
     AutoSuggestState
 > {
-    public static displayName: string = "AutoSuggest";
+    public static displayName: string = `${DisplayNamePrefix}AutoSuggest`;
 
     public static defaultProps: Partial<AutoSuggestProps> = {
         initialValue: "",

--- a/packages/fast-components-react-base/src/badge/badge.spec.tsx
+++ b/packages/fast-components-react-base/src/badge/badge.spec.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import Badge, { BadgeHandledProps, BadgeProps, BadgeUnhandledProps } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -9,8 +10,8 @@ import Badge, { BadgeHandledProps, BadgeProps, BadgeUnhandledProps } from "./ind
 configure({ adapter: new Adapter() });
 
 describe("badge", (): void => {
-    test("should have a displayName that matches the component name", () => {
-        expect((Badge as any).name).toBe(Badge.displayName);
+    test("should have a displayName that includes the component name", () => {
+        expect(`${DisplayNamePrefix}${(Badge as any).name}`).toBe(Badge.displayName);
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/badge/badge.tsx
+++ b/packages/fast-components-react-base/src/badge/badge.tsx
@@ -3,9 +3,9 @@ import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-
 import { BadgeClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { BadgeHandledProps, BadgeUnhandledProps } from "./badge.props";
 import { get } from "lodash-es";
-
+import { DisplayNamePrefix } from "../utilities";
 class Badge extends Foundation<BadgeHandledProps, BadgeUnhandledProps, {}> {
-    public static displayName: string = "Badge";
+    public static displayName: string = `${DisplayNamePrefix}Badge`;
 
     protected handledProps: HandledProps<BadgeHandledProps> = {
         managedClasses: void 0,

--- a/packages/fast-components-react-base/src/breadcrumb/breadcrumb.spec.tsx
+++ b/packages/fast-components-react-base/src/breadcrumb/breadcrumb.spec.tsx
@@ -5,6 +5,7 @@ import Breadcrumb, {
     BreadcrumbClassNameContract,
     BreadcrumbUnhandledProps,
 } from "./breadcrumb";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -21,7 +22,9 @@ const managedClasses: BreadcrumbClassNameContract = {
 
 describe("breadcrumb", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((Breadcrumb as any).name).toBe(Breadcrumb.displayName);
+        expect(`${DisplayNamePrefix}${(Breadcrumb as any).name}`).toBe(
+            Breadcrumb.displayName
+        );
     });
 
     test("should have correct root element type 'nav'", () => {

--- a/packages/fast-components-react-base/src/breadcrumb/breadcrumb.tsx
+++ b/packages/fast-components-react-base/src/breadcrumb/breadcrumb.tsx
@@ -8,13 +8,14 @@ import {
     BreadcrumbUnhandledProps,
 } from "./breadcrumb.props";
 import { get } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 class Breadcrumb extends Foundation<
     BreadcrumbHandledProps,
     BreadcrumbUnhandledProps,
     {}
 > {
-    public static displayName: string = "Breadcrumb";
+    public static displayName: string = `${DisplayNamePrefix}Breadcrumb`;
 
     protected handledProps: HandledProps<BreadcrumbHandledProps> = {
         children: void 0,

--- a/packages/fast-components-react-base/src/button/button.spec.tsx
+++ b/packages/fast-components-react-base/src/button/button.spec.tsx
@@ -11,6 +11,7 @@ import Button, {
     ButtonProps,
     ButtonUnhandledProps,
 } from "./button";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -24,7 +25,7 @@ describe("button", (): void => {
     const href: string = "https://www.microsoft.com";
 
     test("should have a displayName that matches the component name", () => {
-        expect((Button as any).name).toBe(Button.displayName);
+        expect(`${DisplayNamePrefix}${(Button as any).name}`).toBe(Button.displayName);
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/button/button.tsx
+++ b/packages/fast-components-react-base/src/button/button.tsx
@@ -7,6 +7,7 @@ import {
     ButtonClassNameContract,
     ManagedClasses,
 } from "@microsoft/fast-components-class-name-contracts-base";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * Button HTML tags
@@ -17,7 +18,7 @@ export enum ButtonHTMLTags {
 }
 
 class Button extends Foundation<ButtonHandledProps, ButtonUnhandledProps, {}> {
-    public static displayName: string = "Button";
+    public static displayName: string = `${DisplayNamePrefix}Button`;
 
     protected handledProps: HandledProps<ButtonHandledProps> = {
         disabled: void 0,

--- a/packages/fast-components-react-base/src/card/card.spec.tsx
+++ b/packages/fast-components-react-base/src/card/card.spec.tsx
@@ -10,6 +10,7 @@ import Card, {
     CardTag,
     CardUnhandledProps,
 } from "./card";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -22,7 +23,7 @@ describe("card", (): void => {
     };
 
     test("should have a displayName that matches the component name", () => {
-        expect((Card as any).name).toBe(Card.displayName);
+        expect(`${DisplayNamePrefix}${(Card as any).name}`).toBe(Card.displayName);
     });
 
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {

--- a/packages/fast-components-react-base/src/card/card.tsx
+++ b/packages/fast-components-react-base/src/card/card.tsx
@@ -12,9 +12,9 @@ import {
     CardClassNameContract,
     ManagedClasses,
 } from "@microsoft/fast-components-class-name-contracts-base";
-
+import { DisplayNamePrefix } from "../utilities";
 class Card extends Foundation<CardHandledProps, CardUnhandledProps, {}> {
-    public static displayName: string = "Card";
+    public static displayName: string = `${DisplayNamePrefix}Card`;
 
     protected handledProps: HandledProps<CardHandledProps> = {
         children: void 0,

--- a/packages/fast-components-react-base/src/checkbox/checkbox.spec.tsx
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.spec.tsx
@@ -12,6 +12,7 @@ import Checkbox, {
     CheckboxState,
     CheckboxUnhandledProps,
 } from "./checkbox";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -30,7 +31,9 @@ describe("checkbox", (): void => {
     const inputSelector: string = `.${managedClasses.checkbox_input}`;
 
     test("should have a displayName that matches the component name", () => {
-        expect((Checkbox as any).name).toBe(Checkbox.displayName);
+        expect(`${DisplayNamePrefix}${(Checkbox as any).name}`).toBe(
+            Checkbox.displayName
+        );
     });
 
     test("should have correct input attribute type 'checkbox'", () => {

--- a/packages/fast-components-react-base/src/checkbox/checkbox.tsx
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.tsx
@@ -13,6 +13,7 @@ import {
     ManagedClasses,
 } from "@microsoft/fast-components-class-name-contracts-base";
 import { get } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * Checkbox state interface
@@ -26,7 +27,7 @@ class Checkbox extends Foundation<
     CheckboxUnhandledProps,
     CheckboxState
 > {
-    public static displayName: string = "Checkbox";
+    public static displayName: string = `${DisplayNamePrefix}Checkbox`;
 
     /**
      * React life-cycle method

--- a/packages/fast-components-react-base/src/context-menu-item/context-menu-item.spec.tsx
+++ b/packages/fast-components-react-base/src/context-menu-item/context-menu-item.spec.tsx
@@ -8,6 +8,7 @@ import ContextMenuItem, {
     ContextMenuItemUnhandledProps,
 } from "./context-menu-item";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -16,7 +17,9 @@ configure({ adapter: new Adapter() });
 
 describe("context menu item", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((ContextMenuItem as any).name).toBe(ContextMenuItem.displayName);
+        expect(`${DisplayNamePrefix}${(ContextMenuItem as any).name}`).toBe(
+            ContextMenuItem.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/context-menu-item/context-menu-item.tsx
+++ b/packages/fast-components-react-base/src/context-menu-item/context-menu-item.tsx
@@ -8,6 +8,7 @@ import {
     ContextMenuItemProps,
     ContextMenuItemUnhandledProps,
 } from "./context-menu-item.props";
+import { DisplayNamePrefix } from "../utilities";
 
 export enum ContextMenuItemRole {
     menuItem = "menuitem",
@@ -20,7 +21,7 @@ class ContextMenuItem extends Foundation<
     ContextMenuItemUnhandledProps,
     {}
 > {
-    public static displayName: string = "ContextMenuItem";
+    public static displayName: string = `${DisplayNamePrefix}ContextMenuItem`;
 
     public static defaultProps: Partial<ContextMenuItemProps> = {
         role: ContextMenuItemRole.menuItem,

--- a/packages/fast-components-react-base/src/context-menu/context-menu.spec.tsx
+++ b/packages/fast-components-react-base/src/context-menu/context-menu.spec.tsx
@@ -4,6 +4,7 @@ import { configure, mount, shallow, ShallowWrapper } from "enzyme";
 import ContextMenu, { ContextMenuUnhandledProps } from "./context-menu";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 import { ContextMenuItemRole } from "../context-menu-item";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -12,7 +13,9 @@ configure({ adapter: new Adapter() });
 
 describe("context menu", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((ContextMenu as any).name).toBe(ContextMenu.displayName);
+        expect(`${DisplayNamePrefix}${(ContextMenu as any).name}`).toBe(
+            ContextMenu.displayName
+        );
     });
 
     test("should have correct role attribute 'menu'", () => {

--- a/packages/fast-components-react-base/src/context-menu/context-menu.tsx
+++ b/packages/fast-components-react-base/src/context-menu/context-menu.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 import { get, inRange, invert } from "lodash-es";
 import { canUseDOM } from "exenv-es6";
+import { DisplayNamePrefix } from "../utilities";
 
 export interface ContextMenuState {
     /**
@@ -24,7 +25,7 @@ class ContextMenu extends Foundation<
     ContextMenuUnhandledProps,
     ContextMenuState
 > {
-    public static displayName: string = "ContextMenu";
+    public static displayName: string = `${DisplayNamePrefix}ContextMenu`;
 
     private static focusableElementRoles: { [key: string]: string } = invert(
         ContextMenuItemRole

--- a/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
@@ -12,6 +12,7 @@ import Dialog, {
     DialogUnhandledProps,
 } from "./dialog";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -26,7 +27,7 @@ describe("dialog", (): void => {
     };
 
     test("should have a displayName that matches the component name", () => {
-        expect((Dialog as any).name).toBe(Dialog.displayName);
+        expect(`${DisplayNamePrefix}${(Dialog as any).name}`).toBe(Dialog.displayName);
     });
 
     test("should have correct element attribute role 'dialog'", () => {

--- a/packages/fast-components-react-base/src/dialog/dialog.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@microsoft/fast-components-class-name-contracts-base";
 import { canUseDOM } from "exenv-es6";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
+import { DisplayNamePrefix } from "../utilities";
 
 class Dialog extends Foundation<DialogHandledProps, DialogUnhandledProps, {}> {
     public static defaultProps: Partial<DialogProps> = {
@@ -22,7 +23,7 @@ class Dialog extends Foundation<DialogHandledProps, DialogUnhandledProps, {}> {
         visible: false,
     };
 
-    public static displayName: string = "Dialog";
+    public static displayName: string = `${DisplayNamePrefix}Dialog`;
 
     protected handledProps: HandledProps<DialogHandledProps> = {
         describedBy: void 0,

--- a/packages/fast-components-react-base/src/divider/divider.spec.tsx
+++ b/packages/fast-components-react-base/src/divider/divider.spec.tsx
@@ -10,6 +10,7 @@ import Divider, {
     DividerRoles,
     DividerUnhandledProps,
 } from "./divider";
+import { DisplayNamePrefix } from "../utilities";
 
 configure({ adapter: new Adapter() });
 
@@ -19,7 +20,7 @@ describe("divider", (): void => {
     };
 
     test("should have a displayName that matches the component name", () => {
-        expect((Divider as any).name).toBe(Divider.displayName);
+        expect(`${DisplayNamePrefix}${(Divider as any).name}`).toBe(Divider.displayName);
     });
 
     test("should have correct root element type 'hr'", () => {

--- a/packages/fast-components-react-base/src/divider/divider.tsx
+++ b/packages/fast-components-react-base/src/divider/divider.tsx
@@ -12,10 +12,11 @@ import {
     DividerClassNameContract,
     ManagedClasses,
 } from "@microsoft/fast-components-class-name-contracts-base";
+import { DisplayNamePrefix } from "../utilities";
 
 /* tslint:disable-next-line */
 class Divider extends Foundation<DividerHandledProps, DividerUnhandledProps, {}> {
-    public static displayName: string = "Divider";
+    public static displayName: string = `${DisplayNamePrefix}Divider`;
 
     protected handledProps: HandledProps<DividerHandledProps> = {
         managedClasses: void 0,

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -7,6 +7,7 @@ import HorizontalOverflow, {
 } from "./";
 import "raf/polyfill";
 import { ConstructableResizeObserver } from "./resize-observer";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -57,7 +58,9 @@ const managedClasses: HorizontalOverflowClassNameContract = {
 /* tslint:disable:no-string-literal */
 describe("horizontal overflow", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((HorizontalOverflow as any).name).toBe(HorizontalOverflow.displayName);
+        expect(`${DisplayNamePrefix}${(HorizontalOverflow as any).name}`).toBe(
+            HorizontalOverflow.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -20,6 +20,7 @@ import {
     ResizeObserverClassDefinition,
 } from "./resize-observer";
 import { ResizeObserverEntry } from "./resize-observer-entry";
+import { DisplayNamePrefix } from "../utilities";
 
 export enum ButtonDirection {
     previous = "previous",
@@ -41,7 +42,7 @@ class HorizontalOverflow extends Foundation<
     HorizontalOverflowUnhandledProps,
     HorizontalOverflowState
 > {
-    public static displayName: string = "HorizontalOverflow";
+    public static displayName: string = `${DisplayNamePrefix}HorizontalOverflow`;
 
     protected handledProps: HandledProps<HorizontalOverflowHandledProps> = {
         scrollDuration: void 0,

--- a/packages/fast-components-react-base/src/hypertext/hypertext.spec.tsx
+++ b/packages/fast-components-react-base/src/hypertext/hypertext.spec.tsx
@@ -10,6 +10,7 @@ import Hypertext, {
     HypertextProps,
     HypertextUnhandledProps,
 } from "./hypertext";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -22,7 +23,9 @@ describe("hypertext", (): void => {
     };
 
     test("should have a displayName that matches the component name", () => {
-        expect((Hypertext as any).name).toBe(Hypertext.displayName);
+        expect(`${DisplayNamePrefix}${(Hypertext as any).name}`).toBe(
+            Hypertext.displayName
+        );
     });
 
     test("should have correct root element type 'a'", () => {

--- a/packages/fast-components-react-base/src/hypertext/hypertext.tsx
+++ b/packages/fast-components-react-base/src/hypertext/hypertext.tsx
@@ -11,9 +11,10 @@ import {
     ManagedClasses,
 } from "@microsoft/fast-components-class-name-contracts-base";
 import { get } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 class Hypertext extends Foundation<HypertextHandledProps, HypertextUnhandledProps, {}> {
-    public static displayName: string = "Hypertext";
+    public static displayName: string = `${DisplayNamePrefix}Hypertext`;
 
     protected handledProps: HandledProps<HypertextHandledProps> = {
         managedClasses: void 0,

--- a/packages/fast-components-react-base/src/image/image.spec.tsx
+++ b/packages/fast-components-react-base/src/image/image.spec.tsx
@@ -11,6 +11,7 @@ import Image, {
     ImageSlot,
     ImageUnhandledProps,
 } from "./image";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -25,7 +26,7 @@ describe("image", (): void => {
     const alt: string = "Image alt text test string";
 
     test("should have a displayName that matches the component name", () => {
-        expect((Image as any).name).toBe(Image.displayName);
+        expect(`${DisplayNamePrefix}${(Image as any).name}`).toBe(Image.displayName);
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/image/image.tsx
+++ b/packages/fast-components-react-base/src/image/image.tsx
@@ -11,13 +11,14 @@ import {
     ImageClassNameContract,
     ManagedClasses,
 } from "@microsoft/fast-components-class-name-contracts-base";
+import { DisplayNamePrefix } from "../utilities";
 
 export enum ImageSlot {
     source = "source",
 }
 
 class Image extends Foundation<ImageHandledProps, ImageUnhandledProps, {}> {
-    public static displayName: string = "Image";
+    public static displayName: string = `${DisplayNamePrefix}Image`;
 
     protected handledProps: HandledProps<ImageHandledProps> = {
         managedClasses: void 0,

--- a/packages/fast-components-react-base/src/index.spec.ts
+++ b/packages/fast-components-react-base/src/index.spec.ts
@@ -4,7 +4,9 @@ import { includesAllSubdirectoriesAsNamedExports } from "../../../build/helpers/
 describe("index.ts", (): void => {
     test("should export all components in the src directory", () => {
         expect(() => {
-            includesAllSubdirectoriesAsNamedExports(path.resolve(__dirname, "index.ts"));
+            includesAllSubdirectoriesAsNamedExports(path.resolve(__dirname, "index.ts"), [
+                "utilities",
+            ]);
         }).not.toThrow();
     });
 });

--- a/packages/fast-components-react-base/src/label/label.spec.tsx
+++ b/packages/fast-components-react-base/src/label/label.spec.tsx
@@ -11,6 +11,7 @@ import Label, {
     LabelTag,
     LabelUnhandledProps,
 } from "./label";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -24,7 +25,7 @@ describe("label", (): void => {
     };
 
     test("should have a displayName that matches the component name", () => {
-        expect((Label as any).name).toBe(Label.displayName);
+        expect(`${DisplayNamePrefix}${(Label as any).name}`).toBe(Label.displayName);
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/label/label.tsx
+++ b/packages/fast-components-react-base/src/label/label.tsx
@@ -13,9 +13,9 @@ import {
     LabelClassNameContract,
     ManagedClasses,
 } from "@microsoft/fast-components-class-name-contracts-base";
-
+import { DisplayNamePrefix } from "../utilities";
 class Label extends Foundation<LabelHandledProps, LabelUnhandledProps, {}> {
-    public static displayName: string = "Label";
+    public static displayName: string = `${DisplayNamePrefix}Label`;
 
     public static defaultProps: Partial<LabelProps> = {
         tag: LabelTag.label,

--- a/packages/fast-components-react-base/src/listbox-item/listbox-item.spec.tsx
+++ b/packages/fast-components-react-base/src/listbox-item/listbox-item.spec.tsx
@@ -8,6 +8,7 @@ import ListboxItem, {
 } from "./listbox-item";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 import { noop } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -16,7 +17,9 @@ configure({ adapter: new Adapter() });
 
 describe("listbox item", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((ListboxItem as any).name).toBe(ListboxItem.displayName);
+        expect(`${DisplayNamePrefix}${(ListboxItem as any).name}`).toBe(
+            ListboxItem.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/listbox-item/listbox-item.tsx
+++ b/packages/fast-components-react-base/src/listbox-item/listbox-item.tsx
@@ -9,13 +9,14 @@ import {
 } from "./listbox-item.props";
 import { ListboxContext, ListboxContextType } from "../listbox/listbox-context";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
+import { DisplayNamePrefix } from "../utilities";
 
 class ListboxItem extends Foundation<
     ListboxItemHandledProps,
     ListboxItemUnhandledProps,
     {}
 > {
-    public static displayName: string = "ListboxItem";
+    public static displayName: string = `${DisplayNamePrefix}ListboxItem`;
 
     public static contextType: React.Context<ListboxContextType> = ListboxContext;
 

--- a/packages/fast-components-react-base/src/listbox/listbox.spec.tsx
+++ b/packages/fast-components-react-base/src/listbox/listbox.spec.tsx
@@ -4,6 +4,7 @@ import { configure, mount, render, shallow } from "enzyme";
 import Listbox, { ListboxUnhandledProps } from "./listbox";
 import ListboxItem from "../listbox-item";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -22,7 +23,7 @@ document.body.appendChild(container);
 
 describe("listbox", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((Listbox as any).name).toBe(Listbox.displayName);
+        expect(`${DisplayNamePrefix}${(Listbox as any).name}`).toBe(Listbox.displayName);
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/listbox/listbox.tsx
+++ b/packages/fast-components-react-base/src/listbox/listbox.tsx
@@ -12,7 +12,7 @@ import { get, inRange, isEqual } from "lodash-es";
 import { canUseDOM } from "exenv-es6";
 import { ListboxContext, ListboxContextType } from "./listbox-context";
 import { ListboxItemProps } from "../listbox-item";
-
+import { DisplayNamePrefix } from "../utilities";
 export interface ListboxState {
     /**
      * The index of the focusable child
@@ -27,7 +27,7 @@ class Listbox extends Foundation<
     ListboxUnhandledProps,
     ListboxState
 > {
-    public static displayName: string = "Listbox";
+    public static displayName: string = `${DisplayNamePrefix}Listbox`;
 
     public static defaultProps: Partial<ListboxProps> = {
         multiselectable: false,

--- a/packages/fast-components-react-base/src/number-field/number-field.spec.tsx
+++ b/packages/fast-components-react-base/src/number-field/number-field.spec.tsx
@@ -7,6 +7,7 @@ import NumberField, {
     NumberFieldProps,
     NumberFieldUnhandledProps,
 } from "./";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -21,7 +22,9 @@ const managedClasses: NumberFieldManagedClasses = {
 
 describe("number field", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((NumberField as any).name).toBe(NumberField.displayName);
+        expect(`${DisplayNamePrefix}${(NumberField as any).name}`).toBe(
+            NumberField.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/number-field/number-field.tsx
+++ b/packages/fast-components-react-base/src/number-field/number-field.tsx
@@ -13,13 +13,14 @@ import {
     NumberFieldClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-base";
 import { TextFieldType } from "../text-field/index";
+import { DisplayNamePrefix } from "../utilities";
 
 class NumberField extends Foundation<
     NumberFieldHandledProps,
     NumberFieldUnhandledProps,
     {}
 > {
-    public static displayName: string = "NumberField";
+    public static displayName: string = `${DisplayNamePrefix}NumberField`;
 
     protected handledProps: HandledProps<NumberFieldHandledProps> = {
         managedClasses: void 0,

--- a/packages/fast-components-react-base/src/progress/progress.spec.tsx
+++ b/packages/fast-components-react-base/src/progress/progress.spec.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow, ShallowWrapper } from "enzyme";
 import Progress, { ProgressClassNameContract, ProgressType } from "./";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -14,7 +15,9 @@ const managedClasses: ProgressClassNameContract = {
 
 describe("progress", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((Progress as any).name).toBe(Progress.displayName);
+        expect(`${DisplayNamePrefix}${(Progress as any).name}`).toBe(
+            Progress.displayName
+        );
     });
 
     test("should have correct element attribute role 'progressbar'", () => {

--- a/packages/fast-components-react-base/src/progress/progress.tsx
+++ b/packages/fast-components-react-base/src/progress/progress.tsx
@@ -12,6 +12,7 @@ import {
     ManagedClasses,
     ProgressClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-base";
+import { DisplayNamePrefix } from "../utilities";
 
 export enum ProgressType {
     determinate = "determinate",
@@ -24,7 +25,7 @@ class Progress extends Foundation<ProgressHandledProps, ProgressUnhandledProps, 
         maxValue: 100,
     };
 
-    public static displayName: string = "Progress";
+    public static displayName: string = `${DisplayNamePrefix}Progress`;
 
     protected handledProps: HandledProps<ProgressHandledProps> = {
         children: void 0,

--- a/packages/fast-components-react-base/src/radio/radio.spec.tsx
+++ b/packages/fast-components-react-base/src/radio/radio.spec.tsx
@@ -9,6 +9,7 @@ import Radio, {
     RadioSlot,
 } from "./radio";
 import Label from "../label";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * Configure Enzyme
@@ -27,7 +28,7 @@ describe("radio", (): void => {
     const inputSelector: string = `.${managedClasses.radio_input}`;
 
     test("should have a displayName that matches the component name", () => {
-        expect((Radio as any).name).toBe(Radio.displayName);
+        expect(`${DisplayNamePrefix}${(Radio as any).name}`).toBe(Radio.displayName);
     });
 
     test("should have correct input type attribute 'radio'", () => {

--- a/packages/fast-components-react-base/src/radio/radio.tsx
+++ b/packages/fast-components-react-base/src/radio/radio.tsx
@@ -12,6 +12,7 @@ import {
     RadioClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-base";
 import { get } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * Radio slot options
@@ -25,7 +26,7 @@ interface RadioState {
 }
 
 class Radio extends Foundation<RadioHandledProps, RadioUnhandledProps, RadioState> {
-    public static displayName: string = "Radio";
+    public static displayName: string = `${DisplayNamePrefix}Radio`;
 
     public static getDerivedStateFromProps(
         nextProps: RadioProps,

--- a/packages/fast-components-react-base/src/select/select.spec.tsx
+++ b/packages/fast-components-react-base/src/select/select.spec.tsx
@@ -4,6 +4,7 @@ import { configure, mount, render, shallow } from "enzyme";
 import Select, { SelectUnhandledProps } from "./select";
 import ListboxItem from "../listbox-item";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -22,7 +23,7 @@ document.body.appendChild(container);
 
 describe("select", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((Select as any).name).toBe(Select.displayName);
+        expect(`${DisplayNamePrefix}${(Select as any).name}`).toBe(Select.displayName);
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -8,6 +8,7 @@ import { ListboxItemProps } from "../listbox-item";
 import Listbox from "../listbox";
 import Button from "../button";
 import { canUseDOM } from "exenv-es6";
+import { DisplayNamePrefix } from "../utilities";
 
 export interface SelectState {
     value: string | string[];
@@ -17,7 +18,7 @@ export interface SelectState {
 }
 
 class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, SelectState> {
-    public static displayName: string = "Select";
+    public static displayName: string = `${DisplayNamePrefix}Select`;
 
     public static defaultProps: Partial<SelectProps> = {
         multiselectable: false,

--- a/packages/fast-components-react-base/src/tabs/tab-item.tsx
+++ b/packages/fast-components-react-base/src/tabs/tab-item.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { TabItemHandledProps, TabItemUnhandledProps } from "./tab-item.props";
+import { DisplayNamePrefix } from "../utilities";
 
 class TabItem extends Foundation<TabItemHandledProps, TabItemUnhandledProps, {}> {
-    public static displayName: string = "TabItem";
+    public static displayName: string = `${DisplayNamePrefix}TabItem`;
 }
 
 export default TabItem;

--- a/packages/fast-components-react-base/src/tabs/tab-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/tabs/tab-panel.spec.tsx
@@ -1,10 +1,9 @@
 import Adapter from "enzyme-adapter-react-16";
 import React from "react";
-
 import { TabPanelHandledProps, TabPanelProps } from "./tab-panel.props";
 import { configure, shallow, ShallowWrapper } from "enzyme";
-
 import TabPanel from "./tab-panel";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * Configure Enzyme

--- a/packages/fast-components-react-base/src/tabs/tab-panel.tsx
+++ b/packages/fast-components-react-base/src/tabs/tab-panel.tsx
@@ -11,13 +11,14 @@ import {
     TabPanelProps,
     TabPanelUnhandledProps,
 } from "./tab-panel.props";
+import { DisplayNamePrefix } from "../utilities";
 
 class TabPanel extends Foundation<TabPanelHandledProps, TabPanelUnhandledProps, {}> {
     public static defaultProps: Partial<TabPanelProps> = {
         active: false,
     };
 
-    public static displayName: string = "TabPanel";
+    public static displayName: string = `${DisplayNamePrefix}TabPanel`;
 
     protected handledProps: HandledProps<TabPanelHandledProps> = {
         managedClasses: void 0,

--- a/packages/fast-components-react-base/src/tabs/tab.spec.tsx
+++ b/packages/fast-components-react-base/src/tabs/tab.spec.tsx
@@ -1,10 +1,9 @@
 import Adapter from "enzyme-adapter-react-16";
 import React from "react";
-
 import { TabHandledProps, TabProps } from "./tab.props";
 import { configure, shallow, ShallowWrapper } from "enzyme";
-
 import Tab from "./tab";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * Configure Enzyme

--- a/packages/fast-components-react-base/src/tabs/tab.tsx
+++ b/packages/fast-components-react-base/src/tabs/tab.tsx
@@ -11,13 +11,14 @@ import {
     TabProps,
     TabUnhandledProps,
 } from "./tab.props";
+import { DisplayNamePrefix } from "../utilities";
 
 class Tab extends Foundation<TabHandledProps, TabUnhandledProps, {}> {
     public static defaultProps: Partial<TabProps> = {
         active: false,
     };
 
-    public static displayName: string = "Tab";
+    public static displayName: string = `${DisplayNamePrefix}Tab`;
 
     protected handledProps: HandledProps<TabHandledProps> = {
         managedClasses: void 0,

--- a/packages/fast-components-react-base/src/tabs/tabs.spec.tsx
+++ b/packages/fast-components-react-base/src/tabs/tabs.spec.tsx
@@ -20,6 +20,7 @@ import Tabs, {
     TabsSlot,
     TabsUnhandledProps,
 } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 export enum CustomTabsSlot {
     tab = "customTab",
@@ -145,7 +146,7 @@ describe("tabs", (): void => {
     });
 
     test("should have a displayName that matches the component name", () => {
-        expect((Tabs as any).name).toBe(Tabs.displayName);
+        expect(`${DisplayNamePrefix}${(Tabs as any).name}`).toBe(Tabs.displayName);
     });
 
     test("should not throw if managedClasses are not provided", () => {
@@ -242,17 +243,29 @@ describe("tabs", (): void => {
             </Tabs>
         );
 
-        expect(renderedWithChildren.find("Tab").get(0).props["aria-controls"]).toBe(id0);
         expect(
-            renderedWithChildren.find("TabPanel").get(0).props["aria-labelledby"]
+            renderedWithChildren.find(Tab.displayName).get(0).props["aria-controls"]
         ).toBe(id0);
-        expect(renderedWithChildren.find("Tab").get(1).props["aria-controls"]).toBe(id1);
         expect(
-            renderedWithChildren.find("TabPanel").get(1).props["aria-labelledby"]
+            renderedWithChildren.find(TabPanel.displayName).get(0).props[
+                "aria-labelledby"
+            ]
+        ).toBe(id0);
+        expect(
+            renderedWithChildren.find(Tab.displayName).get(1).props["aria-controls"]
         ).toBe(id1);
-        expect(renderedWithChildren.find("Tab").get(2).props["aria-controls"]).toBe(id2);
         expect(
-            renderedWithChildren.find("TabPanel").get(2).props["aria-labelledby"]
+            renderedWithChildren.find(TabPanel.displayName).get(1).props[
+                "aria-labelledby"
+            ]
+        ).toBe(id1);
+        expect(
+            renderedWithChildren.find(Tab.displayName).get(2).props["aria-controls"]
+        ).toBe(id2);
+        expect(
+            renderedWithChildren.find(TabPanel.displayName).get(2).props[
+                "aria-labelledby"
+            ]
         ).toBe(id2);
     });
 
@@ -281,7 +294,7 @@ describe("tabs", (): void => {
         );
 
         expect(renderedWithChildren.prop("children")).not.toBe(undefined);
-        expect(renderedWithChildren.find("Tab").length).toEqual(3);
+        expect(renderedWithChildren.find(Tab.displayName).length).toEqual(3);
     });
 
     test("should handle non existing active id set in props by keeping previous tab active.", () => {
@@ -291,10 +304,10 @@ describe("tabs", (): void => {
             </Tabs>
         );
 
-        expect(renderedWithChildren.find("Tab").length).toEqual(3);
+        expect(renderedWithChildren.find(Tab.displayName).length).toEqual(3);
 
-        const tab1: any = renderedWithChildren.find("Tab").at(0);
-        const tab2: any = renderedWithChildren.find("Tab").at(1);
+        const tab1: any = renderedWithChildren.find(Tab.displayName).at(0);
+        const tab2: any = renderedWithChildren.find(Tab.displayName).at(1);
 
         expect(tab1.prop("active")).toEqual(true);
         expect(tab2.prop("active")).toEqual(false);
@@ -351,42 +364,42 @@ describe("tabs", (): void => {
             />
         );
 
-        const tab1: any = rendered.find("Tab").at(0);
-        const tab2: any = rendered.find("Tab").at(1);
+        const tab1: any = rendered.find(Tab.displayName).at(0);
+        const tab2: any = rendered.find(Tab.displayName).at(1);
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -399,37 +412,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -440,37 +453,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -481,37 +494,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -522,37 +535,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -563,37 +576,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -604,37 +617,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -645,37 +658,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -684,37 +697,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -733,23 +746,23 @@ describe("tabs", (): void => {
         );
 
         rendered
-            .find("Tab")
+            .find(Tab.displayName)
             .at(0)
             .simulate("keydown", { keyCode: KeyCodes.end });
         rendered
-            .find("Tab")
+            .find(Tab.displayName)
             .at(0)
             .simulate("keydown", { keyCode: KeyCodes.home });
         rendered
-            .find("Tab")
+            .find(Tab.displayName)
             .at(0)
             .simulate("keydown", { keyCode: KeyCodes.arrowLeft });
         rendered
-            .find("Tab")
+            .find(Tab.displayName)
             .at(0)
             .simulate("keydown", { keyCode: KeyCodes.arrowRight });
         rendered
-            .find("Tab")
+            .find(Tab.displayName)
             .at(0)
             .simulate("click", {
                 currentTarget: { getAttribute: (): string => id1 },
@@ -765,43 +778,43 @@ describe("tabs", (): void => {
             />
         );
 
-        const tab1: any = rendered.find("Tab").at(0);
-        const tab2: any = rendered.find("Tab").at(1);
-        const tab3: any = rendered.find("Tab").at(2);
+        const tab1: any = rendered.find(Tab.displayName).at(0);
+        const tab2: any = rendered.find(Tab.displayName).at(1);
+        const tab3: any = rendered.find(Tab.displayName).at(2);
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -810,37 +823,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(true);
@@ -849,37 +862,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -888,37 +901,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -927,37 +940,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -966,37 +979,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(true);
@@ -1005,37 +1018,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -1044,37 +1057,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(true);
@@ -1083,37 +1096,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -1124,37 +1137,37 @@ describe("tabs", (): void => {
 
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(0);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("tabIndex")
         ).toEqual(-1);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .prop("active")
         ).toBe(false);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("active")
         ).toBe(true);
         expect(
             rendered
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(2)
                 .prop("active")
         ).toBe(false);
@@ -1213,7 +1226,7 @@ describe("tabs", (): void => {
 
         expect(
             renderedWithChildren
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(0);
@@ -1222,7 +1235,7 @@ describe("tabs", (): void => {
 
 describe("Tab", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((Tab as any).name).toBe(Tab.displayName);
+        expect(`${DisplayNamePrefix}${(Tab as any).name}`).toBe(Tab.displayName);
     });
 
     test("should not throw if managedClasses are not provided", () => {
@@ -1235,13 +1248,15 @@ describe("Tab", (): void => {
 
 describe("TabItem", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((TabItem as any).name).toBe(TabItem.displayName);
+        expect(`${DisplayNamePrefix}${(TabItem as any).name}`).toBe(TabItem.displayName);
     });
 });
 
 describe("TabPanel", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((TabPanel as any).name).toBe(TabPanel.displayName);
+        expect(`${DisplayNamePrefix}${(TabPanel as any).name}`).toBe(
+            TabPanel.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/tabs/tabs.tsx
+++ b/packages/fast-components-react-base/src/tabs/tabs.tsx
@@ -16,6 +16,7 @@ import {
 import Tab, { TabManagedClasses } from "./tab";
 import TabItem from "./tab-item";
 import TabPanel, { TabPanelManagedClasses } from "./tab-panel";
+import { DisplayNamePrefix } from "../utilities";
 
 export enum TabLocation {
     first,
@@ -35,7 +36,7 @@ export interface TabsState {
 }
 
 class Tabs extends Foundation<TabsHandledProps, TabsUnhandledProps, TabsState> {
-    public static displayName: string = "Tabs";
+    public static displayName: string = `${DisplayNamePrefix}Tabs`;
 
     /**
      * React life-cycle method

--- a/packages/fast-components-react-base/src/text-area/text-area.spec.tsx
+++ b/packages/fast-components-react-base/src/text-area/text-area.spec.tsx
@@ -10,6 +10,7 @@ import TextArea, {
     TextAreaProps,
     TextAreaUnhandledProps,
 } from "./text-area";
+import { DisplayNamePrefix } from "../utilities";
 
 const managedClasses: TextAreaClassNameContract = {
     textArea: "text-area-class",
@@ -22,7 +23,9 @@ configure({ adapter: new Adapter() });
 
 describe("text-area", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((TextArea as any).name).toBe(TextArea.displayName);
+        expect(`${DisplayNamePrefix}${(TextArea as any).name}`).toBe(
+            TextArea.displayName
+        );
     });
 
     test("should have correct root element type 'textarea'", () => {

--- a/packages/fast-components-react-base/src/text-area/text-area.tsx
+++ b/packages/fast-components-react-base/src/text-area/text-area.tsx
@@ -11,9 +11,10 @@ import {
     TextAreaClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-base";
 import { get } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 class TextArea extends Foundation<TextAreaHandledProps, TextAreaUnhandledProps, {}> {
-    public static displayName: string = "TextArea";
+    public static displayName: string = `${DisplayNamePrefix}TextArea`;
 
     protected handledProps: HandledProps<TextAreaHandledProps> = {
         managedClasses: void 0,

--- a/packages/fast-components-react-base/src/text-field/text-field.spec.tsx
+++ b/packages/fast-components-react-base/src/text-field/text-field.spec.tsx
@@ -11,6 +11,7 @@ import TextField, {
     TextFieldType,
     TextFieldUnhandledProps,
 } from "./text-field";
+import { DisplayNamePrefix } from "../utilities";
 
 const managedClasses: TextFieldClassNameContract = {
     textField: "text-field-class",
@@ -23,7 +24,9 @@ configure({ adapter: new Adapter() });
 
 describe("text-field", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((TextField as any).name).toBe(TextField.displayName);
+        expect(`${DisplayNamePrefix}${(TextField as any).name}`).toBe(
+            TextField.displayName
+        );
     });
 
     test("should have correct root element type 'input'", () => {

--- a/packages/fast-components-react-base/src/text-field/text-field.tsx
+++ b/packages/fast-components-react-base/src/text-field/text-field.tsx
@@ -12,9 +12,10 @@ import {
     TextFieldClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-base";
 import { get } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 class TextField extends Foundation<TextFieldHandledProps, TextFieldUnhandledProps, {}> {
-    public static displayName: string = "TextField";
+    public static displayName: string = `${DisplayNamePrefix}TextField`;
 
     protected handledProps: HandledProps<TextFieldHandledProps> = {
         managedClasses: void 0,

--- a/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
@@ -11,6 +11,7 @@ import Toggle, {
     ToggleState,
     ToggleUnhandledProps,
 } from "./toggle";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -36,7 +37,7 @@ describe("toggle", (): void => {
     const inputSelector: string = `.${managedClasses.toggle_input}`;
 
     test("should have a displayName that matches the component name", () => {
-        expect((Toggle as any).name).toBe(Toggle.displayName);
+        expect(`${DisplayNamePrefix}${(Toggle as any).name}`).toBe(Toggle.displayName);
     });
 
     test("should have correct input type attribute 'checkbox'", () => {

--- a/packages/fast-components-react-base/src/toggle/toggle.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.tsx
@@ -12,6 +12,7 @@ import {
     ManagedClasses,
     ToggleClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-base";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * Toggle state interface
@@ -24,7 +25,7 @@ export interface ToggleState {
  * Toggle base component
  */
 class Toggle extends Foundation<ToggleHandledProps, ToggleUnhandledProps, ToggleState> {
-    public static displayName: string = "Toggle";
+    public static displayName: string = `${DisplayNamePrefix}Toggle`;
 
     /**
      * React life-cycle method

--- a/packages/fast-components-react-base/src/typography/typography.spec.tsx
+++ b/packages/fast-components-react-base/src/typography/typography.spec.tsx
@@ -12,6 +12,7 @@ import Typography, {
     TypographyTag,
     TypographyUnhandledProps,
 } from "./typography";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -32,7 +33,9 @@ describe("typography", (): void => {
     };
 
     test("should have a displayName that matches the component name", () => {
-        expect((Typography as any).name).toBe(Typography.displayName);
+        expect(`${DisplayNamePrefix}${(Typography as any).name}`).toBe(
+            Typography.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-base/src/typography/typography.tsx
+++ b/packages/fast-components-react-base/src/typography/typography.tsx
@@ -14,6 +14,7 @@ import {
     ManagedClasses,
     TypographyClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-base";
+import { DisplayNamePrefix } from "../utilities";
 
 class Typography extends Foundation<
     TypographyHandledProps,
@@ -24,7 +25,7 @@ class Typography extends Foundation<
         tag: TypographyTag.p,
     };
 
-    public static displayName: string = "Typography";
+    public static displayName: string = `${DisplayNamePrefix}Typography`;
 
     protected handledProps: HandledProps<TypographyHandledProps> = {
         managedClasses: void 0,

--- a/packages/fast-components-react-base/src/utilities/index.ts
+++ b/packages/fast-components-react-base/src/utilities/index.ts
@@ -1,0 +1,3 @@
+const DisplayNamePrefix: string = "Base";
+
+export { DisplayNamePrefix };

--- a/packages/fast-components-react-msft/src/action-toggle/action-toggle.spec.tsx
+++ b/packages/fast-components-react-msft/src/action-toggle/action-toggle.spec.tsx
@@ -12,6 +12,7 @@ import MSFTActionToggle, {
 } from "./action-toggle";
 import { ActionToggle } from "./index";
 import { ActionToggleClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -30,7 +31,9 @@ describe("action toggle", (): void => {
     };
 
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTActionToggle as any).name).toBe(MSFTActionToggle.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTActionToggle as any).name}`).toBe(
+            MSFTActionToggle.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/action-toggle/action-toggle.tsx
+++ b/packages/fast-components-react-msft/src/action-toggle/action-toggle.tsx
@@ -10,6 +10,7 @@ import {
 } from "./action-toggle.props";
 import { actionToggleButtonOverrides } from "@microsoft/fast-components-styles-msft";
 import { isNullOrUndefined } from "util";
+import { DisplayNamePrefix } from "../utilities";
 
 export interface ActionToggleState {
     selected: boolean;
@@ -20,7 +21,7 @@ class ActionToggle extends Foundation<
     ActionToggleUnhandledProps,
     ActionToggleState
 > {
-    public static displayName: string = "ActionToggle";
+    public static displayName: string = `${DisplayNamePrefix}ActionToggle`;
 
     /**
      * React life-cycle method

--- a/packages/fast-components-react-msft/src/action-trigger/action-trigger.spec.tsx
+++ b/packages/fast-components-react-msft/src/action-trigger/action-trigger.spec.tsx
@@ -12,6 +12,7 @@ import MSFTActionTrigger, {
 } from "./action-trigger";
 import { ActionTrigger } from "./index";
 import { ActionTriggerClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -31,7 +32,9 @@ describe("action trigger", (): void => {
     const href: string = "#";
 
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTActionTrigger as any).name).toBe(MSFTActionTrigger.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTActionTrigger as any).name}`).toBe(
+            MSFTActionTrigger.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/action-trigger/action-trigger.tsx
+++ b/packages/fast-components-react-msft/src/action-trigger/action-trigger.tsx
@@ -8,13 +8,14 @@ import {
     ActionTriggerUnhandledProps,
 } from "./action-trigger.props";
 import { actionTriggerButtonOverrides } from "@microsoft/fast-components-styles-msft";
+import { DisplayNamePrefix } from "../utilities";
 
 class ActionTrigger extends Foundation<
     ActionTriggerHandledProps,
     ActionTriggerUnhandledProps,
     {}
 > {
-    public static displayName: string = "ActionTrigger";
+    public static displayName: string = `${DisplayNamePrefix}ActionTrigger`;
 
     protected handledProps: HandledProps<ActionTriggerHandledProps> = {
         appearance: void 0,

--- a/packages/fast-components-react-msft/src/auto-suggest-option/auto-suggest-option.spec.tsx
+++ b/packages/fast-components-react-msft/src/auto-suggest-option/auto-suggest-option.spec.tsx
@@ -11,6 +11,7 @@ import {
     AutoSuggestContext,
     AutoSuggestContextType,
 } from "@microsoft/fast-components-react-base";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -19,7 +20,7 @@ configure({ adapter: new Adapter() });
 
 describe("auto suggest option", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTAutoSuggestOption as any).name).toBe(
+        expect(`${DisplayNamePrefix}${(MSFTAutoSuggestOption as any).name}`).toBe(
             MSFTAutoSuggestOption.displayName
         );
     });

--- a/packages/fast-components-react-msft/src/auto-suggest-option/auto-suggest-option.tsx
+++ b/packages/fast-components-react-msft/src/auto-suggest-option/auto-suggest-option.tsx
@@ -13,13 +13,14 @@ import {
 import { get, slice } from "lodash-es";
 import { startsWith } from "@microsoft/fast-web-utilities";
 import { isNullOrUndefined } from "util";
+import { DisplayNamePrefix } from "../utilities";
 
 class AutoSuggestOption extends Foundation<
     AutoSuggestOptionHandledProps,
     AutoSuggestOptionUnhandledProps,
     {}
 > {
-    public static displayName: string = "AutoSuggestOption";
+    public static displayName: string = `${DisplayNamePrefix}AutoSuggestOption`;
 
     public static contextType: React.Context<AutoSuggestContextType> = AutoSuggestContext;
 

--- a/packages/fast-components-react-msft/src/auto-suggest/auto-suggest.spec.tsx
+++ b/packages/fast-components-react-msft/src/auto-suggest/auto-suggest.spec.tsx
@@ -10,6 +10,7 @@ import {
     AutoSuggestUnhandledProps,
 } from "./index";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -24,7 +25,9 @@ describe("auto suggest", (): void => {
     const href: string = "https://www.microsoft.com";
 
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTAutoSuggest as any).name).toBe(MSFTAutoSuggest.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTAutoSuggest as any).name}`).toBe(
+            MSFTAutoSuggest.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/auto-suggest/auto-suggest.tsx
+++ b/packages/fast-components-react-msft/src/auto-suggest/auto-suggest.tsx
@@ -11,13 +11,14 @@ import {
     AutoSuggestState,
 } from "@microsoft/fast-components-react-base";
 import { TextAction } from "../text-action";
+import { DisplayNamePrefix } from "../utilities";
 
 class AutoSuggest extends Foundation<
     AutoSuggestHandledProps,
     AutoSuggestUnhandledProps,
     {}
 > {
-    public static displayName: string = "AutoSuggest";
+    public static displayName: string = `${DisplayNamePrefix}AutoSuggest`;
 
     protected handledProps: HandledProps<AutoSuggestHandledProps> = {
         listboxId: void 0,

--- a/packages/fast-components-react-msft/src/badge/badge.spec.tsx
+++ b/packages/fast-components-react-msft/src/badge/badge.spec.tsx
@@ -10,6 +10,7 @@ import {
     BadgeSize,
     BadgeUnhandledProps,
 } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -25,7 +26,9 @@ describe("badge", (): void => {
     };
 
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTBadge as any).name).toBe(MSFTBadge.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTBadge as any).name}`).toBe(
+            MSFTBadge.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/badge/badge.tsx
+++ b/packages/fast-components-react-msft/src/badge/badge.tsx
@@ -8,9 +8,10 @@ import {
 } from "./badge.props";
 import { Badge as BaseBadge } from "@microsoft/fast-components-react-base";
 import { get } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 class Badge extends Foundation<BadgeHandledProps, BadgeUnhandledProps, {}> {
-    public static displayName: string = "Badge";
+    public static displayName: string = `${DisplayNamePrefix}Badge`;
 
     public static defaultProps: Partial<BadgeProps> = {
         size: BadgeSize.small,

--- a/packages/fast-components-react-msft/src/button/button.spec.tsx
+++ b/packages/fast-components-react-msft/src/button/button.spec.tsx
@@ -11,6 +11,7 @@ import {
     ButtonProps,
     ButtonUnhandledProps,
 } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -33,7 +34,9 @@ describe("button", (): void => {
     );
 
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTButton as any).name).toBe(MSFTButton.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTButton as any).name}`).toBe(
+            MSFTButton.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/button/button.tsx
+++ b/packages/fast-components-react-msft/src/button/button.tsx
@@ -8,6 +8,7 @@ import {
     ButtonUnhandledProps,
 } from "./button.props";
 import { Button as BaseButton } from "@microsoft/fast-components-react-base";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * Button slot options
@@ -18,7 +19,7 @@ export enum ButtonSlot {
 }
 
 class Button extends Foundation<ButtonHandledProps, ButtonUnhandledProps, {}> {
-    public static displayName: string = "Button";
+    public static displayName: string = `${DisplayNamePrefix}Button`;
 
     protected handledProps: HandledProps<ButtonHandledProps> = {
         appearance: void 0,

--- a/packages/fast-components-react-msft/src/call-to-action/call-to-action.spec.tsx
+++ b/packages/fast-components-react-msft/src/call-to-action/call-to-action.spec.tsx
@@ -12,6 +12,7 @@ import MSFTCallToAction, {
 } from "./call-to-action";
 import { CallToAction } from "./index";
 import { CallToActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -30,7 +31,9 @@ describe("call to action", (): void => {
     const href: string = "#";
 
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTCallToAction as any).name).toBe(MSFTCallToAction.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTCallToAction as any).name}`).toBe(
+            MSFTCallToAction.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/call-to-action/call-to-action.tsx
+++ b/packages/fast-components-react-msft/src/call-to-action/call-to-action.tsx
@@ -9,13 +9,14 @@ import {
 import { get } from "lodash-es";
 import { glyphArrowright } from "@microsoft/fast-glyphs-msft";
 import { callToActionButtonOverrides } from "@microsoft/fast-components-styles-msft";
+import { DisplayNamePrefix } from "../utilities";
 
 class CallToAction extends Foundation<
     CallToActionHandledProps,
     CallToActionUnhandledProps,
     {}
 > {
-    public static displayName: string = "CallToAction";
+    public static displayName: string = `${DisplayNamePrefix}CallToAction`;
 
     protected handledProps: HandledProps<CallToActionHandledProps> = {
         appearance: void 0,

--- a/packages/fast-components-react-msft/src/caption/caption.spec.tsx
+++ b/packages/fast-components-react-msft/src/caption/caption.spec.tsx
@@ -10,6 +10,7 @@ import MSFTCaption, {
     CaptionUnhandledProps,
 } from "./caption";
 import { Caption, CaptionProps } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * Configure Enzyme
@@ -18,7 +19,9 @@ configure({ adapter: new Adapter() });
 
 describe("caption", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTCaption as any).name).toBe(MSFTCaption.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTCaption as any).name}`).toBe(
+            MSFTCaption.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/caption/caption.tsx
+++ b/packages/fast-components-react-msft/src/caption/caption.tsx
@@ -11,6 +11,7 @@ import {
     CaptionUnhandledProps,
 } from "./caption.props";
 import { Typography } from "../typography";
+import { DisplayNamePrefix } from "../utilities";
 
 class Caption extends Foundation<CaptionHandledProps, CaptionUnhandledProps, {}> {
     public static defaultProps: Partial<CaptionProps> = {
@@ -18,7 +19,7 @@ class Caption extends Foundation<CaptionHandledProps, CaptionUnhandledProps, {}>
         size: CaptionSize._1,
     };
 
-    public static displayName: string = "Caption";
+    public static displayName: string = `${DisplayNamePrefix}Caption`;
 
     protected handledProps: HandledProps<CaptionHandledProps> = {
         size: void 0,

--- a/packages/fast-components-react-msft/src/carousel/carousel.spec.tsx
+++ b/packages/fast-components-react-msft/src/carousel/carousel.spec.tsx
@@ -18,6 +18,7 @@ import {
     Paragraph,
     ParagraphSize,
 } from "../index";
+import { DisplayNamePrefix } from "../utilities";
 
 function contentOne(): (className?: string) => React.ReactNode {
     return (className?: string): React.ReactNode => (
@@ -122,7 +123,9 @@ describe("carousel", (): void => {
         items: detailTabItem,
     };
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTCarousel as any).name).toBe(MSFTCarousel.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTCarousel as any).name}`).toBe(
+            MSFTCarousel.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/carousel/carousel.tsx
+++ b/packages/fast-components-react-msft/src/carousel/carousel.tsx
@@ -11,6 +11,7 @@ import { Flipper, FlipperDirection } from "../flipper";
 import { Tabs, TabsItem } from "@microsoft/fast-components-react-base";
 import { TabsClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { get } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * The carousel state interface
@@ -27,7 +28,7 @@ class Carousel extends Foundation<
     CarouselUnhandledProps,
     CarouselState
 > {
-    public static displayName: string = "Carousel";
+    public static displayName: string = `${DisplayNamePrefix}Carousel`;
 
     /**
      * Handled props

--- a/packages/fast-components-react-msft/src/context-menu-item/context-menu-item.spec.tsx
+++ b/packages/fast-components-react-msft/src/context-menu-item/context-menu-item.spec.tsx
@@ -9,6 +9,7 @@ import {
     ContextMenuItemProps,
     ContextMenuItemUnhandledProps,
 } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -19,7 +20,9 @@ describe("context menu item", (): void => {
     const beforeExample: JSX.Element = <div className={"before"}>before</div>;
 
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTContextMenuItem as any).name).toBe(MSFTContextMenuItem.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTContextMenuItem as any).name}`).toBe(
+            MSFTContextMenuItem.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/context-menu-item/context-menu-item.tsx
+++ b/packages/fast-components-react-msft/src/context-menu-item/context-menu-item.tsx
@@ -8,13 +8,14 @@ import {
 } from "./context-menu-item.props";
 import { ContextMenuItem as BaseContextMenuItem } from "@microsoft/fast-components-react-base";
 import { get } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 class ContextMenuItem extends Foundation<
     ContextMenuItemHandledProps,
     ContextMenuItemUnhandledProps,
     {}
 > {
-    public static displayName: string = "ContextMenuItem";
+    public static displayName: string = `${DisplayNamePrefix}ContextMenuItem`;
 
     protected handledProps: HandledProps<ContextMenuItemHandledProps> = {
         before: void 0,

--- a/packages/fast-components-react-msft/src/flipper/flipper.spec.tsx
+++ b/packages/fast-components-react-msft/src/flipper/flipper.spec.tsx
@@ -4,6 +4,7 @@ import { configure, mount, shallow } from "enzyme";
 import examples from "./examples.data";
 import MSFTFlipper, { FlipperHandledProps, FlipperUnhandledProps } from "./flipper";
 import { Flipper, FlipperProps } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -12,7 +13,9 @@ configure({ adapter: new Adapter() });
 
 describe("flipper", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTFlipper as any).name).toBe(MSFTFlipper.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTFlipper as any).name}`).toBe(
+            MSFTFlipper.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/flipper/flipper.tsx
+++ b/packages/fast-components-react-msft/src/flipper/flipper.tsx
@@ -13,9 +13,10 @@ import {
     FlipperClassNameContract,
     ManagedClasses,
 } from "@microsoft/fast-components-class-name-contracts-msft";
+import { DisplayNamePrefix } from "../utilities";
 
 class Flipper extends Foundation<FlipperHandledProps, FlipperUnhandledProps, {}> {
-    public static displayName: string = "Flipper";
+    public static displayName: string = `${DisplayNamePrefix}Flipper`;
 
     protected handledProps: HandledProps<FlipperHandledProps> = {
         label: void 0,

--- a/packages/fast-components-react-msft/src/heading/heading.spec.tsx
+++ b/packages/fast-components-react-msft/src/heading/heading.spec.tsx
@@ -10,6 +10,7 @@ import MSFTHeading, {
 } from "./heading";
 import { Typography } from "@microsoft/fast-components-react-base";
 import { Heading, HeadingProps } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -18,7 +19,9 @@ configure({ adapter: new Adapter() });
 
 describe("heading", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTHeading as any).name).toBe(MSFTHeading.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTHeading as any).name}`).toBe(
+            MSFTHeading.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/heading/heading.tsx
+++ b/packages/fast-components-react-msft/src/heading/heading.tsx
@@ -14,9 +14,10 @@ import {
     HeadingClassNameContract,
     ManagedClasses,
 } from "@microsoft/fast-components-class-name-contracts-msft";
+import { DisplayNamePrefix } from "../utilities";
 
 class Heading extends Foundation<HeadingHandledProps, HeadingUnhandledProps, {}> {
-    public static displayName: string = "Heading";
+    public static displayName: string = `${DisplayNamePrefix}Heading`;
 
     protected handledProps: HandledProps<HeadingHandledProps> = {
         size: void 0,

--- a/packages/fast-components-react-msft/src/index.spec.ts
+++ b/packages/fast-components-react-msft/src/index.spec.ts
@@ -4,7 +4,9 @@ import { includesAllSubdirectoriesAsNamedExports } from "../../../build/helpers/
 describe("index.ts", (): void => {
     test("should export all components in the src directory", () => {
         expect(() => {
-            includesAllSubdirectoriesAsNamedExports(path.resolve(__dirname, "index.ts"));
+            includesAllSubdirectoriesAsNamedExports(path.resolve(__dirname, "index.ts"), [
+                "utilities",
+            ]);
         }).not.toThrow();
     });
 });

--- a/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
+++ b/packages/fast-components-react-msft/src/metatext/metatext.spec.tsx
@@ -10,6 +10,7 @@ import MSFTMetatext, {
     MetatextUnhandledProps,
 } from "./metatext";
 import { Metatext } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -18,7 +19,9 @@ configure({ adapter: new Adapter() });
 
 describe("metatext", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTMetatext as any).name).toBe(MSFTMetatext.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTMetatext as any).name}`).toBe(
+            MSFTMetatext.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/metatext/metatext.tsx
+++ b/packages/fast-components-react-msft/src/metatext/metatext.tsx
@@ -15,13 +15,14 @@ import {
     ManagedClasses,
     MetatextClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-msft";
+import { DisplayNamePrefix } from "../utilities";
 
 class Metatext extends Foundation<MetatextHandledProps, MetatextUnhandledProps, {}> {
     public static defaultProps: Partial<MetatextProps> = {
         tag: MetatextTag.span,
     };
 
-    public static displayName: string = "Metatext";
+    public static displayName: string = `${DisplayNamePrefix}Metatext`;
 
     protected handledProps: HandledProps<MetatextHandledProps> = {
         managedClasses: void 0,

--- a/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
+++ b/packages/fast-components-react-msft/src/paragraph/paragraph.spec.tsx
@@ -10,6 +10,7 @@ import MSFTParagraph, {
     ParagraphUnhandledProps,
 } from "./paragraph";
 import { Paragraph } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -18,7 +19,9 @@ configure({ adapter: new Adapter() });
 
 describe("paragraph", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTParagraph as any).name).toBe(MSFTParagraph.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTParagraph as any).name}`).toBe(
+            MSFTParagraph.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/paragraph/paragraph.tsx
+++ b/packages/fast-components-react-msft/src/paragraph/paragraph.tsx
@@ -15,13 +15,14 @@ import {
     ManagedClasses,
     ParagraphClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-msft";
+import { DisplayNamePrefix } from "../utilities";
 
 class Paragraph extends Foundation<ParagraphHandledProps, ParagraphUnhandledProps, {}> {
     public static defaultProps: Partial<ParagraphProps> = {
         size: ParagraphSize._3,
     };
 
-    public static displayName: string = "Paragraph";
+    public static displayName: string = `${DisplayNamePrefix}Paragraph`;
 
     protected handledProps: HandledProps<ParagraphHandledProps> = {
         size: void 0,

--- a/packages/fast-components-react-msft/src/pivot/pivot.spec.tsx
+++ b/packages/fast-components-react-msft/src/pivot/pivot.spec.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
-import { TabsItem } from "@microsoft/fast-components-react-base";
+import { Tab, TabPanel, TabsItem } from "@microsoft/fast-components-react-base";
 import { PivotClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import MSFTPivot, { PivotHandledProps, PivotUnhandledProps } from "./pivot";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -72,7 +73,9 @@ const detailNull: TabsItem[] = [
 
 describe("pivot", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTPivot as any).name).toBe(MSFTPivot.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTPivot as any).name}`).toBe(
+            MSFTPivot.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {
@@ -164,7 +167,7 @@ describe("pivot", (): void => {
 
         expect(
             renderedWithChildren
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(1)
                 .prop("tabIndex")
         ).toEqual(0);
@@ -182,7 +185,7 @@ describe("pivot", (): void => {
 
         expect(
             renderedWithChildren
-                .find("Tab")
+                .find(Tab.displayName)
                 .at(0)
                 .childAt(0)
                 .prop("className")
@@ -201,7 +204,7 @@ describe("pivot", (): void => {
 
         expect(
             renderedWithChildren
-                .find("TabPanel")
+                .find(TabPanel.displayName)
                 .at(0)
                 .childAt(0)
                 .prop("className")

--- a/packages/fast-components-react-msft/src/pivot/pivot.tsx
+++ b/packages/fast-components-react-msft/src/pivot/pivot.tsx
@@ -17,6 +17,7 @@ import { Direction } from "@microsoft/fast-web-utilities";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { Tabs as BaseTabs } from "@microsoft/fast-components-react-base";
 import { PivotProps } from ".";
+import { DisplayNamePrefix } from "../utilities";
 
 export interface PivotState {
     offsetX: number;
@@ -25,7 +26,7 @@ export interface PivotState {
 }
 
 class Pivot extends Foundation<PivotHandledProps, PivotUnhandledProps, PivotState> {
-    public static displayName: string = "Pivot";
+    public static displayName: string = `${DisplayNamePrefix}Pivot`;
 
     /**
      * React life-cycle method

--- a/packages/fast-components-react-msft/src/progress/progress.spec.tsx
+++ b/packages/fast-components-react-msft/src/progress/progress.spec.tsx
@@ -5,6 +5,7 @@ import examples from "./examples.data";
 import { ProgressClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import MSFTProgress from "./progress";
 import { ProgressProps } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -12,6 +13,12 @@ import { ProgressProps } from "./index";
 configure({ adapter: new Adapter() });
 
 describe("progress", (): void => {
+    test("should have a displayName that matches the component name", () => {
+        expect(`${DisplayNamePrefix}${(MSFTProgress as any).name}`).toBe(
+            MSFTProgress.displayName
+        );
+    });
+
     test("should not throw if managedClasses are not provided", () => {
         expect(() => {
             shallow(<MSFTProgress />);

--- a/packages/fast-components-react-msft/src/progress/progress.tsx
+++ b/packages/fast-components-react-msft/src/progress/progress.tsx
@@ -14,6 +14,7 @@ import {
     ProgressClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-msft";
 import { Progress as BaseProgress } from "@microsoft/fast-components-react-base";
+import { DisplayNamePrefix } from "../utilities";
 
 class Progress extends Foundation<ProgressHandledProps, ProgressUnhandledProps, {}> {
     public static defaultProps: Partial<ProgressProps> = {
@@ -21,7 +22,7 @@ class Progress extends Foundation<ProgressHandledProps, ProgressUnhandledProps, 
         maxValue: 100,
     };
 
-    public static displayName: string = "Progress";
+    public static displayName: string = `${DisplayNamePrefix}Progress`;
 
     private static indicatorCount: number = 2;
 

--- a/packages/fast-components-react-msft/src/select-option/select-option.spec.tsx
+++ b/packages/fast-components-react-msft/src/select-option/select-option.spec.tsx
@@ -7,6 +7,7 @@ import {
     SelectOptionHandledProps,
     SelectOptionUnhandledProps,
 } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -15,7 +16,9 @@ configure({ adapter: new Adapter() });
 
 describe("select option", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTSelectOption as any).name).toBe(MSFTSelectOption.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTSelectOption as any).name}`).toBe(
+            MSFTSelectOption.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/select-option/select-option.tsx
+++ b/packages/fast-components-react-msft/src/select-option/select-option.tsx
@@ -6,13 +6,14 @@ import {
 } from "./select-option.props";
 import { ListboxItem as BaseListboxItem } from "@microsoft/fast-components-react-base";
 import { get } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 class SelectOption extends Foundation<
     SelectOptionHandledProps,
     SelectOptionUnhandledProps,
     {}
 > {
-    public static displayName: string = "SelectOption";
+    public static displayName: string = `${DisplayNamePrefix}SelectOption`;
 
     protected handledProps: HandledProps<SelectOptionHandledProps> = {
         glyph: void 0,

--- a/packages/fast-components-react-msft/src/select/select.spec.tsx
+++ b/packages/fast-components-react-msft/src/select/select.spec.tsx
@@ -4,6 +4,7 @@ import { configure, mount, shallow } from "enzyme";
 import MSFTSelect from "./select";
 import { SelectOption } from "../select-option";
 import { Select, SelectHandledProps, SelectProps, SelectUnhandledProps } from "./index";
+import { DisplayNamePrefix } from "../utilities";
 
 /*
  * Configure Enzyme
@@ -18,7 +19,9 @@ describe("button", (): void => {
     const href: string = "https://www.microsoft.com";
 
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTSelect as any).name).toBe(MSFTSelect.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTSelect as any).name}`).toBe(
+            MSFTSelect.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/select/select.tsx
+++ b/packages/fast-components-react-msft/src/select/select.tsx
@@ -10,9 +10,10 @@ import {
 import { Select as BaseSelect, SelectState } from "@microsoft/fast-components-react-base";
 import { Button, ButtonAppearance } from "../button";
 import { selectDisplayButtonOverrides } from "@microsoft/fast-components-styles-msft";
+import { DisplayNamePrefix } from "../utilities";
 
 class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, {}> {
-    public static displayName: string = "Select";
+    public static displayName: string = `${DisplayNamePrefix}Select`;
 
     protected handledProps: HandledProps<SelectHandledProps> = {
         disabled: void 0,

--- a/packages/fast-components-react-msft/src/subheading/subheading.spec.tsx
+++ b/packages/fast-components-react-msft/src/subheading/subheading.spec.tsx
@@ -11,6 +11,7 @@ import MSFTSubheading, {
 } from "./subheading";
 import { Subheading, SubheadingProps } from "./index";
 import { TypographySize } from "../typography";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * Configure enzyme
@@ -19,7 +20,9 @@ configure({ adapter: new Adapter() });
 
 describe("subheading", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((MSFTSubheading as any).name).toBe(MSFTSubheading.displayName);
+        expect(`${DisplayNamePrefix}${(MSFTSubheading as any).name}`).toBe(
+            MSFTSubheading.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/subheading/subheading.tsx
+++ b/packages/fast-components-react-msft/src/subheading/subheading.tsx
@@ -10,12 +10,12 @@ import {
     SubheadingTag,
     SubheadingUnhandledProps,
 } from "./subheading.props";
-
 import { Typography } from "../typography";
 import {
     ManagedClasses,
     SubheadingClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-msft";
+import { DisplayNamePrefix } from "../utilities";
 
 class Subheading extends Foundation<
     SubheadingHandledProps,
@@ -27,7 +27,7 @@ class Subheading extends Foundation<
         tag: SubheadingTag.h3,
     };
 
-    public static displayName: string = "Subheading";
+    public static displayName: string = `${DisplayNamePrefix}Subheading`;
 
     protected handledProps: HandledProps<SubheadingHandledProps> = {
         size: void 0,

--- a/packages/fast-components-react-msft/src/text-action/text-action.spec.tsx
+++ b/packages/fast-components-react-msft/src/text-action/text-action.spec.tsx
@@ -9,6 +9,7 @@ import TextAction, {
 } from "./text-action";
 import { TextActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { Button } from "../button";
+import { DisplayNamePrefix } from "../utilities";
 
 const managedClasses: TextActionClassNameContract = {
     textAction: "text-action",
@@ -26,7 +27,9 @@ configure({ adapter: new Adapter() });
 
 describe("text-action", (): void => {
     test("should have a displayName that matches the component name", () => {
-        expect((TextAction as any).name).toBe(TextAction.displayName);
+        expect(`${DisplayNamePrefix}${(TextAction as any).name}`).toBe(
+            TextAction.displayName
+        );
     });
 
     test("should not throw if managedClasses are not provided", () => {

--- a/packages/fast-components-react-msft/src/text-action/text-action.tsx
+++ b/packages/fast-components-react-msft/src/text-action/text-action.tsx
@@ -9,6 +9,7 @@ import {
 import { textFieldOverrides } from "@microsoft/fast-components-styles-msft";
 import { TextField } from "../text-field";
 import { get } from "lodash-es";
+import { DisplayNamePrefix } from "../utilities";
 
 /**
  * Text action state interface
@@ -21,7 +22,7 @@ class TextAction extends Foundation<
     TextActionUnhandledProps,
     TextActionState
 > {
-    public static displayName: string = "TextAction";
+    public static displayName: string = `${DisplayNamePrefix}TextAction`;
 
     public static defaultProps: Partial<TextActionProps> = {
         buttonPosition: TextActionButtonPosition.after,

--- a/packages/fast-components-react-msft/src/utilities/index.ts
+++ b/packages/fast-components-react-msft/src/utilities/index.ts
@@ -1,0 +1,3 @@
+const DisplayNamePrefix: string = "MSFT";
+
+export { DisplayNamePrefix };


### PR DESCRIPTION
# Description
We were giving identical display names to both base components and the styled MSFT components.  This change prepends the display names of components according to which package they come from.

I also added the ability to exclude subdirectories by name from "includesAllSubdirectoriesAsNamedExports" tests.

## Motivation & context
Having identical display names for different components made some tasks difficult.  Using display name as a query selector in tests, for example, is not nearly as useful if the display name is not unique per component.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [x] This change causes current functionality to break.
Yes, any code that references display name will break as the value has changed. Probably uncommon outside of tests.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.
