### PR TITLE
fix: adds utility to retrieve swatch based on contrast comparisons

### DIFF
--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -1,3 +1,17 @@
+import { ButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
+import {
+    applyFocusVisible,
+    directionSwitch,
+    format,
+    toPx,
+} from "@microsoft/fast-jss-utilities";
+import {
+    DesignSystem,
+    DesignSystemResolver,
+    ensureDesignSystemDefaults,
+} from "../design-system";
+import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
 import {
     accentFillActive,
     accentFillHover,
@@ -18,30 +32,16 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
-import {
-    applyFocusVisible,
-    Direction,
-    directionSwitch,
-    format,
-    toPx,
-} from "@microsoft/fast-jss-utilities";
-import {
-    DesignSystem,
-    ensureDesignSystemDefaults,
-    withDesignSystemDefaults,
-} from "../design-system";
-import {
-    ComponentStyles,
-    ComponentStyleSheet,
-    CSSRules,
-} from "@microsoft/fast-jss-manager";
-import { glyphSize, height, horizontalSpacing } from "../utilities/density";
+import { isDarkMode, Palette, swatchByContrast } from "../utilities/color/palette";
 import { applyCursorPointer } from "../utilities/cursor";
-import { ButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
+import { glyphSize, height, horizontalSpacing } from "../utilities/density";
+import {
+    accentPalette,
+    focusOutlineWidth,
+    outlineWidth,
+} from "../utilities/design-system";
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
-import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 
 const transparentBackground: CSSRules<DesignSystem> = {
     backgroundColor: "transparent",
@@ -79,6 +79,27 @@ const applyTransparentBackplateStyles: CSSRules<DesignSystem> = {
         ...transparentBackground,
     },
 };
+
+const primaryButtonInnerFocusRect: DesignSystemResolver<string> = swatchByContrast(
+    neutralFocus
+)(accentPalette)(
+    (
+        referenceColor: string,
+        sourcePalette: Palette,
+        designSystem: DesignSystem
+    ): number => {
+        return sourcePalette.indexOf(accentFillRest(designSystem));
+    }
+)(
+    (referenceIndex: number, palette: string[], designSystem: DesignSystem): 1 | -1 => {
+        return isDarkMode({
+            ...designSystem,
+            backgroundColor: neutralFocus(designSystem),
+        })
+            ? -1
+            : 1;
+    }
+)((contrastRatio: number): boolean => contrastRatio >= 4.5);
 
 const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
     button: {
@@ -131,6 +152,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         },
         ...applyFocusVisible<DesignSystem>({
             borderColor: neutralFocus,
+            boxShadow: format("0 0 0 2px inset {0}", primaryButtonInnerFocusRect),
         }),
         "& $button_beforeContent, & $button_afterContent": {
             fill: accentForegroundCut,

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.spec.ts
@@ -45,21 +45,17 @@ describe("neutralForegroundHint", (): void => {
         );
     });
 
-    test("should always return a color that has at least 4.5 : 1 against the background", (): void => {
-        neutralPalette.concat(accentPalette).forEach(
-            (swatch: Swatch): void => {
-                function retrieveContrast(
-                    resolvedSwatch: Swatch,
-                    fn: SwatchRecipe
-                ): number {
-                    return parseFloat(
-                        contrast(
-                            fn(() => resolvedSwatch)(designSystemDefaults),
-                            resolvedSwatch
-                        ).toPrecision(3)
-                    );
-                }
-
+    function retrieveContrast(resolvedSwatch: Swatch, fn: SwatchRecipe): number {
+        return parseFloat(
+            contrast(
+                fn(() => resolvedSwatch)(designSystemDefaults),
+                resolvedSwatch
+            ).toPrecision(3)
+        );
+    }
+    neutralPalette.concat(accentPalette).forEach(
+        (swatch: Swatch): void => {
+            test(`${swatch} should always be at least 4.5 : 1 against the background`, (): void => {
                 expect(
                     retrieveContrast(swatch, neutralForegroundHint)
                     // Because neutralForegroundHint follows the direction patterns of neutralForeground,
@@ -72,7 +68,7 @@ describe("neutralForegroundHint", (): void => {
                 expect(retrieveContrast(swatch, neutralForegroundHintLarge)).toBeLessThan(
                     3.3
                 );
-            }
-        );
-    });
+            });
+        }
+    );
 });

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.spec.ts
@@ -15,9 +15,9 @@ describe("neutralForegroundHint", (): void => {
         expect(neutralForegroundHint(undefined as any)).toBe("#737373");
     });
 
-    test("should always return a color from the neutral palette", (): void => {
-        neutralPalette.concat(accentPalette).forEach(
-            (swatch: Swatch): void => {
+    neutralPalette.concat(accentPalette).forEach(
+        (swatch: Swatch): void => {
+            test(`${swatch} should resolve a color from the neutral palette`, (): void => {
                 expect(
                     neutralPalette.indexOf(
                         neutralForegroundHint(
@@ -27,9 +27,9 @@ describe("neutralForegroundHint", (): void => {
                         )
                     )
                 ).not.toBe(-1);
-            }
-        );
-    });
+            });
+        }
+    );
 
     test("should return the same color from both methods of setting the reference background", (): void => {
         neutralPalette.concat(accentPalette).forEach(
@@ -45,7 +45,7 @@ describe("neutralForegroundHint", (): void => {
         );
     });
 
-    test("should always return a color that has at least 4.5 : 1 against the background", (): void => {
+    xtest("should always return a color that has at least 4.5 : 1 against the background", (): void => {
         neutralPalette.concat(accentPalette).forEach(
             (swatch: Swatch): void => {
                 function retrieveContrast(

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.spec.ts
@@ -45,7 +45,7 @@ describe("neutralForegroundHint", (): void => {
         );
     });
 
-    xtest("should always return a color that has at least 4.5 : 1 against the background", (): void => {
+    test("should always return a color that has at least 4.5 : 1 against the background", (): void => {
         neutralPalette.concat(accentPalette).forEach(
             (swatch: Swatch): void => {
                 function retrieveContrast(

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.ts
@@ -48,7 +48,7 @@ function neutralForegroundHintFactory(contrastTarget: number): SwatchRecipe {
         backgroundResolver: SwatchResolver
     ): SwatchResolver;
     function neutralForegroundHintInternal(arg: any): any {
-        const algo: ReturnType<
+        const algorithm: ReturnType<
             typeof neutralForegroundHintAlgorithm
         > = neutralForegroundHintAlgorithm(
             (instanceContrast: number): boolean => {
@@ -58,14 +58,14 @@ function neutralForegroundHintFactory(contrastTarget: number): SwatchRecipe {
 
         if (typeof arg === "function") {
             return (designSystem: DesignSystem): Swatch => {
-                return algo(
+                return algorithm(
                     Object.assign({}, designSystem, {
                         backgroundColor: arg(designSystem),
                     })
                 );
             };
         } else {
-            return algo(arg);
+            return algorithm(arg);
         }
     }
 

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.ts
@@ -2,6 +2,7 @@ import { DesignSystem } from "../../design-system";
 import {
     findClosestSwatchIndex,
     findSwatchIndex,
+    isDarkMode,
     Palette,
     palette,
     PaletteType,
@@ -30,7 +31,7 @@ function neturalForegroundHintDirectionResolver(
     referenceIndex: number,
     sourcePalette: Palette
 ): 1 | -1 {
-    return referenceIndex >= Math.floor(sourcePalette.length / 2) ? -1 : 1;
+    return referenceIndex > Math.ceil(sourcePalette.length / 2) ? -1 : 1;
 }
 
 const neutralForegroundHintAlgorithm: ReturnType<

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
@@ -11,6 +11,8 @@ import {
 import designSystemDefaults, { DesignSystem } from "../../design-system";
 import { accent } from "./color-constants";
 import { Swatch } from "./common";
+import { neutralForeground } from "./neutral-foreground";
+import { neutralPalette } from "../design-system";
 
 describe("palette", (): void => {
     test("should return a function", (): void => {
@@ -177,6 +179,81 @@ describe("swatchByMode", (): void => {
 
 describe("swatchByContrast", (): void => {
     test("should return a function", (): void => {
-        expect(typeof swatchByContrast()).toBe("function");
+        expect(typeof swatchByContrast({} as any)).toBe("function");
+    });
+    describe("indexResolver", (): void => {
+        test("should pass a reference color as the first argument", (): void => {
+            const indexResolver: jest.SpyInstance = jest.fn(() => 0);
+            const directionResolver: jest.SpyInstance = jest.fn(() => 1);
+            const contrastCondition: jest.SpyInstance = jest.fn(() => false);
+
+            swatchByContrast("#FFF")(neutralPalette)(indexResolver as any)(
+                directionResolver as any
+            )(contrastCondition as any)({} as DesignSystem);
+            expect(indexResolver).toHaveBeenCalledTimes(1);
+            expect(indexResolver.mock.calls[0][0]).toBe("#FFF");
+        });
+        test("should pass the palette as the second argument", (): void => {
+            const indexResolver: jest.SpyInstance = jest.fn(() => 0);
+            const directionResolver: jest.SpyInstance = jest.fn(() => 1);
+            const contrastCondition: jest.SpyInstance = jest.fn(() => false);
+            const colorPalette: string[] = ["foo"];
+
+            swatchByContrast("#FFF")(() => colorPalette)(indexResolver as any)(
+                directionResolver as any
+            )(contrastCondition as any)({} as DesignSystem);
+            expect(indexResolver).toHaveBeenCalledTimes(1);
+            expect(indexResolver.mock.calls[0][1]).toBe(colorPalette);
+        });
+        test("should pass the designSystem as the third argument", (): void => {
+            const indexResolver: jest.SpyInstance = jest.fn(() => 0);
+            const directionResolver: jest.SpyInstance = jest.fn(() => 1);
+            const contrastCondition: jest.SpyInstance = jest.fn(() => false);
+            const designSystem: DesignSystem = {} as DesignSystem;
+
+            swatchByContrast("#FFF")(neutralPalette)(indexResolver as any)(
+                directionResolver as any
+            )(contrastCondition as any)(designSystem);
+            expect(indexResolver).toHaveBeenCalledTimes(1);
+            expect(indexResolver.mock.calls[0][2]).toBe(designSystem);
+        });
+    });
+    describe("directionResolver", (): void => {
+        test("should pass the reference index as the first argument", (): void => {
+            const index: number = 77;
+            const indexResolver: jest.SpyInstance = jest.fn(() => index);
+            const directionResolver: jest.SpyInstance = jest.fn(() => 1);
+            const contrastCondition: jest.SpyInstance = jest.fn(() => false);
+
+            swatchByContrast("#FFF")(neutralPalette)(indexResolver as any)(
+                directionResolver as any
+            )(contrastCondition as any)({} as DesignSystem);
+            expect(directionResolver).toHaveBeenCalledTimes(1);
+            expect(directionResolver.mock.calls[0][0]).toBe(index);
+        });
+        test("should pass the palette as the second argument", (): void => {
+            const indexResolver: jest.SpyInstance = jest.fn(() => 0);
+            const directionResolver: jest.SpyInstance = jest.fn(() => 1);
+            const contrastCondition: jest.SpyInstance = jest.fn(() => false);
+            const colorPalette: string[] = ["foo"];
+
+            swatchByContrast("#FFF")(() => colorPalette)(indexResolver as any)(
+                directionResolver as any
+            )(contrastCondition as any)({} as DesignSystem);
+            expect(directionResolver).toHaveBeenCalledTimes(1);
+            expect(directionResolver.mock.calls[0][1]).toBe(colorPalette);
+        });
+        test("should pass the designSystem as the third argument", (): void => {
+            const indexResolver: jest.SpyInstance = jest.fn(() => 0);
+            const directionResolver: jest.SpyInstance = jest.fn(() => 1);
+            const contrastCondition: jest.SpyInstance = jest.fn(() => false);
+            const designSystem: DesignSystem = {} as DesignSystem;
+
+            swatchByContrast("#FFF")(neutralPalette)(indexResolver as any)(
+                directionResolver as any
+            )(contrastCondition as any)(designSystem);
+            expect(directionResolver).toHaveBeenCalledTimes(1);
+            expect(directionResolver.mock.calls[0][2]).toBe(designSystem);
+        });
     });
 });

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
@@ -220,7 +220,7 @@ describe("swatchByContrast", (): void => {
     });
     describe("directionResolver", (): void => {
         test("should pass the reference index as the first argument", (): void => {
-            const index: number = 77;
+            const index: number = 20;
             const indexResolver: jest.SpyInstance = jest.fn(() => index);
             const directionResolver: jest.SpyInstance = jest.fn(() => 1);
             const contrastCondition: jest.SpyInstance = jest.fn(() => false);
@@ -230,6 +230,32 @@ describe("swatchByContrast", (): void => {
             )(contrastCondition as any)({} as DesignSystem);
             expect(directionResolver).toHaveBeenCalledTimes(1);
             expect(directionResolver.mock.calls[0][0]).toBe(index);
+        });
+        test("should recieve recieve the palette length - 1 if the resolved index is greater than the palette length", (): void => {
+            const index: number = 77;
+            const indexResolver: jest.SpyInstance = jest.fn(() => index);
+            const directionResolver: jest.SpyInstance = jest.fn(() => 1);
+            const contrastCondition: jest.SpyInstance = jest.fn(() => false);
+
+            swatchByContrast("#FFF")(neutralPalette)(indexResolver as any)(
+                directionResolver as any
+            )(contrastCondition as any)({} as DesignSystem);
+            expect(directionResolver).toHaveBeenCalledTimes(1);
+            expect(directionResolver.mock.calls[0][0]).toBe(
+                neutralPalette({} as DesignSystem).length - 1
+            );
+        });
+        test("should recieve recieve 0 if the resolved index is less than 0", (): void => {
+            const index: number = -20;
+            const indexResolver: jest.SpyInstance = jest.fn(() => index);
+            const directionResolver: jest.SpyInstance = jest.fn(() => 1);
+            const contrastCondition: jest.SpyInstance = jest.fn(() => false);
+
+            swatchByContrast("#FFF")(neutralPalette)(indexResolver as any)(
+                directionResolver as any
+            )(contrastCondition as any)({} as DesignSystem);
+            expect(directionResolver).toHaveBeenCalledTimes(1);
+            expect(directionResolver.mock.calls[0][0]).toBe(0);
         });
         test("should pass the palette as the second argument", (): void => {
             const indexResolver: jest.SpyInstance = jest.fn(() => 0);
@@ -255,5 +281,71 @@ describe("swatchByContrast", (): void => {
             expect(directionResolver).toHaveBeenCalledTimes(1);
             expect(directionResolver.mock.calls[0][2]).toBe(designSystem);
         });
+    });
+
+    test("should return the color at the inital index if it satisfies the predicate", (): void => {
+        const indexResolver: () => number = (): number => 0;
+        const directionResolver: () => 1 | -1 = (): 1 | -1 => 1;
+        const contrastCondition: () => boolean = (): boolean => true;
+        const designSystem: DesignSystem = {} as DesignSystem;
+        const sourcePalette: string[] = ["#111", "#222", "#333"];
+
+        expect(
+            swatchByContrast("#FFF")(() => sourcePalette)(indexResolver)(
+                directionResolver
+            )(contrastCondition)(designSystem)
+        ).toBe(sourcePalette[0]);
+    });
+    test("should return the color at the last index when direction is 1 and no value satisfies the predicate", (): void => {
+        const indexResolver: () => number = (): number => 0;
+        const directionResolver: () => 1 | -1 = (): 1 | -1 => 1;
+        const contrastCondition: () => boolean = (): boolean => false;
+        const designSystem: DesignSystem = {} as DesignSystem;
+        const sourcePalette: string[] = ["#111", "#222", "#333"];
+
+        expect(
+            swatchByContrast("#FFF")(() => sourcePalette)(indexResolver)(
+                directionResolver
+            )(contrastCondition)(designSystem)
+        ).toBe(sourcePalette[sourcePalette.length - 1]);
+    });
+    test("should return the color at the first index when direction is -1 and no value satisfies the predicate", (): void => {
+        const sourcePalette: string[] = ["#111", "#222", "#333"];
+        const indexResolver: () => number = (): number => sourcePalette.length - 1;
+        const directionResolver: () => 1 | -1 = (): 1 | -1 => 1;
+        const contrastCondition: () => boolean = (): boolean => false;
+        const designSystem: DesignSystem = {} as DesignSystem;
+
+        expect(
+            swatchByContrast("#FFF")(() => sourcePalette)(indexResolver)(
+                directionResolver
+            )(contrastCondition)(designSystem)
+        ).toBe(sourcePalette[sourcePalette.length - 1]);
+    });
+    test("should return the color at the last index when initialIndex is greater than the last index", (): void => {
+        const sourcePalette: string[] = ["#111", "#222", "#333"];
+        const indexResolver: () => number = (): number => sourcePalette.length;
+        const directionResolver: () => 1 | -1 = (): 1 | -1 => 1;
+        const contrastCondition: () => boolean = (): boolean => false;
+        const designSystem: DesignSystem = {} as DesignSystem;
+
+        expect(
+            swatchByContrast("#FFF")(() => sourcePalette)(indexResolver)(
+                directionResolver
+            )(contrastCondition)(designSystem)
+        ).toBe(sourcePalette[sourcePalette.length - 1]);
+    });
+    test("should return the color at the first index when initialIndex is less than 0", (): void => {
+        const sourcePalette: string[] = ["#111", "#222", "#333"];
+        const indexResolver: () => number = (): number => sourcePalette.length;
+        const directionResolver: () => 1 | -1 = (): 1 | -1 => -1;
+        const contrastCondition: () => boolean = (): boolean => false;
+        const designSystem: DesignSystem = {} as DesignSystem;
+
+        expect(
+            swatchByContrast("#FFF")(() => sourcePalette)(indexResolver)(
+                directionResolver
+            )(contrastCondition)(designSystem)
+        ).toBe(sourcePalette[0]);
     });
 });

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
@@ -5,6 +5,7 @@ import {
     palette,
     Palette,
     PaletteType,
+    swatchByContrast,
     swatchByMode,
 } from "./palette";
 import designSystemDefaults, { DesignSystem } from "../../design-system";
@@ -171,5 +172,11 @@ describe("swatchByMode", (): void => {
                 backgroundColor: "#000",
             } as DesignSystem)
         ).toBe(designSystemDefaults.accentPalette[7]);
+    });
+});
+
+describe("swatchByContrast", (): void => {
+    test("should return a function", (): void => {
+        expect(typeof swatchByContrast()).toBe("function");
     });
 });

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -180,7 +180,20 @@ export function swatchByMode(
 /**
  * Retrieves a swatch from an input palette, where the swatch's contrast against the reference color
  * passes an input condition. The direction to search in the palette is determined by an input condition.
- * The search for the palette will begin by another input function that should return the starting index.
+ * Where to begin the search in the palette will be determined another input function that should return the starting index.
+ * example: swatchByContrast(
+ *              "#FFF" // compare swatches against "#FFF"
+ *          )(
+ *              neutralPalette // use the neutral palette from the DesignSystem - since this is a function, it will be evaluated with the DesignSystem
+ *          )(
+ *              () => 0 // begin searching for a swatch at the beginning of the neutral palette
+ *          )(
+ *              () => 1 // While searching, search in the direction toward the end of the array (-1 moves towards the beginning of the array)
+ *          )(
+ *              (contrast: number) => contrast >= 4.5 // A swatch is only valid if the contrast is greater than 4.5
+ *          )(
+ *              designSystem // Pass the design-system. The first swatch that passes the previous condition will be returned from this function
+ *          )
  */
 export function swatchByContrast(referenceColor: string | SwatchResolver) {
     /**

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -228,17 +228,17 @@ export function swatchByContrast(referenceColor: string | SwatchResolver) {
                                 ? referenceColor(designSystem)
                                 : referenceColor;
                         const sourcePalette: Palette = paletteResolver(designSystem);
-                        const initialSearchIndex: number = indexResolver(
-                            color,
-                            sourcePalette,
-                            designSystem
+                        const initialSearchIndex: number = clamp(
+                            indexResolver(color, sourcePalette, designSystem),
+                            0,
+                            sourcePalette.length - 1
                         );
                         const direction: 1 | -1 = directionResolver(
                             initialSearchIndex,
                             sourcePalette,
                             designSystem
                         );
-                        const length: number = sourcePalette.length - 1;
+                        const length: number = sourcePalette.length;
                         let index: number = initialSearchIndex;
 
                         while (


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
There are several circumstances where we need to retrieve a swatch that has a contrast relative to some other contrast. This change introduces a genericised function that allows doing so where the inputs and conditions can be customized to the circumstance.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->