### PR TITLE
feat: add public function to breakpoint tracker to get current breakpoint

### DIFF
--- a/packages/fast-layouts-react/src/utilities/breakpoint-tracker.spec.ts
+++ b/packages/fast-layouts-react/src/utilities/breakpoint-tracker.spec.ts
@@ -1,5 +1,5 @@
 import BreakpointTracker, { BreakpointTrackerCallback } from "./breakpoint-tracker";
-import { Breakpoints, defaultBreakpoints } from "./breakpoints";
+import { Breakpoint, Breakpoints, defaultBreakpoints } from "./breakpoints";
 
 /* tslint:disable:no-string-literal */
 describe("breakpointTracker", (): void => {
@@ -35,6 +35,12 @@ describe("breakpointTracker", (): void => {
         BreakpointTracker.subscribe(subscriber.onBreakpointChange);
 
         expect(BreakpointTracker.breakpoints).toEqual(defaultBreakpoints);
+    });
+
+    test("should provide a breakpoint value when `currentBreakpoint` is called", (): void => {
+        BreakpointTracker.subscribe(subscriber.onBreakpointChange);
+
+        expect(typeof BreakpointTracker.currentBreakpoint() === "number").toBe(true);
     });
 
     test("should set new breakpoint values when provided", (): void => {

--- a/packages/fast-layouts-react/src/utilities/breakpoint-tracker.ts
+++ b/packages/fast-layouts-react/src/utilities/breakpoint-tracker.ts
@@ -92,6 +92,13 @@ class BreakpointTracker {
     };
 
     /**
+     * Returns the current breakpoint
+     */
+    public currentBreakpoint = (): Breakpoint => {
+        return this.breakpoint;
+    };
+
+    /**
      * Call all subscribed callbacks
      */
     public notifySubscribers(breakpoint: Breakpoint): void {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Currently there is no way to gather the current breakpoint value without an update. This PR exposes a public function which provides access to the current breakpoint at any given time without needing to trigger an update.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->