### PR TITLE
fix: Update locales so en-rtl applies rtl attribute

### DIFF
--- a/packages/fast-development-site-react/src/components/site/index.tsx
+++ b/packages/fast-development-site-react/src/components/site/index.tsx
@@ -53,6 +53,7 @@ import { Direction } from "@microsoft/fast-web-utilities";
 
 export const localeDirectionMapping: { [key: string]: Direction } = {
     en: Direction.ltr,
+    "en-rtl": Direction.rtl,
 };
 
 export function isRTL(locale: string): boolean {


### PR DESCRIPTION
# Description
Added a mapping for "en-rtl" so rtl is actually applied when it is selected

## Motivation & context
Noticed it wasn't working while developing components.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.
