### PR TITLE
fix: handle key arrow events to prevent unwanted scrolling in listbox & autosuggest

### DIFF
--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
@@ -319,10 +319,12 @@ class AutoSuggest extends Foundation<
 
             case KeyCodes.arrowDown:
                 this.focusOnMenu(1);
+                e.preventDefault();
                 break;
 
             case KeyCodes.arrowUp:
                 this.focusOnMenu(-1);
+                e.preventDefault();
                 break;
 
             default:

--- a/packages/fast-components-react-base/src/listbox/listbox.tsx
+++ b/packages/fast-components-react-base/src/listbox/listbox.tsx
@@ -474,7 +474,7 @@ class Listbox extends Foundation<
                         this.toggleItem(itemProps);
                     }
                 }
-
+                event.preventDefault();
                 break;
 
             case KeyCodes.arrowUp:
@@ -489,6 +489,7 @@ class Listbox extends Foundation<
                         this.toggleItem(itemData);
                     }
                 }
+                event.preventDefault();
                 break;
 
             case KeyCodes.end:


### PR DESCRIPTION
I noticed weird scrolling behavior on these components, realized we weren't marking the events as handled so browser did the scroll thing.

## Motivation & context
Poor user experience, focused elements could get scrolled out of view.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.
