### PR TITLE
fix: styling for actionToggle, contextMenuItem & textAction

### DIFF
--- a/packages/fast-components-styles-msft/src/action-toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/action-toggle/index.ts
@@ -75,7 +75,7 @@ const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = (
                 },
             },
             "&$actionToggle__disabled $actionToggle_selectedGlyph, &$actionToggle__disabled $actionToggle_unselectedGlyph": {
-                fill: neutralForegroundRest,
+                fill: accentForegroundRest,
             },
         },
         actionToggle__justified: {
@@ -93,7 +93,7 @@ const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = (
                 },
             },
             "&$actionToggle__disabled $actionToggle_selectedGlyph, &$actionToggle__disabled $actionToggle_unselectedGlyph": {
-                fill: neutralForegroundRest,
+                fill: accentForegroundRest,
             },
         },
         actionToggle__outline: {

--- a/packages/fast-components-styles-msft/src/action-trigger/index.ts
+++ b/packages/fast-components-styles-msft/src/action-trigger/index.ts
@@ -73,7 +73,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = (
                 },
             },
             "&$actionTrigger__disabled $actionTrigger_glyph": {
-                fill: neutralForegroundRest,
+                fill: accentForegroundRest,
             },
         },
         actionTrigger__justified: {
@@ -91,7 +91,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = (
                 },
             },
             "&$actionTrigger__disabled $actionTrigger_glyph": {
-                fill: neutralForegroundRest,
+                fill: accentForegroundRest,
             },
         },
         actionTrigger__outline: {

--- a/packages/fast-components-styles-msft/src/context-menu-item/index.ts
+++ b/packages/fast-components-styles-msft/src/context-menu-item/index.ts
@@ -55,11 +55,9 @@ const styles: ComponentStyles<ContextMenuItemClassNameContract, DesignSystem> = 
             borderColor: neutralFocus,
         }),
         "&:hover": {
-            color: neutralForegroundHover,
             background: neutralFillStealthHover,
         },
         "&:active": {
-            color: neutralForegroundActive,
             background: neutralFillStealthActive,
         },
     },

--- a/packages/fast-components-styles-msft/src/text-action/index.ts
+++ b/packages/fast-components-styles-msft/src/text-action/index.ts
@@ -97,6 +97,14 @@ const styles: ComponentStyles<TextActionClassNameContract, DesignSystem> = (
         },
         textAction__disabled: {
             ...applyDisabledState(designSystem),
+            "&:hover": {
+                background: neutralFillInputRest,
+                borderColor: neutralOutlineRest,
+            },
+            "&:active": {
+                background: neutralFillInputRest,
+                borderColor: neutralOutlineRest,
+            },
         },
         textAction_button: {
             borderColor: "transparent",

--- a/packages/fast-components-styles-msft/src/text-action/index.ts
+++ b/packages/fast-components-styles-msft/src/text-action/index.ts
@@ -76,11 +76,11 @@ const styles: ComponentStyles<TextActionClassNameContract, DesignSystem> = (
             display: "flex",
             flexDirection: "row",
             transition: "all 0.2s ease-in-out",
-            "&:hover:enabled": {
+            "&:hover": {
                 background: neutralFillInputHover,
                 borderColor: neutralOutlineHover,
             },
-            "&:active:enabled": {
+            "&:active": {
                 background: neutralFillInputActive,
                 borderColor: neutralOutlineActive,
             },


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

1. Action toggle/trigger lightweight disabled icon color is wrong, but goes right on hover.
2. Text action border missing hover state color change
3. Context menu item foreground should not change colors on states

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->