### PR TITLE
feat: use defaults as values if the data has not been set and adds an indicator in the UI to signify that the data is default

### DIFF
--- a/packages/fast-tooling-react/src/__tests__/schemas/arrays.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/arrays.schema.json
@@ -31,6 +31,43 @@
                     "string"
                 ]
             }
+        },
+        "stringsWithDefault": {
+            "title": "Array of strings with default",
+            "type": "array",
+            "items": {
+                "title": "String",
+                "type": "string"
+            },
+            "default": [
+                "foo",
+                "bar"
+            ]
+        },
+        "objectsWithDefault": {
+            "title": "Array of objects with default",
+            "type": "array",
+            "items": {
+                "title": "Object",
+                "type": "object",
+                "properties": {
+                    "string": {
+                        "title": "String",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "string"
+                ]
+            },
+            "default": [
+                {
+                    "string": "foo"
+                },
+                {
+                    "string": "bar"
+                }
+            ]
         }
     },
     "required": [

--- a/packages/fast-tooling-react/src/__tests__/schemas/badge.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/badge.schema.json
@@ -53,6 +53,66 @@
                 "title": "String item",
                 "type": "string"
             }
+        },
+        "stringWithDefault": {
+            "title": "Textarea",
+            "badge": "info",
+            "badgeDescription": "More information is provided",
+            "type": "string",
+            "default": "Hello world"
+        },
+        "booleanWithDefault": {
+            "title": "Checkbox",
+            "badge": "warning",
+            "badgeDescription": "Warning message",
+            "type": "boolean",
+            "default": true
+        },
+        "enumWithDefault": {
+            "title": "Select",
+            "badge": "locked",
+            "badgeDescription": "This field is locked",
+            "type": "string",
+            "enum": [
+                "span",
+                "button"
+            ],
+            "default": "button"
+        },
+        "numberWithDefault": {
+            "title": "Numberfield",
+            "badge": "info",
+            "badgeDescription": "More information is provided",
+            "type": "number",
+            "default": 42
+        },
+        "objectWithDefault": {
+            "title": "Object (no required items)",
+            "badge": "warning",
+            "badgeDescription": "Warning message",
+            "type": "object",
+            "properties": {
+                "number": {
+                    "type": "number"
+                }
+            },
+            "default": {
+                "number": 100
+            }
+        },
+        "arrayWithDefault": {
+            "title": "Array",
+            "type": "array",
+            "badge": "warning",
+            "badgeDescription": "Warning message",
+            "items": {
+                "title": "String item",
+                "type": "string"
+            },
+            "default": [
+                "foo",
+                "bar"
+            ]
         }
     },
     "reactProperties": {
@@ -61,6 +121,18 @@
             "type": "children",
             "badge": "warning",
             "badgeDescription": "Warning message"
+        },
+        "childrenWithDefault": {
+            "title": "Children",
+            "type": "children",
+            "badge": "warning",
+            "badgeDescription": "Warning message",
+            "default": {
+                "id": "textField",
+                "props": {
+                    "text": "Hello world"
+                }
+            }
         }
     }
 }

--- a/packages/fast-tooling-react/src/__tests__/schemas/checkbox.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/checkbox.schema.json
@@ -13,6 +13,11 @@
             "title": "Optional Checkbox",
             "type": "boolean"
         },
+        "defaultToggle": {
+            "title": "Default Checkbox",
+            "type": "boolean",
+            "default": true
+        },
         "disabledToggle": {
             "title": "Disabled Checkbox",
             "type": "boolean",

--- a/packages/fast-tooling-react/src/__tests__/schemas/number-field.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/number-field.schema.json
@@ -24,6 +24,11 @@
             "maximum": 50,
             "multipleOf": 5
         },
+        "defaultNumber": {
+            "title": "Default number",
+            "type": "number",
+            "default": 5
+        },
         "optionalNumber": {
             "title": "Optional number field",
             "type": "number"

--- a/packages/fast-tooling-react/src/__tests__/schemas/objects.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/objects.schema.json
@@ -61,6 +61,18 @@
                     }
                 }
             }
+        },
+        "optionalObjectWithDefaultValue": {
+            "title": "object with defaultValues",
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "string"
+                }
+            },
+            "default": {
+                "foo": "bar"
+            }
         }
     },
     "required": [

--- a/packages/fast-tooling-react/src/__tests__/schemas/textarea.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/textarea.schema.json
@@ -14,15 +14,29 @@
             ],
             "default": "button"
         },
-        "text": {
-            "title": "Text",
+        "textWithExamples": {
+            "title": "Text with examples",
             "type": "string",
-            "example": "Example text"
+            "examples": [
+                "Example text"
+            ]
         },
-        "optionalText": {
-            "title": "Optional text",
+        "textWithDefault": {
+            "title": "Text with default",
             "type": "string",
-            "example": "Example text"
+            "default": "Default value"
+        },
+        "optionalTextWithExamples": {
+            "title": "Optional text with examples",
+            "type": "string",
+            "examples": [
+                "Example text"
+            ]
+        },
+        "optionalTextWithDefault": {
+            "title": "Optional text with default",
+            "type": "string",
+            "default": "Default value"
         },
         "optionalTag": {
             "title": "Optional tag",
@@ -46,13 +60,16 @@
         "disabledText": {
             "title": "Disabled text area",
             "type": "string",
-            "example": "Example text",
+            "examples": [
+                "Example text"
+            ],
             "disabled": true
         }
     },
     "required": [
         "tag",
-        "text",
+        "textWithDefault",
+        "textWithExamples",
         "disabledText"
     ]
 }

--- a/packages/fast-tooling-react/src/form/form/form-control.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-control.spec.tsx
@@ -56,7 +56,7 @@ describe("FormControl", () => {
         const rendered: any = mount(
             <FormControl
                 {...formControlProps}
-                schema={textareaSchema.properties.text}
+                schema={textareaSchema.properties.textWithDefault}
                 schemaLocation={"properties.text"}
                 dataLocation={"text"}
                 propertyName={"text"}

--- a/packages/fast-tooling-react/src/form/form/form-item.array.props.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.array.props.ts
@@ -14,10 +14,12 @@ export interface FormItemArrayClassNameContract {
     formItemArray_controlLabel?: string;
     formItemArray_controlLabelRegion?: string;
     formItemArray_controlRegion?: string;
+    formItemArray_defaultValueIndicator?: string;
     formItemArray_existingItemList?: string;
     formItemArray_existingItemListItem?: string;
     formItemArray_existingItemListItem__sorting?: string;
     formItemArray_existingItemListItemLink?: string;
+    formItemArray_existingItemListItemLink__default?: string;
     formItemArray_existingItemRemoveButton?: string;
     formItemArray_invalidMessage?: string;
     formItemArray_softRemove?: string;

--- a/packages/fast-tooling-react/src/form/form/form-item.array.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.array.spec.tsx
@@ -33,12 +33,15 @@ const managedClasses: FormItemArrayClassNameContract = {
     formItemArray_addItemLabel: "formItemArray_addItemLabel-class",
     formItemArray_addItemButton: "formItemArray_controlAddButton-class",
     formItemArray_controlLabel: "formItemArray_controlLabel-class",
+    formItemArray_defaultValueIndicator: "formItemArray_defaultValueIndicator-class",
     formItemArray_existingItemList: "formItemArray_existingItemList-class",
     formItemArray_existingItemListItem: "formItemArray_existingItemListItem-class",
     formItemArray_existingItemListItem__sorting:
         "formItemArray_existingItemListItem__sorting-class",
     formItemArray_existingItemListItemLink:
         "formItemArray_existingItemListItemLink-class",
+    formItemArray_existingItemListItemLink__default:
+        "formItemArray_existingItemListItemLink__default-class",
     formItemArray_existingItemRemoveButton:
         "formItemArray_existingItemRemoveButton-class",
 };
@@ -285,5 +288,66 @@ describe("Array", () => {
         rendered.setProps({ invalidMessage: invalidMessage2 });
 
         expect(rendered.html().includes(invalidMessage2)).toBe(true);
+    });
+    test("should show a default indicator if default values exist and no data is available", () => {
+        const rendered: any = mount(
+            <FormItemArray
+                {...arrayProps}
+                data={undefined}
+                default={[]}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemArray_defaultValueIndicator}`)
+        ).toHaveLength(1);
+    });
+    test("should not show a default indicator if data exists", () => {
+        const rendered: any = mount(
+            <FormItemArray
+                {...arrayProps}
+                data={[]}
+                default={[]}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemArray_defaultValueIndicator}`)
+        ).toHaveLength(0);
+    });
+    test("should show default values if they exist and no data is available", () => {
+        const defaultArrayItem1: string = "foo";
+        const defaultArrayItem2: string = "bar";
+        const rendered: any = mount(
+            <FormItemArray
+                {...arrayProps}
+                data={undefined}
+                default={[defaultArrayItem1, defaultArrayItem2]}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(rendered.html().includes(defaultArrayItem1)).toBe(true);
+        expect(rendered.html().includes(defaultArrayItem2)).toBe(true);
+    });
+    test("should not show default values if data exists", () => {
+        const arrayItem1: string = "foo";
+        const arrayItem2: string = "bar";
+        const defaultArrayItem1: string = "hello";
+        const defaultArrayItem2: string = "world";
+        const rendered: any = mount(
+            <FormItemArray
+                {...arrayProps}
+                data={[arrayItem1, arrayItem2]}
+                default={[defaultArrayItem1, defaultArrayItem2]}
+                managedClasses={managedClasses}
+            />
+        );
+        expect(rendered.html().includes(arrayItem1)).toBe(true);
+        expect(rendered.html().includes(arrayItem2)).toBe(true);
+        expect(rendered.html().includes(defaultArrayItem1)).toBe(false);
+        expect(rendered.html().includes(defaultArrayItem2)).toBe(false);
     });
 });

--- a/packages/fast-tooling-react/src/form/form/form-item.array.style.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.array.style.ts
@@ -3,10 +3,9 @@ import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import {
     accent,
     applyCleanListStyle,
-    applyControl,
     applyControlRegion,
     applyControlWrapper,
-    applyFormItemBadge,
+    applyFormItemIndicator,
     applyGlobalStyle,
     applyInvalidMessage,
     applyLabelRegionStyle,
@@ -36,7 +35,7 @@ const styles: ComponentStyles<FormItemArrayClassNameContract, {}> = {
         maxWidth: "calc(100% - 30px)",
     },
     formItemArray_badge: {
-        ...applyFormItemBadge(),
+        ...applyFormItemIndicator(),
     },
     formItemArray_control: {
         width: "100%",
@@ -89,6 +88,9 @@ const styles: ComponentStyles<FormItemArrayClassNameContract, {}> = {
     formItemArray_controlRegion: {
         ...applyControlRegion(),
     },
+    formItemArray_defaultValueIndicator: {
+        ...applyFormItemIndicator(),
+    },
     formItemArray_existingItemList: {
         ...applyCleanListStyle(),
         fontSize: "12px",
@@ -119,6 +121,9 @@ const styles: ComponentStyles<FormItemArrayClassNameContract, {}> = {
         height: "30px",
         lineHeight: "30px",
         width: "calc(100% - 30px)",
+    },
+    formItemArray_existingItemListItemLink__default: {
+        cursor: "auto",
     },
     formItemArray_existingItemRemoveButton: {
         ...applyRemoveItemStyle(),

--- a/packages/fast-tooling-react/src/form/form/form-item.array.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.array.tsx
@@ -60,6 +60,12 @@ class FormItemArray extends FormItemBase<
                         >
                             {label}
                         </label>
+                        {this.renderDefaultValueIndicator(
+                            get(
+                                this.props,
+                                "managedClasses.formItemArray_defaultValueIndicator"
+                            )
+                        )}
                         {this.renderBadge(
                             get(this.props, "managedClasses.formItemArray_badge")
                         )}
@@ -154,35 +160,6 @@ class FormItemArray extends FormItemBase<
     }
 
     /**
-     * Render the links to an array section to be activated
-     */
-    private renderExistingArrayItems(): React.ReactNode {
-        const arraySections: string[] = getArrayLinks(this.props.data);
-        const props: any = Object.assign({}, sortingProps, {
-            onSortEnd: this.handleSort,
-            helperClass: this.props.managedClasses
-                .formItemArray_existingItemListItem__sorting,
-        });
-
-        if (arraySections.length > 0) {
-            return React.createElement(
-                SortableContainer(() => {
-                    return (
-                        <ul
-                            className={
-                                this.props.managedClasses.formItemArray_existingItemList
-                            }
-                        >
-                            {this.generateArrayLinkItems()}
-                        </ul>
-                    );
-                }),
-                props
-            );
-        }
-    }
-
-    /**
      * Array add/remove item click handler factory
      */
     private arrayItemClickHandlerFactory(
@@ -256,9 +233,7 @@ class FormItemArray extends FormItemBase<
                 id={uniqueId(index.toString())}
             >
                 <a
-                    className={
-                        this.props.managedClasses.formItemArray_existingItemListItemLink
-                    }
+                    className={this.getArrayItemClassNames()}
                     onClick={this.arrayClickHandlerFactory(value, index)}
                 >
                     {value}
@@ -267,6 +242,37 @@ class FormItemArray extends FormItemBase<
             </SortableListItem>
         );
     };
+
+    private generateDefaultArrayLinkItem = (
+        value: any,
+        index: number
+    ): React.ReactNode => {
+        return (
+            <li
+                className={this.props.managedClasses.formItemArray_existingItemListItem}
+                key={`item-${index}`}
+                id={uniqueId(index.toString())}
+            >
+                <span className={this.getArrayItemClassNames(true)}>{value}</span>
+            </li>
+        );
+    };
+
+    private getArrayItemClassNames(isDefault?: boolean): string {
+        let classes: string = get(
+            this.props,
+            "managedClasses.formItemArray_existingItemListItemLink"
+        );
+
+        if (isDefault) {
+            classes = `${classes} ${get(
+                this.props,
+                "managedClasses.formItemArray_existingItemListItemLink__default"
+            )}`;
+        }
+
+        return classes;
+    }
 
     /**
      * Generates UI for all items in an array
@@ -288,6 +294,14 @@ class FormItemArray extends FormItemBase<
         );
     }
 
+    private generateDefaultArrayLinkItems(): React.ReactNode {
+        return getArrayLinks(this.props.default).map(
+            (value: any, index: number): React.ReactNode => {
+                return this.generateDefaultArrayLinkItem(value, index);
+            }
+        );
+    }
+
     /**
      * Handle user drag and drop interactions
      */
@@ -297,6 +311,45 @@ class FormItemArray extends FormItemBase<
             arrayMove(this.props.data, oldIndex, newIndex)
         );
     };
+
+    /**
+     * Generates the links to an array section to be activated
+     */
+    private renderExistingArrayItems(): React.ReactNode {
+        const hasData: boolean = Array.isArray(this.props.data);
+        const hasDefault: boolean = Array.isArray(this.props.default);
+
+        if (hasData) {
+            const props: any = Object.assign({}, sortingProps, {
+                onSortEnd: this.handleSort,
+                helperClass: this.props.managedClasses
+                    .formItemArray_existingItemListItem__sorting,
+            });
+
+            return React.createElement(
+                SortableContainer(() => {
+                    return (
+                        <ul
+                            className={
+                                this.props.managedClasses.formItemArray_existingItemList
+                            }
+                        >
+                            {this.generateArrayLinkItems()}
+                        </ul>
+                    );
+                }),
+                props
+            );
+        }
+
+        if (hasDefault) {
+            return (
+                <ul className={this.props.managedClasses.formItemArray_existingItemList}>
+                    {this.generateDefaultArrayLinkItems()}
+                </ul>
+            );
+        }
+    }
 }
 
 export { FormItemArray };

--- a/packages/fast-tooling-react/src/form/form/form-item.base.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.base.tsx
@@ -74,6 +74,35 @@ abstract class FormItemBase<P, S> extends React.Component<P & FormItemCommon, S>
         }
     }
 
+    /**
+     * Renders an indicator that signifies that the value
+     * displayed is a default value
+     */
+    public renderDefaultValueIndicator(className: string): React.ReactNode {
+        if (
+            typeof this.props.data === "undefined" &&
+            typeof this.props.default !== "undefined"
+        ) {
+            return (
+                <svg
+                    className={className}
+                    viewBox="0 0 16 16"
+                    height="14"
+                    width="14"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <title>This is the default value</title>
+                    <path
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M9.86 1.252A6.795 6.795 0 0 0 8 1c-.645 0-1.268.084-1.868.252a7.01 7.01 0 0 0-3.088 1.8c-.42.422-.785.893-1.093 1.414a7.052 7.052 0 0 0-.707 1.675A7.015 7.015 0 0 0 1 8c0 .645.081 1.268.244 1.868.168.594.404 1.152.707 1.674a7.44 7.44 0 0 0 1.093 1.414c.427.42.898.785 1.414 1.093.522.303 1.08.539 1.674.707.6.163 1.223.244 1.868.244s1.265-.081 1.86-.244a7.055 7.055 0 0 0 1.674-.707 7.103 7.103 0 0 0 2.507-2.507 6.8 6.8 0 0 0 .707-1.674C14.916 9.268 15 8.645 15 8s-.084-1.265-.252-1.86a6.621 6.621 0 0 0-.707-1.674 6.71 6.71 0 0 0-1.094-1.413 6.712 6.712 0 0 0-1.413-1.094 6.622 6.622 0 0 0-1.675-.707zm-.287 12.46c-.504.141-1.029.211-1.573.211a5.848 5.848 0 0 1-2.987-.808 6.191 6.191 0 0 1-1.203-.925 6.193 6.193 0 0 1-.925-1.203A5.852 5.852 0 0 1 2.077 8a5.851 5.851 0 0 1 .808-2.987 6.023 6.023 0 0 1 2.129-2.129A5.852 5.852 0 0 1 8 2.078a5.851 5.851 0 0 1 4.181 1.742A5.816 5.816 0 0 1 13.924 8a5.848 5.848 0 0 1-.808 2.987 6.022 6.022 0 0 1-2.128 2.128 5.852 5.852 0 0 1-1.414.598zm-2.65-1.724l5.225-5.225-.757-.757-4.468 4.468L4.61 8.16l-.757.757 3.071 3.071z"
+                    />
+                </svg>
+            );
+        }
+    }
+
     public handleSoftRemove = (): void => {
         if (typeof this.props.data !== "undefined") {
             this.cache = this.props.data;

--- a/packages/fast-tooling-react/src/form/form/form-item.checkbox.props.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.checkbox.props.ts
@@ -1,5 +1,4 @@
 import FormItemCommon from "./form-item.props";
-import { ManagedClasses } from "@microsoft/fast-jss-manager";
 
 /**
  * Checkbox class name contract
@@ -9,6 +8,7 @@ export interface FormItemCheckboxClassNameContract {
     formItemCheckbox__disabled?: string;
     formItemCheckbox_badge?: string;
     formItemCheckbox_control?: string;
+    formItemCheckbox_defaultValueIndicator?: string;
     formItemCheckbox_label?: string;
     formItemCheckbox_input?: string;
     formItemCheckbox_invalidMessage?: string;
@@ -16,5 +16,5 @@ export interface FormItemCheckboxClassNameContract {
     formItemCheckbox_softRemoveInput?: string;
 }
 
-export type FormItemCheckboxProps = FormItemCommon &
-    ManagedClasses<FormItemCheckboxClassNameContract>;
+/* tslint:disable-next-line */
+export interface FormItemCheckboxProps extends FormItemCommon {}

--- a/packages/fast-tooling-react/src/form/form/form-item.checkbox.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.checkbox.spec.tsx
@@ -1,15 +1,32 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
-import FormItemCommon from "./form-item.props";
-import Checkbox from "./form-item.checkbox";
+import { FormItemCheckbox } from "./form-item.checkbox";
+import {
+    FormItemCheckboxClassNameContract,
+    FormItemCheckboxProps,
+} from "./form-item.checkbox.props";
 
 /*
  * Configure Enzyme
  */
 configure({ adapter: new Adapter() });
 
-const checkboxProps: FormItemCommon = {
+const managedClasses: FormItemCheckboxClassNameContract = {
+    formItemCheckbox: "formItemCheckbox-class",
+    formItemCheckbox__disabled: "formItemCheckbox__disabled-class",
+    formItemCheckbox_badge: "formItemCheckbox_badge-class",
+    formItemCheckbox_control: "formItemCheckbox_control-class",
+    formItemCheckbox_input: "formItemCheckbox_input-class",
+    formItemCheckbox_invalidMessage: "formItemCheckbox_invalidMessage-class",
+    formItemCheckbox_label: "formItemCheckbox_label-class",
+    formItemCheckbox_softRemove: "formItemCheckbox_softRemove-class",
+    formItemCheckbox_softRemoveInput: "formItemCheckbox_softRemoveInput-class",
+    formItemCheckbox_defaultValueIndicator:
+        "formItemCheckbox_defaultValueIndicator-class",
+};
+
+const checkboxProps: FormItemCheckboxProps = {
     index: 1,
     dataLocation: "",
     data: false,
@@ -22,21 +39,29 @@ const checkboxProps: FormItemCommon = {
 describe("Checkbox", () => {
     test("should not throw", () => {
         expect(() => {
-            shallow(<Checkbox {...checkboxProps} />);
+            shallow(
+                <FormItemCheckbox {...checkboxProps} managedClasses={managedClasses} />
+            );
         }).not.toThrow();
     });
     test("should generate an input HTML element", () => {
-        const rendered: any = mount(<Checkbox {...checkboxProps} />);
+        const rendered: any = mount(
+            <FormItemCheckbox {...checkboxProps} managedClasses={managedClasses} />
+        );
 
         expect(rendered.find("input")).toHaveLength(2);
     });
     test("should generate a label HTML element", () => {
-        const rendered: any = mount(<Checkbox {...checkboxProps} />);
+        const rendered: any = mount(
+            <FormItemCheckbox {...checkboxProps} managedClasses={managedClasses} />
+        );
 
         expect(rendered.find("label")).toHaveLength(1);
     });
     test("should have an `id` attribute on the HTML input element and a corresponding `for` attribute on the HTML label element", () => {
-        const rendered: any = mount(<Checkbox {...checkboxProps} />);
+        const rendered: any = mount(
+            <FormItemCheckbox {...checkboxProps} managedClasses={managedClasses} />
+        );
         const input: any = rendered.find("input").at(0);
         const label: any = rendered.find("label");
 
@@ -45,7 +70,11 @@ describe("Checkbox", () => {
     test("should fire an `onChange` callback with the input is changed", () => {
         const handleChange: any = jest.fn();
         const rendered: any = mount(
-            <Checkbox {...checkboxProps} onChange={handleChange} />
+            <FormItemCheckbox
+                {...checkboxProps}
+                onChange={handleChange}
+                managedClasses={managedClasses}
+            />
         );
 
         rendered
@@ -57,7 +86,13 @@ describe("Checkbox", () => {
         expect(handleChange.mock.calls[0][1]).toEqual(true);
     });
     test("should be disabled when disabled props is passed", () => {
-        const rendered: any = mount(<Checkbox {...checkboxProps} disabled={true} />);
+        const rendered: any = mount(
+            <FormItemCheckbox
+                {...checkboxProps}
+                disabled={true}
+                managedClasses={managedClasses}
+            />
+        );
 
         const input: any = rendered.find("input");
 
@@ -67,7 +102,12 @@ describe("Checkbox", () => {
     test("should remove the data if the soft remove is triggered", () => {
         const handleChange: any = jest.fn();
         const rendered: any = mount(
-            <Checkbox {...checkboxProps} data={true} onChange={handleChange} />
+            <FormItemCheckbox
+                {...checkboxProps}
+                data={true}
+                onChange={handleChange}
+                managedClasses={managedClasses}
+            />
         );
 
         rendered
@@ -82,7 +122,12 @@ describe("Checkbox", () => {
         const handleChange: any = jest.fn();
         const data: boolean = true;
         const rendered: any = mount(
-            <Checkbox {...checkboxProps} data={data} onChange={handleChange} />
+            <FormItemCheckbox
+                {...checkboxProps}
+                data={data}
+                onChange={handleChange}
+                managedClasses={managedClasses}
+            />
         );
 
         rendered
@@ -103,7 +148,11 @@ describe("Checkbox", () => {
     test("should be invalid if an invalid message is passed", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <Checkbox {...checkboxProps} invalidMessage={invalidMessage} />
+            <FormItemCheckbox
+                {...checkboxProps}
+                invalidMessage={invalidMessage}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(
@@ -117,7 +166,11 @@ describe("Checkbox", () => {
     test("should not be invalid if an invalid message is passed as an empty string", () => {
         const invalidMessage: string = "";
         const rendered: any = mount(
-            <Checkbox {...checkboxProps} invalidMessage={invalidMessage} />
+            <FormItemCheckbox
+                {...checkboxProps}
+                invalidMessage={invalidMessage}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(
@@ -131,7 +184,11 @@ describe("Checkbox", () => {
     test("should not show an invalid message inline if `invalidMessage` is passed and `displayValidationInline` is undefined", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <Checkbox {...checkboxProps} invalidMessage={invalidMessage} />
+            <FormItemCheckbox
+                {...checkboxProps}
+                invalidMessage={invalidMessage}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.html().includes(invalidMessage)).toBe(false);
@@ -139,8 +196,9 @@ describe("Checkbox", () => {
     test("should show an invalid message inline if `invalidMessage` is passed and `displayValidationInline` is true", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <Checkbox
+            <FormItemCheckbox
                 {...checkboxProps}
+                managedClasses={managedClasses}
                 invalidMessage={invalidMessage}
                 displayValidationInline={true}
             />
@@ -152,8 +210,9 @@ describe("Checkbox", () => {
         const invalidMessage1: string = "Foo";
         const invalidMessage2: string = "Bar";
         const rendered: any = mount(
-            <Checkbox
+            <FormItemCheckbox
                 {...checkboxProps}
+                managedClasses={managedClasses}
                 invalidMessage={invalidMessage1}
                 displayValidationInline={true}
             />
@@ -164,5 +223,66 @@ describe("Checkbox", () => {
         rendered.setProps({ invalidMessage: invalidMessage2 });
 
         expect(rendered.html().includes(invalidMessage2)).toBe(true);
+    });
+    test("should show a default indicator if default values exist and no data is available", () => {
+        const rendered: any = mount(
+            <FormItemCheckbox
+                {...checkboxProps}
+                managedClasses={managedClasses}
+                data={undefined}
+                default={true}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemCheckbox_defaultValueIndicator}`)
+        ).toHaveLength(1);
+    });
+    test("should not show a default indicator if data exists", () => {
+        const rendered: any = mount(
+            <FormItemCheckbox
+                {...checkboxProps}
+                managedClasses={managedClasses}
+                data={false}
+                default={true}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemCheckbox_defaultValueIndicator}`)
+        ).toHaveLength(0);
+    });
+    test("should show default values if they exist and no data is available", () => {
+        const rendered: any = mount(
+            <FormItemCheckbox
+                {...checkboxProps}
+                managedClasses={managedClasses}
+                data={undefined}
+                default={true}
+            />
+        );
+
+        expect(
+            rendered
+                .find("input")
+                .at(0)
+                .prop("value")
+        ).toBe(true.toString());
+    });
+    test("should not show default values if data exists", () => {
+        const rendered: any = mount(
+            <FormItemCheckbox
+                {...checkboxProps}
+                managedClasses={managedClasses}
+                data={false}
+                default={true}
+            />
+        );
+        expect(
+            rendered
+                .find("input")
+                .at(0)
+                .prop("value")
+        ).toBe(false.toString());
     });
 });

--- a/packages/fast-tooling-react/src/form/form/form-item.checkbox.style.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.checkbox.style.ts
@@ -2,8 +2,8 @@ import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import { FormItemCheckboxClassNameContract } from "./form-item.checkbox.props";
 import {
     applyControlSingleLineWrapper,
-    applyFormItemBadge,
     applyFormItemDisabled,
+    applyFormItemIndicator,
     applyInvalidMessage,
     applyLabelStyle,
     applySoftRemove,
@@ -24,7 +24,10 @@ const styles: ComponentStyles<FormItemCheckboxClassNameContract, {}> = {
         ...applyFormItemDisabled(),
     },
     formItemCheckbox_badge: {
-        ...applyFormItemBadge(),
+        ...applyFormItemIndicator(),
+    },
+    formItemCheckbox_defaultValueIndicator: {
+        ...applyFormItemIndicator(),
     },
     formItemCheckbox_label: {
         ...applyLabelStyle(),

--- a/packages/fast-tooling-react/src/form/form/form-item.checkbox.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.checkbox.tsx
@@ -2,16 +2,21 @@ import React from "react";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import { get } from "lodash-es";
-import FormItemCommon from "./form-item.props";
 import styles from "./form-item.checkbox.style";
-import { FormItemCheckboxProps } from "./form-item.checkbox.props";
+import {
+    FormItemCheckboxClassNameContract,
+    FormItemCheckboxProps,
+} from "./form-item.checkbox.props";
 import FormItemBase from "./form-item.base";
 
 /**
  * Schema form component definition
  * @extends React.Component
  */
-class FormItemCheckbox extends FormItemBase<FormItemCheckboxProps, {}> {
+class FormItemCheckbox extends FormItemBase<
+    FormItemCheckboxProps & ManagedClasses<FormItemCheckboxClassNameContract>,
+    {}
+> {
     public static displayName: string = "FormItemCheckbox";
 
     public render(): JSX.Element {
@@ -44,6 +49,12 @@ class FormItemCheckbox extends FormItemBase<FormItemCheckboxProps, {}> {
                     >
                         {this.props.label}
                     </label>
+                    {this.renderDefaultValueIndicator(
+                        get(
+                            this.props,
+                            "managedClasses.formItemCheckbox_defaultValueIndicator"
+                        )
+                    )}
                     {this.renderBadge(
                         get(this.props, "managedClasses.formItemCheckbox_badge")
                     )}
@@ -85,4 +96,5 @@ class FormItemCheckbox extends FormItemBase<FormItemCheckboxProps, {}> {
     };
 }
 
+export { FormItemCheckbox };
 export default manageJss(styles)(FormItemCheckbox);

--- a/packages/fast-tooling-react/src/form/form/form-item.children.props.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.children.props.ts
@@ -11,8 +11,10 @@ export interface FormItemChildrenClassNameContract {
     formItemChildren_control?: string;
     formItemChildren_controlLabel?: string;
     formItemChildren_controlLabelRegion?: string;
+    formItemChildren_defaultValueIndicator?: string;
     formItemChildren_existingChildren?: string;
     formItemChildren_existingChildrenItem?: string;
+    formItemChildren_existingChildrenItem__default?: string;
     formItemChildren_existingChildrenItem__sorting?: string;
     formItemChildren_existingChildrenItemLink?: string;
     formItemChildren_existingChildrenItemContent?: string;

--- a/packages/fast-tooling-react/src/form/form/form-item.children.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.children.spec.tsx
@@ -2,13 +2,45 @@ import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
-import Children from "./form-item.children";
-import { FormItemChildrenProps } from "./form-item.children.props";
+import { FormItemChildren } from "./form-item.children";
+import {
+    FormItemChildrenClassNameContract,
+    FormItemChildrenProps,
+} from "./form-item.children.props";
 
 /*
  * Configure Enzyme
  */
 configure({ adapter: new Adapter() });
+
+const managedClasses: FormItemChildrenClassNameContract = {
+    formItemChildren: "formItemChildren-class",
+    formItemChildren_badge: "formItemChildren_badge-class",
+    formItemChildren_childrenList: "formItemChildren_childrenList-class",
+    formItemChildren_childrenListControl: "formItemChildren_childrenListControl-class",
+    formItemChildren_childrenListInput: "formItemChildren_childrenListInput-class",
+    formItemChildren_childrenListItem: "formItemChildren_childrenListItem-class",
+    formItemChildren_childrenListTrigger: "formItemChildren_childrenListTrigger-class",
+    formItemChildren_control: "formItemChildren_control-class",
+    formItemChildren_controlLabel: "formItemChildren_controlLabel-class",
+    formItemChildren_controlLabelRegion: "formItemChildren_controlLabelRegion-class",
+    formItemChildren_defaultValueIndicator:
+        "formItemChildren_defaultValueIndicator-class",
+    formItemChildren_delete: "formItemChildren_delete-class",
+    formItemChildren_deleteButton: "formItemChildren_deleteButton-class",
+    formItemChildren_existingChildren: "formItemChildren_existingChildren-class",
+    formItemChildren_existingChildrenItem: "formItemChildren_existingChildrenItem-class",
+    formItemChildren_existingChildrenItemContent:
+        "formItemChildren_existingChildrenItemContent-class",
+    formItemChildren_existingChildrenItemLink:
+        "formItemChildren_existingChildrenItemLink-class",
+    formItemChildren_existingChildrenItemName:
+        "formItemChildren_existingChildrenItemName-class",
+    formItemChildren_existingChildrenItem__default:
+        "formItemChildren_existingChildrenItem__default-class",
+    formItemChildren_existingChildrenItem__sorting:
+        "formItemChildren_existingChildrenItem__sorting-class",
+};
 
 const childrenProps: FormItemChildrenProps = {
     index: 0,
@@ -55,46 +87,62 @@ const childrenProps: FormItemChildrenProps = {
 describe("Children", () => {
     test("should not throw", () => {
         expect(() => {
-            mount(<Children {...childrenProps} />);
+            mount(
+                <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+            );
         }).not.toThrow();
     });
     test("should generate a text input", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
 
         expect(rendered.find("input")).toHaveLength(1);
     });
     test("should add an `aria-autocomplete` with `list` value on a text input", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
         const input: any = rendered.find("input");
 
         expect(input.props()["aria-autocomplete"]).toEqual("list");
     });
     test("should generate a button", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
 
         expect(rendered.find("button")).toHaveLength(1);
     });
     test("should generate a label", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
 
         expect(rendered.find("label")).toHaveLength(1);
     });
     test("should generate a listbox", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
         const listbox: any = rendered.find("ul");
 
         expect(listbox).toHaveLength(1);
         expect(listbox.props()["role"]).toEqual("listbox");
     });
     test("should add an `aria-controls` on a text input with the same value as the id of the `listbox`", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
         const inputAriaControls: string = rendered.find("input").props()["aria-controls"];
         const listboxId: string = rendered.find("ul").props()["id"];
 
         expect(inputAriaControls).toEqual(listboxId);
     });
     test("should add an `aria-labelledby` on a text input with the same value as the id of the `label`", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
         const inputAriaLabelledby: string = rendered.find("input").props()[
             "aria-labelledby"
         ];
@@ -103,13 +151,17 @@ describe("Children", () => {
         expect(inputAriaLabelledby).toEqual(labelId);
     });
     test("should have a listbox with an `aria-hidden` attribute set to `true`", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
         const listbox: any = rendered.find("ul");
 
         expect(listbox.props()["aria-hidden"]).toEqual(true);
     });
     test("should have a listbox with an `aria-hidden` attribute set to `false` when the button is clicked", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
         const button: any = rendered.find("button");
 
         button.simulate("click");
@@ -119,13 +171,17 @@ describe("Children", () => {
         expect(listbox.props()["aria-hidden"]).toEqual(false);
     });
     test("should generate options based on the `childOptions` provided", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
         const listboxItems: any = rendered.find("ul li");
 
         expect(listboxItems).toHaveLength(3);
     });
     test("should generate options based on the `childOptions` provided and filtered by a search term", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
         const input: any = rendered.find("input");
 
         input.simulate("change", { target: { value: "beta" } });
@@ -135,7 +191,9 @@ describe("Children", () => {
         expect(listboxItems).toHaveLength(2);
     });
     test("should have a listbox that can be navigated by the `down` key", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
         const button: any = rendered.find("button");
         const input: any = rendered.find("input");
 
@@ -194,7 +252,9 @@ describe("Children", () => {
         ).toEqual(true);
     });
     test("should have a listbox that can be navigated by the `up` key", () => {
-        const rendered: any = mount(<Children {...childrenProps} />);
+        const rendered: any = mount(
+            <FormItemChildren {...childrenProps} managedClasses={managedClasses} />
+        );
         const button: any = rendered.find("button");
         const input: any = rendered.find("input");
 
@@ -254,7 +314,11 @@ describe("Children", () => {
     });
     test("should show if children are present in the data as an item with a button", () => {
         const renderedWithOneChild: any = mount(
-            <Children {...childrenProps} data={{ id: "alpha", props: {} }} />
+            <FormItemChildren
+                {...childrenProps}
+                data={{ id: "alpha", props: {} }}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(
@@ -265,7 +329,11 @@ describe("Children", () => {
         ).toHaveLength(1);
 
         const renderedWithOneChildString: any = mount(
-            <Children {...childrenProps} data={"hello world"} />
+            <FormItemChildren
+                {...childrenProps}
+                data={"hello world"}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(
@@ -276,8 +344,9 @@ describe("Children", () => {
         ).toHaveLength(1);
 
         const renderedWithThreeChildren: any = mount(
-            <Children
+            <FormItemChildren
                 {...childrenProps}
+                managedClasses={managedClasses}
                 data={[
                     {
                         id: "alpha",
@@ -301,7 +370,13 @@ describe("Children", () => {
     });
     test("should fire a callback to update the data when an `option` in the `listbox` is clicked", () => {
         const callback: any = jest.fn();
-        const rendered: any = mount(<Children {...childrenProps} onChange={callback} />);
+        const rendered: any = mount(
+            <FormItemChildren
+                {...childrenProps}
+                onChange={callback}
+                managedClasses={managedClasses}
+            />
+        );
 
         rendered
             .find("ul")
@@ -317,8 +392,9 @@ describe("Children", () => {
     test("should fire a callback to update the data when a default text `option` in the `listbox` is clicked", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <Children
+            <FormItemChildren
                 {...childrenProps}
+                managedClasses={managedClasses}
                 defaultChildOptions={["text"]}
                 onChange={callback}
             />
@@ -338,7 +414,13 @@ describe("Children", () => {
     });
     test("should not add a child option to the data when a value has been added to the `input` that is an empty string", () => {
         const callback: any = jest.fn();
-        const rendered: any = mount(<Children {...childrenProps} onChange={callback} />);
+        const rendered: any = mount(
+            <FormItemChildren
+                {...childrenProps}
+                onChange={callback}
+                managedClasses={managedClasses}
+            />
+        );
 
         rendered.find("input").simulate("change", { target: { value: "" } });
         rendered.find("input").simulate("keydown", { keyCode: KeyCodes.enter });
@@ -347,7 +429,13 @@ describe("Children", () => {
     });
     test("should not add a child option to the data when a value has been added to the `input` that does not partially match any of the options", () => {
         const callback: any = jest.fn();
-        const rendered: any = mount(<Children {...childrenProps} onChange={callback} />);
+        const rendered: any = mount(
+            <FormItemChildren
+                {...childrenProps}
+                onChange={callback}
+                managedClasses={managedClasses}
+            />
+        );
 
         rendered.find("input").simulate("change", { target: { value: "echo" } });
         rendered.find("input").simulate("keydown", { keyCode: KeyCodes.enter });
@@ -356,7 +444,13 @@ describe("Children", () => {
     });
     test("should add a child option to the data when a value has been added to the `input` that at least partially matches one of the options", () => {
         const callback: any = jest.fn();
-        const rendered: any = mount(<Children {...childrenProps} onChange={callback} />);
+        const rendered: any = mount(
+            <FormItemChildren
+                {...childrenProps}
+                onChange={callback}
+                managedClasses={managedClasses}
+            />
+        );
 
         rendered.find("input").simulate("change", { target: { value: "b" } });
         rendered.find("input").simulate("keydown", { keyCode: KeyCodes.enter });
@@ -367,8 +461,9 @@ describe("Children", () => {
     test("should remove a child option from the data when the remove button has been clicked", () => {
         const callback: any = jest.fn();
         const renderedWithTwoChildren: any = mount(
-            <Children
+            <FormItemChildren
                 {...childrenProps}
+                managedClasses={managedClasses}
                 data={[
                     {
                         id: "alpha",
@@ -394,5 +489,60 @@ describe("Children", () => {
         expect(callback).toHaveBeenCalled();
         expect(callback.mock.calls[0][1]).toEqual(undefined);
         expect(callback.mock.calls[0][2]).toEqual(true);
+    });
+    test("should show a default indicator if default values exist and no data is available", () => {
+        const rendered: any = mount(
+            <FormItemChildren
+                {...childrenProps}
+                managedClasses={managedClasses}
+                data={undefined}
+                default={"foo"}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemChildren_defaultValueIndicator}`)
+        ).toHaveLength(1);
+    });
+    test("should not show a default indicator if data exists", () => {
+        const rendered: any = mount(
+            <FormItemChildren
+                {...childrenProps}
+                managedClasses={managedClasses}
+                data={"foo"}
+                default={"bar"}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemChildren_defaultValueIndicator}`)
+        ).toHaveLength(0);
+    });
+    test("should show default values if they exist and no data is available", () => {
+        const children: string = "foo";
+        const rendered: any = mount(
+            <FormItemChildren
+                {...childrenProps}
+                managedClasses={managedClasses}
+                data={undefined}
+                default={children}
+            />
+        );
+
+        expect(rendered.html().includes(children)).toBe(true);
+    });
+    test("should not show default values if data exists", () => {
+        const children: string = "foo";
+        const defaultChildren: string = "bar";
+        const rendered: any = mount(
+            <FormItemChildren
+                {...childrenProps}
+                managedClasses={managedClasses}
+                data={children}
+                default={defaultChildren}
+            />
+        );
+        expect(rendered.html().includes(children)).toBe(true);
+        expect(rendered.html().includes(defaultChildren)).toBe(false);
     });
 });

--- a/packages/fast-tooling-react/src/form/form/form-item.children.style.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.children.style.ts
@@ -6,7 +6,7 @@ import {
     applyCleanListStyle,
     applyControl,
     applyControlWrapper,
-    applyFormItemBadge,
+    applyFormItemIndicator,
     applyGlobalStyle,
     applyInputStyle,
     applyLabelRegionStyle,
@@ -29,7 +29,7 @@ const styles: ComponentStyles<FormItemChildrenClassNameContract, {}> = {
         ...applyControlWrapper(),
     },
     formItemChildren_badge: {
-        ...applyFormItemBadge(),
+        ...applyFormItemIndicator(),
     },
     formItemChildren_control: {
         ...applyControl(),
@@ -40,6 +40,9 @@ const styles: ComponentStyles<FormItemChildrenClassNameContract, {}> = {
     },
     formItemChildren_controlLabelRegion: {
         ...applyLabelRegionStyle(),
+    },
+    formItemChildren_defaultValueIndicator: {
+        ...applyFormItemIndicator(),
     },
     formItemChildren_existingChildren: {
         ...applyCleanListStyle(),
@@ -61,10 +64,14 @@ const styles: ComponentStyles<FormItemChildrenClassNameContract, {}> = {
         "&$formItemChildren_existingChildrenItem__sorting": {
             backgroundColor: background100,
         },
+        "&$formItemChildren_existingChildrenItem__default": {
+            cursor: "auto",
+        },
         "&:hover": {
             backgroundColor: "rgba(255, 255, 255, 0.04)",
         },
     },
+    formItemChildren_existingChildrenItem__default: {},
     formItemChildren_existingChildrenItemLink: {
         width: "calc(100% - 36px)",
         "&$formItemChildren_existingChildrenItemName, &$formItemChildren_existingChildrenItemContent": {

--- a/packages/fast-tooling-react/src/form/form/form-item.children.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.children.tsx
@@ -108,11 +108,18 @@ class FormItemChildren extends FormItemBase<
                         >
                             {this.props.label}
                         </label>
+                        {this.renderDefaultValueIndicator(
+                            get(
+                                this.props,
+                                "managedClasses.formItemChildren_defaultValueIndicator"
+                            )
+                        )}
                         {this.renderBadge(
                             get(this.props, "managedClasses.formItemChildren_badge")
                         )}
                     </div>
                 </div>
+                {this.renderDefaultChildren()}
                 {this.renderExistingChildren()}
                 {this.renderAddChild()}
             </div>
@@ -246,9 +253,7 @@ class FormItemChildren extends FormItemBase<
         // see: https://github.com/clauderic/react-sortable-hoc/issues/305
         return (
             <SortableListItem
-                className={
-                    this.props.managedClasses.formItemChildren_existingChildrenItem
-                }
+                className={this.getExistingChildItemClassNames()}
                 key={`item-${index}`}
                 id={uniqueId(index ? index.toString() : "")}
             >
@@ -375,6 +380,88 @@ class FormItemChildren extends FormItemBase<
         }
 
         return null;
+    }
+
+    /**
+     * Render default children
+     */
+    private renderDefaultChildren(): React.ReactNode {
+        if (
+            typeof this.props.data === "undefined" &&
+            typeof this.props.default !== "undefined"
+        ) {
+            const defaultValue: any[] = Array.isArray(this.props.default)
+                ? this.props.default
+                : [this.props.default];
+
+            const defaultChildItems: React.ReactNode = this.renderDefaultChildItems(
+                defaultValue
+            );
+
+            return (
+                <ul
+                    className={
+                        this.props.managedClasses.formItemChildren_existingChildren
+                    }
+                >
+                    {defaultChildItems}
+                </ul>
+            );
+        }
+    }
+
+    /**
+     * Render default child items
+     */
+    private renderDefaultChildItems(defaultValue: any[]): React.ReactNode {
+        return defaultValue.map(
+            (defaultItem: ChildComponent, index: number): JSX.Element => {
+                const displayValue: string =
+                    typeof defaultItem === "object"
+                        ? this.generateChildOptionText(defaultItem)
+                        : defaultItem;
+
+                return (
+                    <li
+                        key={`item-${index}`}
+                        className={this.getExistingChildItemClassNames(true)}
+                    >
+                        <span
+                            className={
+                                this.props.managedClasses
+                                    .formItemChildren_existingChildrenItemLink
+                            }
+                        >
+                            <span
+                                className={
+                                    this.props.managedClasses
+                                        .formItemChildren_existingChildrenItemName
+                                }
+                            >
+                                {displayValue}
+                            </span>
+                            {this.renderExistingChildCaption(defaultItem)}
+                        </span>
+                    </li>
+                );
+            }
+        );
+    }
+
+    private getExistingChildItemClassNames(isDefault?: boolean): string {
+        let classes: string = get(
+            this.props,
+            "managedClasses.formItemChildren_existingChildrenItem"
+        );
+
+        if (isDefault) {
+            classes = `${classes} ${get(
+                this.props,
+                "managedClasses.formItemChildren_existingChildrenItem__default"
+            )}`;
+        }
+
+        return classes;
     }
 
     /**
@@ -718,4 +805,5 @@ class FormItemChildren extends FormItemBase<
     }
 }
 
+export { FormItemChildren };
 export default manageJss(styles)(FormItemChildren);

--- a/packages/fast-tooling-react/src/form/form/form-item.number-field.props.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.number-field.props.ts
@@ -10,6 +10,7 @@ export interface FormItemNumberFieldClassNameContract {
     formItemNumberField_controlLabel?: string;
     formItemNumberField_controlLabelRegion?: string;
     formItemNumberField_controlInput?: string;
+    formItemNumberField_defaultValueIndicator?: string;
     formItemNumberField__disabled?: string;
     formItemNumberField_softRemove?: string;
     formItemNumberField_softRemoveInput?: string;

--- a/packages/fast-tooling-react/src/form/form/form-item.number-field.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.number-field.spec.tsx
@@ -2,12 +2,30 @@ import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import FormItemCommon from "./form-item.props";
-import NumberField from "./form-item.number-field";
+import { FormItemNumberField } from "./form-item.number-field";
+import { FormItemNumberFieldClassNameContract } from "./form-item.number-field.props";
 
 /*
  * Configure Enzyme
  */
 configure({ adapter: new Adapter() });
+
+const managedClasses: FormItemNumberFieldClassNameContract = {
+    formItemNumberField: "formItemNumberField-class",
+    formItemNumberField__disabled: "formItemNumberField__disabled-class",
+    formItemNumberField_badge: "formItemNumberField_badge-class",
+    formItemNumberField_control: "formItemNumberField_control-class",
+    formItemNumberField_controlInput: "formItemNumberField_controlInput-class",
+    formItemNumberField_controlLabel: "formItemNumberField_controlLabel-class",
+    formItemNumberField_controlLabelRegion:
+        "formItemNumberField_controlLabelRegion-class",
+    formItemNumberField_controlRegion: "formItemNumberField_controlRegion-class",
+    formItemNumberField_defaultValueIndicator:
+        "formItemNumberField_defaultValueIndicator-class",
+    formItemNumberField_invalidMessage: "formItemNumberField_invalidMessage-class",
+    formItemNumberField_softRemove: "formItemNumberField_softRemove-class",
+    formItemNumberField_softRemoveInput: "formItemNumberField_softRemoveInput-class",
+};
 
 const numberFieldProps: FormItemCommon = {
     index: 1,
@@ -22,22 +40,35 @@ const numberFieldProps: FormItemCommon = {
 describe("NumberField", () => {
     test("should not throw", () => {
         expect(() => {
-            shallow(<NumberField {...numberFieldProps} />);
+            shallow(
+                <FormItemNumberField
+                    {...numberFieldProps}
+                    managedClasses={managedClasses}
+                />
+            );
         }).not.toThrow();
     });
     test("should generate an HTML input element", () => {
-        const rendered: any = mount(<NumberField {...numberFieldProps} />);
+        const rendered: any = mount(
+            <FormItemNumberField {...numberFieldProps} managedClasses={managedClasses} />
+        );
 
         expect(rendered.find("input")).toHaveLength(2);
     });
     test("should generate an HTML label element", () => {
-        const rendered: any = mount(<NumberField {...numberFieldProps} />);
+        const rendered: any = mount(
+            <FormItemNumberField {...numberFieldProps} managedClasses={managedClasses} />
+        );
 
         expect(rendered.find("label")).toHaveLength(1);
     });
     test("should be disabled when disabled props is passed", () => {
         const rendered: any = mount(
-            <NumberField {...numberFieldProps} disabled={true} />
+            <FormItemNumberField
+                {...numberFieldProps}
+                disabled={true}
+                managedClasses={managedClasses}
+            />
         );
         expect(rendered.find("input")).toHaveLength(2);
         expect(
@@ -48,7 +79,9 @@ describe("NumberField", () => {
         ).toBeTruthy();
     });
     test("should have an `id` attribute on the HTML input element and a corresponding `for` attribute on the HTML label element", () => {
-        const rendered: any = mount(<NumberField {...numberFieldProps} />);
+        const rendered: any = mount(
+            <FormItemNumberField {...numberFieldProps} managedClasses={managedClasses} />
+        );
         const input: any = rendered.find("input").at(0);
         const label: any = rendered.find("label");
 
@@ -57,7 +90,11 @@ describe("NumberField", () => {
     test("should fire an `onChange` callback with the input is changed", () => {
         const handleChange: any = jest.fn();
         const rendered: any = mount(
-            <NumberField {...numberFieldProps} onChange={handleChange} />
+            <FormItemNumberField
+                {...numberFieldProps}
+                onChange={handleChange}
+                managedClasses={managedClasses}
+            />
         );
 
         rendered
@@ -71,7 +108,12 @@ describe("NumberField", () => {
     test("should remove the data if the soft remove is triggered", () => {
         const handleChange: any = jest.fn();
         const rendered: any = mount(
-            <NumberField {...numberFieldProps} data={10} onChange={handleChange} />
+            <FormItemNumberField
+                {...numberFieldProps}
+                data={10}
+                onChange={handleChange}
+                managedClasses={managedClasses}
+            />
         );
 
         rendered
@@ -86,7 +128,12 @@ describe("NumberField", () => {
         const handleChange: any = jest.fn();
         const data: number = 10;
         const rendered: any = mount(
-            <NumberField {...numberFieldProps} data={data} onChange={handleChange} />
+            <FormItemNumberField
+                {...numberFieldProps}
+                data={data}
+                onChange={handleChange}
+                managedClasses={managedClasses}
+            />
         );
 
         rendered
@@ -107,7 +154,11 @@ describe("NumberField", () => {
     test("should be invalid if an invalid message is passed", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <NumberField {...numberFieldProps} invalidMessage={invalidMessage} />
+            <FormItemNumberField
+                {...numberFieldProps}
+                invalidMessage={invalidMessage}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(
@@ -121,7 +172,11 @@ describe("NumberField", () => {
     test("should not be invalid if an invalid message is passed as an empty string", () => {
         const invalidMessage: string = "";
         const rendered: any = mount(
-            <NumberField {...numberFieldProps} invalidMessage={invalidMessage} />
+            <FormItemNumberField
+                {...numberFieldProps}
+                invalidMessage={invalidMessage}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(
@@ -135,7 +190,11 @@ describe("NumberField", () => {
     test("should not show an invalid message inline if `invalidMessage` is passed and `displayValidationInline` is undefined", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <NumberField {...numberFieldProps} invalidMessage={invalidMessage} />
+            <FormItemNumberField
+                {...numberFieldProps}
+                invalidMessage={invalidMessage}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.html().includes(invalidMessage)).toBe(false);
@@ -143,8 +202,9 @@ describe("NumberField", () => {
     test("should show an invalid message inline if `invalidMessage` is passed and `displayValidationInline` is true", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <NumberField
+            <FormItemNumberField
                 {...numberFieldProps}
+                managedClasses={managedClasses}
                 invalidMessage={invalidMessage}
                 displayValidationInline={true}
             />
@@ -156,8 +216,9 @@ describe("NumberField", () => {
         const invalidMessage1: string = "Foo";
         const invalidMessage2: string = "Bar";
         const rendered: any = mount(
-            <NumberField
+            <FormItemNumberField
                 {...numberFieldProps}
+                managedClasses={managedClasses}
                 invalidMessage={invalidMessage1}
                 displayValidationInline={true}
             />
@@ -168,5 +229,69 @@ describe("NumberField", () => {
         rendered.setProps({ invalidMessage: invalidMessage2 });
 
         expect(rendered.html().includes(invalidMessage2)).toBe(true);
+    });
+    test("should show a default indicator if default values exist and no data is available", () => {
+        const rendered: any = mount(
+            <FormItemNumberField
+                {...numberFieldProps}
+                managedClasses={managedClasses}
+                data={undefined}
+                default={5}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemNumberField_defaultValueIndicator}`)
+        ).toHaveLength(1);
+    });
+    test("should not show a default indicator if data exists", () => {
+        const rendered: any = mount(
+            <FormItemNumberField
+                {...numberFieldProps}
+                managedClasses={managedClasses}
+                data={10}
+                default={5}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemNumberField_defaultValueIndicator}`)
+        ).toHaveLength(0);
+    });
+    test("should show default values if they exist and no data is available", () => {
+        const defaultValue: number = 5;
+        const rendered: any = mount(
+            <FormItemNumberField
+                {...numberFieldProps}
+                managedClasses={managedClasses}
+                data={undefined}
+                default={defaultValue}
+            />
+        );
+
+        expect(
+            rendered
+                .find("input")
+                .at(0)
+                .prop("value")
+        ).toBe(defaultValue.toString());
+    });
+    test("should not show default values if data exists", () => {
+        const value: number = 5;
+        const defaultValue: number = 10;
+        const rendered: any = mount(
+            <FormItemNumberField
+                {...numberFieldProps}
+                managedClasses={managedClasses}
+                data={value}
+                default={defaultValue}
+            />
+        );
+        expect(
+            rendered
+                .find("input")
+                .at(0)
+                .prop("value")
+        ).toBe(value.toString());
     });
 });

--- a/packages/fast-tooling-react/src/form/form/form-item.number-field.style.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.number-field.style.ts
@@ -3,8 +3,8 @@ import {
     applyControl,
     applyControlRegion,
     applyControlWrapper,
-    applyFormItemBadge,
     applyFormItemDisabled,
+    applyFormItemIndicator,
     applyInputStyle,
     applyInvalidMessage,
     applyLabelRegionStyle,
@@ -22,7 +22,7 @@ const styles: ComponentStyles<FormItemNumberFieldClassNameContract, {}> = {
         ...applyFormItemDisabled(),
     },
     formItemNumberField_badge: {
-        ...applyFormItemBadge(),
+        ...applyFormItemIndicator(),
     },
     formItemNumberField_control: {
         ...applyControl(),
@@ -39,6 +39,9 @@ const styles: ComponentStyles<FormItemNumberFieldClassNameContract, {}> = {
     formItemNumberField_controlInput: {
         ...applyInputStyle(),
         width: "100%",
+    },
+    formItemNumberField_defaultValueIndicator: {
+        ...applyFormItemIndicator(),
     },
     formItemNumberField_softRemove: {
         ...applySoftRemove(),

--- a/packages/fast-tooling-react/src/form/form/form-item.number-field.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.number-field.tsx
@@ -21,8 +21,6 @@ class FormItemNumberField extends FormItemBase<
     public static displayName: string = "FormItemNumberField";
 
     public render(): JSX.Element {
-        const value: string = getStringValue(this.props.data, this.props.default);
-
         return (
             <div className={this.generateClassNames()}>
                 <div
@@ -48,6 +46,12 @@ class FormItemNumberField extends FormItemBase<
                             >
                                 {this.props.label}
                             </label>
+                            {this.renderDefaultValueIndicator(
+                                get(
+                                    this.props,
+                                    "managedClasses.formItemNumberField_defaultValueIndicator"
+                                )
+                            )}
                             {this.renderBadge(
                                 get(
                                     this.props,
@@ -61,8 +65,8 @@ class FormItemNumberField extends FormItemBase<
                             }
                             id={this.props.dataLocation}
                             type="number"
-                            value={value}
-                            name={`number${value}`}
+                            value={this.getValue()}
+                            name={this.props.dataLocation}
                             onChange={this.handleChange}
                             min={this.props.min}
                             max={this.props.max}
@@ -122,6 +126,11 @@ class FormItemNumberField extends FormItemBase<
 
         return classes;
     }
+
+    private getValue(): string {
+        return getStringValue(this.props.data, this.props.default);
+    }
 }
 
+export { FormItemNumberField };
 export default manageJss(styles)(FormItemNumberField);

--- a/packages/fast-tooling-react/src/form/form/form-item.section-link.props.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.section-link.props.ts
@@ -8,6 +8,7 @@ export interface FormItemSectionLinkClassNameContract {
     formItemSectionLink_anchor?: string;
     formItemSectionLink_badge?: string;
     formItemSectionLink_controlRegion?: string;
+    formItemSectionLink_defaultValueIndicator?: string;
     formItemSectionLink_invalidMessage?: string;
     formItemSectionLink_softRemove?: string;
     formItemSectionLink_softRemoveInput?: string;

--- a/packages/fast-tooling-react/src/form/form/form-item.section-link.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.section-link.spec.tsx
@@ -1,13 +1,28 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
-import FormItemSectionLink from "./form-item.section-link";
-import { FormItemSectionLinkProps } from "./form-item.section-link.props";
+import { FormItemSectionLink } from "./form-item.section-link";
+import {
+    FormItemSectionLinkClassNameContract,
+    FormItemSectionLinkProps,
+} from "./form-item.section-link.props";
 
 /*
  * Configure Enzyme
  */
 configure({ adapter: new Adapter() });
+
+const managedClasses: FormItemSectionLinkClassNameContract = {
+    formItemSectionLink: "formItemSectionLink-class",
+    formItemSectionLink_anchor: "formItemSectionLink_anchor-class",
+    formItemSectionLink_badge: "formItemSectionLink_badge-class",
+    formItemSectionLink_controlRegion: "formItemSectionLink_controlRegion-class",
+    formItemSectionLink_defaultValueIndicator:
+        "formItemSectionLink_defaultValueIndicator-class",
+    formItemSectionLink_invalidMessage: "formItemSectionLink_invalidMessage-class",
+    formItemSectionLink_softRemove: "formItemSectionLink_softRemove-class",
+    formItemSectionLink_softRemoveInput: "formItemSectionLink_softRemoveInput-class",
+};
 
 const formItemSectionLinkProps: FormItemSectionLinkProps = {
     index: 1,
@@ -24,12 +39,20 @@ const formItemSectionLinkProps: FormItemSectionLinkProps = {
 describe("NumberField", () => {
     test("should not throw", () => {
         expect(() => {
-            shallow(<FormItemSectionLink {...formItemSectionLinkProps} />);
+            shallow(
+                <FormItemSectionLink
+                    {...formItemSectionLinkProps}
+                    managedClasses={managedClasses}
+                />
+            );
         }).not.toThrow();
     });
     test("should generate an HTML anchor element", () => {
         const rendered: any = mount(
-            <FormItemSectionLink {...formItemSectionLinkProps} />
+            <FormItemSectionLink
+                {...formItemSectionLinkProps}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.find("a")).toHaveLength(1);
@@ -39,6 +62,7 @@ describe("NumberField", () => {
         const rendered: any = mount(
             <FormItemSectionLink
                 {...formItemSectionLinkProps}
+                managedClasses={managedClasses}
                 onUpdateSection={handleSectionUpdate}
             />
         );
@@ -56,6 +80,7 @@ describe("NumberField", () => {
         const renderedWithTestLocations: any = mount(
             <FormItemSectionLink
                 {...formItemSectionLinkProps}
+                managedClasses={managedClasses}
                 onUpdateSection={handleSectionUpdateWithTestLocations}
                 schemaLocation={"properties.test"}
                 dataLocation={"test"}
@@ -78,6 +103,7 @@ describe("NumberField", () => {
         const rendered: any = mount(
             <FormItemSectionLink
                 {...formItemSectionLinkProps}
+                managedClasses={managedClasses}
                 data={10}
                 onChange={handleChange}
             />
@@ -97,6 +123,7 @@ describe("NumberField", () => {
         const rendered: any = mount(
             <FormItemSectionLink
                 {...formItemSectionLinkProps}
+                managedClasses={managedClasses}
                 data={data}
                 onChange={handleChange}
             />
@@ -122,6 +149,7 @@ describe("NumberField", () => {
         const rendered: any = mount(
             <FormItemSectionLink
                 {...formItemSectionLinkProps}
+                managedClasses={managedClasses}
                 data={"foo"}
                 invalidMessage={invalidMessage}
             />
@@ -134,6 +162,7 @@ describe("NumberField", () => {
         const rendered: any = mount(
             <FormItemSectionLink
                 {...formItemSectionLinkProps}
+                managedClasses={managedClasses}
                 data={"foo"}
                 invalidMessage={invalidMessage}
                 displayValidationInline={true}
@@ -148,6 +177,7 @@ describe("NumberField", () => {
         const rendered: any = mount(
             <FormItemSectionLink
                 {...formItemSectionLinkProps}
+                managedClasses={managedClasses}
                 invalidMessage={invalidMessage1}
                 displayValidationInline={true}
             />
@@ -158,5 +188,33 @@ describe("NumberField", () => {
         rendered.setProps({ invalidMessage: invalidMessage2 });
 
         expect(rendered.html().includes(invalidMessage2)).toBe(true);
+    });
+    test("should show a default indicator if default values exist and no data is available", () => {
+        const rendered: any = mount(
+            <FormItemSectionLink
+                {...formItemSectionLinkProps}
+                managedClasses={managedClasses}
+                data={undefined}
+                default={{}}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemSectionLink_defaultValueIndicator}`)
+        ).toHaveLength(1);
+    });
+    test("should not show a default indicator if data exists", () => {
+        const rendered: any = mount(
+            <FormItemSectionLink
+                {...formItemSectionLinkProps}
+                managedClasses={managedClasses}
+                data={{}}
+                default={{}}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemSectionLink_defaultValueIndicator}`)
+        ).toHaveLength(0);
     });
 });

--- a/packages/fast-tooling-react/src/form/form/form-item.section-link.style.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.section-link.style.ts
@@ -4,7 +4,7 @@ import {
     applyControl,
     applyControlRegion,
     applyControlSingleLineWrapper,
-    applyFormItemBadge,
+    applyFormItemIndicator,
     applyInvalidMessage,
     applySoftRemove,
     applySoftRemoveInput,
@@ -24,10 +24,13 @@ const styles: ComponentStyles<FormItemSectionLinkClassNameContract, {}> = {
         lineHeight: "23px",
     },
     formItemSectionLink_badge: {
-        ...applyFormItemBadge(),
+        ...applyFormItemIndicator(),
     },
     formItemSectionLink_controlRegion: {
         ...applyControlRegion(),
+    },
+    formItemSectionLink_defaultValueIndicator: {
+        ...applyFormItemIndicator(),
     },
     formItemSectionLink_invalidMessage: {
         ...applyInvalidMessage(),

--- a/packages/fast-tooling-react/src/form/form/form-item.section-link.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.section-link.tsx
@@ -38,6 +38,12 @@ class FormItemSectionLink extends FormItemBase<
                     >
                         {this.props.label}
                     </a>
+                    {this.renderDefaultValueIndicator(
+                        get(
+                            this.props,
+                            "managedClasses.formItemSectionLink_defaultValueIndicator"
+                        )
+                    )}
                     {this.renderBadge(
                         get(this.props, "managedClasses.formItemSectionLink_badge")
                     )}
@@ -67,4 +73,5 @@ class FormItemSectionLink extends FormItemBase<
     };
 }
 
+export { FormItemSectionLink };
 export default manageJss(styles)(FormItemSectionLink);

--- a/packages/fast-tooling-react/src/form/form/form-item.select.props.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.select.props.ts
@@ -13,6 +13,7 @@ export interface FormItemSelectClassNameContract {
     formItemSelect_controlRegion?: string;
     formItemSelect_controlSpan?: string;
     formItemSelect_controlInput?: string;
+    formItemSelect_defaultValueIndicator?: string;
     formItemSelect_invalidMessage?: string;
     formItemSelect_softRemove?: string;
     formItemSelect_softRemoveInput?: string;

--- a/packages/fast-tooling-react/src/form/form/form-item.select.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.select.spec.tsx
@@ -1,13 +1,32 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
-import Select from "./form-item.select";
-import { FormItemSelectProps } from "./form-item.select.props";
+import { FormItemSelect } from "./form-item.select";
+import {
+    FormItemSelectClassNameContract,
+    FormItemSelectProps,
+} from "./form-item.select.props";
 
 /*
  * Configure Enzyme
  */
 configure({ adapter: new Adapter() });
+
+const managedClasses: FormItemSelectClassNameContract = {
+    formItemSelect: "formItemSelect-class",
+    formItemSelect__disabled: "formItemSelect__disabled-class",
+    formItemSelect_badge: "formItemSelect_badge-class",
+    formItemSelect_control: "formItemSelect_control-class",
+    formItemSelect_controlInput: "formItemSelect_controlInput-class",
+    formItemSelect_controlLabel: "formItemSelect_controlLabel-class",
+    formItemSelect_controlLabelRegion: "formItemSelect_controlLabelRegion-class",
+    formItemSelect_controlRegion: "formItemSelect_controlRegion-class",
+    formItemSelect_controlSpan: "formItemSelect_controlSpan-class",
+    formItemSelect_defaultValueIndicator: "formItemSelect_defaultValueIndicator-class",
+    formItemSelect_invalidMessage: "formItemSelect_invalidMessage-class",
+    formItemSelect_softRemove: "formItemSelect_softRemove-class",
+    formItemSelect_softRemoveInput: "formItemSelect_softRemoveInput-class",
+};
 
 const selectProps: FormItemSelectProps = {
     index: 1,
@@ -23,39 +42,60 @@ const selectProps: FormItemSelectProps = {
 describe("Select", () => {
     test("should not throw", () => {
         expect(() => {
-            shallow(<Select {...selectProps} />);
+            shallow(<FormItemSelect {...selectProps} managedClasses={managedClasses} />);
         }).not.toThrow();
     });
     test("should generate an HTML select element", () => {
-        const rendered: any = mount(<Select {...selectProps} />);
+        const rendered: any = mount(
+            <FormItemSelect {...selectProps} managedClasses={managedClasses} />
+        );
 
         expect(rendered.find("select")).toHaveLength(1);
     });
     test("should not generate an HTML select element when there is only one option and select is required", () => {
         const rendered: any = mount(
-            <Select {...selectProps} options={["foo"]} required={true} />
+            <FormItemSelect
+                {...selectProps}
+                options={["foo"]}
+                required={true}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.find("select")).toHaveLength(0);
     });
     test("should generate an HTML select element when there is only one option and select is optional", () => {
-        const rendered: any = mount(<Select {...selectProps} options={["foo"]} />);
+        const rendered: any = mount(
+            <FormItemSelect
+                {...selectProps}
+                options={["foo"]}
+                managedClasses={managedClasses}
+            />
+        );
 
         expect(rendered.find("select")).toHaveLength(1);
     });
     test("should generate HTML options for each passed option", () => {
-        const renderedNoOptions: any = mount(<Select {...selectProps} />);
+        const renderedNoOptions: any = mount(
+            <FormItemSelect {...selectProps} managedClasses={managedClasses} />
+        );
 
         expect(renderedNoOptions.find("option")).toHaveLength(0);
 
         const renderedOptions: any = mount(
-            <Select {...selectProps} options={["foo", "bar"]} />
+            <FormItemSelect
+                {...selectProps}
+                options={["foo", "bar"]}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(renderedOptions.find("option")).toHaveLength(2);
     });
     test("should generate an HTML label", () => {
-        const rendered: any = mount(<Select {...selectProps} />);
+        const rendered: any = mount(
+            <FormItemSelect {...selectProps} managedClasses={managedClasses} />
+        );
 
         expect(rendered.find("label")).toHaveLength(1);
     });
@@ -63,7 +103,12 @@ describe("Select", () => {
         const handleChange: any = jest.fn();
 
         const rendered: any = mount(
-            <Select {...selectProps} onChange={handleChange} options={["foo", "bar"]} />
+            <FormItemSelect
+                {...selectProps}
+                onChange={handleChange}
+                options={["foo", "bar"]}
+                managedClasses={managedClasses}
+            />
         );
 
         const selectElement: any = rendered.find("select");
@@ -78,7 +123,12 @@ describe("Select", () => {
         const handleChange: any = jest.fn();
 
         const rendered: any = mount(
-            <Select {...selectProps} onChange={handleChange} options={[1, 2]} />
+            <FormItemSelect
+                {...selectProps}
+                onChange={handleChange}
+                options={[1, 2]}
+                managedClasses={managedClasses}
+            />
         );
 
         const selectElement: any = rendered.find("select");
@@ -91,7 +141,12 @@ describe("Select", () => {
     });
     test("should be disabled when disabled props is passed", () => {
         const rendered: any = mount(
-            <Select {...selectProps} disabled={true} options={[1, 2]} />
+            <FormItemSelect
+                {...selectProps}
+                disabled={true}
+                options={[1, 2]}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.find("select")).toHaveLength(1);
@@ -100,8 +155,9 @@ describe("Select", () => {
     test("should remove the data if the soft remove is triggered", () => {
         const handleChange: any = jest.fn();
         const rendered: any = mount(
-            <Select
+            <FormItemSelect
                 {...selectProps}
+                managedClasses={managedClasses}
                 data={"foo"}
                 options={["foo", "bar"]}
                 onChange={handleChange}
@@ -117,8 +173,9 @@ describe("Select", () => {
         const handleChange: any = jest.fn();
         const data: string = "foo";
         const rendered: any = mount(
-            <Select
+            <FormItemSelect
                 {...selectProps}
+                managedClasses={managedClasses}
                 data={data}
                 options={["foo", "bar"]}
                 onChange={handleChange}
@@ -137,8 +194,9 @@ describe("Select", () => {
     test("should be invalid if an invalid message is passed", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <Select
+            <FormItemSelect
                 {...selectProps}
+                managedClasses={managedClasses}
                 data={"foo"}
                 options={["foo", "bar"]}
                 invalidMessage={invalidMessage}
@@ -156,8 +214,9 @@ describe("Select", () => {
     test("should not be invalid if an invalid message is passed as an empty string", () => {
         const invalidMessage: string = "";
         const rendered: any = mount(
-            <Select
+            <FormItemSelect
                 {...selectProps}
+                managedClasses={managedClasses}
                 data={"foo"}
                 options={["foo", "bar"]}
                 invalidMessage={invalidMessage}
@@ -175,8 +234,9 @@ describe("Select", () => {
     test("should not show an invalid message inline if `invalidMessage` is passed and `displayValidationInline` is undefined", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <Select
+            <FormItemSelect
                 {...selectProps}
+                managedClasses={managedClasses}
                 data={"foo"}
                 options={["foo", "bar"]}
                 invalidMessage={invalidMessage}
@@ -188,8 +248,9 @@ describe("Select", () => {
     test("should show an invalid message inline if `invalidMessage` is passed and `displayValidationInline` is true", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <Select
+            <FormItemSelect
                 {...selectProps}
+                managedClasses={managedClasses}
                 data={"foo"}
                 options={["foo", "bar"]}
                 invalidMessage={invalidMessage}
@@ -203,8 +264,9 @@ describe("Select", () => {
         const invalidMessage1: string = "Foo";
         const invalidMessage2: string = "Bar";
         const rendered: any = mount(
-            <Select
+            <FormItemSelect
                 {...selectProps}
+                managedClasses={managedClasses}
                 data={"foo"}
                 options={["foo", "bar"]}
                 invalidMessage={invalidMessage1}
@@ -217,5 +279,72 @@ describe("Select", () => {
         rendered.setProps({ invalidMessage: invalidMessage2 });
 
         expect(rendered.html().includes(invalidMessage2)).toBe(true);
+    });
+    test("should show a default indicator if default values exist and no data is available", () => {
+        const rendered: any = mount(
+            <FormItemSelect
+                {...selectProps}
+                managedClasses={managedClasses}
+                options={["foo", "bar"]}
+                data={undefined}
+                default={"foo"}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemSelect_defaultValueIndicator}`)
+        ).toHaveLength(1);
+    });
+    test("should not show a default indicator if data exists", () => {
+        const rendered: any = mount(
+            <FormItemSelect
+                {...selectProps}
+                managedClasses={managedClasses}
+                options={["foo", "bar"]}
+                data={"foo"}
+                default={"bar"}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemSelect_defaultValueIndicator}`)
+        ).toHaveLength(0);
+    });
+    test("should show default values if they exist and no data is available", () => {
+        const defaultValue: string = "foo";
+        const rendered: any = mount(
+            <FormItemSelect
+                {...selectProps}
+                managedClasses={managedClasses}
+                options={["foo", "bar"]}
+                data={undefined}
+                default={defaultValue}
+            />
+        );
+
+        expect(
+            rendered
+                .find("select")
+                .at(0)
+                .prop("value")
+        ).toBe(`\"${defaultValue}\"`);
+    });
+    test("should not show default values if data exists", () => {
+        const value: string = "foo";
+        const defaultValue: string = "bar";
+        const rendered: any = mount(
+            <FormItemSelect
+                {...selectProps}
+                managedClasses={managedClasses}
+                data={value}
+                default={defaultValue}
+            />
+        );
+        expect(
+            rendered
+                .find("select")
+                .at(0)
+                .prop("value")
+        ).toBe(`\"${value}\"`);
     });
 });

--- a/packages/fast-tooling-react/src/form/form/form-item.select.style.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.select.style.ts
@@ -3,8 +3,8 @@ import {
     applyControl,
     applyControlRegion,
     applyControlWrapper,
-    applyFormItemBadge,
     applyFormItemDisabled,
+    applyFormItemIndicator,
     applyInvalidMessage,
     applyLabelRegionStyle,
     applyLabelStyle,
@@ -23,7 +23,7 @@ const styles: ComponentStyles<FormItemSelectClassNameContract, {}> = {
         ...applyFormItemDisabled(),
     },
     formItemSelect_badge: {
-        ...applyFormItemBadge(),
+        ...applyFormItemIndicator(),
     },
     formItemSelect_control: {
         ...applyControl(),
@@ -42,6 +42,9 @@ const styles: ComponentStyles<FormItemSelectClassNameContract, {}> = {
     },
     formItemSelect_controlInput: {
         ...applySelectInputStyles(),
+    },
+    formItemSelect_defaultValueIndicator: {
+        ...applyFormItemIndicator(),
     },
     formItemSelect_invalidMessage: {
         ...applyInvalidMessage(),

--- a/packages/fast-tooling-react/src/form/form/form-item.select.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.select.tsx
@@ -50,6 +50,12 @@ class FormItemSelect extends FormItemBase<
                             >
                                 {this.props.label}
                             </label>
+                            {this.renderDefaultValueIndicator(
+                                get(
+                                    this.props,
+                                    "managedClasses.formItemSelect_defaultValueIndicator"
+                                )
+                            )}
                             {this.renderBadge(
                                 get(this.props, "managedClasses.formItemSelect_badge")
                             )}
@@ -149,4 +155,5 @@ class FormItemSelect extends FormItemBase<
     }
 }
 
+export { FormItemSelect };
 export default manageJss(styles)(FormItemSelect);

--- a/packages/fast-tooling-react/src/form/form/form-item.textarea.props.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.textarea.props.ts
@@ -12,6 +12,7 @@ export interface FormItemTextareaClassNameContract {
     formItemTextarea_controlLabel?: string;
     formItemTextarea_controlLabelRegion?: string;
     formItemTextarea_controlTextarea?: string;
+    formItemTextarea_defaultValueIndicator?: string;
     formItemTextarea_invalidMessage?: string;
     formItemTextarea_softRemove?: string;
     formItemTextarea_softRemoveInput?: string;

--- a/packages/fast-tooling-react/src/form/form/form-item.textarea.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.textarea.spec.tsx
@@ -1,13 +1,32 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
-import Textarea from "./form-item.textarea";
-import { FormItemTextareaProps } from "./form-item.textarea.props";
+import { FormItemTextarea } from "./form-item.textarea";
+import {
+    FormItemTextareaClassNameContract,
+    FormItemTextareaProps,
+} from "./form-item.textarea.props";
 
 /*
  * Configure Enzyme
  */
 configure({ adapter: new Adapter() });
+
+const managedClasses: FormItemTextareaClassNameContract = {
+    formItemTextarea: "formItemTextarea-class",
+    formItemTextarea__disabled: "formItemTextarea__disabled-class",
+    formItemTextarea_badge: "formItemTextarea_badge-class",
+    formItemTextarea_control: "formItemTextarea_control-class",
+    formItemTextarea_controlLabel: "formItemTextarea_controlLabel-class",
+    formItemTextarea_controlLabelRegion: "formItemTextarea_controlLabelRegion-class",
+    formItemTextarea_controlRegion: "formItemTextarea_controlRegion-class",
+    formItemTextarea_controlTextarea: "formItemTextarea_controlTextarea-class",
+    formItemTextarea_defaultValueIndicator:
+        "formItemTextarea_defaultValueIndicator-class",
+    formItemTextarea_invalidMessage: "formItemTextarea_invalidMessage-class",
+    formItemTextarea_softRemove: "formItemTextarea_softRemove-class",
+    formItemTextarea_softRemoveInput: "formItemTextarea_softRemoveInput-class",
+};
 
 const textareaProps: FormItemTextareaProps = {
     index: 1,
@@ -22,21 +41,29 @@ const textareaProps: FormItemTextareaProps = {
 describe("Textarea", () => {
     test("should not throw", () => {
         expect(() => {
-            shallow(<Textarea {...textareaProps} />);
+            shallow(
+                <FormItemTextarea {...textareaProps} managedClasses={managedClasses} />
+            );
         }).not.toThrow();
     });
     test("should generate an HTML textarea element", () => {
-        const rendered: any = mount(<Textarea {...textareaProps} />);
+        const rendered: any = mount(
+            <FormItemTextarea {...textareaProps} managedClasses={managedClasses} />
+        );
 
         expect(rendered.find("textarea")).toHaveLength(1);
     });
     test("should generate an HTML label element", () => {
-        const rendered: any = mount(<Textarea {...textareaProps} />);
+        const rendered: any = mount(
+            <FormItemTextarea {...textareaProps} managedClasses={managedClasses} />
+        );
 
         expect(rendered.find("label")).toHaveLength(1);
     });
     test("should have an `id` attribute on the HTML textarea element and a corresponding `for` attribute on the HTML label element", () => {
-        const rendered: any = mount(<Textarea {...textareaProps} />);
+        const rendered: any = mount(
+            <FormItemTextarea {...textareaProps} managedClasses={managedClasses} />
+        );
         const label: any = rendered.find("label");
         const textarea: any = rendered.find("textarea");
 
@@ -45,7 +72,11 @@ describe("Textarea", () => {
     test("should fire an `onChange` callback when the textarea value is changed", () => {
         const handleChange: any = jest.fn();
         const rendered: any = mount(
-            <Textarea {...textareaProps} onChange={handleChange} />
+            <FormItemTextarea
+                {...textareaProps}
+                onChange={handleChange}
+                managedClasses={managedClasses}
+            />
         );
 
         rendered.find("textarea").simulate("change", { target: { value: "foo" } });
@@ -56,7 +87,12 @@ describe("Textarea", () => {
     test("should remove the data if the soft remove is triggered", () => {
         const handleChange: any = jest.fn();
         const rendered: any = mount(
-            <Textarea {...textareaProps} data={"foo"} onChange={handleChange} />
+            <FormItemTextarea
+                {...textareaProps}
+                data={"foo"}
+                onChange={handleChange}
+                managedClasses={managedClasses}
+            />
         );
 
         rendered.find("input").simulate("change");
@@ -66,7 +102,12 @@ describe("Textarea", () => {
     });
     test("should be disabled when disabled props is passed", () => {
         const rendered: any = mount(
-            <Textarea {...textareaProps} data={"foo"} disabled={true} />
+            <FormItemTextarea
+                {...textareaProps}
+                data={"foo"}
+                disabled={true}
+                managedClasses={managedClasses}
+            />
         );
         const wrapper: any = rendered.find("textarea");
 
@@ -77,7 +118,12 @@ describe("Textarea", () => {
         const handleChange: any = jest.fn();
         const data: string = "foo";
         const rendered: any = mount(
-            <Textarea {...textareaProps} data={data} onChange={handleChange} />
+            <FormItemTextarea
+                {...textareaProps}
+                data={data}
+                onChange={handleChange}
+                managedClasses={managedClasses}
+            />
         );
 
         rendered.find("input").simulate("change");
@@ -92,7 +138,11 @@ describe("Textarea", () => {
     test("should be invalid if an invalid message is passed", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <Textarea {...textareaProps} invalidMessage={invalidMessage} />
+            <FormItemTextarea
+                {...textareaProps}
+                invalidMessage={invalidMessage}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(
@@ -106,7 +156,11 @@ describe("Textarea", () => {
     test("should not be invalid if an invalid message is passed as an empty string", () => {
         const invalidMessage: string = "";
         const rendered: any = mount(
-            <Textarea {...textareaProps} invalidMessage={invalidMessage} />
+            <FormItemTextarea
+                {...textareaProps}
+                invalidMessage={invalidMessage}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(
@@ -120,7 +174,12 @@ describe("Textarea", () => {
     test("should not show an invalid message inline if `invalidMessage` is passed and `displayValidationInline` is undefined", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <Textarea {...textareaProps} data={"foo"} invalidMessage={invalidMessage} />
+            <FormItemTextarea
+                {...textareaProps}
+                data={"foo"}
+                invalidMessage={invalidMessage}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.html().includes(invalidMessage)).toBe(false);
@@ -128,8 +187,9 @@ describe("Textarea", () => {
     test("should show an invalid message inline if `invalidMessage` is passed and `displayValidationInline` is true", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <Textarea
+            <FormItemTextarea
                 {...textareaProps}
+                managedClasses={managedClasses}
                 data={"foo"}
                 invalidMessage={invalidMessage}
                 displayValidationInline={true}
@@ -142,8 +202,9 @@ describe("Textarea", () => {
         const invalidMessage1: string = "Foo";
         const invalidMessage2: string = "Bar";
         const rendered: any = mount(
-            <Textarea
+            <FormItemTextarea
                 {...textareaProps}
+                managedClasses={managedClasses}
                 invalidMessage={invalidMessage1}
                 displayValidationInline={true}
             />
@@ -154,5 +215,69 @@ describe("Textarea", () => {
         rendered.setProps({ invalidMessage: invalidMessage2 });
 
         expect(rendered.html().includes(invalidMessage2)).toBe(true);
+    });
+    test("should show a default indicator if default values exist and no data is available", () => {
+        const rendered: any = mount(
+            <FormItemTextarea
+                {...textareaProps}
+                managedClasses={managedClasses}
+                data={undefined}
+                default={"foo"}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemTextarea_defaultValueIndicator}`)
+        ).toHaveLength(1);
+    });
+    test("should not show a default indicator if data exists", () => {
+        const rendered: any = mount(
+            <FormItemTextarea
+                {...textareaProps}
+                managedClasses={managedClasses}
+                data={"foo"}
+                default={"bar"}
+            />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.formItemTextarea_defaultValueIndicator}`)
+        ).toHaveLength(0);
+    });
+    test("should show default values if they exist and no data is available", () => {
+        const defaultValue: string = "foo";
+        const rendered: any = mount(
+            <FormItemTextarea
+                {...textareaProps}
+                managedClasses={managedClasses}
+                data={undefined}
+                default={defaultValue}
+            />
+        );
+
+        expect(
+            rendered
+                .find("textarea")
+                .at(0)
+                .prop("value")
+        ).toBe(defaultValue);
+    });
+    test("should not show default values if data exists", () => {
+        const value: string = "foo";
+        const defaultValue: string = "bar";
+        const rendered: any = mount(
+            <FormItemTextarea
+                {...textareaProps}
+                managedClasses={managedClasses}
+                data={value}
+                default={defaultValue}
+            />
+        );
+        expect(
+            rendered
+                .find("textarea")
+                .at(0)
+                .prop("value")
+        ).toBe(value);
     });
 });

--- a/packages/fast-tooling-react/src/form/form/form-item.textarea.style.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.textarea.style.ts
@@ -3,15 +3,14 @@ import {
     applyControl,
     applyControlRegion,
     applyControlWrapper,
-    applyFormItemBadge,
     applyFormItemDisabled,
+    applyFormItemIndicator,
     applyInputStyle,
     applyInvalidMessage,
     applyLabelRegionStyle,
     applyLabelStyle,
     applySoftRemove,
     applySoftRemoveInput,
-    error,
 } from "../../style";
 import { FormItemTextareaClassNameContract } from "./form-item.textarea.props";
 
@@ -26,7 +25,7 @@ const styles: ComponentStyles<FormItemTextareaClassNameContract, {}> = {
         ...applyFormItemDisabled(),
     },
     formItemTextarea_badge: {
-        ...applyFormItemBadge(),
+        ...applyFormItemIndicator(),
     },
     formItemTextarea_control: {
         ...applyControl(),
@@ -45,6 +44,9 @@ const styles: ComponentStyles<FormItemTextareaClassNameContract, {}> = {
         width: "100%",
         resize: "none",
         fontFamily: "inherit",
+    },
+    formItemTextarea_defaultValueIndicator: {
+        ...applyFormItemIndicator(),
     },
     formItemTextarea_softRemove: {
         ...applySoftRemove(),

--- a/packages/fast-tooling-react/src/form/form/form-item.textarea.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.textarea.tsx
@@ -39,6 +39,12 @@ class FormItemTextarea extends FormItemBase<
                             >
                                 {this.props.label}
                             </label>
+                            {this.renderDefaultValueIndicator(
+                                get(
+                                    this.props,
+                                    "managedClasses.formItemTextarea_defaultValueIndicator"
+                                )
+                            )}
                             {this.renderBadge(
                                 get(this.props, "managedClasses.formItemTextarea_badge")
                             )}
@@ -52,7 +58,7 @@ class FormItemTextarea extends FormItemBase<
                             rows={
                                 typeof this.props.rows === "number" ? this.props.rows : 3
                             }
-                            value={this.props.data || ""}
+                            value={this.getValue()}
                             onChange={this.handleChange}
                             disabled={this.props.disabled}
                             ref={this.textAreaRef}
@@ -88,6 +94,19 @@ class FormItemTextarea extends FormItemBase<
 
         return classes;
     }
+
+    private getValue(): string {
+        if (typeof this.props.data === "undefined") {
+            if (typeof this.props.default === "string") {
+                return this.props.default;
+            }
+
+            return "";
+        }
+
+        return this.props.data;
+    }
 }
 
+export { FormItemTextarea };
 export default manageJss(styles)(FormItemTextarea);

--- a/packages/fast-tooling-react/src/style/utilities.ts
+++ b/packages/fast-tooling-react/src/style/utilities.ts
@@ -51,12 +51,12 @@ export function applyTriggerStyle(color: string): CSSRules<{}> {
     };
 }
 
-export function applyFormItemBadge(): CSSRules<{}> {
+export function applyFormItemIndicator(): CSSRules<{}> {
     return {
         fill: foreground800,
-        padding: "0 5px",
+        padding: "0 4px",
         alignSelf: "center",
-        minWidth: "12px",
+        minWidth: "14px",
     };
 }
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
This adds the defaults to be displayed as values if no value has been set and adds an indicator to notify the user that the value for the form element is a default value.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Resolves #1588 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->