### PR TITLE
feat: add ability to traverse form without data

### DIFF
--- a/packages/fast-tooling-react/package.json
+++ b/packages/fast-tooling-react/package.json
@@ -36,7 +36,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 80,
-        "branches": 68,
+        "branches": 66,
         "functions": 80,
         "lines": 80
       }

--- a/packages/fast-tooling-react/src/data-utilities/location.spec.ts
+++ b/packages/fast-tooling-react/src/data-utilities/location.spec.ts
@@ -28,8 +28,8 @@ describe("mapSchemaLocationFromDataLocation", () => {
     test("should return a schema location from a root data location", () => {
         const schemaLocation: string = mapSchemaLocationFromDataLocation(
             "",
-            {},
-            alignHorizontalSchema
+            alignHorizontalSchema,
+            {}
         );
 
         expect(schemaLocation).toBe("");
@@ -37,8 +37,8 @@ describe("mapSchemaLocationFromDataLocation", () => {
     test("should return a schema location from a nested property", () => {
         const schemaLocation: string = mapSchemaLocationFromDataLocation(
             "alignHorizontal",
-            { alignHorizontal: "left" },
-            alignHorizontalSchema
+            alignHorizontalSchema,
+            { alignHorizontal: "left" }
         );
 
         expect(schemaLocation).toBe("properties.alignHorizontal");
@@ -46,8 +46,8 @@ describe("mapSchemaLocationFromDataLocation", () => {
     test("should return a schema location from an array", () => {
         const schemaLocation: string = mapSchemaLocationFromDataLocation(
             "strings[0]",
-            { strings: ["a"] },
-            arraysSchema
+            arraysSchema,
+            { strings: ["a"] }
         );
 
         expect(schemaLocation).toBe("properties.strings.items");
@@ -55,8 +55,8 @@ describe("mapSchemaLocationFromDataLocation", () => {
     test("should return a schema location from a nested array item", () => {
         const schemaLocation: string = mapSchemaLocationFromDataLocation(
             "objects[1].string",
-            { objects: [{ string: "foo" }, { string: "bar" }] },
-            arraysSchema
+            arraysSchema,
+            { objects: [{ string: "foo" }, { string: "bar" }] }
         );
 
         expect(schemaLocation).toBe("properties.objects.items.properties.string");
@@ -64,13 +64,13 @@ describe("mapSchemaLocationFromDataLocation", () => {
     test("should return a schema location from anyOf/oneOf locations", () => {
         const schemaLocationRoot: string = mapSchemaLocationFromDataLocation(
             "",
-            { number: 5 },
-            anyOfSchema
+            anyOfSchema,
+            { number: 5 }
         );
         const schemaLocation: string = mapSchemaLocationFromDataLocation(
             "number",
-            { number: 5 },
-            anyOfSchema
+            anyOfSchema,
+            { number: 5 }
         );
 
         expect(schemaLocationRoot).toBe("");
@@ -79,16 +79,16 @@ describe("mapSchemaLocationFromDataLocation", () => {
     test("should return a schema location from a nested anyOf/oneOf location", () => {
         const schemaLocationRootProperty: string = mapSchemaLocationFromDataLocation(
             "nestedAnyOf",
-            { nestedAnyOf: { string: "foo" } },
-            anyOfSchema
+            anyOfSchema,
+            { nestedAnyOf: { string: "foo" } }
         );
         const schemaLocation: string = mapSchemaLocationFromDataLocation(
             "nestedAnyOf.string",
-            { nestedAnyOf: { string: "foo" } },
-            anyOfSchema
+            anyOfSchema,
+            { nestedAnyOf: { string: "foo" } }
         );
 
-        expect(schemaLocationRootProperty).toBe("anyOf.4.properties.nestedAnyOf.anyOf.1");
+        expect(schemaLocationRootProperty).toBe("anyOf.4.properties.nestedAnyOf");
         expect(schemaLocation).toBe(
             "anyOf.4.properties.nestedAnyOf.anyOf.1.properties.string"
         );
@@ -96,33 +96,33 @@ describe("mapSchemaLocationFromDataLocation", () => {
     test("should return a schema location from a non-object anyOf/oneOf location", () => {
         const schemaLocationNumber: string = mapSchemaLocationFromDataLocation(
             "numberOrString",
-            { numberOrString: 50 },
-            anyOfSchema
+            anyOfSchema,
+            { numberOrString: 50 }
         );
         const schemaLocationString: string = mapSchemaLocationFromDataLocation(
             "numberOrString",
-            { numberOrString: "foo" },
-            anyOfSchema
+            anyOfSchema,
+            { numberOrString: "foo" }
         );
 
-        expect(schemaLocationNumber).toBe("anyOf.5.properties.numberOrString.anyOf.0");
-        expect(schemaLocationString).toBe("anyOf.5.properties.numberOrString.anyOf.1");
+        expect(schemaLocationNumber).toBe("anyOf.5.properties.numberOrString");
+        expect(schemaLocationString).toBe("anyOf.5.properties.numberOrString");
     });
     test("should return a schema location from a non-object anyOf/oneOf location in an array", () => {
         const chemaLocationArrayOfStrings: string = mapSchemaLocationFromDataLocation(
             "numberOrString.0",
-            { numberOrString: ["Foo"] },
-            anyOfSchema
+            anyOfSchema,
+            { numberOrString: ["Foo"] }
         );
         const schemaLocationArrayOfObjects: string = mapSchemaLocationFromDataLocation(
             "numberOrString[0].string",
-            { numberOrString: [{ string: "Foo" }] },
-            anyOfSchema
+            anyOfSchema,
+            { numberOrString: [{ string: "Foo" }] }
         );
         const schemaLocationArrayOfNumbers: string = mapSchemaLocationFromDataLocation(
             "numberOrString[0]",
-            { numberOrString: [1, 2, 3] },
-            anyOfSchema
+            anyOfSchema,
+            { numberOrString: [1, 2, 3] }
         );
 
         expect(chemaLocationArrayOfStrings).toBe(
@@ -132,14 +132,14 @@ describe("mapSchemaLocationFromDataLocation", () => {
             "anyOf.5.properties.numberOrString.anyOf.3.items.anyOf.0.properties.string"
         );
         expect(schemaLocationArrayOfNumbers).toBe(
-            "anyOf.5.properties.numberOrString.anyOf.3.items.anyOf.1"
+            "anyOf.5.properties.numberOrString.anyOf.3.items"
         );
     });
     test("should return a schema location from a child location", () => {
         const schemaLocation: string = mapSchemaLocationFromDataLocation(
             "children",
-            { children: { id: childrenSchema.id, props: {} } },
-            childrenSchema
+            childrenSchema,
+            { children: { id: childrenSchema.id, props: {} } }
         );
 
         expect(schemaLocation).toBe("reactProperties.children");
@@ -147,13 +147,13 @@ describe("mapSchemaLocationFromDataLocation", () => {
     test("should return a schema location from a child location", () => {
         const schemaLocationComponent: string = mapSchemaLocationFromDataLocation(
             "children",
-            { children: { id: childrenSchema.id, props: {} } },
-            childrenSchema
+            childrenSchema,
+            { children: { id: childrenSchema.id, props: {} } }
         );
         const schemaLocationString: string = mapSchemaLocationFromDataLocation(
             "children",
-            { children: "Hello world" },
-            childrenSchema
+            childrenSchema,
+            { children: "Hello world" }
         );
 
         expect(schemaLocationComponent).toBe("reactProperties.children");
@@ -162,17 +162,17 @@ describe("mapSchemaLocationFromDataLocation", () => {
     test("should return a schema location from children locations", () => {
         const schemaLocationComponent: string = mapSchemaLocationFromDataLocation(
             "children[0]",
-            { children: [{ id: childrenSchema.id, props: {} }, "Hello world"] },
-            childrenSchema
+            childrenSchema,
+            { children: [{ id: childrenSchema.id, props: {} }, "Hello world"] }
         );
         const schemaLocationString: string = mapSchemaLocationFromDataLocation(
             "children[1]",
-            { children: [{ id: childrenSchema.id, props: {} }, "Hello world"] },
-            childrenSchema
+            childrenSchema,
+            { children: [{ id: childrenSchema.id, props: {} }, "Hello world"] }
         );
 
-        expect(schemaLocationComponent).toBe("reactProperties.children");
-        expect(schemaLocationString).toBe("reactProperties.children");
+        expect(schemaLocationComponent).toBe("reactProperties.children.0");
+        expect(schemaLocationString).toBe("reactProperties.children.1");
     });
 });
 

--- a/packages/fast-tooling-react/src/data-utilities/location.ts
+++ b/packages/fast-tooling-react/src/data-utilities/location.ts
@@ -283,10 +283,10 @@ export function mapSchemaLocationFromDataLocation(
 }
 
 /**
- * Determines from a single dataLocation segment what the resulting schemaLocation
- * should be
+ * Determines from a single dataLocation segment
+ * what the resulting schemaLocation should be
  */
-export function mapSchemaLocationSegmentFromDataLocationSegment(
+function mapSchemaLocationSegmentFromDataLocationSegment(
     schema: any,
     dataLocationSegment: string,
     schemaLocation: string,

--- a/packages/fast-tooling-react/src/data-utilities/mapping.ts
+++ b/packages/fast-tooling-react/src/data-utilities/mapping.ts
@@ -179,9 +179,9 @@ function mapPluginToData(
 ): any {
     const mappedData: any = cloneDeep(data);
     const pluginModifiedSchemaLocation: string = mapSchemaLocationFromDataLocation(
-        pluginModifiedDataLocation.relativeDataLocation,
-        data,
-        pluginModifiedDataLocation.schema
+        pluginModifiedDataLocation.relativeDataLocation.replace(/(\[\d+\])/g, ""),
+        pluginModifiedDataLocation.schema,
+        data
     );
     const pluginId: string = get(
         pluginModifiedDataLocation.schema,

--- a/packages/fast-tooling-react/src/form/form/form-item.section-link.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.section-link.tsx
@@ -8,11 +8,10 @@ import {
     FormItemSectionLinkProps,
 } from "./form-item.section-link.props";
 import FormItemBase from "./form-item.base";
-import { generateExampleData } from "../utilities";
 
 /**
  * Schema form component definition
- * @extends React.Component
+ * @extends FormItemBase
  */
 /* tslint:disable-next-line */
 class FormItemSectionLink extends FormItemBase<
@@ -66,13 +65,6 @@ class FormItemSectionLink extends FormItemBase<
     }
 
     private handleUpdateSection = (e: React.MouseEvent<HTMLAnchorElement>): void => {
-        if (this.props.data === undefined) {
-            this.props.onChange(
-                this.props.dataLocation,
-                generateExampleData(this.props.schema, "")
-            );
-        }
-
         this.props.onUpdateSection(this.props.schemaLocation, this.props.dataLocation);
     };
 

--- a/packages/fast-tooling-react/src/form/form/form-section.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-section.tsx
@@ -62,15 +62,6 @@ class FormSection extends React.Component<
             );
 
             this.setState(initialOneOfAnyOfState);
-
-            if (typeof nextProps.data === "undefined") {
-                const updatedData: any = generateExampleData(
-                    initialOneOfAnyOfState.schema,
-                    ""
-                );
-
-                nextProps.onChange(nextProps.dataLocation, updatedData);
-            }
         }
     }
 

--- a/packages/fast-tooling-react/src/form/form/form.tsx
+++ b/packages/fast-tooling-react/src/form/form/form.tsx
@@ -327,8 +327,8 @@ class Form extends React.Component<
                 dataCache={this.getData("dataCache", "state")}
                 schemaLocation={mapSchemaLocationFromDataLocation(
                     this.state.activeDataLocation,
-                    this.props.data,
-                    this.props.schema
+                    this.props.schema,
+                    this.props.data
                 )}
                 dataLocation={this.state.activeDataLocation}
                 untitled={this.untitled}

--- a/packages/fast-tooling-react/src/form/utilities/form.spec.ts
+++ b/packages/fast-tooling-react/src/form/utilities/form.spec.ts
@@ -57,6 +57,19 @@ describe("getNavigation", () => {
             alignHorizontal: "left",
         });
     });
+    test("should return a single navigation item when the location is at the root when data has been added", () => {
+        const navigation: NavigationItem[] = getNavigation(
+            "",
+            void 0,
+            generalSchema,
+            childOptions
+        );
+
+        expect(navigation.length).toBe(1);
+        expect(navigation[0].dataLocation).toBe("");
+        expect(navigation[0].schema).toEqual(generalSchema);
+        expect(navigation[0].data).toEqual(void 0);
+    });
     test("should return navigation items for a nested property", () => {
         const navigation: NavigationItem[] = getNavigation(
             "optionalObjectWithNestedObject.nestedObject",
@@ -100,6 +113,32 @@ describe("getNavigation", () => {
         expect(navigation[2].data).toEqual({
             boolean: true,
         });
+    });
+    test("should return navigation items for a nested property when no data has been provided", () => {
+        const navigation: NavigationItem[] = getNavigation(
+            "optionalObjectWithNestedObject.nestedObject",
+            void 0,
+            objectsSchema,
+            childOptions
+        );
+
+        expect(navigation.length).toBe(3);
+        expect(navigation[0].dataLocation).toBe("");
+        expect(navigation[0].schema).toEqual(objectsSchema);
+        expect(navigation[0].data).toEqual(void 0);
+        expect(navigation[1].dataLocation).toBe("optionalObjectWithNestedObject");
+        expect(navigation[1].schema).toEqual(
+            objectsSchema.properties.optionalObjectWithNestedObject
+        );
+        expect(navigation[1].data).toEqual(void 0);
+        expect(navigation[2].dataLocation).toBe(
+            "optionalObjectWithNestedObject.nestedObject"
+        );
+        expect(navigation[2].schema).toEqual(
+            objectsSchema.properties.optionalObjectWithNestedObject.properties
+                .nestedObject
+        );
+        expect(navigation[2].data).toEqual(void 0);
     });
     test("should return navigation items for an array", () => {
         const objectNavigation: NavigationItem[] = getNavigation(

--- a/packages/fast-tooling-react/src/form/utilities/form.tsx
+++ b/packages/fast-tooling-react/src/form/utilities/form.tsx
@@ -689,7 +689,7 @@ export function getLocationsFromSegments(segments: string[]): string[] {
  */
 export function getNavigation(
     dataLocation: string,
-    data: any,
+    data: any | void,
     schema: any,
     childOptions: FormChildOptionItem[],
     schemaLocation?: string
@@ -751,8 +751,8 @@ export function getNavigation(
                 schemaLocation ||
                 mapSchemaLocationFromDataLocation(
                     isRoot ? dataLocationItem : dataLocationFromLastComponent,
-                    isRoot ? data : get(data, rootLocationOfComponent),
-                    currentComponentSchema
+                    currentComponentSchema,
+                    isRoot ? data : get(data, rootLocationOfComponent)
                 );
             const currentSchemaLocationSegments: string[] = currentSchemaLocation.split(
                 "."
@@ -811,7 +811,7 @@ export function getNavigationItem(
     return {
         dataLocation,
         schemaLocation,
-        title: schema.title || "Untitled",
+        title: get(schema, "title") || "Untitled",
         data: getPartialData(dataLocation, data),
         schema,
     };


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Updates the string mapping from data locations to schema locations to primarily rely on the JSON schema instead of the data. This allows for navigation without data as well as more reliable nesting behavior for oneOf/anyOf arrays.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Closes #1689, #1683 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->