### PR TITLE
fix: prevent documentation site API links from routing to 404 pages

### DIFF
--- a/build/documentation/generate-typedocs.js
+++ b/build/documentation/generate-typedocs.js
@@ -104,7 +104,6 @@ function execute() {
 
             if(valid) {
                 dryRun ? console.log(`...generate TypeDoc API files for ${packageName}`) : createAPIFiles(packageName, srcPath);
-                dryRun ? console.log(`...add API link to ${packageName}`) : addAPILinkToReadme(packageName);
             }
 
         });
@@ -139,6 +138,7 @@ function createAPIFiles(packageName, srcPath) {
         } else {
             console.log(`${packageName} - TypeDoc API docs generated`)
             addHeaderToReadme(packageName);
+            addAPILinkToReadme(packageName);
         }
     });
 

--- a/website/pages/_config.yml
+++ b/website/pages/_config.yml
@@ -1,0 +1,3 @@
+include:
+  - "_*_.html"
+  - "_*_.*.html"


### PR DESCRIPTION
# Description

This fix adds a `_config.yml` file to the `website/build` folder so that github pages will load files with an underscore prefix. Also changes when 'API Reference' links are added to `readme.md` files to prevent them from linking to api documentation that wasn't built. 

## Motivation & context

Fix #1544 
Github pages wouldn't recognize the documentation site api files because they had an underscore prefix, a `.nojekyll` or `_config.yml` file needed to be added to the sites root folder for them to be recognized. More info on can be found [here](https://help.github.com/en/articles/files-that-start-with-an-underscore-are-missing). 
'API Reference' links would be added to package readme.md documentation files even if the api documentation didn't build correctly. This would lead to a 404 error, since the link wasn't linking to anything in these cases.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.
        - Start your description with `add`, `update`, or `remove.`

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->