### PR TITLE
fix: use a merge strategy for oneOf/anyOfs during validation

### DIFF
--- a/packages/fast-tooling-react/app/pages/form/index.ts
+++ b/packages/fast-tooling-react/app/pages/form/index.ts
@@ -39,6 +39,12 @@ export const nestedOneOf: ExampleComponent = {
     schema: NestedOneOfSchema,
 };
 
+import MergedOneOfSchema from "../../../src/__tests__/schemas/merged-one-of.schema.json";
+
+export const mergedOneOf: ExampleComponent = {
+    schema: MergedOneOfSchema,
+};
+
 import ObjectsSchema from "../../../src/__tests__/schemas/objects.schema.json";
 
 export const objects: ExampleComponent = {

--- a/packages/fast-tooling-react/src/__tests__/schemas/merged-one-of.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/merged-one-of.schema.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "id": "mergedOneOf",
+    "properties": {
+        "foo": {
+            "title": "Foo",
+            "type": "object",
+            "required": [
+                "a",
+                "b"
+            ],
+            "oneOf": [
+                {
+                    "title": "Overridden Foo 1",
+                    "description": "A is string",
+                    "properties": {
+                        "a": {
+                            "title": "A",
+                            "type": "string"
+                        },
+                        "b": {
+                            "title": "B",
+                            "type": "number"
+                        }
+                    }
+                },
+                {
+                    "title": "Overridden Foo 2",
+                    "description": "B is string",
+                    "properties": {
+                        "a": {
+                            "title": "A",
+                            "type": "number"
+                        },
+                        "b": {
+                            "title": "B",
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/packages/fast-tooling-react/src/form/utilities/form.spec.ts
+++ b/packages/fast-tooling-react/src/form/utilities/form.spec.ts
@@ -2,6 +2,7 @@ import "jest";
 import {
     BreadcrumbItem,
     getBreadcrumbs,
+    getInitialOneOfAnyOfState,
     getNavigation,
     getSchemaByDataLocation,
     HandleBreadcrumbClick,
@@ -13,11 +14,13 @@ import arraysSchema from "../../__tests__/schemas/arrays.schema.json";
 import generalSchema from "../../__tests__/schemas/general.schema.json";
 import objectsSchema from "../../__tests__/schemas/objects.schema.json";
 import oneOfSchema from "../../__tests__/schemas/one-of.schema.json";
+import mergedOneOfSchema from "../../__tests__/schemas/merged-one-of.schema.json";
 import anyOfSchema from "../../__tests__/schemas/any-of.schema.json";
 import childrenSchema from "../../__tests__/schemas/children.schema.json";
 import textFieldSchema from "../../__tests__/schemas/textarea.schema.json";
 import deeplyNestedOneOfSchema from "../../__tests__/schemas/one-of-deeply-nested.schema.json";
 import { reactChildrenStringSchema } from "../form/form-item.children.text";
+import { InitialOneOfAnyOfState, oneOfAnyOfType } from "../form/form-section.props";
 
 /**
  * Gets the navigation
@@ -755,6 +758,9 @@ describe("getBreadcrumbs", () => {
     });
 });
 
+/**
+ * Gets a schema by data location (lodash path syntax)
+ */
 describe("getSchemaByDataLocation", () => {
     test("should return the schema given from data requiring no children", () => {
         const data: any = {
@@ -819,5 +825,41 @@ describe("getSchemaByDataLocation", () => {
             ]
         );
         expect(schema2.id).toBe(textFieldSchema.id);
+    });
+});
+
+/**
+ * Gets an initial oneOfAnyOf state
+ */
+describe("getInitialOneOfAnyOfState", () => {
+    test("should get the initial oneOf/anyOf activeIndex and oneOf/anyOf keyword", () => {
+        const initialOneOfAnyOfNoData: InitialOneOfAnyOfState = getInitialOneOfAnyOfState(
+            mergedOneOfSchema.properties.foo,
+            {}
+        );
+        const initialOneOfAnyOfWithData: InitialOneOfAnyOfState = getInitialOneOfAnyOfState(
+            mergedOneOfSchema.properties.foo,
+            {
+                a: 5,
+                b: "foo",
+            }
+        );
+
+        expect(initialOneOfAnyOfNoData.oneOfAnyOf).toEqual({
+            type: oneOfAnyOfType.oneOf,
+            activeIndex: 0,
+        });
+        expect(initialOneOfAnyOfWithData.oneOfAnyOf).toEqual({
+            type: oneOfAnyOfType.oneOf,
+            activeIndex: 1,
+        });
+    });
+    test("should correctly get the oneOf/anyOf schema and merge it with any definitions outside of the selected oneOf/anyOf item", () => {
+        const initialOneOfAnyOfNoData: InitialOneOfAnyOfState = getInitialOneOfAnyOfState(
+            mergedOneOfSchema.properties.foo,
+            {}
+        );
+
+        expect(initialOneOfAnyOfNoData.schema.required).toEqual(["a", "b"]);
     });
 });


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Uses a merge to correctly validate against oneOf/anyOf subschemas.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Resolves #1684 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->