### PR TITLE
feat: add name prop to checkbox component

### DIFF
--- a/packages/fast-components-react-base/src/checkbox/checkbox.props.ts
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.props.ts
@@ -28,6 +28,11 @@ export interface CheckboxHandledProps extends CheckboxManagedClasses {
     disabled?: boolean;
 
     /**
+     * The name of the input
+     */
+    name?: string;
+
+    /**
      * The indeterminate option
      */
     indeterminate?: boolean;

--- a/packages/fast-components-react-base/src/checkbox/checkbox.schema.json
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.schema.json
@@ -21,6 +21,11 @@
         "inputId": {
             "title": "Input element ID",
             "type": "string"
+        },
+        "name": {
+            "title": "Name",
+            "type": "string",
+            "example": "name"
         }
     },
     "reactProperties": {

--- a/packages/fast-components-react-base/src/checkbox/checkbox.spec.tsx
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.spec.tsx
@@ -75,6 +75,19 @@ describe("checkbox", (): void => {
         expect(rendered.find(".input-class[disabled]").prop("disabled")).toBe(true);
     });
 
+    test("should add `name` attribute to the input element when the name prop is passed", () => {
+        const checkboxName: string = "checkbox-name";
+        const rendered: any = shallow(
+            <Checkbox
+                managedClasses={managedClasses}
+                name={checkboxName}
+                inputId={"id"}
+            />
+        );
+
+        expect(rendered.find(".input-class").prop("name")).toBe(checkboxName);
+    });
+
     test("should initialize as unchecked if the `checked` prop is not provided", () => {
         expect(
             shallow(<Checkbox managedClasses={managedClasses} inputId="id" />).state(

--- a/packages/fast-components-react-base/src/checkbox/checkbox.tsx
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.tsx
@@ -57,6 +57,7 @@ class Checkbox extends Foundation<
         inputId: void 0,
         indeterminate: void 0,
         managedClasses: void 0,
+        name: void 0,
         onChange: void 0,
     };
 
@@ -101,6 +102,7 @@ class Checkbox extends Foundation<
                 <input
                     className={get(this.props, "managedClasses.checkbox_input")}
                     id={this.props.inputId}
+                    name={this.props.name}
                     type="checkbox"
                     ref={this.inputRef}
                     onChange={this.handleCheckboxChange}

--- a/packages/fast-components-react-base/src/checkbox/examples.data.tsx
+++ b/packages/fast-components-react-base/src/checkbox/examples.data.tsx
@@ -37,6 +37,7 @@ const examples: ComponentFactoryExample<CheckboxHandledProps> = {
             ...classes,
             checked: true,
             inputId: "checkbox2",
+            name: "checkbox-name",
         },
         {
             ...classes,

--- a/packages/fast-components-react-msft/src/checkbox/checkbox.schema.json
+++ b/packages/fast-components-react-msft/src/checkbox/checkbox.schema.json
@@ -21,6 +21,11 @@
         "inputId": {
             "title": "Input element ID",
             "type": "string"
+        },
+        "name": {
+            "title": "Name",
+            "type": "string",
+            "example": "name"
         }
     },
     "reactProperties": {


### PR DESCRIPTION
Closes issue referenced in #1639. Same issue for radio is present for checkbox due to the nested nature of the input.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->