### PR TITLE
feat: [DRAFT] add viewport aware positioner component

### DIFF
--- a/packages/fast-components-class-name-contracts-base/src/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/index.ts
@@ -26,3 +26,4 @@ export * from "./text-area";
 export * from "./text-field";
 export * from "./toggle";
 export * from "./typography";
+export * from "./viewport-positioner";

--- a/packages/fast-components-class-name-contracts-base/src/select/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/select/index.ts
@@ -26,4 +26,49 @@ export interface SelectClassNameContract {
      * The multi select modifier
      */
     select__multiSelectable?: string;
+
+    /**
+     * The root of the select's viewport positioner component
+     */
+    select_viewportPositioner?: string;
+
+    /**
+     * left positioner horizontal state
+     */
+    select_viewportPositioner__left?: string;
+
+    /**
+     * center left positioner horizontal state
+     */
+    select_viewportPositioner__centerLeft?: string;
+
+    /**
+     * right positioner horizontal state
+     */
+    select_viewportPositioner__right?: string;
+
+    /**
+     * center right positioner horizontal state
+     */
+    select_viewportPositioner__centerRight?: string;
+
+    /**
+     * top positioner vertical state
+     */
+    select_viewportPositioner__top?: string;
+
+    /**
+     * middle top positioner vertical state
+     */
+    select_viewportPositioner__middleTop?: string;
+
+    /**
+     * bottom positioner vertical state
+     */
+    select_viewportPositioner__bottom?: string;
+
+    /**
+     * middle bottom positioner vertical state
+     */
+    select_viewportPositioner__middleBottom?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/viewport-positioner/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/viewport-positioner/index.ts
@@ -8,42 +8,42 @@ export interface ViewportPositionerClassNameContract {
     viewportPositioner?: string;
 
     /**
-     *
+     * left positioner horizontal state
      */
     viewportPositioner__left?: string;
 
     /**
-     *
+     * center left positioner horizontal state
      */
     viewportPositioner__centerLeft?: string;
 
     /**
-     *
+     * right positioner horizontal state
      */
     viewportPositioner__right?: string;
 
     /**
-     *
+     * center right positioner horizontal state
      */
     viewportPositioner__centerRight?: string;
 
     /**
-     *
+     * top positioner vertical state
      */
     viewportPositioner__top?: string;
 
     /**
-     *
+     * middle top positioner vertical state
      */
     viewportPositioner__middleTop?: string;
 
     /**
-     *
+     * bottom positioner vertical state
      */
     viewportPositioner__bottom?: string;
 
     /**
-     *
+     * middle bottom positioner vertical state
      */
     viewportPositioner__middleBottom?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/viewport-positioner/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/viewport-positioner/index.ts
@@ -1,0 +1,49 @@
+/**
+ * The class name contract for the viewport positioner component
+ */
+export interface ViewportPositionerClassNameContract {
+    /**
+     * The root of the viewport positioner component
+     */
+    viewportPositioner?: string;
+
+    /**
+     *
+     */
+    viewportPositioner__left?: string;
+
+    /**
+     *
+     */
+    viewportPositioner__centerLeft?: string;
+
+    /**
+     *
+     */
+    viewportPositioner__right?: string;
+
+    /**
+     *
+     */
+    viewportPositioner__centerRight?: string;
+
+    /**
+     *
+     */
+    viewportPositioner__top?: string;
+
+    /**
+     *
+     */
+    viewportPositioner__middleTop?: string;
+
+    /**
+     *
+     */
+    viewportPositioner__bottom?: string;
+
+    /**
+     *
+     */
+    viewportPositioner__middleBottom?: string;
+}

--- a/packages/fast-components-react-base/app/examples.ts
+++ b/packages/fast-components-react-base/app/examples.ts
@@ -78,3 +78,6 @@ export { ToggleExamples };
 
 import TypographyExamples from "../src/typography/examples.data";
 export { TypographyExamples };
+
+import ViewportPositionerExamples from "../src/viewport-positioner/examples.data";
+export { ViewportPositionerExamples };

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -15,11 +15,7 @@ import {
     PositionChange,
 } from "./horizontal-overflow.props";
 import throttle from "raf-throttle";
-import {
-    ConstructableResizeObserver,
-    ResizeObserverClassDefinition,
-    ResizeObserverEntry,
-} from "../utilities";
+import { ResizeObserverClassDefinition, ResizeObserverEntry } from "../utilities";
 import { DisplayNamePrefix } from "../utilities";
 
 export enum ButtonDirection {

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -15,7 +15,11 @@ import {
     PositionChange,
 } from "./horizontal-overflow.props";
 import throttle from "raf-throttle";
-import { ResizeObserverClassDefinition, ResizeObserverEntry } from "../utilities";
+import {
+    ConstructableResizeObserver,
+    ResizeObserverClassDefinition,
+    ResizeObserverEntry,
+} from "../utilities";
 import { DisplayNamePrefix } from "../utilities";
 
 export enum ButtonDirection {

--- a/packages/fast-components-react-base/src/index.ts
+++ b/packages/fast-components-react-base/src/index.ts
@@ -105,3 +105,7 @@ export * from "./toggle";
 import Typography from "./typography";
 export { Typography };
 export * from "./typography";
+
+import ViewportPositioner from "./viewport-positioner";
+export { ViewportPositioner };
+export * from "./viewport-positioner";

--- a/packages/fast-components-react-base/src/listbox/listbox.tsx
+++ b/packages/fast-components-react-base/src/listbox/listbox.tsx
@@ -13,6 +13,7 @@ import { canUseDOM } from "exenv-es6";
 import { ListboxContext, ListboxContextType } from "./listbox-context";
 import { ListboxItemProps } from "../listbox-item";
 import { DisplayNamePrefix } from "../utilities";
+
 export interface ListboxState {
     /**
      * The index of the focusable child

--- a/packages/fast-components-react-base/src/select/examples.data.tsx
+++ b/packages/fast-components-react-base/src/select/examples.data.tsx
@@ -28,6 +28,16 @@ const managedClasses: SelectManagedClasses = {
         select_menu: "select_menu",
         select_menu__open: "select_menu__open",
         select__multiSelectable: "select__multiSelectable",
+        select_viewportPositioner: "select_viewportPositioner",
+        select_viewportPositioner__left: "select_viewportPositioner__left",
+        select_viewportPositioner__centerLeft: "select_viewportPositioner__centerLeft",
+        select_viewportPositioner__right: "select_viewportPositioner__right",
+        select_viewportPositioner__centerRight: "select_viewportPositioner__centerRight",
+        select_viewportPositioner__top: "select_viewportPositioner__top",
+        select_viewportPositioner__middleTop: "select_viewportPositioner__middleTop",
+        select_viewportPositioner__bottom: "select_viewportPositioner__bottom",
+        select_viewportPositioner__middleBottom:
+            "select_viewportPositioner__middleBottom",
     },
 };
 

--- a/packages/fast-components-react-base/src/select/select.props.ts
+++ b/packages/fast-components-react-base/src/select/select.props.ts
@@ -41,6 +41,12 @@ export interface SelectHandledProps extends SelectManagedClasses {
     isMenuOpen?: boolean;
 
     /**
+     * Whether to use viewport aware positioning
+     * (ie. can open above the trigger if it needs the room)
+     */
+    enableViewportPositioning?: boolean;
+
+    /**
      * Specifies that the control is disabled
      */
     disabled?: boolean;

--- a/packages/fast-components-react-base/src/select/select.props.ts
+++ b/packages/fast-components-react-base/src/select/select.props.ts
@@ -18,7 +18,7 @@ export interface SelectMenuFlyoutConfig {
     /**
      *  Ref to the element the positioner is anchored to
      */
-    viewPort?: React.RefObject<any>;
+    viewport?: React.RefObject<any>;
 
     /**
      *  The positioning mode for the horizontal axis, default is uncontrolled

--- a/packages/fast-components-react-base/src/select/select.props.ts
+++ b/packages/fast-components-react-base/src/select/select.props.ts
@@ -5,9 +5,71 @@ import {
 } from "@microsoft/fast-components-class-name-contracts-base";
 import { ListboxItemProps } from "../listbox-item";
 import { SelectState } from "./select";
+import {
+    AxisPositioningMode,
+    HorizontalPosition,
+    VerticalPosition,
+} from "../viewport-positioner";
 
 export interface SelectManagedClasses extends ManagedClasses<SelectClassNameContract> {}
 export interface SelectUnhandledProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export interface SelectMenuFlyoutConfig {
+    /**
+     *  Ref to the element the positioner is anchored to
+     */
+    viewPort?: React.RefObject<any>;
+
+    /**
+     *  The positioning mode for the horizontal axis, default is uncontrolled
+     */
+    horizontalPositioningMode?: AxisPositioningMode;
+
+    /**
+     *  The default horizontal position, layout favors the widest option if unset
+     */
+    defaultHorizontalPosition?: HorizontalPosition;
+
+    /**
+     *  The width at which the positioner switches from the default position to the widest one
+     */
+    horizontalThreshold?: number;
+
+    /**
+     *  When enabled the positioner will not move out of the viewport on the horizontal axis
+     */
+    horizontalAlwaysInView?: boolean;
+
+    /**
+     *  The positioning mode for the vertical axis, default is uncontrolled
+     */
+    verticalPositioningMode?: AxisPositioningMode;
+
+    /**
+     * The default vertical position, layout favors the tallest option if unset
+     */
+    defaultVerticalPosition?: VerticalPosition;
+
+    /**
+     *  The height at which the positioner switches from the default position to the tallest one
+     */
+    verticalThreshold?: number;
+
+    /**
+     *  When enabled the positioner will not move out of the viewport on the vertical axis
+     */
+    verticalAlwaysInView?: boolean;
+
+    /**
+     * The disabled state
+     */
+    disabled?: boolean;
+
+    /**
+     * When true the positioner remains fixed relative to it's anchor after the first render
+     */
+    fixedAfterInitialPlacement?: boolean;
+}
 
 export interface SelectHandledProps extends SelectManagedClasses {
     /**
@@ -96,6 +158,11 @@ export interface SelectHandledProps extends SelectManagedClasses {
      * element that provides it an accessible name
      */
     labelledBy?: string;
+
+    /**
+     * The onValueChange event handler
+     */
+    menuFlyoutConfig?: SelectMenuFlyoutConfig;
 }
 
 export type SelectProps = SelectHandledProps & SelectUnhandledProps;

--- a/packages/fast-components-react-base/src/select/select.schema.json
+++ b/packages/fast-components-react-base/src/select/select.schema.json
@@ -50,9 +50,78 @@
             "title":"Labelled by",
             "type":"string"
         },
-        "enableViewportPositioning": {
-            "title":"Viewport aware positioning",
-            "type":"boolean"
+        "menuFlyoutConfig": {
+            "title": "Flyout menu configuration",
+            "type": "object",
+            "description": "Configures the viewport positioner used by the flyout menu",
+            "properties": {
+                "disabled": {
+                    "title": "Disabled",
+                    "type": "boolean"
+                },
+                "horizontalPositioningMode": {
+                    "title": "Horizontal positioning mode",
+                    "type": "string",
+                    "default": "uncontrolled",
+                    "enum": [
+                        "uncontrolled",
+                        "flipOutward",
+                        "flipInward"
+                    ]
+                },
+                "defaultHorizontalPosition": {
+                    "title": "Default horizontal position",
+                    "type": "string",
+                    "default": "uncontrolled",
+                    "enum": [
+                        "left",
+                        "centerLeft",
+                        "centerRight",
+                        "right"
+                    ]
+                },
+                "horizontalThreshold": {
+                    "title": "Horizontal threshold",
+                    "type": "number"
+                },
+                "horizontalAlwaysInView": {
+                    "title": "Horizontal always in view",
+                    "type": "boolean"
+                },
+                "verticalPositioningMode": {
+                    "title": "Vertical positioning mode",
+                    "type": "string",
+                    "default": "uncontrolled",
+                    "enum": [
+                        "uncontrolled",
+                        "flipOutward",
+                        "flipInward"
+                    ]
+                },
+                "defaultVerticalPosition": {
+                    "title": "Default vertical position",
+                    "type": "string",
+                    "default": "uncontrolled",
+                    "enum": [
+                        "top",
+                        "middleTop",
+                        "middleBottom",
+                        "bottom"
+                    ]
+                },
+                "verticalThreshold": {
+                    "title": "Vertical threshold",
+                    "type": "number"
+                },
+                "verticalAlwaysInView": {
+                    "title": "Vertical always in view",
+                    "type": "boolean"
+                },
+                "fixedAfterInitialPlacement": {
+                    "title": "Fixed after initial placement",
+                    "type": "boolean"
+                }
+            }
         }
     },
     "reactProperties": {

--- a/packages/fast-components-react-base/src/select/select.schema.json
+++ b/packages/fast-components-react-base/src/select/select.schema.json
@@ -49,6 +49,10 @@
         "labelledBy": {
             "title":"Labelled by",
             "type":"string"
+        },
+        "enableViewportPositioning": {
+            "title":"Viewport aware positioning",
+            "type":"boolean"
         }
     },
     "reactProperties": {

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { RefObject } from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { get, isEqual } from "lodash-es";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
@@ -6,7 +6,6 @@ import { SelectClassNameContract } from "@microsoft/fast-components-class-name-c
 import { SelectHandledProps, SelectProps, SelectUnhandledProps } from "./select.props";
 import { ListboxItemProps } from "../listbox-item";
 import Listbox from "../listbox";
-import Button from "../button";
 import { canUseDOM } from "exenv-es6";
 import { DisplayNamePrefix } from "../utilities";
 
@@ -25,6 +24,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         disabled: false,
         defaultSelection: [],
         placeholder: "",
+        enableViewportPositioning: false,
     };
 
     /**
@@ -45,11 +45,10 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         onValueChange: void 0,
         placeholder: void 0,
         autoFocus: void 0,
+        enableViewportPositioning: void 0,
     };
 
-    private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
-        HTMLDivElement
-    >();
+    private rootElement: React.RefObject<HTMLDivElement> = React.createRef();
 
     /**
      * constructor
@@ -346,14 +345,14 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
             return null;
         }
         return (
-            <Button
+            <button
                 disabled={props.disabled}
                 aria-labelledby={props.labelledBy || null}
                 aria-haspopup={true}
                 aria-expanded={state.isMenuOpen}
             >
                 {state.displayString}
-            </Button>
+            </button>
         );
     };
 

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -249,7 +249,57 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
             shouldFocusOnMount = this.props.multiselectable;
         }
         return (
-            <ViewportPostioner anchor={this.rootElement} {...this.getFlyoutConfig()}>
+            <ViewportPostioner
+                anchor={this.rootElement}
+                {...this.getFlyoutConfig()}
+                managedClasses={{
+                    viewportPositioner: get(
+                        this.props.managedClasses,
+                        "select_viewportPositioner",
+                        ""
+                    ),
+                    viewportPositioner__left: get(
+                        this.props.managedClasses,
+                        "select_viewportPositioner__left",
+                        ""
+                    ),
+                    viewportPositioner__centerLeft: get(
+                        this.props.managedClasses,
+                        "select_viewportPositioner__centerLeft",
+                        ""
+                    ),
+                    viewportPositioner__centerRight: get(
+                        this.props.managedClasses,
+                        "select_viewportPositioner__centerRight",
+                        ""
+                    ),
+                    viewportPositioner__right: get(
+                        this.props.managedClasses,
+                        "select_viewportPositioner__right",
+                        ""
+                    ),
+                    viewportPositioner__top: get(
+                        this.props.managedClasses,
+                        "select_viewportPositioner__top",
+                        ""
+                    ),
+                    viewportPositioner__middleTop: get(
+                        this.props.managedClasses,
+                        "select_viewportPositioner__middleTop",
+                        ""
+                    ),
+                    viewportPositioner__middleBottom: get(
+                        this.props.managedClasses,
+                        "select_viewportPositioner__middleBottom",
+                        ""
+                    ),
+                    viewportPositioner__bottom: get(
+                        this.props.managedClasses,
+                        "select_viewportPositioner__bottom",
+                        ""
+                    ),
+                }}
+            >
                 <Listbox
                     labelledBy={this.props.labelledBy}
                     disabled={this.props.disabled}

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -11,7 +11,7 @@ import {
 } from "./select.props";
 import { ListboxItemProps } from "../listbox-item";
 import Listbox from "../listbox";
-import ViewportPostioner, { AxisPositioningMode } from "../viewport-positioner";
+import ViewportPostioner from "../viewport-positioner";
 import { canUseDOM } from "exenv-es6";
 import { DisplayNamePrefix } from "../utilities";
 
@@ -30,7 +30,6 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         disabled: false,
         defaultSelection: [],
         placeholder: "",
-        enableViewportPositioning: false,
     };
 
     /**

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -1,11 +1,17 @@
 import React, { RefObject } from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
-import { get, isEqual } from "lodash-es";
+import { get, isEqual, isNil } from "lodash-es";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 import { SelectClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { SelectHandledProps, SelectProps, SelectUnhandledProps } from "./select.props";
+import {
+    SelectHandledProps,
+    SelectMenuFlyoutConfig,
+    SelectProps,
+    SelectUnhandledProps,
+} from "./select.props";
 import { ListboxItemProps } from "../listbox-item";
 import Listbox from "../listbox";
+import ViewportPostioner, { AxisPositioningMode } from "../viewport-positioner";
 import { canUseDOM } from "exenv-es6";
 import { DisplayNamePrefix } from "../utilities";
 
@@ -45,7 +51,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         onValueChange: void 0,
         placeholder: void 0,
         autoFocus: void 0,
-        enableViewportPositioning: void 0,
+        menuFlyoutConfig: void 0,
     };
 
     private rootElement: React.RefObject<HTMLDivElement> = React.createRef();
@@ -244,27 +250,40 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
             shouldFocusOnMount = this.props.multiselectable;
         }
         return (
-            <Listbox
-                labelledBy={this.props.labelledBy}
-                disabled={this.props.disabled}
-                focusItemOnMount={shouldFocusOnMount}
-                multiselectable={this.props.multiselectable}
-                defaultSelection={this.state.selectedItems}
-                selectedItems={this.props.selectedItems}
-                onSelectedItemsChanged={this.updateSelection}
-                managedClasses={{
-                    listbox: get(this.props.managedClasses, "select_menu", ""),
-                    listbox__disabled: get(
-                        this.props.managedClasses,
-                        "select_menuDisabled",
-                        ""
-                    ),
-                }}
-            >
-                {this.props.children}
-            </Listbox>
+            <ViewportPostioner anchor={this.rootElement} {...this.getFlyoutConfig()}>
+                <Listbox
+                    labelledBy={this.props.labelledBy}
+                    disabled={this.props.disabled}
+                    focusItemOnMount={shouldFocusOnMount}
+                    multiselectable={this.props.multiselectable}
+                    defaultSelection={this.state.selectedItems}
+                    selectedItems={this.props.selectedItems}
+                    onSelectedItemsChanged={this.updateSelection}
+                    managedClasses={{
+                        listbox: get(this.props.managedClasses, "select_menu", ""),
+                        listbox__disabled: get(
+                            this.props.managedClasses,
+                            "select_menuDisabled",
+                            ""
+                        ),
+                    }}
+                >
+                    {this.props.children}
+                </Listbox>
+            </ViewportPostioner>
         );
     }
+
+    /**
+     * Gets the flyout menu configuration
+     */
+    private getFlyoutConfig = (): SelectMenuFlyoutConfig => {
+        if (!isNil(this.props.menuFlyoutConfig)) {
+            return this.props.menuFlyoutConfig;
+        }
+
+        return {};
+    };
 
     /**
      * Updates selection state and associated values

--- a/packages/fast-components-react-base/src/viewport-positioner/README.md
+++ b/packages/fast-components-react-base/src/viewport-positioner/README.md
@@ -1,0 +1,51 @@
+## Viewport positioner
+
+The *viewport positioner* component is a container that positions itself relative to an anchor element while trying to take maximum advantage of the space available in the viewport.  For example it could enable a menu to open above or below a control depending on the size and scroll positon of the viewport.
+
+### Usage
+
+The *viewport positioner* and the anchor element it is attached to must both be children of the specified viewport element. There should also be no other scrollable elements in the DOM hierarchy between these elements and the viewport.  The *viewport positioner* element will have its position attribute programmatically set to "relative" and the component also writes in values for the top, right, bottom, left, transform-origin and tranform attributes. 
+
+If no "anchor" is specified the component will be disabled and not attempt to adjust layout. If no viewport is specified the component will assume the viewport is the root document element of the page.
+
+Authors can specify a positioning mode for each axis or leave it "uncontrolled" and use other means (ie. their own css) to manage the positioner's layout on that axis.  The "flipOutward" positioning mode ensures that the positioner does not overlap with the anchor on that axis and butts up against the outer edges of the anchor element.  With the "flipInward" positioning mode set the positioner will overlap with the anchor on the axis specified but will only extend beyond the anchor on the side with the most available space.
+
+FlipOutward:
+
+Anchor
+       |Positioner
+
+ or
+
+             Anchor
+ Positioner|
+
+ FlipInward:
+
+ Anchor
+ |Positioner
+
+ or 
+
+      Anchor
+ Positioner|
+
+ The positioning mode chosen determines the positions that can be chosen.  The "flipOutward" mode allows the "left" and "right" positions only on the horizontal axis, while the "flipInward" mode allows the "centerLeft" and "centerRight" positions. The vertical axis behaves similarly though the positions are named differently.  
+ 
+ If a default position is specified for a particular axis and there is enough space that position will be set.  Whether there is enough space is determined by comparing the threshold size for the axis (or the height/width of the positioner if no threshold specified) to the available space for that position. If there is not enough space, or if no default position is specified, the positioner chooses the position with the most available space.
+
+The chosen position determines which side of the positioner is fixed to the anchor.  For example if the chosen position for the horizontal axis is "left" the positioner will have its "right" property set to a value corresponding to the left edge of the anchor and the "left" propertly will be unset.
+
+The *viewport positioner* adds css classes to itself based on the chosen positions (ie. "viewportPositioner__left", "viewportPositioner__right", etc...) to enable authors to style the positioner and its contents based on relative position.
+
+The "AlwaysInView" props for each axis allows authors to specify whether the positioner should remain on screen when the anchor element is scrolled off.  The *viewport positioner* accomplishes this by setting the translate transform and translate origin properties of the component.
+
+The "fixedAfterInitialPlacement" prop is set the component will not adjust positioning after the initial render.
+
+
+
+
+
+
+
+

--- a/packages/fast-components-react-base/src/viewport-positioner/examples.data.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/examples.data.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
+import schema from "./viewport-positioner.schema.json";
+import ViewportPositioner, {
+    ViewportPositionerHandledProps,
+    ViewportPositionerManagedClasses,
+} from "./viewport-positioner";
+import Documentation from "./.tmp/documentation";
+
+const managedClasses: ViewportPositionerManagedClasses = {
+    managedClasses: {
+        viewportPositioner: "viewportPositioner",
+        viewportPositioner__left: "viewportPositioner__left",
+        viewportPositioner__centerLeft: "viewportPositioner__centerLeft",
+        viewportPositioner__right: "viewportPositioner__right",
+        viewportPositioner__centerRight: "viewportPositioner__centerRight",
+        viewportPositioner__top: "viewportPositioner__top",
+        viewportPositioner__middleTop: "viewportPositioner__middleTop",
+        viewportPositioner__bottom: "viewportPositioner__bottom",
+    },
+};
+
+const examples: ComponentFactoryExample<ViewportPositionerHandledProps> = {
+    name: "Viewport positioner",
+    component: ViewportPositioner,
+    schema: schema as any,
+    documentation: <Documentation />,
+    detailData: {
+        ...managedClasses,
+        children: "Viewport positioner",
+    },
+    data: [
+        {
+            ...managedClasses,
+            children: "Viewport positioner",
+        },
+    ],
+};
+
+export default examples;

--- a/packages/fast-components-react-base/src/viewport-positioner/index.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/index.ts
@@ -1,0 +1,4 @@
+import ViewportPositioner from "./viewport-positioner";
+
+export default ViewportPositioner;
+export * from "./viewport-positioner";

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
@@ -1,0 +1,102 @@
+import React from "react";
+import {
+    ManagedClasses,
+    ViewportPositionerClassNameContract,
+} from "@microsoft/fast-components-class-name-contracts-base";
+
+export interface ViewportPositionerManagedClasses
+    extends ManagedClasses<ViewportPositionerClassNameContract> {}
+export interface ViewportPositionerUnhandledProps
+    extends React.HTMLAttributes<HTMLDivElement> {}
+
+export enum HorizontalPosition {
+    left = "left",
+    centerLeft = "centerLeft",
+    centerRight = "centerRight",
+    right = "right",
+    uncontrolled = "uncontrolled",
+}
+
+export enum VerticalPosition {
+    top = "top",
+    middleTop = "middleTop",
+    middleBottom = "middleBottom",
+    bottom = "bottom",
+    uncontrolled = "uncontrolled",
+}
+
+export enum AxisPositioningMode {
+    uncontrolled = "uncontrolled",
+    flipOutward = "flipOutward",
+    flipInward = "flipInward",
+}
+
+export interface ViewportPositionerHandledProps extends ViewportPositionerManagedClasses {
+    /**
+     *  Ref to the element the positioner is anchored to
+     */
+    anchor?: React.RefObject<any>;
+
+    /**
+     *  Ref to the viewport the positioner is constrained to
+     */
+    viewport?: React.RefObject<any>;
+
+    /**
+     *  The positioning mode for the horizontal axis, default is uncontrolled
+     */
+    horizontalPositioningMode?: AxisPositioningMode;
+
+    /**
+     *  The default horizontal position, layout favors the widest option if unset
+     */
+    defaultHorizontalPosition?: HorizontalPosition;
+
+    /**
+     *  The width at which the positioner switches from the default position to the widest one
+     */
+    horizontalThreshold?: number;
+
+    /**
+     *  When enabled the positioner will not move out of the viewport on the horizontal axis
+     */
+    horizontalAlwaysInView?: boolean;
+
+    /**
+     *  The positioning mode for the vertical axis, default is uncontrolled
+     */
+    verticalPositioningMode?: AxisPositioningMode;
+
+    /**
+     * The default vertical position, layout favors the tallest option if unset
+     */
+    defaultVerticalPosition?: VerticalPosition;
+
+    /**
+     *  The height at which the positioner switches from the default position to the tallest one
+     */
+    verticalThreshold?: number;
+
+    /**
+     *  When enabled the positioner will not move out of the viewport on the vertical axis
+     */
+    vericalAlwaysInView?: boolean;
+
+    /**
+     * The disabled state
+     */
+    disabled?: boolean;
+
+    /**
+     * When true the positioner remains fixed relative to it's anchor after the first render
+     */
+    fixedAfterInitialPlacement?: boolean;
+
+    /**
+     * The children of the viewport positioner
+     */
+    children?: React.ReactNode;
+}
+
+export type ViewportPositionerProps = ViewportPositionerHandledProps &
+    ViewportPositionerUnhandledProps;

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
@@ -80,7 +80,7 @@ export interface ViewportPositionerHandledProps extends ViewportPositionerManage
     /**
      *  When enabled the positioner will not move out of the viewport on the vertical axis
      */
-    vericalAlwaysInView?: boolean;
+    verticalAlwaysInView?: boolean;
 
     /**
      * The disabled state

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.schema.json
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.schema.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Viewport positioner",
+    "description": "A viewport positioner component's schema definition.",
+    "type": "object",
+    "id": "@microsoft/fast-components-react-base/viewport-positioner",
+    "properties": {
+        "disabled": {
+            "title": "Disabled",
+            "type": "boolean"
+        },
+        "horizontalPositioningMode": {
+            "title": "Horizontal positioning mode",
+            "type": "string",
+            "default": "uncontrolled",
+            "enum": [
+                "uncontrolled",
+                "flipOutward",
+                "flipInward"
+            ]
+        },
+        "defaultHorizontalPosition": {
+            "title": "Default horizontal position",
+            "type": "string",
+            "default": "uncontrolled",
+            "enum": [
+                "left",
+                "centerLeft",
+                "centerRight",
+                "right"
+            ]
+        },
+        "horizontalThreshold": {
+            "title": "Horizontal threshold",
+            "type": "number"
+        },
+        "horizontalAlwaysInView": {
+            "title": "Horizontal always in view",
+            "type": "boolean"
+        },
+        "verticalPositioningMode": {
+            "title": "Vertical positioning mode",
+            "type": "string",
+            "default": "uncontrolled",
+            "enum": [
+                "uncontrolled",
+                "flipOutward",
+                "flipInward"
+            ]
+        },
+        "defaultVerticalPosition": {
+            "title": "Default vertical position",
+            "type": "string",
+            "default": "uncontrolled",
+            "enum": [
+                "top",
+                "middleTop",
+                "middleBottom",
+                "bottom"
+            ]
+        },
+        "verticalThreshold": {
+            "title": "Vertical threshold",
+            "type": "number"
+        },
+        "verticalAlwaysInView": {
+            "title": "Vertical always in view",
+            "type": "boolean"
+        },
+        "fixedAfterInitialPlacement": {
+            "title": "Fixed after initial placement",
+            "type": "boolean"
+        }
+    },
+    "reactProperties": {
+        "children": {
+            "title": "Children",
+            "type": "children",
+            "defaults": [
+                "text"
+            ]
+        }
+    }
+}
+

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -8,12 +8,44 @@ import ViewportPositioner, {
     ViewportPositionerUnhandledProps,
 } from "./viewport-positioner";
 import { DisplayNamePrefix } from "../utilities";
-import { HorizontalPosition } from "./viewport-positioner.props";
+import {
+    AxisPositioningMode,
+    HorizontalPosition,
+    VerticalPosition,
+} from "./viewport-positioner.props";
 
 /*
  * Configure Enzyme
  */
 configure({ adapter: new Adapter() });
+
+const viewportRect: ClientRect = {
+    top: 0,
+    right: 100,
+    bottom: 100,
+    left: 0,
+    height: 100,
+    width: 100,
+};
+
+// positioner rects are described by -x-y coordinates
+const positionerRectX20Y20: ClientRect = {
+    top: 20,
+    right: 30,
+    bottom: 30,
+    left: 20,
+    height: 10,
+    width: 10,
+};
+
+const positionerRectX70Y70: ClientRect = {
+    top: 70,
+    right: 80,
+    bottom: 80,
+    left: 70,
+    height: 10,
+    width: 10,
+};
 
 const managedClasses: ViewportPositionerClassNameContract = {
     viewportPositioner: "viewportPositioner",
@@ -22,11 +54,12 @@ const managedClasses: ViewportPositionerClassNameContract = {
     viewportPositioner__right: "viewportPositioner__right",
     viewportPositioner__centerRight: "viewportPositioner__centerRight",
     viewportPositioner__top: "viewportPositioner__top",
-    viewportPositioner__middleTop: "viewportPositioner",
+    viewportPositioner__middleTop: "viewportPositioner__middleTop",
     viewportPositioner__bottom: "viewportPositioner__bottom",
     viewportPositioner__middleBottom: "viewportPositioner__middleBottom",
 };
 
+/* tslint:disable:no-string-literal */
 describe("viewport positioner", (): void => {
     test("should have a displayName that matches the component name", () => {
         expect(`${DisplayNamePrefix}${(ViewportPositioner as any).name}`).toBe(
@@ -51,9 +84,6 @@ describe("viewport positioner", (): void => {
     });
 
     test("should be disabled without an anchor", (): void => {
-        const container: HTMLDivElement = document.createElement("div");
-        document.body.appendChild(container);
-
         const rendered: any = mount(
             <div>
                 <ViewportPositioner
@@ -65,14 +95,9 @@ describe("viewport positioner", (): void => {
 
         const positioner: any = rendered.find("BaseViewportPositioner");
         expect(positioner.instance().state.disabled).toBe(true);
-
-        document.body.removeChild(container);
     });
 
     test("should be enabled with an anchor", (): void => {
-        const container: HTMLDivElement = document.createElement("div");
-        document.body.appendChild(container);
-
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
@@ -82,7 +107,6 @@ describe("viewport positioner", (): void => {
                 <div ref={anchorElement} />
                 <ViewportPositioner
                     anchor={anchorElement}
-                    // defaultHorizontalPosition={HorizontalPosition.left}
                     managedClasses={managedClasses}
                 />
             </div>
@@ -90,7 +114,661 @@ describe("viewport positioner", (): void => {
 
         const positioner: any = rendered.find("BaseViewportPositioner");
         expect(positioner.instance().state.disabled).toBe(false);
+    });
 
-        document.body.removeChild(container);
+    test("should be disabled when disabled prop is set", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div>
+                <div ref={anchorElement} />
+                <ViewportPositioner
+                    disabled={true}
+                    anchor={anchorElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+        expect(positioner.instance().state.disabled).toBe(true);
+    });
+
+    test("positioning values applied correctly for specified default position - pt1", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div>
+                <div ref={anchorElement} />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.flipOutward}
+                    defaultHorizontalPosition={HorizontalPosition.left}
+                    verticalPositioningMode={AxisPositioningMode.flipOutward}
+                    defaultVerticalPosition={VerticalPosition.top}
+                    anchor={anchorElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            HorizontalPosition.left
+        );
+        expect(positioner.instance().state.right).not.toBe(null);
+        expect(positioner.instance().state.left).toBe(null);
+        expect(positioner.instance().state.xTransformOrigin).toBe("right");
+        expect(positioner.instance().rootElement.current.className).toContain(
+            managedClasses.viewportPositioner__left
+        );
+
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            VerticalPosition.top
+        );
+        expect(positioner.instance().state.bottom).not.toBe(null);
+        expect(positioner.instance().state.top).toBe(null);
+        expect(positioner.instance().state.yTransformOrigin).toBe("bottom");
+        expect(positioner.instance().rootElement.current.className).toContain(
+            managedClasses.viewportPositioner__top
+        );
+    });
+
+    test("positioning values applied correctly for specified default position - pt2", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div>
+                <div ref={anchorElement} />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.flipOutward}
+                    defaultHorizontalPosition={HorizontalPosition.right}
+                    verticalPositioningMode={AxisPositioningMode.flipOutward}
+                    defaultVerticalPosition={VerticalPosition.bottom}
+                    anchor={anchorElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            HorizontalPosition.right
+        );
+        expect(positioner.instance().state.right).toBe(null);
+        expect(positioner.instance().state.left).not.toBe(null);
+        expect(positioner.instance().state.xTransformOrigin).toBe("left");
+        expect(positioner.instance().rootElement.current.className).toContain(
+            managedClasses.viewportPositioner__right
+        );
+
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            VerticalPosition.bottom
+        );
+        expect(positioner.instance().state.bottom).toBe(null);
+        expect(positioner.instance().state.top).not.toBe(null);
+        expect(positioner.instance().state.yTransformOrigin).toBe("top");
+        expect(positioner.instance().rootElement.current.className).toContain(
+            managedClasses.viewportPositioner__bottom
+        );
+    });
+
+    test("positioning values applied correctly for specified default position - pt3", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div>
+                <div ref={anchorElement} />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.flipInward}
+                    defaultHorizontalPosition={HorizontalPosition.centerLeft}
+                    verticalPositioningMode={AxisPositioningMode.flipInward}
+                    defaultVerticalPosition={VerticalPosition.middleTop}
+                    anchor={anchorElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            HorizontalPosition.centerLeft
+        );
+        expect(positioner.instance().state.right).not.toBe(null);
+        expect(positioner.instance().state.left).toBe(null);
+        expect(positioner.instance().state.xTransformOrigin).toBe("right");
+        expect(positioner.instance().rootElement.current.className).toContain(
+            managedClasses.viewportPositioner__centerLeft
+        );
+
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            VerticalPosition.middleTop
+        );
+        expect(positioner.instance().state.bottom).not.toBe(null);
+        expect(positioner.instance().state.top).toBe(null);
+        expect(positioner.instance().state.yTransformOrigin).toBe("bottom");
+        expect(positioner.instance().rootElement.current.className).toContain(
+            managedClasses.viewportPositioner__middleTop
+        );
+    });
+
+    test("positioning values applied correctly for specified default position - pt4", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div>
+                <div ref={anchorElement} />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.flipInward}
+                    defaultHorizontalPosition={HorizontalPosition.centerRight}
+                    verticalPositioningMode={AxisPositioningMode.flipInward}
+                    defaultVerticalPosition={VerticalPosition.middleBottom}
+                    anchor={anchorElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            HorizontalPosition.centerRight
+        );
+        expect(positioner.instance().state.right).toBe(null);
+        expect(positioner.instance().state.left).not.toBe(null);
+        expect(positioner.instance().state.xTransformOrigin).toBe("left");
+        expect(positioner.instance().rootElement.current.className).toContain(
+            managedClasses.viewportPositioner__centerRight
+        );
+
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            VerticalPosition.middleBottom
+        );
+        expect(positioner.instance().state.bottom).toBe(null);
+        expect(positioner.instance().state.top).not.toBe(null);
+        expect(positioner.instance().state.yTransformOrigin).toBe("top");
+        expect(positioner.instance().rootElement.current.className).toContain(
+            managedClasses.viewportPositioner__middleBottom
+        );
+    });
+
+    test("Option sizes calculated correctly - flipOutward", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div
+                style={{
+                    height: "100px",
+                    width: "100px",
+                }}
+                ref={viewportElement}
+            >
+                <div
+                    style={{
+                        height: "10px",
+                        width: "10px",
+                    }}
+                    ref={anchorElement}
+                />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.flipOutward}
+                    verticalPositioningMode={AxisPositioningMode.flipOutward}
+                    anchor={anchorElement}
+                    viewport={viewportElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        positioner.instance().viewportRect = viewportRect;
+        positioner.instance().positionerRect = positionerRectX70Y70;
+        positioner.instance().anchorTop = 80;
+        positioner.instance().anchorRight = 90;
+        positioner.instance().anchorBottom = 90;
+        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorWidth = 10;
+        positioner.instance().anchorHeight = 10;
+        positioner.instance().scrollTop = 0;
+        positioner.instance().scrollLeft = 0;
+
+        expect(positioner.instance()["getOptionWidth"](HorizontalPosition.left)).toBe(80);
+        expect(positioner.instance()["getOptionWidth"](HorizontalPosition.right)).toBe(
+            10
+        );
+        expect(positioner.instance()["getOptionHeight"](VerticalPosition.top)).toBe(80);
+        expect(positioner.instance()["getOptionHeight"](VerticalPosition.bottom)).toBe(
+            10
+        );
+    });
+
+    test("Option sizes calculated correctly - flipInward", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div
+                style={{
+                    height: "100px",
+                    width: "100px",
+                }}
+                ref={viewportElement}
+            >
+                <div
+                    style={{
+                        height: "10px",
+                        width: "10px",
+                    }}
+                    ref={anchorElement}
+                />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.flipInward}
+                    verticalPositioningMode={AxisPositioningMode.flipInward}
+                    anchor={anchorElement}
+                    viewport={viewportElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        positioner.instance().viewportRect = viewportRect;
+        positioner.instance().positionerRect = positionerRectX70Y70;
+        positioner.instance().anchorTop = 80;
+        positioner.instance().anchorRight = 90;
+        positioner.instance().anchorBottom = 90;
+        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorWidth = 10;
+        positioner.instance().anchorHeight = 10;
+        positioner.instance().scrollTop = 0;
+        positioner.instance().scrollLeft = 0;
+
+        expect(
+            positioner.instance()["getOptionWidth"](HorizontalPosition.centerLeft)
+        ).toBe(90);
+        expect(
+            positioner.instance()["getOptionWidth"](HorizontalPosition.centerRight)
+        ).toBe(20);
+        expect(positioner.instance()["getOptionHeight"](VerticalPosition.middleTop)).toBe(
+            90
+        );
+        expect(
+            positioner.instance()["getOptionHeight"](VerticalPosition.middleBottom)
+        ).toBe(20);
+    });
+
+    test("Correct options returned for a specified positioning mode - flipInwards", (): void => {
+        const rendered: any = mount(
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.flipInward}
+                verticalPositioningMode={AxisPositioningMode.flipInward}
+            />
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        const horizontalPositions: HorizontalPosition[] = positioner
+            .instance()
+            ["getHorizontalPositioningOptions"]();
+        const verticalPositions: VerticalPosition[] = positioner
+            .instance()
+            ["getVerticalPositioningOptions"]();
+
+        expect(horizontalPositions.length).toBe(2);
+        expect(horizontalPositions.indexOf(HorizontalPosition.centerLeft)).not.toBe(-1);
+        expect(horizontalPositions.indexOf(HorizontalPosition.centerRight)).not.toBe(-1);
+        expect(verticalPositions.length).toBe(2);
+        expect(verticalPositions.indexOf(VerticalPosition.middleTop)).not.toBe(-1);
+        expect(verticalPositions.indexOf(VerticalPosition.middleBottom)).not.toBe(-1);
+    });
+
+    test("Correct options returned for a specified positioning mode - flipOutwards", (): void => {
+        const rendered: any = mount(
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.flipOutward}
+                verticalPositioningMode={AxisPositioningMode.flipOutward}
+            />
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        const horizontalPositions: HorizontalPosition[] = positioner
+            .instance()
+            ["getHorizontalPositioningOptions"]();
+        const verticalPositions: VerticalPosition[] = positioner
+            .instance()
+            ["getVerticalPositioningOptions"]();
+
+        expect(horizontalPositions.length).toBe(2);
+        expect(horizontalPositions.indexOf(HorizontalPosition.left)).not.toBe(-1);
+        expect(horizontalPositions.indexOf(HorizontalPosition.right)).not.toBe(-1);
+        expect(verticalPositions.length).toBe(2);
+        expect(verticalPositions.indexOf(VerticalPosition.top)).not.toBe(-1);
+        expect(verticalPositions.indexOf(VerticalPosition.bottom)).not.toBe(-1);
+    });
+
+    test("widest option chosen by default - pt1", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div
+                style={{
+                    height: "100px",
+                    width: "100px",
+                }}
+                ref={viewportElement}
+            >
+                <div
+                    style={{
+                        height: "10px",
+                        width: "10px",
+                    }}
+                    ref={anchorElement}
+                />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.flipOutward}
+                    verticalPositioningMode={AxisPositioningMode.flipOutward}
+                    anchor={anchorElement}
+                    viewport={viewportElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        positioner.instance().viewportRect = viewportRect;
+        positioner.instance().positionerRect = positionerRectX70Y70;
+        positioner.instance().anchorTop = 80;
+        positioner.instance().anchorRight = 90;
+        positioner.instance().anchorBottom = 90;
+        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorWidth = 10;
+        positioner.instance().anchorHeight = 10;
+        positioner.instance().scrollTop = 0;
+        positioner.instance().scrollLeft = 0;
+
+        positioner.instance()["updateLayout"]();
+
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            HorizontalPosition.left
+        );
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            VerticalPosition.top
+        );
+    });
+
+    test("widest option chosen by default - pt2", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div
+                style={{
+                    height: "100px",
+                    width: "100px",
+                }}
+                ref={viewportElement}
+            >
+                <div
+                    style={{
+                        height: "10px",
+                        width: "10px",
+                    }}
+                    ref={anchorElement}
+                />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.flipOutward}
+                    verticalPositioningMode={AxisPositioningMode.flipOutward}
+                    anchor={anchorElement}
+                    viewport={viewportElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        positioner.instance().viewportRect = viewportRect;
+        positioner.instance().positionerRect = positionerRectX20Y20;
+        positioner.instance().anchorTop = 10;
+        positioner.instance().anchorRight = 20;
+        positioner.instance().anchorBottom = 20;
+        positioner.instance().anchorLeft = 10;
+        positioner.instance().anchorWidth = 10;
+        positioner.instance().anchorHeight = 10;
+        positioner.instance().scrollTop = 0;
+        positioner.instance().scrollLeft = 0;
+
+        positioner.instance()["updateLayout"]();
+
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            HorizontalPosition.right
+        );
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            VerticalPosition.bottom
+        );
+    });
+
+    test("Translate transforms calculated correctly - top/left", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div
+                style={{
+                    height: "100px",
+                    width: "100px",
+                }}
+                ref={viewportElement}
+            >
+                <div
+                    style={{
+                        height: "10px",
+                        width: "10px",
+                    }}
+                    ref={anchorElement}
+                />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.flipInward}
+                    verticalPositioningMode={AxisPositioningMode.flipInward}
+                    anchor={anchorElement}
+                    viewport={viewportElement}
+                    managedClasses={managedClasses}
+                    horizontalAlwaysInView={true}
+                    verticalAlwaysInView={true}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        positioner.instance().viewportRect = viewportRect;
+        positioner.instance().anchorTop = 200;
+        positioner.instance().anchorRight = 210;
+        positioner.instance().anchorBottom = 210;
+        positioner.instance().anchorLeft = 200;
+
+        expect(
+            positioner
+                .instance()
+                ["calculateHorizontalTranslate"](HorizontalPosition.centerLeft)
+        ).toBe(-111);
+        expect(
+            positioner.instance()["calculateHorizontalTranslate"](HorizontalPosition.left)
+        ).toBe(-101);
+        expect(
+            positioner
+                .instance()
+                ["calculateVerticalTranslate"](VerticalPosition.middleTop)
+        ).toBe(-111);
+        expect(
+            positioner.instance()["calculateVerticalTranslate"](VerticalPosition.top)
+        ).toBe(-101);
+    });
+
+    test("Translate transforms calculated correctly - bottom/right", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div
+                style={{
+                    height: "100px",
+                    width: "100px",
+                }}
+                ref={viewportElement}
+            >
+                <div
+                    style={{
+                        height: "10px",
+                        width: "10px",
+                    }}
+                    ref={anchorElement}
+                />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.flipInward}
+                    verticalPositioningMode={AxisPositioningMode.flipInward}
+                    anchor={anchorElement}
+                    viewport={viewportElement}
+                    managedClasses={managedClasses}
+                    horizontalAlwaysInView={true}
+                    verticalAlwaysInView={true}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        positioner.instance().viewportRect = viewportRect;
+        positioner.instance().anchorTop = -210;
+        positioner.instance().anchorRight = -200;
+        positioner.instance().anchorBottom = -200;
+        positioner.instance().anchorLeft = -210;
+
+        expect(
+            positioner
+                .instance()
+                ["calculateHorizontalTranslate"](HorizontalPosition.centerRight)
+        ).toBe(211);
+        expect(
+            positioner
+                .instance()
+                ["calculateHorizontalTranslate"](HorizontalPosition.right)
+        ).toBe(201);
+        expect(
+            positioner
+                .instance()
+                ["calculateVerticalTranslate"](VerticalPosition.middleBottom)
+        ).toBe(211);
+        expect(
+            positioner.instance()["calculateVerticalTranslate"](VerticalPosition.bottom)
+        ).toBe(201);
+    });
+
+    test("Positioner moves on updateLayout() when spacing changes", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div
+                style={{
+                    height: "100px",
+                    width: "100px",
+                }}
+                ref={viewportElement}
+            >
+                <div
+                    style={{
+                        height: "10px",
+                        width: "10px",
+                    }}
+                    ref={anchorElement}
+                />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.flipOutward}
+                    verticalPositioningMode={AxisPositioningMode.flipOutward}
+                    anchor={anchorElement}
+                    viewport={viewportElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        positioner.instance().viewportRect = viewportRect;
+        positioner.instance().positionerRect = positionerRectX70Y70;
+        positioner.instance().anchorTop = 80;
+        positioner.instance().anchorRight = 90;
+        positioner.instance().anchorBottom = 90;
+        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorWidth = 10;
+        positioner.instance().anchorHeight = 10;
+        positioner.instance().scrollTop = 0;
+        positioner.instance().scrollLeft = 0;
+
+        positioner.instance()["updateLayout"]();
+
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            HorizontalPosition.left
+        );
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            VerticalPosition.top
+        );
+
+        positioner.instance().anchorTop = 10;
+        positioner.instance().anchorRight = 20;
+        positioner.instance().anchorBottom = 20;
+        positioner.instance().anchorLeft = 10;
+
+        positioner.instance()["updateLayout"]();
+
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            HorizontalPosition.right
+        );
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            VerticalPosition.bottom
+        );
     });
 });

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -2,17 +2,29 @@ import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import ViewportPositioner, {
+    ViewportPositionerClassNameContract,
     ViewportPositionerHandledProps,
     ViewportPositionerProps,
     ViewportPositionerUnhandledProps,
 } from "./viewport-positioner";
 import { DisplayNamePrefix } from "../utilities";
-import { Direction } from "@microsoft/fast-web-utilities";
 
 /*
  * Configure Enzyme
  */
 configure({ adapter: new Adapter() });
+
+const managedClasses: ViewportPositionerClassNameContract = {
+    viewportPositioner: "viewportPositioner",
+    viewportPositioner__left: "viewportPositioner__left",
+    viewportPositioner__centerLeft: "viewportPositioner__centerLeft",
+    viewportPositioner__right: "viewportPositioner__right",
+    viewportPositioner__centerRight: "viewportPositioner__centerRight",
+    viewportPositioner__top: "viewportPositioner__top",
+    viewportPositioner__middleTop: "viewportPositioner",
+    viewportPositioner__bottom: "viewportPositioner__bottom",
+    viewportPositioner__middleBottom: "viewportPositioner__middleBottom",
+};
 
 describe("viewport positioner", (): void => {
     test("should have a displayName that matches the component name", () => {

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
+import { configure, mount, shallow } from "enzyme";
+import ViewportPositioner, {
+    ViewportPositionerHandledProps,
+    ViewportPositionerProps,
+    ViewportPositionerUnhandledProps,
+} from "./viewport-positioner";
+import { DisplayNamePrefix } from "../utilities";
+import { Direction } from "@microsoft/fast-web-utilities";
+
+/*
+ * Configure Enzyme
+ */
+configure({ adapter: new Adapter() });
+
+describe("viewport positioner", (): void => {
+    test("should have a displayName that matches the component name", () => {
+        expect(`${DisplayNamePrefix}${(ViewportPositioner as any).name}`).toBe(
+            ViewportPositioner.displayName
+        );
+    });
+
+    test("should not throw if managedClasses are not provided", () => {
+        expect(() => {
+            shallow(<ViewportPositioner />);
+        }).not.toThrow();
+    });
+
+    test("should implement unhandledProps", (): void => {
+        const unhandledProps: ViewportPositionerUnhandledProps = {
+            "aria-label": "label",
+        };
+
+        const rendered: any = shallow(<ViewportPositioner {...unhandledProps} />);
+
+        expect(rendered.first().prop("aria-label")).toEqual("label");
+    });
+});

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -8,6 +8,7 @@ import ViewportPositioner, {
     ViewportPositionerUnhandledProps,
 } from "./viewport-positioner";
 import { DisplayNamePrefix } from "../utilities";
+import { HorizontalPosition } from "./viewport-positioner.props";
 
 /*
  * Configure Enzyme
@@ -47,5 +48,49 @@ describe("viewport positioner", (): void => {
         const rendered: any = shallow(<ViewportPositioner {...unhandledProps} />);
 
         expect(rendered.first().prop("aria-label")).toEqual("label");
+    });
+
+    test("should be disabled without an anchor", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const rendered: any = mount(
+            <div>
+                <ViewportPositioner
+                    defaultHorizontalPosition={HorizontalPosition.left}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+        expect(positioner.instance().state.disabled).toBe(true);
+
+        document.body.removeChild(container);
+    });
+
+    test("should be enabled with an anchor", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div>
+                <div ref={anchorElement} />
+                <ViewportPositioner
+                    anchor={anchorElement}
+                    // defaultHorizontalPosition={HorizontalPosition.left}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+        expect(positioner.instance().state.disabled).toBe(false);
+
+        document.body.removeChild(container);
     });
 });

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -221,7 +221,8 @@ class ViewportPositioner extends Foundation<
         if (this.state.disabled) {
             if (
                 (this.props.disabled === undefined || this.props.disabled === false) &&
-                isNil(this.positionerRect)
+                isNil(this.positionerRect) &&
+                !isNil(this.props.anchor)
             ) {
                 return {
                     position: "relative",
@@ -247,7 +248,6 @@ class ViewportPositioner extends Foundation<
             right: this.state.right === null ? null : `${this.state.right}px`,
             bottom: this.state.bottom === null ? null : `${this.state.bottom}px`,
             left: this.state.left === null ? null : `${this.state.left}px`,
-            background: "red",
         };
     };
 

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -1,0 +1,775 @@
+import React from "react";
+import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
+import { get, isNil } from "lodash-es";
+import { ViewportPositionerClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
+import {
+    AxisPositioningMode,
+    HorizontalPosition,
+    VerticalPosition,
+    ViewportPositionerHandledProps,
+    ViewportPositionerProps,
+    ViewportPositionerUnhandledProps,
+} from "./viewport-positioner.props";
+import { ResizeObserverClassDefinition } from "../horizontal-overflow/resize-observer";
+import { ResizeObserverEntry } from "../horizontal-overflow/resize-observer-entry";
+import { DisplayNamePrefix } from "../utilities";
+import { canUseDOM } from "exenv-es6";
+
+export interface ViewportPositionerState {
+    disabled: boolean;
+    transformOrigin: string;
+    xTranslate: number;
+    yTranslate: number;
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+    currentVerticalPosition: VerticalPosition;
+    currentHorizontalPosition: HorizontalPosition;
+    initialLayoutComplete: boolean;
+}
+
+class ViewportPositioner extends Foundation<
+    ViewportPositionerHandledProps,
+    ViewportPositionerUnhandledProps,
+    ViewportPositionerState
+> {
+    public static displayName: string = `${DisplayNamePrefix}ViewportPositioner`;
+
+    public static defaultProps: Partial<ViewportPositionerProps> = {
+        horizontalPositioningMode: AxisPositioningMode.uncontrolled,
+        defaultHorizontalPosition: HorizontalPosition.uncontrolled,
+        verticalPositioningMode: AxisPositioningMode.uncontrolled,
+        defaultVerticalPosition: VerticalPosition.uncontrolled,
+        horizontalAlwaysInView: false,
+        vericalAlwaysInView: false,
+        fixedAfterInitialPlacement: false,
+    };
+
+    protected handledProps: HandledProps<ViewportPositionerHandledProps> = {
+        managedClasses: void 0,
+        anchor: void 0,
+        viewport: void 0,
+        horizontalPositioningMode: void 0,
+        defaultHorizontalPosition: void 0,
+        horizontalThreshold: void 0,
+        horizontalAlwaysInView: void 0,
+        verticalPositioningMode: void 0,
+        defaultVerticalPosition: void 0,
+        verticalThreshold: void 0,
+        vericalAlwaysInView: void 0,
+        fixedAfterInitialPlacement: void 0,
+        disabled: void 0,
+    };
+
+    private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
+        HTMLDivElement
+    >();
+
+    private openRequestAnimationFrame: number = null;
+
+    /**
+     * Throttle resize request animation frame usage
+     */
+    // private throttledResize: throttle;
+
+    private collisionDetector: IntersectionObserver;
+    private resizeDetector: ResizeObserverClassDefinition;
+
+    private viewportRect: ClientRect | DOMRect;
+    private positionerRect: ClientRect | DOMRect;
+    private anchorHeight: number = 0;
+    private anchorWidth: number = 0;
+    private anchorTop: number = 0;
+    private anchorRight: number = 0;
+    private anchorBottom: number = 0;
+    private anchorLeft: number = 0;
+
+    private scrollTop: number = 0;
+    private scrollLeft: number = 0;
+
+    /**
+     * constructor
+     */
+    constructor(props: ViewportPositionerProps) {
+        super(props);
+
+        this.state = {
+            disabled: true,
+
+            transformOrigin: "",
+            xTranslate: 0,
+            yTranslate: 0,
+            top: null,
+            right: null,
+            bottom: null,
+            left: null,
+            currentHorizontalPosition: HorizontalPosition.uncontrolled,
+            currentVerticalPosition: VerticalPosition.uncontrolled,
+            initialLayoutComplete: false,
+        };
+    }
+
+    public componentDidMount(): void {
+        this.checkComponentConfig();
+        this.requestFrame();
+    }
+
+    public componentWillUnmount(): void {
+        this.disableComponent();
+    }
+
+    public componentDidUpdate(prevProps: ViewportPositionerProps): void {
+        if (
+            isNil(prevProps.anchor) !== isNil(this.props.anchor) ||
+            isNil(prevProps.viewport) !== isNil(this.props.viewport) ||
+            prevProps.disabled !== this.props.disabled
+        ) {
+            this.checkComponentConfig();
+        }
+    }
+
+    /**
+     * Renders the component
+     */
+    public render(): React.ReactElement<HTMLDivElement> {
+        return (
+            <div
+                ref={this.rootElement}
+                {...this.unhandledProps()}
+                className={this.generateClassNames()}
+                style={this.getPositioningStyles()}
+            >
+                {this.props.children}
+            </div>
+        );
+    }
+
+    /**
+     * Create class-names
+     */
+    protected generateClassNames(): string {
+        let classNames: string = get(this.props, "managedClasses.viewportPositioner", "");
+
+        switch (this.state.currentHorizontalPosition) {
+            case HorizontalPosition.left:
+                classNames = classNames.concat(
+                    " ",
+                    get(this.props.managedClasses, "viewportPositioner__left", "")
+                );
+                break;
+
+            case HorizontalPosition.centerLeft:
+                classNames = classNames.concat(
+                    " ",
+                    get(this.props.managedClasses, "viewportPositioner__centerLeft", "")
+                );
+                break;
+
+            case HorizontalPosition.centerRight:
+                classNames = classNames.concat(
+                    " ",
+                    get(this.props.managedClasses, "viewportPositioner__centerRight", "")
+                );
+                break;
+
+            case HorizontalPosition.right:
+                classNames = classNames.concat(
+                    " ",
+                    get(this.props.managedClasses, "viewportPositioner__right", "")
+                );
+                break;
+        }
+
+        switch (this.state.currentVerticalPosition) {
+            case VerticalPosition.top:
+                classNames = classNames.concat(
+                    " ",
+                    get(this.props.managedClasses, "viewportPositioner__top", "")
+                );
+                break;
+
+            case VerticalPosition.middleTop:
+                classNames = classNames.concat(
+                    " ",
+                    get(this.props.managedClasses, "viewportPositioner__middleTop", "")
+                );
+                break;
+
+            case VerticalPosition.middleBottom:
+                classNames = classNames.concat(
+                    " ",
+                    get(this.props.managedClasses, "viewportPositioner__middleBottom", "")
+                );
+                break;
+
+            case VerticalPosition.bottom:
+                classNames = classNames.concat(
+                    " ",
+                    get(this.props.managedClasses, "viewportPositioner__bottom", "")
+                );
+                break;
+        }
+
+        return super.generateClassNames(classNames);
+    }
+
+    /**
+     *  gets the CSS classes to be programmatically applied to the component
+     */
+    private getPositioningStyles = (): {} => {
+        if (this.state.disabled) {
+            if (
+                (this.props.disabled === undefined || this.props.disabled === false) &&
+                isNil(this.positionerRect)
+            ) {
+                return {
+                    position: "relative",
+                    opacity: "0",
+                };
+            }
+            return null;
+        } else if (isNil(this.positionerRect)) {
+            return {
+                position: "relative",
+                opacity: "0",
+            };
+        }
+
+        return {
+            position: "relative",
+            transformOrigin: this.state.transformOrigin,
+            transform: `translate(
+                ${Math.floor(this.state.xTranslate)}px, 
+                ${Math.floor(this.state.yTranslate)}px
+            )`,
+            top: this.state.top === null ? null : `${this.state.top}px`,
+            right: this.state.right === null ? null : `${this.state.right}px`,
+            bottom: this.state.bottom === null ? null : `${this.state.bottom}px`,
+            left: this.state.left === null ? null : `${this.state.left}px`,
+            background: "red",
+        };
+    };
+
+    /**
+     *  Checks whether component should be disabled or not
+     */
+    private checkComponentConfig = (): void => {
+        if (!canUseDOM() || this.props.disabled === true || isNil(this.props.anchor)) {
+            this.disableComponent();
+            return;
+        }
+        this.enableComponent();
+    };
+
+    /**
+     *  Get available Horizontal positions based on positioning mode
+     */
+    private getHorizontalPositiontingOptions = (): HorizontalPosition[] => {
+        switch (this.props.horizontalPositioningMode) {
+            case AxisPositioningMode.flipInward:
+                return [HorizontalPosition.centerLeft, HorizontalPosition.centerRight];
+
+            case AxisPositioningMode.flipOutward:
+                return [HorizontalPosition.left, HorizontalPosition.right];
+        }
+    };
+
+    /**
+     * Get available Vertical positions based on positioning mode
+     */
+    private getVerticalPositiontingOptions = (): VerticalPosition[] => {
+        switch (this.props.verticalPositioningMode) {
+            case AxisPositioningMode.flipInward:
+                return [VerticalPosition.middleTop, VerticalPosition.middleBottom];
+
+            case AxisPositioningMode.flipOutward:
+                return [VerticalPosition.top, VerticalPosition.bottom];
+        }
+    };
+
+    /**
+     *  Get the width available for a particular horizontal position
+     */
+    private getOptionWidth = (positionOption: HorizontalPosition): number => {
+        const spaceLeft: number = this.anchorLeft - this.viewportRect.left;
+        const spaceRight: number =
+            this.viewportRect.right - (this.anchorLeft + this.anchorWidth);
+
+        switch (positionOption) {
+            case HorizontalPosition.left:
+                return spaceLeft;
+            case HorizontalPosition.centerLeft:
+                return spaceLeft + this.anchorWidth;
+            case HorizontalPosition.centerRight:
+                return spaceRight + this.anchorWidth;
+            case HorizontalPosition.right:
+                return spaceRight;
+        }
+    };
+
+    /**
+     *  Get the height available for a particular vertical position
+     */
+    private getOptionHeight = (positionOption: VerticalPosition): number => {
+        const spaceAbove: number = this.anchorTop - this.viewportRect.top;
+        const spaceBelow: number =
+            this.viewportRect.bottom - (this.anchorTop + this.anchorHeight);
+
+        switch (positionOption) {
+            case VerticalPosition.top:
+                return spaceAbove;
+            case VerticalPosition.middleTop:
+                return spaceAbove + this.anchorHeight;
+            case VerticalPosition.middleBottom:
+                return spaceBelow + this.anchorHeight;
+            case VerticalPosition.bottom:
+                return spaceBelow;
+        }
+    };
+
+    /**
+     *  Enable the component
+     */
+    private enableComponent = (): void => {
+        if (!this.state.disabled || this.props.disabled) {
+            return;
+        }
+
+        this.setState({
+            disabled: false,
+        });
+
+        this.collisionDetector = new IntersectionObserver(this.handleCollision, {
+            root:
+                this.props.viewport !== undefined && this.props.viewport.current !== null
+                    ? this.props.viewport.current
+                    : null,
+            rootMargin: "0px",
+            threshold: [0, 1],
+        });
+
+        this.collisionDetector.observe(this.rootElement.current);
+        this.collisionDetector.observe(this.props.anchor.current);
+
+        if ((window as WindowWithResizeObserver).ResizeObserver) {
+            this.resizeDetector = new (window as WindowWithResizeObserver).ResizeObserver(
+                this.handleAnchorResize
+            );
+            this.resizeDetector.observe(this.props.anchor.current);
+        }
+
+        this.props.viewport !== undefined && this.props.viewport.current !== null
+            ? this.props.viewport.current.addEventListener("scroll", this.handleScroll)
+            : document.addEventListener("scroll", this.handleScroll);
+    };
+
+    /**
+     *  Disable the component
+     */
+    private disableComponent = (): void => {
+        if (this.state.disabled) {
+            return;
+        }
+        this.setState({
+            disabled: true,
+        });
+        if (this.openRequestAnimationFrame !== null) {
+            window.cancelAnimationFrame(this.openRequestAnimationFrame);
+            this.openRequestAnimationFrame = null;
+        }
+
+        this.collisionDetector.unobserve(this.rootElement.current);
+        this.collisionDetector.unobserve(this.props.anchor.current);
+        this.collisionDetector.disconnect();
+        this.collisionDetector = null;
+
+        // TODO #1142 https://github.com/Microsoft/fast-dna/issues/1142
+        // Full browser support imminent
+        // Revisit usage once Safari and Firefox adapt
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1272409
+        // https://bugs.webkit.org/show_bug.cgi?id=157743
+        if (this.resizeDetector && typeof this.resizeDetector.disconnect === "function") {
+            this.resizeDetector.unobserve(this.props.anchor.current);
+            this.resizeDetector.disconnect();
+            this.resizeDetector = null;
+        }
+
+        this.props.viewport !== undefined && this.props.viewport.current !== null
+            ? this.props.viewport.current.addEventListener("scroll", this.handleScroll)
+            : document.addEventListener("scroll", this.handleScroll);
+    };
+
+    /**
+     *  Handle scroll events
+     */
+    private handleScroll = (): void => {
+        this.requestFrame();
+    };
+
+    /**
+     *  Handle anchor resize events
+     */
+    private handleAnchorResize = (entries: ResizeObserverEntry[]): void => {
+        const entry: ResizeObserverEntry = entries[0];
+        this.anchorHeight = entry.contentRect.height;
+        this.anchorWidth = entry.contentRect.width;
+
+        if (this.state.currentVerticalPosition === VerticalPosition.top) {
+            this.anchorBottom = this.anchorTop + this.anchorHeight;
+        } else {
+            this.anchorTop = this.anchorBottom - this.anchorHeight;
+        }
+
+        if (this.state.currentHorizontalPosition === HorizontalPosition.left) {
+            this.anchorRight = this.anchorLeft + this.anchorWidth;
+        } else {
+            this.anchorLeft = this.anchorRight - this.anchorWidth;
+        }
+
+        this.requestFrame();
+    };
+
+    /**
+     *  Handle collisions
+     */
+    private handleCollision = (
+        entries: IntersectionObserverEntry[],
+        observer: IntersectionObserver
+    ): void => {
+        entries.forEach((entry: IntersectionObserverEntry) => {
+            if (entry.target === this.rootElement.current) {
+                this.processPositionerCollision(entry);
+            } else {
+                this.processAnchorCollision(entry);
+            }
+        });
+
+        this.scrollTop =
+            this.props.viewport !== undefined
+                ? this.props.viewport.current.scrollingElement.scrollTop
+                : window.document.scrollingElement.scrollTop;
+
+        this.scrollLeft =
+            this.props.viewport !== undefined
+                ? this.props.viewport.current.scrollingElement.scrollLeft
+                : window.document.scrollingElement.scrollLeft;
+
+        this.requestFrame();
+    };
+
+    /**
+     *  Update data based on anchor collisions
+     */
+    private processAnchorCollision = (anchorEntry: IntersectionObserverEntry): void => {
+        this.viewportRect = anchorEntry.rootBounds;
+        this.anchorTop = anchorEntry.boundingClientRect.top;
+        this.anchorRight = anchorEntry.boundingClientRect.right;
+        this.anchorBottom = anchorEntry.boundingClientRect.bottom;
+        this.anchorHeight = anchorEntry.boundingClientRect.height;
+        this.anchorWidth = anchorEntry.boundingClientRect.width;
+    };
+
+    /**
+     *  Update data based on positioner collisions
+     */
+    private processPositionerCollision = (
+        positionerEntry: IntersectionObserverEntry
+    ): void => {
+        this.viewportRect = positionerEntry.rootBounds;
+        this.positionerRect = positionerEntry.boundingClientRect;
+
+        switch (this.state.currentVerticalPosition) {
+            case VerticalPosition.top:
+                this.anchorTop = this.positionerRect.bottom - this.state.yTranslate;
+                this.anchorBottom = this.anchorTop + this.anchorHeight;
+                break;
+
+            case VerticalPosition.middleTop:
+                this.anchorBottom = this.positionerRect.bottom - this.state.yTranslate;
+                this.anchorTop = this.anchorBottom - this.anchorHeight;
+                break;
+
+            case VerticalPosition.middleBottom:
+                this.anchorTop = this.positionerRect.top - this.state.yTranslate;
+                this.anchorBottom = this.anchorTop + this.anchorHeight;
+                break;
+
+            case VerticalPosition.bottom:
+                this.anchorBottom = this.positionerRect.top - this.state.yTranslate;
+                this.anchorTop = this.anchorBottom - this.anchorHeight;
+                break;
+        }
+
+        switch (this.state.currentHorizontalPosition) {
+            case HorizontalPosition.left:
+                this.anchorLeft = this.positionerRect.right - this.state.xTranslate;
+                this.anchorRight = this.anchorLeft + this.anchorWidth;
+                break;
+
+            case HorizontalPosition.centerLeft:
+                this.anchorRight = this.positionerRect.right - this.state.xTranslate;
+                this.anchorLeft = this.anchorRight - this.anchorWidth;
+                break;
+
+            case HorizontalPosition.centerRight:
+                this.anchorLeft = this.positionerRect.left - this.state.xTranslate;
+                this.anchorRight = this.anchorLeft + this.anchorWidth;
+                break;
+
+            case HorizontalPosition.right:
+                this.anchorRight = this.positionerRect.left - this.state.xTranslate;
+                this.anchorLeft = this.anchorRight - this.anchorWidth;
+                break;
+        }
+    };
+
+    /**
+     * Check for scroll changes in viewport and adjust position data
+     */
+    private updateForScrolling = (): void => {
+        const scrollTop: number =
+            this.props.viewport !== undefined
+                ? this.props.viewport.current.scrollingElement.scrollTop
+                : window.document.scrollingElement.scrollTop;
+
+        const scrollLeft: number =
+            this.props.viewport !== undefined
+                ? this.props.viewport.current.scrollingElement.scrollLeft
+                : window.document.scrollingElement.scrollLeft;
+
+        if (this.scrollTop !== scrollTop) {
+            const verticalScrollDelta: number = this.scrollTop - scrollTop;
+            this.scrollTop = scrollTop;
+            this.anchorTop = this.anchorTop + verticalScrollDelta;
+            this.anchorBottom = this.anchorBottom + verticalScrollDelta;
+        }
+
+        if (this.scrollLeft !== scrollLeft) {
+            const horizontalScrollDelta: number = this.scrollLeft - scrollLeft;
+            this.scrollLeft = scrollLeft;
+            this.anchorLeft = this.anchorLeft + horizontalScrollDelta;
+            this.anchorRight = this.anchorRight + horizontalScrollDelta;
+        }
+    };
+
+    /**
+     *  Recalculate layout related state values
+     */
+    private updateLayout = (): void => {
+        this.openRequestAnimationFrame = null;
+        if (
+            this.state.disabled ||
+            isNil(this.viewportRect) ||
+            isNil(this.positionerRect) ||
+            (this.props.fixedAfterInitialPlacement && this.state.initialLayoutComplete)
+        ) {
+            return;
+        }
+
+        this.updateForScrolling();
+
+        let top: number = null;
+        let right: number = null;
+        let bottom: number = null;
+        let left: number = null;
+        let xTransformOrigin: string = "left";
+        let yTransformOrigin: string = "top";
+
+        let desiredVerticalPosition: VerticalPosition = this.props
+            .defaultVerticalPosition;
+        let desiredHorizontalPosition: HorizontalPosition = this.props
+            .defaultHorizontalPosition;
+
+        if (this.props.horizontalPositioningMode !== AxisPositioningMode.uncontrolled) {
+            const horizontalOptions: HorizontalPosition[] = this.getHorizontalPositiontingOptions();
+
+            const horizontalThreshold: number =
+                this.props.horizontalThreshold !== undefined
+                    ? this.props.horizontalThreshold
+                    : this.positionerRect.width;
+
+            if (
+                horizontalOptions.indexOf(desiredHorizontalPosition) === -1 ||
+                this.getOptionWidth(desiredHorizontalPosition) < horizontalThreshold
+            ) {
+                let widest: number = 0;
+                horizontalOptions.forEach((horizontalPosition: HorizontalPosition) => {
+                    const thisWidth: number = this.getOptionWidth(horizontalPosition);
+                    if (thisWidth > widest) {
+                        widest = thisWidth;
+                        desiredHorizontalPosition = horizontalPosition;
+                    }
+                });
+            }
+
+            switch (desiredHorizontalPosition) {
+                case HorizontalPosition.left:
+                    xTransformOrigin = "right";
+                    right = this.positionerRect.width;
+                    break;
+
+                case HorizontalPosition.centerLeft:
+                    xTransformOrigin = "right";
+                    right = 0;
+                    break;
+
+                case HorizontalPosition.centerRight:
+                    xTransformOrigin = "left";
+                    left = 0;
+                    break;
+
+                case HorizontalPosition.right:
+                    xTransformOrigin = "left";
+                    left = this.anchorWidth;
+                    break;
+            }
+        }
+
+        if (this.props.verticalPositioningMode !== AxisPositioningMode.uncontrolled) {
+            const verticalOptions: VerticalPosition[] = this.getVerticalPositiontingOptions();
+
+            const verticalThreshold: number =
+                this.props.verticalThreshold !== undefined
+                    ? this.props.verticalThreshold
+                    : this.positionerRect.height;
+
+            if (
+                verticalOptions.indexOf(desiredVerticalPosition) === -1 ||
+                this.getOptionHeight(desiredVerticalPosition) < verticalThreshold
+            ) {
+                let tallest: number = 0;
+                verticalOptions.forEach((verticalPosition: VerticalPosition) => {
+                    const thisHeight: number = this.getOptionHeight(verticalPosition);
+                    if (thisHeight > tallest) {
+                        tallest = thisHeight;
+                        desiredVerticalPosition = verticalPosition;
+                    }
+                });
+            }
+
+            switch (desiredVerticalPosition) {
+                case VerticalPosition.top:
+                    yTransformOrigin = "bottom";
+                    bottom = this.positionerRect.height + this.anchorHeight;
+                    break;
+
+                case VerticalPosition.middleTop:
+                    yTransformOrigin = "bottom";
+                    bottom = this.positionerRect.height;
+                    break;
+
+                case VerticalPosition.middleBottom:
+                    yTransformOrigin = "top";
+                    top = -this.anchorHeight;
+                    break;
+
+                case VerticalPosition.bottom:
+                    yTransformOrigin = "top";
+                    top = 0;
+                    break;
+            }
+        }
+
+        this.setState({
+            transformOrigin: `${xTransformOrigin} ${yTransformOrigin}`,
+            xTranslate: this.calclulateHorizontalTranslate(desiredHorizontalPosition),
+            yTranslate: this.calclulateVerticalTranslate(desiredVerticalPosition),
+            top,
+            right,
+            bottom,
+            left,
+            currentHorizontalPosition: desiredHorizontalPosition,
+            currentVerticalPosition: desiredVerticalPosition,
+            initialLayoutComplete: true,
+        });
+    };
+
+    /**
+     *  Calculate horizontal tranlation to keep positioner in view
+     */
+    private calclulateHorizontalTranslate = (
+        horizontalPosition: HorizontalPosition
+    ): number => {
+        if (!this.props.horizontalAlwaysInView) {
+            return 0;
+        }
+
+        let translate: number = 0;
+
+        switch (horizontalPosition) {
+            case HorizontalPosition.left:
+                translate = this.viewportRect.right - this.anchorLeft;
+                translate = translate < 0 ? translate - 1 : 0;
+                break;
+
+            case HorizontalPosition.centerLeft:
+                translate = this.viewportRect.right - this.anchorRight;
+                translate = translate < 0 ? translate - 1 : 0;
+                break;
+
+            case HorizontalPosition.centerRight:
+                translate = this.viewportRect.left - this.anchorLeft;
+                translate = translate > 0 ? translate + 1 : 0;
+                break;
+
+            case HorizontalPosition.right:
+                translate = this.viewportRect.left - this.anchorRight;
+                translate = translate > 0 ? translate + 1 : 0;
+                break;
+        }
+        return translate;
+    };
+
+    /**
+     *  Calculate vertical tranlation to keep positioner in view
+     */
+    private calclulateVerticalTranslate = (
+        verticalPosition: VerticalPosition
+    ): number => {
+        if (!this.props.vericalAlwaysInView) {
+            return 0;
+        }
+
+        let translate: number = 0;
+
+        switch (verticalPosition) {
+            case VerticalPosition.top:
+                translate = this.viewportRect.bottom - this.anchorTop;
+                translate = translate < 0 ? translate - 1 : 0;
+                break;
+
+            case VerticalPosition.middleTop:
+                translate = this.viewportRect.bottom - this.anchorBottom;
+                translate = translate < 0 ? translate - 1 : 0;
+                break;
+
+            case VerticalPosition.middleBottom:
+                translate = this.viewportRect.top - this.anchorTop;
+                translate = translate < 0 ? 0 : translate + 1;
+                break;
+
+            case VerticalPosition.bottom:
+                translate = this.viewportRect.top - this.anchorBottom;
+                translate = translate < 0 ? 0 : translate + 1;
+                break;
+        }
+
+        return translate;
+    };
+
+    /**
+     * Request's an animation frame if there are currently no open animation frame requests
+     */
+    private requestFrame = (): void => {
+        if (this.openRequestAnimationFrame === null) {
+            this.openRequestAnimationFrame = window.requestAnimationFrame(
+                this.updateLayout
+            );
+        }
+    };
+}
+
+export default ViewportPositioner;
+export * from "./viewport-positioner.props";
+export { ViewportPositionerClassNameContract };

--- a/packages/fast-components-react-msft/src/select/select.schema.json
+++ b/packages/fast-components-react-msft/src/select/select.schema.json
@@ -50,9 +50,78 @@
             "title":"Labelled by",
             "type":"string"
         },
-        "enableViewportPositioning": {
-            "title":"Viewport aware positioning",
-            "type":"boolean"
+        "menuFlyoutConfig": {
+            "title": "Flyout menu configuration",
+            "type": "object",
+            "description": "Configures the viewport positioner used by the flyout menu",
+            "properties": {
+                "disabled": {
+                    "title": "Disabled",
+                    "type": "boolean"
+                },
+                "horizontalPositioningMode": {
+                    "title": "Horizontal positioning mode",
+                    "type": "string",
+                    "default": "uncontrolled",
+                    "enum": [
+                        "uncontrolled",
+                        "flipOutward",
+                        "flipInward"
+                    ]
+                },
+                "defaultHorizontalPosition": {
+                    "title": "Default horizontal position",
+                    "type": "string",
+                    "default": "uncontrolled",
+                    "enum": [
+                        "left",
+                        "centerLeft",
+                        "centerRight",
+                        "right"
+                    ]
+                },
+                "horizontalThreshold": {
+                    "title": "Horizontal threshold",
+                    "type": "number"
+                },
+                "horizontalAlwaysInView": {
+                    "title": "Horizontal always in view",
+                    "type": "boolean"
+                },
+                "verticalPositioningMode": {
+                    "title": "Vertical positioning mode",
+                    "type": "string",
+                    "default": "uncontrolled",
+                    "enum": [
+                        "uncontrolled",
+                        "flipOutward",
+                        "flipInward"
+                    ]
+                },
+                "defaultVerticalPosition": {
+                    "title": "Default vertical position",
+                    "type": "string",
+                    "default": "uncontrolled",
+                    "enum": [
+                        "top",
+                        "middleTop",
+                        "middleBottom",
+                        "bottom"
+                    ]
+                },
+                "verticalThreshold": {
+                    "title": "Vertical threshold",
+                    "type": "number"
+                },
+                "verticalAlwaysInView": {
+                    "title": "Vertical always in view",
+                    "type": "boolean"
+                },
+                "fixedAfterInitialPlacement": {
+                    "title": "Fixed after initial placement",
+                    "type": "boolean"
+                }
+            }
         }
     },
     "reactProperties": {

--- a/packages/fast-components-react-msft/src/select/select.schema.json
+++ b/packages/fast-components-react-msft/src/select/select.schema.json
@@ -49,6 +49,10 @@
         "labelledBy": {
             "title":"Labelled by",
             "type":"string"
+        },
+        "enableViewportPositioning": {
+            "title":"Viewport aware positioning",
+            "type":"boolean"
         }
     },
     "reactProperties": {

--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -26,6 +26,7 @@ const styles: ComponentStyles<SelectClassNameContract, DesignSystem> = {
     select: {
         minWidth: "276px",
         maxWidth: "374px",
+        height: height(),
     },
 
     select_button: {
@@ -67,7 +68,7 @@ const styles: ComponentStyles<SelectClassNameContract, DesignSystem> = {
         ...applyFloatingCornerRadius(),
         ...applyElevation(ElevationMultiplier.e11),
         zIndex: "1",
-        position: "absolute",
+        position: "relative",
         width: "100%",
         margin: "0",
         padding: format("{0} 0", toPx<DesignSystem>(designUnit)),


### PR DESCRIPTION
# Description
Still adding tests and figuring out how to gracefully deal with cases where resize and intersection observer are not available.  But seems in a good enough state for folks to take a look and provide feedback.

Essentially, this component enables an author to create a container that will position itself relative to another "anchor" element in the same viewport based on available space. 

## Motivation & context
Necessary to implement ui elements that take into account the available space in the viewport and the positioning of the anchor element to determine their own position.  Examples might include menus that expand in a different direction based on available space, flyouts, tooltips, context menus, etc...  

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.


## Process & policy checklist

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x ] I have updated the project documentation to reflect my changes.
- [x ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project
