### PR TITLE
fix: add onFocus and onBlur callbacks to the input within text action

### DIFF
--- a/packages/fast-components-react-msft/src/text-action/text-action.props.ts
+++ b/packages/fast-components-react-msft/src/text-action/text-action.props.ts
@@ -46,6 +46,16 @@ export interface TextActionHandledProps
      * The trailing glyph
      */
     afterGlyph?: (classname?: string) => React.ReactNode;
+
+    /**
+     * Callback for when text action input is focused
+     */
+    onFocus?: (e?: React.FocusEvent<HTMLInputElement>) => void;
+
+    /**
+     * Callback for when text action input is blurred
+     */
+    onBlur?: (e?: React.FocusEvent<HTMLInputElement>) => void;
 }
 
 export type TextActionProps = TextActionHandledProps & TextActionUnhandledProps;

--- a/packages/fast-components-react-msft/src/text-action/text-action.tsx
+++ b/packages/fast-components-react-msft/src/text-action/text-action.tsx
@@ -98,20 +98,28 @@ class TextAction extends Foundation<
     }
 
     /**
-     * Adds focus state to outer wrapper
+     * Adds focus state to outer wrapper and fires callback if passed
      * In order to correctly focus the input and then the
      * possible button, a class must be added instead of using
      * focus-within via style
      */
-    private handleOnFocus = (): void => {
+    private handleOnFocus = (e: React.FocusEvent<HTMLInputElement>): void => {
         this.setState({ focused: true });
+
+        if (typeof this.props.onFocus === "function") {
+            this.props.onFocus(e);
+        }
     };
 
     /**
-     * Removes focus state
+     * Removes focus state and fires callback if passed
      */
-    private handleOnBlur = (): void => {
+    private handleOnBlur = (e: React.FocusEvent<HTMLInputElement>): void => {
         this.setState({ focused: false });
+
+        if (typeof this.props.onBlur === "function") {
+            this.props.onBlur(e);
+        }
     };
 
     /**


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

Closes [#1645](https://github.com/Microsoft/fast-dna/issues/1645)

# Description

Adds callbacks for onFocus and onBlur to the input within text action

<!--- Describe your changes. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->