### PR TITLE
fix: deprecate id prop in listbox items

### DIFF
--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
@@ -8,7 +8,7 @@ import {
     AutoSuggestProps,
     AutoSuggestUnhandledProps,
 } from "./auto-suggest.props";
-import { ListboxItemProps } from "../listbox-item";
+import ListboxItem, { ListboxItemProps } from "../listbox-item";
 import Listbox from "../listbox";
 import TextField, { TextFieldType } from "../text-field";
 import { AutoSuggestContext, AutoSuggestContextType } from "./auto-suggest-context";
@@ -214,7 +214,7 @@ class AutoSuggest extends Foundation<
     ): React.ReactNode => {
         const listboxId: string = state.isMenuOpen ? props.listboxId : null;
         const activedescendantId: string =
-            state.focusedItem !== null ? state.focusedItem.id : null;
+            state.focusedItem !== null ? ListboxItem.getItemId(state.focusedItem) : null;
         return (
             <TextField
                 disabled={props.disabled}
@@ -397,7 +397,7 @@ class AutoSuggest extends Foundation<
         );
 
         const currentItemIndex: number = Listbox.getItemIndexById(
-            this.state.focusedItem.id,
+            ListboxItem.getItemId(this.state.focusedItem),
             this.props.children
         );
 
@@ -420,7 +420,8 @@ class AutoSuggest extends Foundation<
 
         if (
             nextFocusableItem === null ||
-            nextFocusableItem.id === this.state.focusedItem.id
+            ListboxItem.getItemId(nextFocusableItem) ===
+                ListboxItem.getItemId(this.state.focusedItem)
         ) {
             // at the end of the list, focus on input
             this.focusOnInput();

--- a/packages/fast-components-react-base/src/listbox-item/README.md
+++ b/packages/fast-components-react-base/src/listbox-item/README.md
@@ -2,7 +2,11 @@
 A component designed to work as a child of the *listbox*.
 
 ### Usage
-The component required "id" prop must be unique and is applied as an id to to the resulting element in the dom.  Developers should not examine *listbox-item* components to determine their selected state, but rather hook up to the "onSelectedItemsChanged" callback on the parent listbox.
+All listbox items should have a itemId unique to the scope of the listbox.  If no itemId is provided the item is identified by its value.  If multiple list items could share the same value authors should provide itemId's or unexpected behavior may occur.
+
+Note: The "id" prop is being depracated, please use "itemId" instead.  Authors who have some need for the item's html "id" attribute to be populated should continue to do so, but will need to provide an itemId as well in a future update.  
+
+Developers should not examine *listbox-item* components to determine their selected state, but rather hook up to the "onSelectedItemsChanged" callback on the parent listbox.
 
 ### Accessibility
 The *listbox-item* generates an html element with role="option" as well as "aria-selected" and "aria-disabled" attributes. 

--- a/packages/fast-components-react-base/src/listbox-item/listbox-item.props.ts
+++ b/packages/fast-components-react-base/src/listbox-item/listbox-item.props.ts
@@ -25,8 +25,15 @@ export interface ListboxItemHandledProps extends ListboxItemManagedClasses {
 
     /**
      * The unique id for the item
+     * @deprecated - this prop will be removed, use itemId instead
      */
-    id: string;
+    id?: string;
+
+    /**
+     * The id of this item, must be unique in the context of a particular listbox
+     * (this does not get written to the html id attibute of the component)
+     */
+    itemId?: string;
 
     /**
      * Friendly string that may be used in UI display

--- a/packages/fast-components-react-base/src/listbox-item/listbox-item.tsx
+++ b/packages/fast-components-react-base/src/listbox-item/listbox-item.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
-import { get } from "lodash-es";
+import { get, isNil } from "lodash-es";
 import { ListboxItemClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import {
     ListboxItemHandledProps,
@@ -34,9 +34,9 @@ class ListboxItem extends Foundation<
      * The "id" prop is being depracated and should not be used.
      */
     public static getItemId = (props: ListboxItemProps): string => {
-        return !ListboxItem.isNullOrUndefined(props.itemId)
+        return !isNil(props.itemId)
             ? props.itemId
-            : !ListboxItem.isNullOrUndefined(props.id)
+            : !isNil(props.id)
                 ? props.id
                 : props.value;
     };
@@ -46,23 +46,16 @@ class ListboxItem extends Foundation<
      */
     public static getItemIdFromElement = (element: Element): string => {
         let idToUse: string = element.getAttribute("itemId");
-        if (!ListboxItem.isNullOrUndefined(idToUse)) {
+        if (!isNil(idToUse)) {
             return idToUse;
         }
 
         idToUse = element.getAttribute("id");
-        if (!ListboxItem.isNullOrUndefined(idToUse)) {
+        if (!isNil(idToUse)) {
             return idToUse;
         }
 
         return element.getAttribute("value");
-    };
-
-    public static isNullOrUndefined = (value: string): boolean => {
-        if (value === undefined || value === null || value === "") {
-            return true;
-        }
-        return false;
     };
 
     protected handledProps: HandledProps<ListboxItemHandledProps> = {

--- a/packages/fast-components-react-base/src/listbox-item/listbox-item.tsx
+++ b/packages/fast-components-react-base/src/listbox-item/listbox-item.tsx
@@ -10,6 +10,7 @@ import {
 import { ListboxContext, ListboxContextType } from "../listbox/listbox-context";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 import { DisplayNamePrefix } from "../utilities";
+import { string } from "prop-types";
 
 class ListboxItem extends Foundation<
     ListboxItemHandledProps,
@@ -24,11 +25,52 @@ class ListboxItem extends Foundation<
         disabled: false,
     };
 
+    /**
+     * Gets the id to use for the item
+     * Authors who's items all have unique values can choose to
+     * not provide an itemId and the values of the items will be used as id's,
+     * otherwise use itemId.  All listbox items of a particular listbox should use the same
+     * approach with respect to using values or itemId or results could be unexpected.
+     * The "id" prop is being depracated and should not be used.
+     */
+    public static getItemId = (props: ListboxItemProps): string => {
+        return !ListboxItem.isNullOrUndefined(props.itemId)
+            ? props.itemId
+            : !ListboxItem.isNullOrUndefined(props.id)
+                ? props.id
+                : props.value;
+    };
+
+    /**
+     * Gets the id to use for an listbox item by examining the associated Element
+     */
+    public static getItemIdFromElement = (element: Element): string => {
+        let idToUse: string = element.getAttribute("itemId");
+        if (!ListboxItem.isNullOrUndefined(idToUse)) {
+            return idToUse;
+        }
+
+        idToUse = element.getAttribute("id");
+        if (!ListboxItem.isNullOrUndefined(idToUse)) {
+            return idToUse;
+        }
+
+        return element.getAttribute("value");
+    };
+
+    public static isNullOrUndefined = (value: string): boolean => {
+        if (value === undefined || value === null || value === "") {
+            return true;
+        }
+        return false;
+    };
+
     protected handledProps: HandledProps<ListboxItemHandledProps> = {
         disabled: void 0,
         displayString: void 0,
         managedClasses: void 0,
         id: void 0,
+        itemId: void 0,
         onInvoke: void 0,
         value: void 0,
     };
@@ -36,13 +78,14 @@ class ListboxItem extends Foundation<
     /**
      * Renders the component
      */
+
     public render(): React.ReactElement<HTMLDivElement> {
         return (
             <div
                 {...this.unhandledProps()}
                 className={this.generateClassNames()}
                 role="option"
-                id={this.props.id}
+                id={this.props.id || null}
                 aria-selected={this.isItemSelected()}
                 aria-disabled={this.props.disabled}
                 onClick={this.handleClick}
@@ -88,7 +131,10 @@ class ListboxItem extends Foundation<
             isSelected =
                 (this.context as ListboxContextType).listboxSelectedItems.filter(
                     (item: ListboxItemProps) => {
-                        return item.id === this.props.id;
+                        return (
+                            ListboxItem.getItemId(item) ===
+                            ListboxItem.getItemId(this.props)
+                        );
                     }
                 ).length === 1;
         }

--- a/packages/fast-components-react-base/src/listbox/listbox.tsx
+++ b/packages/fast-components-react-base/src/listbox/listbox.tsx
@@ -11,8 +11,9 @@ import { KeyCodes, startsWith } from "@microsoft/fast-web-utilities";
 import { get, inRange, isEqual } from "lodash-es";
 import { canUseDOM } from "exenv-es6";
 import { ListboxContext, ListboxContextType } from "./listbox-context";
-import { ListboxItemProps } from "../listbox-item";
+import ListboxItem, { ListboxItemProps } from "../listbox-item";
 import { DisplayNamePrefix } from "../utilities";
+
 export interface ListboxState {
     /**
      * The index of the focusable child
@@ -77,10 +78,7 @@ class Listbox extends Foundation<
         const childrenAsArray: React.ReactNode[] = React.Children.toArray(children);
         return childrenAsArray.findIndex(
             (child: React.ReactElement<any>): boolean => {
-                if (
-                    child.props[Listbox.idPropertyKey] === undefined ||
-                    child.props[Listbox.idPropertyKey] !== itemId
-                ) {
+                if (ListboxItem.getItemId(child.props) !== itemId) {
                     return false;
                 }
                 return true;
@@ -122,10 +120,7 @@ class Listbox extends Foundation<
 
         const matchNode: React.ReactNode = childrenAsArray.find(
             (child: React.ReactElement<any>): boolean => {
-                if (
-                    child.props[Listbox.idPropertyKey] === undefined ||
-                    child.props[Listbox.idPropertyKey] !== itemId
-                ) {
+                if (ListboxItem.getItemId(child.props) !== itemId) {
                     return false;
                 }
                 return true;
@@ -167,7 +162,7 @@ class Listbox extends Foundation<
                 if (typeof item === "string") {
                     itemId = item;
                 } else {
-                    itemId = item.id;
+                    itemId = ListboxItem.getItemId(item);
                 }
 
                 const itemNode: React.ReactElement<any> = this.getNodeById(
@@ -353,7 +348,7 @@ class Listbox extends Foundation<
 
         while (inRange(focusIndex, children.length)) {
             const child: Element = children[focusIndex];
-            focusItemId = child.id;
+            focusItemId = ListboxItem.getItemIdFromElement(child);
             if (this.isFocusableElement(child)) {
                 if (!this.props.disabled) {
                     child.focus();
@@ -376,7 +371,10 @@ class Listbox extends Foundation<
 
         focusIndex =
             selection.length > 0
-                ? Listbox.getItemIndexById(selection[0].id, this.props.children)
+                ? Listbox.getItemIndexById(
+                      ListboxItem.getItemId(selection[0]),
+                      this.props.children
+                  )
                 : this.domChildren().findIndex(this.isFocusableElement);
 
         if (focusIndex !== -1) {
@@ -434,7 +432,7 @@ class Listbox extends Foundation<
 
         this.setState({
             focusIndex,
-            focussedItemId: item.id,
+            focussedItemId: ListboxItem.getItemId(item),
         });
 
         if (!this.props.multiselectable) {
@@ -609,7 +607,7 @@ class Listbox extends Foundation<
     private toggleItem = (item: ListboxItemProps): void => {
         const culledSelection: ListboxItemProps[] = this.state.selectedItems.filter(
             (listboxItem: ListboxItemProps) => {
-                return listboxItem.id !== item.id;
+                return ListboxItem.getItemId(listboxItem) !== ListboxItem.getItemId(item);
             }
         );
         if (culledSelection.length < this.state.selectedItems.length) {

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -4,7 +4,7 @@ import { get, isEqual } from "lodash-es";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 import { SelectClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { SelectHandledProps, SelectProps, SelectUnhandledProps } from "./select.props";
-import { ListboxItemProps } from "../listbox-item";
+import ListboxItem, { ListboxItemProps } from "../listbox-item";
 import Listbox from "../listbox";
 import Button from "../button";
 import { canUseDOM } from "exenv-es6";
@@ -433,7 +433,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
 
         if (this.state.selectedItems.length === 1) {
             const selectedItemIndex: number = Listbox.getItemIndexById(
-                this.state.selectedItems[0].id,
+                ListboxItem.getItemId(this.state.selectedItems[0]),
                 this.props.children
             );
             if (selectedItemIndex !== -1) {

--- a/packages/fast-components-react-msft/src/auto-suggest-option/README.md
+++ b/packages/fast-components-react-msft/src/auto-suggest-option/README.md
@@ -2,7 +2,9 @@
 A component designed to work as a child of the *auto-suggest* component.
 
 ### Usage
-The component required "id" prop must be unique and is applied as an id to to the resulting element in the dom.
+An *auto-suggest-option* should have a itemId unique to the scope of the parent *auto-suggest*.  If no itemId is provided the option is identified by its value.  If multiple options could share the same value authors should provide itemId's or unexpected behavior may occur.
+
+Note: The "id" prop is being depracated, please use "itemId" instead.  Authors who have some need for the item's html "id" attribute to be populated should continue to do so, but will need to provide an itemId as well in a future update.
 
 ### Accessibility
 The *auto-suggest-option* component generates an html element with role="option" as well as "aria-selected" and "aria-disabled" attributes. 

--- a/packages/fast-components-react-msft/src/auto-suggest-option/auto-suggest-option.tsx
+++ b/packages/fast-components-react-msft/src/auto-suggest-option/auto-suggest-option.tsx
@@ -10,7 +10,7 @@ import {
     AutoSuggestContextType,
     ListboxItem as BaseListboxItem,
 } from "@microsoft/fast-components-react-base";
-import { get, slice } from "lodash-es";
+import { get } from "lodash-es";
 import { startsWith } from "@microsoft/fast-web-utilities";
 import { isNullOrUndefined } from "util";
 import { DisplayNamePrefix } from "../utilities";
@@ -40,7 +40,7 @@ class AutoSuggestOption extends Foundation<
         return (
             <BaseListboxItem
                 {...this.unhandledProps()}
-                id={this.props.id}
+                id={this.props.id || null}
                 value={this.props.value}
                 managedClasses={{
                     listboxItem: get(this.props.managedClasses, "autoSuggestOption", ""),

--- a/packages/fast-components-react-msft/src/auto-suggest/auto-suggest.tsx
+++ b/packages/fast-components-react-msft/src/auto-suggest/auto-suggest.tsx
@@ -9,6 +9,7 @@ import {
 import {
     AutoSuggest as BaseAutoSuggest,
     AutoSuggestState,
+    ListboxItem,
 } from "@microsoft/fast-components-react-base";
 import { TextAction } from "../text-action";
 import { DisplayNamePrefix } from "../utilities";
@@ -60,7 +61,7 @@ class AutoSuggest extends Foundation<
     ): React.ReactNode => {
         const listboxId: string = state.isMenuOpen ? props.listboxId : null;
         const activedescendantId: string =
-            state.focusedItem !== null ? state.focusedItem.id : null;
+            state.focusedItem !== null ? ListboxItem.getItemId(state.focusedItem) : null;
         return (
             <TextAction
                 disabled={props.disabled}

--- a/packages/fast-components-react-msft/src/select-option/README.md
+++ b/packages/fast-components-react-msft/src/select-option/README.md
@@ -2,7 +2,11 @@
 A component designed to work as a child of the *select* component.
 
 ### Usage
-The component required "id" prop must be unique and is applied as an id to to the resulting element in the dom.  Developers should not examine *select-option* components to determine their selected state, but rather hook up to the "onSelectedItemsChanged" callback on the parent select component.
+All *select-option* components should have an itemId unique to the scope of the parent *select*.  If no itemId is provided the item is identified by its value.  If multiple options could share the same value authors should provide itemId's or unexpected behavior may occur.
+
+Note: The "id" prop is being depracated, please use "itemId" instead.  Authors who have some need for the item's html "id" attribute to be populated should continue to do so, but will need to provide an itemId as well in a future update. 
+
+Developers should not examine *select-option* components to determine their selected state, but rather hook up to the "onSelectedItemsChanged" callback on the parent select component.
 
 ### Accessibility
 The *select-option* component generates an html element with role="option" as well as "aria-selected" and "aria-disabled" attributes. 

--- a/packages/fast-components-react-msft/src/select-option/select-option.tsx
+++ b/packages/fast-components-react-msft/src/select-option/select-option.tsx
@@ -26,7 +26,7 @@ class SelectOption extends Foundation<
         return (
             <BaseListboxItem
                 {...this.unhandledProps()}
-                id={this.props.id}
+                id={this.props.id || null}
                 displayString={this.props.displayString}
                 value={this.props.value}
                 managedClasses={{


### PR DESCRIPTION
# Description
Listbox items use an "id" prop to identify themselves. Because id attributes must be unique application wide this adds an extra burden to developers.  Since we only need an id that is unique within the scope of a particular list we will switch to use another property name - "itemId", which we will not write to the component's "id" attribute.

The "id" prop will continue to be supported until the next major version of the component library at which time it will be removed as a breaking change.

Additionally we fallback to use "value" as an identifier if no other id is provided. I'm admittedly on the fence about this bit as it makes the 90% case easier as most lists are composed of items with unique values anyway, but does it introduce unnecessary complexity? 

## Motivation & context
Developer feedback that unique id's were unnecessarily burdensome.
https://github.com/Microsoft/fast-dna/issues/1713

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.
