### PR TITLE
feat: add design system support for font weights

### DIFF
--- a/packages/fast-components-styles-msft/src/badge/index.ts
+++ b/packages/fast-components-styles-msft/src/badge/index.ts
@@ -11,8 +11,8 @@ import { accentForegroundCut, neutralForegroundRest } from "../utilities/color";
 import { Swatch } from "../utilities/color/common";
 import { applyCursorDefault } from "../utilities/cursor";
 import { horizontalSpacing } from "../utilities/density";
-import { fontWeight } from "../utilities/fonts";
 import { applyScaledTypeRamp } from "../utilities/typography";
+import { applyFontWeightNormal, applyFontWeightSemiBold } from "../utilities/fonts";
 
 const styles: ComponentStyles<BadgeClassNameContract, DesignSystem> = (
     config: DesignSystem
@@ -27,11 +27,11 @@ const styles: ComponentStyles<BadgeClassNameContract, DesignSystem> = (
     return {
         badge: {
             ...applyScaledTypeRamp("t7"),
+            ...applyFontWeightSemiBold(),
             ...ellipsis(),
             overflow: "hidden",
             ...applyCursorDefault(),
             boxSizing: "border-box",
-            fontWeight: `${fontWeight.semibold}`,
             display: "inline-block",
             maxWidth: "215px",
             color: neutralForegroundRest,
@@ -39,7 +39,7 @@ const styles: ComponentStyles<BadgeClassNameContract, DesignSystem> = (
         },
         badge__filled: {
             ...applyCornerRadius(),
-            fontWeight: `${fontWeight.normal}`,
+            ...applyFontWeightNormal(),
             backgroundColor: filledBackground,
             color: accentForegroundCut((): Swatch => filledBackground),
         },

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -4,6 +4,7 @@ import { ColorPalette, ColorRGBA64, parseColorHexRGB } from "@microsoft/fast-col
 import { Palette } from "../utilities/color/palette";
 import { TypeRamp } from "../utilities/typography";
 import { withDefaults } from "@microsoft/fast-jss-utilities";
+import { defaultFontWeights, FontWeight } from "../utilities/fonts";
 
 export type DensityOffset = -3 | -2 | -1 | 0 | 1 | 2 | 3;
 
@@ -52,6 +53,11 @@ export interface DesignSystem {
      * The primary direction of the view.
      */
     direction: Direction;
+
+    /**
+     * An object representing the supported font weights
+     */
+    fontWeight?: FontWeight;
 
     /**
      * The corner default radius applied to controls.
@@ -151,6 +157,7 @@ const designSystemDefaults: DesignSystem = {
     direction: Direction.ltr,
     cornerRadius: 2,
     focusOutlineWidth: 2,
+    fontWeight: defaultFontWeights,
     disabledOpacity: 0.3,
     outlineWidth: 1,
     neutralPalette: createColorPalette(new ColorRGBA64(0.5, 0.5, 0.5, 1)),

--- a/packages/fast-components-styles-msft/src/heading/index.ts
+++ b/packages/fast-components-styles-msft/src/heading/index.ts
@@ -1,36 +1,27 @@
-import { DesignSystem } from "../design-system";
+import { DesignSystem, withDesignSystemDefaults } from "../design-system";
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import { HeadingClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { fontWeight } from "../utilities/fonts";
+import { applyFontWeightSemiBold } from "../utilities/fonts";
 
-function applyHeadingStyles(): CSSRules<DesignSystem> {
-    return {
-        fontWeight: `${fontWeight.semibold}`,
-    };
-}
-
-/**
- * TODO #306: Pull font weight styles when we have an API for font/variable font properties
- */
 const styles: ComponentStyles<HeadingClassNameContract, DesignSystem> = {
     heading: {
         "&$heading__1": {
-            ...applyHeadingStyles(),
+            ...applyFontWeightSemiBold(),
         },
         "&$heading__2": {
-            ...applyHeadingStyles(),
+            ...applyFontWeightSemiBold(),
         },
         "&$heading__3": {
-            ...applyHeadingStyles(),
+            ...applyFontWeightSemiBold(),
         },
         "&$heading__4": {
-            ...applyHeadingStyles(),
+            ...applyFontWeightSemiBold(),
         },
         "&$heading__5": {
-            ...applyHeadingStyles(),
+            ...applyFontWeightSemiBold(),
         },
         "&$heading__6": {
-            ...applyHeadingStyles(),
+            ...applyFontWeightSemiBold(),
         },
     },
     heading__1: {},

--- a/packages/fast-components-styles-msft/src/paragraph/index.ts
+++ b/packages/fast-components-styles-msft/src/paragraph/index.ts
@@ -1,11 +1,11 @@
-import { DesignSystem } from "../design-system";
+import { DesignSystem, withDesignSystemDefaults } from "../design-system";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { ParagraphClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { fontWeight } from "../utilities/fonts";
+import { applyFontWeightNormal } from "../utilities/fonts";
 
 const styles: ComponentStyles<ParagraphClassNameContract, DesignSystem> = {
     paragraph: {
-        fontWeight: `${fontWeight.normal}`,
+        ...applyFontWeightNormal(),
     },
     paragraph__1: {},
     paragraph__2: {},

--- a/packages/fast-components-styles-msft/src/patterns/input-field.ts
+++ b/packages/fast-components-styles-msft/src/patterns/input-field.ts
@@ -1,7 +1,6 @@
 import { horizontalSpacing } from "../utilities/density";
-import { fontWeight } from "../utilities/fonts";
 import { CSSRules } from "@microsoft/fast-jss-manager";
-import { DesignSystem } from "../design-system";
+import { DesignSystem, withDesignSystemDefaults } from "../design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import {
     neutralFillInputActive,
@@ -17,6 +16,7 @@ import {
 import { applyCornerRadius } from "../utilities/border";
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
+import { applyFontWeightNormal } from "../utilities/fonts";
 
 /**
  * Shared input field styles
@@ -24,13 +24,13 @@ import { applyScaledTypeRamp } from "../utilities/typography";
 export function inputFieldStyles(designSystem: DesignSystem): CSSRules<{}> {
     return {
         ...applyScaledTypeRamp("t7"),
+        ...applyFontWeightNormal(),
         background: neutralFillInputRest,
         border: `${toPx(designSystem.outlineWidth)} solid ${neutralOutlineRest(
             designSystem
         )}`,
         color: neutralForegroundRest,
         fontFamily: "inherit",
-        fontWeight: fontWeight.normal.toString(),
         boxSizing: "border-box",
         padding: `0 ${horizontalSpacing(designSystem.outlineWidth)(designSystem)}`,
         ...applyCornerRadius(),

--- a/packages/fast-components-styles-msft/src/subheading/index.ts
+++ b/packages/fast-components-styles-msft/src/subheading/index.ts
@@ -1,33 +1,27 @@
-import { DesignSystem } from "../design-system";
+import { DesignSystem, withDesignSystemDefaults } from "../design-system";
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import { SubheadingClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { fontWeight } from "../utilities/fonts";
-
-function applySubheadingStyles(): CSSRules<DesignSystem> {
-    return {
-        fontWeight: `${fontWeight.normal}`,
-    };
-}
+import { applyFontWeightNormal } from "../utilities/fonts";
 
 const styles: ComponentStyles<SubheadingClassNameContract, DesignSystem> = {
     subheading: {
         "&$subheading__1": {
-            ...applySubheadingStyles(),
+            ...applyFontWeightNormal(),
         },
         "&$subheading__2": {
-            ...applySubheadingStyles(),
+            ...applyFontWeightNormal(),
         },
         "&$subheading__3": {
-            ...applySubheadingStyles(),
+            ...applyFontWeightNormal(),
         },
         "&$subheading__4": {
-            ...applySubheadingStyles(),
+            ...applyFontWeightNormal(),
         },
         "&$subheading__5": {
-            ...applySubheadingStyles(),
+            ...applyFontWeightNormal(),
         },
         "&$subheading__6": {
-            ...applySubheadingStyles(),
+            ...applyFontWeightNormal(),
         },
     },
     subheading__1: {},

--- a/packages/fast-components-styles-msft/src/utilities/fonts.ts
+++ b/packages/fast-components-styles-msft/src/utilities/fonts.ts
@@ -1,3 +1,10 @@
+import { CSSRules } from "@microsoft/fast-jss-manager";
+import {
+    DesignSystem,
+    DesignSystemResolver,
+    ensureDesignSystemDefaults,
+} from "../design-system";
+
 export interface FontWeight {
     light: number;
     semilight: number;
@@ -6,10 +13,43 @@ export interface FontWeight {
     bold: number;
 }
 
-export const fontWeight: FontWeight = {
+export const defaultFontWeights: FontWeight = {
     light: 100,
     semilight: 200,
     normal: 400,
     semibold: 600,
     bold: 700,
 };
+
+/**
+ * @deprecated - use applyFontWeight instead
+ */
+export const fontWeight: FontWeight = defaultFontWeights;
+
+function weight(index: keyof FontWeight): DesignSystemResolver<string> {
+    return ensureDesignSystemDefaults(
+        (designSystem: DesignSystem): string => {
+            return `${designSystem.fontWeight[index]}`;
+        }
+    );
+}
+
+export function applyFontWeightLight(): CSSRules<DesignSystem> {
+    return { fontWeight: weight("light") };
+}
+
+export function applyFontWeightSemiLight(): CSSRules<DesignSystem> {
+    return { fontWeight: weight("semilight") };
+}
+
+export function applyFontWeightNormal(): CSSRules<DesignSystem> {
+    return { fontWeight: weight("normal") };
+}
+
+export function applyFontWeightSemiBold(): CSSRules<DesignSystem> {
+    return { fontWeight: weight("semibold") };
+}
+
+export function applyFontWeightBold(): CSSRules<DesignSystem> {
+    return { fontWeight: weight("bold") };
+}


### PR DESCRIPTION
closes #306 

This is a transparent change to how we manage font weights in order to provide support for variable font use. Instead of using internal constants, we expose a way to support user declared values. This allows users to pass different design system values for fontWeight depending on if they want to / can support variable fonts in a given experience. Additionally, this is an important move as we've been operating under an internal assumption that font weights are constant and defined but font family is not. Technically while certain font families support similar weights, our previous implementation was tightly coupled to the MSFT SegoeUI font family.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.
        - Start your description with `add`, `update`, or `remove.`

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->