### PR TITLE
fix: update the current breakpoint value when new breakpoints are set

### DIFF
--- a/packages/fast-layouts-react/src/utilities/breakpoint-tracker.spec.ts
+++ b/packages/fast-layouts-react/src/utilities/breakpoint-tracker.spec.ts
@@ -61,4 +61,27 @@ describe("breakpointTracker", (): void => {
         // Expect default values
         expect(BreakpointTracker.breakpoints).toEqual(defaultBreakpoints);
     });
+
+    test("should update `currentBreakpoint` value when new breakpoint values provided", (): void => {
+        const breakpointsOne: Breakpoints = [0, 500, 900, 1400];
+        const breakpointsTwo: Breakpoints = [0, 200, 400, 600, 800];
+
+        // set innerWidth to 700
+        (window as any)["innerWidth"] = 700;
+
+        // Set breakpoints set one
+        BreakpointTracker.breakpoints = breakpointsOne;
+
+        // Expect new values
+        expect(BreakpointTracker.currentBreakpoint()).toEqual(1);
+
+        // Set breakpoints set two
+        BreakpointTracker.breakpoints = breakpointsTwo;
+
+        // Expect new values
+        expect(BreakpointTracker.currentBreakpoint()).toEqual(3);
+
+        // Update to default values
+        BreakpointTracker.breakpoints = defaultBreakpoints;
+    });
 });

--- a/packages/fast-layouts-react/src/utilities/breakpoint-tracker.ts
+++ b/packages/fast-layouts-react/src/utilities/breakpoint-tracker.ts
@@ -56,6 +56,8 @@ class BreakpointTracker {
      */
     public set breakpoints(breakpointConfig: Breakpoints) {
         this._breakpoints = breakpointConfig;
+
+        this.breakpoint = identifyBreakpoint(window.innerWidth, this._breakpoints);
     }
 
     /**


### PR DESCRIPTION
# Description

Update current breakpoint value in BreakpointTracker when new Breakpoint values is set.

## Motivation & context

https://github.com/Microsoft/fast-dna/issues/1625

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.