### PR TITLE
fix: add experimental color recipe calculations

### DIFF
--- a/packages/fast-color-explorer/app/app.tsx
+++ b/packages/fast-color-explorer/app/app.tsx
@@ -41,9 +41,6 @@ class App extends React.Component<AppProps, {}> {
                                         colors={palette(PaletteType.neutral)(
                                             this.props.designSystem
                                         )}
-                                        markedColor={
-                                            this.props.designSystem.neutralBaseColor
-                                        }
                                         createAnchors={true}
                                         scrollToItem={this.handleGradientScroll}
                                     />
@@ -53,9 +50,6 @@ class App extends React.Component<AppProps, {}> {
                                         colors={palette(PaletteType.accent)(
                                             this.props.designSystem
                                         )}
-                                        markedColor={
-                                            this.props.designSystem.accentBaseColor
-                                        }
                                         createAnchors={false}
                                     />
                                 </Row>

--- a/packages/fast-color-explorer/app/design-system.ts
+++ b/packages/fast-color-explorer/app/design-system.ts
@@ -3,8 +3,7 @@ import {
     DesignSystemDefaults,
 } from "@microsoft/fast-components-styles-msft";
 
-/* tslint:disable-next-line */
-export interface ColorsDesignSystem extends DesignSystem {}
+export type ColorsDesignSystem = DesignSystem;
 export const colorsDesignSystem: ColorsDesignSystem = Object.assign(
     {},
     DesignSystemDefaults

--- a/packages/fast-color-explorer/app/design-system.ts
+++ b/packages/fast-color-explorer/app/design-system.ts
@@ -2,9 +2,22 @@ import {
     DesignSystem,
     DesignSystemDefaults,
 } from "@microsoft/fast-components-styles-msft";
+import {
+    accentPaletteConfig,
+    createColorPalette,
+    neutralPaletteConfig,
+} from "@microsoft/fast-components-styles-msft";
+import { ColorRGBA64, parseColorHexRGB } from "@microsoft/fast-colors";
+import { AccentColors } from "./colors";
 
 export type ColorsDesignSystem = DesignSystem;
 export const colorsDesignSystem: ColorsDesignSystem = Object.assign(
     {},
-    DesignSystemDefaults
+    DesignSystemDefaults,
+    {
+        neutralPalette: createColorPalette(new ColorRGBA64(0.5, 0.5, 0.5, 1)),
+        accentPalette: createColorPalette(parseColorHexRGB(
+            AccentColors.blue
+        ) as ColorRGBA64),
+    }
 );

--- a/packages/fast-color-explorer/app/gradient.tsx
+++ b/packages/fast-color-explorer/app/gradient.tsx
@@ -10,24 +10,9 @@ const styles: any = (designSystem: ColorsDesignSystem): any => {
             width: "100%",
         },
         gradient_item: {
-            display: "flex",
+            display: "block",
             flex: "1",
             height: "100%",
-        },
-        gradient_item__marked: {
-            position: "relative",
-            "&::before": {
-                width: "6px",
-                height: "6px",
-                margin: "0 auto",
-                content: "''",
-                opacity: "0.5",
-                position: "relative",
-                border: "solid 1px white",
-                borderRadius: "50%",
-                display: "block",
-                alignSelf: "center",
-            },
         },
     };
 };
@@ -35,7 +20,6 @@ const styles: any = (designSystem: ColorsDesignSystem): any => {
 interface GradientProps {
     managedClasses: any;
     colors: string[];
-    markedColor?: string;
     createAnchors?: boolean;
     scrollToItem?: (index: number, align: string) => void;
 }
@@ -54,21 +38,10 @@ class BaseGradient extends React.Component<GradientProps, {}> {
 
     private createItems(): React.ReactNode {
         return this.props.colors.map((item: string, index: number) => {
-            let classNames: string = this.props.managedClasses.gradient_item;
-
-            if (
-                this.props.markedColor !== undefined &&
-                item.toUpperCase() === this.props.markedColor.toUpperCase()
-            ) {
-                classNames = `${classNames} ${
-                    this.props.managedClasses.gradient_item__marked
-                }`;
-            }
-
             return (
                 <a
                     key={index}
-                    className={classNames}
+                    className={this.props.managedClasses.gradient_item}
                     style={{
                         background: this.props.colors[index],
                     }}

--- a/packages/fast-color-explorer/app/state.ts
+++ b/packages/fast-color-explorer/app/state.ts
@@ -1,6 +1,8 @@
 import { Action, createStore } from "redux";
 import { ColorsDesignSystem, colorsDesignSystem } from "./design-system";
 import { ColorRGBA64 } from "@microsoft/fast-colors";
+import { merge } from "lodash-es";
+import { Color } from "csstype";
 import { createColorPalette } from "@microsoft/fast-components-styles-msft";
 
 export enum ComponentTypes {
@@ -36,15 +38,12 @@ export interface Action {
  * Re-assign a palette value based on an input color reference
  */
 function setPalette(
-    palette: "accent" | "neutral"
+    palette: "accentPalette" | "neutralPalette"
 ): (state: AppState, value: ColorRGBA64) => AppState {
-    const paletteKey: string = palette + "Palette";
-    const baseColorKey: string = palette + "BaseColor";
     return (state: AppState, value: ColorRGBA64): AppState => {
         const designSystem: ColorsDesignSystem = {
             ...state.designSystem,
-            [paletteKey]: createColorPalette(value),
-            [baseColorKey]: value.toStringHexRGB(),
+            [palette]: createColorPalette(value),
         };
 
         return {
@@ -54,8 +53,8 @@ function setPalette(
     };
 }
 
-const setAccentPalette: ReturnType<typeof setPalette> = setPalette("accent");
-const setNeutralPalette: ReturnType<typeof setPalette> = setPalette("neutral");
+const setAccentPalette: ReturnType<typeof setPalette> = setPalette("accentPalette");
+const setNeutralPalette: ReturnType<typeof setPalette> = setPalette("neutralPalette");
 
 function rootReducer(state: AppState, action: any): AppState {
     switch (action.type) {

--- a/packages/fast-components-class-name-contracts-msft/src/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/index.ts
@@ -21,3 +21,4 @@ export * from "./slider";
 export * from "./slider-label";
 export * from "./subheading";
 export * from "./text-action";
+export * from "./text-field";

--- a/packages/fast-components-class-name-contracts-msft/src/text-action/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/text-action/index.ts
@@ -8,6 +8,16 @@ export interface TextActionClassNameContract {
     textAction: string;
 
     /**
+     * The filled appearance modifier
+     */
+    textAction__filled?: string;
+
+    /**
+     * The outline appearance modifier
+     */
+    textAction__outline?: string;
+
+    /**
      * The disabled state
      */
     textAction__disabled: string;

--- a/packages/fast-components-class-name-contracts-msft/src/text-field/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/text-field/index.ts
@@ -1,0 +1,16 @@
+import { TextFieldClassNameContract as BaseTextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
+
+/**
+ * The class name contract for the text field component
+ */
+export interface TextFieldClassNameContract extends BaseTextFieldClassNameContract {
+    /**
+     * The filled appearance modifier
+     */
+    textField__filled?: string;
+
+    /**
+     * The outline appearance modifier
+     */
+    textField__outline?: string;
+}

--- a/packages/fast-components-react-msft/src/text-action/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/text-action/examples.data.tsx
@@ -3,7 +3,7 @@ import { TextAction, TextActionProps } from "./index";
 import schema from "./text-action.schema.json";
 import Documentation from "./.tmp/documentation";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
-import { TextActionButtonPosition } from "./text-action.props";
+import { TextActionAppearance, TextActionButtonPosition } from "./text-action.props";
 import { SVGGlyph } from "../../app/components/svg-svg-element";
 import svgSchema from "../../app/components/svg-svg-element.schema.json";
 import buttonSchema from "../button/button.schema.json";
@@ -36,6 +36,7 @@ const examples: ComponentFactoryExample<TextActionProps> = {
     data: [
         {
             title: "Search",
+            placeholder: "Search",
             button: {
                 id: buttonSchema.id,
                 props: {
@@ -171,6 +172,17 @@ const examples: ComponentFactoryExample<TextActionProps> = {
                     },
                 },
             } as any,
+            beforeGlyph: {
+                id: svgSchema.id,
+                props: {
+                    path: SVGGlyph.user,
+                },
+            } as any,
+        },
+        {
+            title: "Search",
+            placeholder: "Search",
+            appearance: TextActionAppearance.filled,
             beforeGlyph: {
                 id: svgSchema.id,
                 props: {

--- a/packages/fast-components-react-msft/src/text-action/index.ts
+++ b/packages/fast-components-react-msft/src/text-action/index.ts
@@ -3,6 +3,7 @@ import { FoundationProps } from "@microsoft/fast-components-foundation-react";
 import MSFTTextAction from "./text-action";
 import { TextActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import {
+    TextActionAppearance,
     TextActionButtonPosition,
     TextActionHandledProps as MSFTTextActionHandledProps,
     TextActionManagedClasses,
@@ -31,6 +32,7 @@ type TextActionProps = ManagedJSSProps<
 
 export {
     TextAction,
+    TextActionAppearance,
     TextActionButtonPosition,
     TextActionHandledProps,
     TextActionManagedClasses,

--- a/packages/fast-components-react-msft/src/text-action/text-action.props.ts
+++ b/packages/fast-components-react-msft/src/text-action/text-action.props.ts
@@ -6,7 +6,11 @@ import {
     TextFieldManagedClasses,
 } from "@microsoft/fast-components-react-base";
 import { Omit, Subtract } from "utility-types";
-import { ButtonAppearance } from "../button/button.props";
+
+export enum TextActionAppearance {
+    filled = "filled",
+    outline = "outline",
+}
 
 export enum TextActionButtonPosition {
     before = "before",
@@ -21,6 +25,11 @@ export interface TextActionUnhandledProps
 export interface TextActionHandledProps
     extends Subtract<TextFieldHandledProps, TextFieldManagedClasses>,
         TextActionManagedClasses {
+    /**
+     * The text action appearance
+     */
+    appearance?: TextActionAppearance;
+
     /**
      * The text action button
      */

--- a/packages/fast-components-react-msft/src/text-action/text-action.schema.json
+++ b/packages/fast-components-react-msft/src/text-action/text-action.schema.json
@@ -13,6 +13,14 @@
         "placeholder": {
             "title": "Placeholder",
             "type": "string"
+        },
+        "appearance": {
+            "title": "Appearance",
+            "type": "string",
+            "enum": [
+                "filled",
+                "outline"
+            ]
         }
     },
     "reactProperties": {

--- a/packages/fast-components-react-msft/src/text-action/text-action.spec.tsx
+++ b/packages/fast-components-react-msft/src/text-action/text-action.spec.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import TextAction, {
+    TextActionAppearance,
     TextActionButtonPosition,
     TextActionHandledProps,
     TextActionProps,
@@ -13,6 +14,8 @@ import { DisplayNamePrefix } from "../utilities";
 
 const managedClasses: TextActionClassNameContract = {
     textAction: "text-action",
+    textAction__filled: "text-action--filled",
+    textAction__outline: "text-action--outline",
     textAction__disabled: "text-action--disabled",
     textAction__focus: "text-action--focus",
     textAction_button: "text-action-button",
@@ -35,7 +38,35 @@ describe("text-action", (): void => {
     test("should not throw if managedClasses are not provided", () => {
         expect(() => {
             shallow(<TextAction />);
+            shallow(<TextAction appearance={TextActionAppearance.filled} />);
+            shallow(<TextAction appearance={TextActionAppearance.outline} />);
         }).not.toThrow();
+    });
+
+    test("should apply a 'filled' html class when appearance is filled", () => {
+        const rendered: any = mount(
+            <TextAction
+                appearance={TextActionAppearance.filled}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(rendered.find("div").prop("className")).toContain(
+            managedClasses.textAction__filled
+        );
+    });
+
+    test("should apply an 'outline' html class when appearance is outline", () => {
+        const rendered: any = mount(
+            <TextAction
+                appearance={TextActionAppearance.outline}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(rendered.find("div").prop("className")).toContain(
+            managedClasses.textAction__outline
+        );
     });
 
     test("should return an object that includes all valid props which are not enumerated as handledProps", () => {

--- a/packages/fast-components-react-msft/src/text-action/text-action.tsx
+++ b/packages/fast-components-react-msft/src/text-action/text-action.tsx
@@ -1,12 +1,18 @@
 import React from "react";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {
+    TextActionAppearance,
     TextActionButtonPosition,
     TextActionHandledProps,
     TextActionProps,
     TextActionUnhandledProps,
 } from "./text-action.props";
-import { textFieldOverrides } from "@microsoft/fast-components-styles-msft";
+import {
+    DesignSystemResolver,
+    neutralFillInputRest,
+    neutralFillRest,
+    textFieldOverrides,
+} from "@microsoft/fast-components-styles-msft";
 import { TextField } from "../text-field";
 import { get } from "lodash-es";
 import { DisplayNamePrefix } from "../utilities";
@@ -29,6 +35,7 @@ class TextAction extends Foundation<
     };
 
     protected handledProps: HandledProps<TextActionHandledProps> = {
+        appearance: void 0,
         afterGlyph: void 0,
         beforeGlyph: void 0,
         button: void 0,
@@ -77,6 +84,15 @@ class TextAction extends Foundation<
      */
     protected generateClassNames(): string {
         let classNames: string = get(this.props, "managedClasses.textAction", "");
+
+        if (this.props.appearance) {
+            classNames = `${classNames} ${get(
+                this.props,
+                `managedClasses.textAction__${
+                    TextActionAppearance[this.props.appearance]
+                }`
+            )}`;
+        }
 
         if (this.props.disabled) {
             classNames = `${classNames} ${get(

--- a/packages/fast-components-react-msft/src/text-field/examples.data.tsx
+++ b/packages/fast-components-react-msft/src/text-field/examples.data.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ComponentFactoryExample } from "@microsoft/fast-development-site-react";
-import { TextField, TextFieldProps, TextFieldType } from "./index";
+import { TextField, TextFieldAppearance, TextFieldProps, TextFieldType } from "./index";
 import schema from "./text-field.schema.json";
 import Documentation from "./.tmp/documentation";
 
@@ -43,6 +43,11 @@ export default {
         {
             placeholder: "Enter Password",
             type: TextFieldType.password,
+        },
+        {
+            placeholder: "Placeholder",
+            type: TextFieldType.text,
+            appearance: TextFieldAppearance.filled,
         },
     ],
 } as ComponentFactoryExample<TextFieldProps>;

--- a/packages/fast-components-react-msft/src/text-field/index.ts
+++ b/packages/fast-components-react-msft/src/text-field/index.ts
@@ -1,14 +1,13 @@
 import React from "react";
-import { FoundationProps } from "@microsoft/fast-components-foundation-react";
-import {
-    TextField as BaseTextField,
-    TextFieldClassNameContract,
-    TextFieldHandledProps as BaseTextFieldHandledProps,
+import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import MSFTTextField, {
+    TextFieldAppearance,
+    TextFieldHandledProps as MSFTTextFieldHandledProps,
     TextFieldManagedClasses,
-    TextFieldProps as BaseTextFieldProps,
-    TextFieldType,
+    TextFieldProps as MSFTTextFieldProps,
     TextFieldUnhandledProps,
-} from "@microsoft/fast-components-react-base";
+} from "./text-field";
+import { TextFieldType } from "@microsoft/fast-components-react-base";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { DesignSystem, TextFieldStyles } from "@microsoft/fast-components-styles-msft";
 import { Subtract } from "utility-types";
@@ -18,13 +17,13 @@ import { Subtract } from "utility-types";
  * compiler infer the type instead of re-declaring just for the package export
  */
 /* tslint:disable-next-line:typedef */
-const TextField = manageJss(TextFieldStyles)(BaseTextField);
+const TextField = manageJss(TextFieldStyles)(MSFTTextField);
 type TextField = InstanceType<typeof TextField>;
 
 interface TextFieldHandledProps
-    extends Subtract<BaseTextFieldHandledProps, TextFieldManagedClasses> {}
+    extends Subtract<MSFTTextFieldHandledProps, TextFieldManagedClasses> {}
 type TextFieldProps = ManagedJSSProps<
-    BaseTextFieldProps,
+    MSFTTextFieldProps,
     TextFieldClassNameContract,
     DesignSystem
 >;
@@ -34,6 +33,7 @@ export {
     TextFieldHandledProps,
     TextFieldUnhandledProps,
     TextField,
+    TextFieldAppearance,
     TextFieldProps,
     TextFieldType,
 };

--- a/packages/fast-components-react-msft/src/text-field/text-field.props.ts
+++ b/packages/fast-components-react-msft/src/text-field/text-field.props.ts
@@ -1,0 +1,31 @@
+import React from "react";
+import { Subtract } from "utility-types";
+import {
+    TextFieldHandledProps as BaseTextFieldHandledProps,
+    TextFieldManagedClasses as BaseTextFieldManagedClasses,
+    TextFieldUnhandledProps as BaseTextFieldUnhandledProps,
+} from "@microsoft/fast-components-react-base";
+import {
+    ManagedClasses,
+    TextFieldClassNameContract,
+} from "@microsoft/fast-components-class-name-contracts-msft";
+
+export enum TextFieldAppearance {
+    filled = "filled",
+    outline = "outline",
+}
+
+export interface TextFieldManagedClasses
+    extends ManagedClasses<TextFieldClassNameContract> {}
+export interface TextFieldHandledProps
+    extends TextFieldManagedClasses,
+        Subtract<BaseTextFieldHandledProps, BaseTextFieldManagedClasses> {
+    /**
+     * The TextField appearance
+     */
+    appearance?: TextFieldAppearance;
+}
+
+/* tslint:disable-next-line:no-empty-interface */
+export interface TextFieldUnhandledProps extends BaseTextFieldUnhandledProps {}
+export type TextFieldProps = TextFieldHandledProps & TextFieldUnhandledProps;

--- a/packages/fast-components-react-msft/src/text-field/text-field.schema.json
+++ b/packages/fast-components-react-msft/src/text-field/text-field.schema.json
@@ -26,6 +26,14 @@
         "placeholder": {
             "title": "Placeholder",
             "type": "string"
+        },
+        "appearance": {
+            "title": "Appearance",
+            "type": "string",
+            "enum": [
+                "filled",
+                "outline"
+            ]
         }
     }
 }

--- a/packages/fast-components-react-msft/src/text-field/text-field.spec.tsx
+++ b/packages/fast-components-react-msft/src/text-field/text-field.spec.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
+import { configure, mount, shallow } from "enzyme";
+import TextField, {
+    TextFieldAppearance,
+    TextFieldHandledProps,
+    TextFieldProps,
+    TextFieldUnhandledProps,
+} from "./text-field";
+import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import { DisplayNamePrefix } from "../utilities";
+
+const managedClasses: TextFieldClassNameContract = {
+    textField: "text-field",
+    textField__filled: "text-field--filled",
+    textField__outline: "text-field--outline",
+};
+
+/*
+ * Configure Enzyme
+ */
+configure({ adapter: new Adapter() });
+
+describe("text-field", (): void => {
+    test("should have a displayName that matches the component name", () => {
+        expect(`${DisplayNamePrefix}${(TextField as any).name}`).toBe(
+            TextField.displayName
+        );
+    });
+
+    test("should not throw if managedClasses are not provided", () => {
+        expect(() => {
+            shallow(<TextField />);
+            shallow(<TextField appearance={TextFieldAppearance.filled} />);
+            shallow(<TextField appearance={TextFieldAppearance.outline} />);
+        }).not.toThrow();
+    });
+
+    test("should apply a 'filled' html class when appearance is filled", () => {
+        const rendered: any = mount(
+            <TextField
+                appearance={TextFieldAppearance.filled}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(rendered.find("input").prop("className")).toContain(
+            managedClasses.textField__filled
+        );
+    });
+
+    test("should apply an 'outline' html class when appearance is outline", () => {
+        const rendered: any = mount(
+            <TextField
+                appearance={TextFieldAppearance.outline}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(rendered.find("input").prop("className")).toContain(
+            managedClasses.textField__outline
+        );
+    });
+
+    test("should return an object that includes all valid props which are not enumerated as handledProps", () => {
+        const handledProps: TextFieldHandledProps = {
+            managedClasses,
+        };
+
+        const unhandledProps: TextFieldUnhandledProps = {
+            "aria-hidden": true,
+        };
+        const props: TextFieldProps = { ...handledProps, ...unhandledProps };
+        const rendered: any = mount(<TextField {...props} />);
+
+        expect(rendered.find("input").prop("aria-hidden")).not.toBe(undefined);
+        expect(rendered.find("input").prop("aria-hidden")).toEqual(true);
+    });
+
+    test("should set a default type of `text` on inner input", () => {
+        const rendered: any = mount(<TextField managedClasses={managedClasses} />);
+
+        expect(rendered.find("input").prop("type")).not.toBe(undefined);
+        expect(rendered.find("input").prop("type")).toEqual("text");
+    });
+
+    test("should NOT render with a disabled value if no `disabled` prop is passed", () => {
+        const rendered: any = mount(<TextField managedClasses={managedClasses} />);
+
+        expect(rendered.find("input").prop("disabled")).toBe(null);
+    });
+
+    test("should render with a `disabled` value when `disabled` prop is passed", () => {
+        const rendered: any = mount(
+            <TextField managedClasses={managedClasses} disabled={true} />
+        );
+
+        expect(rendered.find("input").prop("disabled")).toBe(true);
+    });
+
+    test("should NOT render with a placeholder value if no `placeholder` prop is passed", () => {
+        const rendered: any = mount(<TextField managedClasses={managedClasses} />);
+
+        expect(rendered.find("input").prop("placeholder")).toBe(null);
+    });
+
+    test("should render with a placeholder value when `placeholder` prop is passed", () => {
+        const rendered: any = mount(
+            <TextField managedClasses={managedClasses} placeholder={"Test"} />
+        );
+
+        expect(rendered.find("input").prop("placeholder")).toEqual("Test");
+    });
+});

--- a/packages/fast-components-react-msft/src/text-field/text-field.tsx
+++ b/packages/fast-components-react-msft/src/text-field/text-field.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { get } from "lodash-es";
+import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
+import {
+    TextFieldAppearance,
+    TextFieldHandledProps,
+    TextFieldManagedClasses,
+    TextFieldUnhandledProps,
+} from "./text-field.props";
+import { TextField as BaseTextField } from "@microsoft/fast-components-react-base";
+import { DisplayNamePrefix } from "../utilities";
+
+class TextField extends Foundation<TextFieldHandledProps, TextFieldUnhandledProps, {}> {
+    public static displayName: string = `${DisplayNamePrefix}TextField`;
+
+    protected handledProps: HandledProps<TextFieldHandledProps> = {
+        appearance: void 0,
+        managedClasses: void 0,
+    };
+
+    /**
+     * Renders the component
+     */
+    public render(): React.ReactElement<HTMLInputElement> {
+        return (
+            <BaseTextField
+                {...this.unhandledProps()}
+                className={this.generateClassNames()}
+                managedClasses={this.props.managedClasses}
+                disabled={this.props.disabled}
+            />
+        );
+    }
+
+    /**
+     * Generates class names
+     */
+    protected generateClassNames(): string {
+        const className: string = this.props.appearance
+            ? get(
+                  this.props,
+                  `managedClasses.textField__${
+                      TextFieldAppearance[this.props.appearance]
+                  }`
+              )
+            : "";
+
+        return super.generateClassNames(className);
+    }
+}
+
+export default TextField;
+export * from "./text-field.props";

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -9,33 +9,17 @@ export type DensityOffset = -3 | -2 | -1 | 0 | 1 | 2 | 3;
 
 export interface DesignSystem {
     /**
-     * The value typically used for backgrounds of elements.
+     * The value typically used for backgrounds of elements
      */
     backgroundColor: string;
 
     /**
-     * The neutral color, which the neutralPalette is based on.
-     * Keep this value in sync with neutralPalette.
-     */
-    neutralBaseColor: string;
-
-    /**
-     * The accent color, which the accentPalette is based on.
-     * Keep this value in sync with accentPalette.
-     */
-    accentBaseColor: string;
-
-    /**
-     * An array of colors in a ramp from light to dark, used to lookup values for neutral color recipes.
-     * Keep this value in sync with neutralBaseColor.
-     * Typically generated using color-palette in @microsoft/fast-colors.
+     * Configuration object to derive the neutral palette. Expects a ColorPaletteConfig from @microsoft/fast-colors
      */
     neutralPalette: Palette;
 
     /**
-     * An array of colors in a ramp from light to dark, used to lookup values for neutral color recipes.
-     * Keep this value in sync with accentBaseColor.
-     * Typically generated using color-palette in @microsoft/fast-colors.
+     * Configuration object to derive the accent palette. Expects a ColorPaletteConfig from @microsoft/fast-colors
      */
     accentPalette: Palette;
 
@@ -70,7 +54,7 @@ export interface DesignSystem {
     direction: Direction;
 
     /**
-     * An object representing the supported font weights.
+     * An object representing the supported font weights
      */
     fontWeight?: FontWeight;
 
@@ -95,7 +79,7 @@ export interface DesignSystem {
     disabledOpacity: number;
 
     /**
-     * Color swatch deltas for accent-fill recipe.
+     * Color swatch deltas for accent-fill recipe
      */
     accentFillRestDelta: number;
     accentFillHoverDelta: number;
@@ -103,14 +87,14 @@ export interface DesignSystem {
     accentFillSelectedDelta: number;
 
     /**
-     * Color swatch deltas for accent-foreground recipe.
+     * Color swatch deltas for accent-foreground recipe
      */
     accentForegroundRestDelta: number;
     accentForegroundHoverDelta: number;
     accentForegroundActiveDelta: number;
 
     /*
-     * Color swatch deltas for neutral-fill recipe.
+     * Color swatch deltas for neutral-fill recipe
      */
     neutralFillRestDelta: number;
     neutralFillHoverDelta: number;
@@ -118,7 +102,7 @@ export interface DesignSystem {
     neutralFillSelectedDelta: number;
 
     /**
-     * Color swatch deltas for neutral-fill-input recipe.
+     * Color swatch deltas for neutral-fill-input recipe
      */
     neutralFillInputRestDelta: number;
     neutralFillInputHoverDelta: number;
@@ -126,7 +110,7 @@ export interface DesignSystem {
     neutralFillInputSelectedDelta: number;
 
     /**
-     * Color swatch deltas for neutral-fill-stealth recipe.
+     * Color swatch deltas for neutral-fill-stealth recipe
      */
     neutralFillStealthRestDelta: number;
     neutralFillStealthHoverDelta: number;
@@ -134,12 +118,12 @@ export interface DesignSystem {
     neutralFillStealthSelectedDelta: number;
 
     /**
-     * Color swatch deltas for neutral-fill-card recipe.
+     * Color swatch deltas for neutral-fill-card recipe
      */
     neutralFillCardDelta: number;
 
     /**
-     * Color swatch deltas for neutral-foreground recipe.
+     * Color swatch deltas for neutral-foreground
      */
     neutralForegroundDarkIndex: number;
     neutralForegroundLightIndex: number;
@@ -147,7 +131,7 @@ export interface DesignSystem {
     neutralForegroundActiveDelta: number;
 
     /**
-     * Color swatch deltas for neutral-outline recipe.
+     * Color swatch deltas for neutral-outline
      */
     neutralOutlineRestDelta: number;
     neutralOutlineHoverDelta: number;
@@ -169,8 +153,6 @@ export function createColorPalette(baseColor: ColorRGBA64): Palette {
 
 const designSystemDefaults: DesignSystem = {
     backgroundColor: white,
-    neutralBaseColor: "#808080",
-    accentBaseColor: "#0078D4",
     contrast: 0,
     density: 0,
     designUnit: 4,

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -171,18 +171,18 @@ const designSystemDefaults: DesignSystem = {
      * Recipe Deltas
      */
     accentFillRestDelta: 0,
-    accentFillHoverDelta: 2,
-    accentFillActiveDelta: 4,
+    accentFillHoverDelta: -2,
+    accentFillActiveDelta: 2,
     accentFillSelectedDelta: 12,
 
     accentForegroundRestDelta: 0,
-    accentForegroundHoverDelta: 4,
-    accentForegroundActiveDelta: 8,
+    accentForegroundHoverDelta: -2,
+    accentForegroundActiveDelta: 2,
 
     neutralFillRestDelta: 4,
     neutralFillHoverDelta: 3,
-    neutralFillActiveDelta: 2,
-    neutralFillSelectedDelta: 8,
+    neutralFillActiveDelta: 5,
+    neutralFillSelectedDelta: 4,
 
     neutralFillInputRestDelta: 4,
     neutralFillInputHoverDelta: 4,
@@ -191,8 +191,8 @@ const designSystemDefaults: DesignSystem = {
 
     neutralFillStealthRestDelta: 0,
     neutralFillStealthHoverDelta: 3,
-    neutralFillStealthActiveDelta: 2,
-    neutralFillStealthSelectedDelta: 8,
+    neutralFillStealthActiveDelta: 5,
+    neutralFillStealthSelectedDelta: 4,
 
     neutralFillCardDelta: 2,
 
@@ -202,9 +202,9 @@ const designSystemDefaults: DesignSystem = {
     neutralForegroundHoverDelta: 8,
     neutralForegroundActiveDelta: 16,
 
-    neutralOutlineRestDelta: 12,
-    neutralOutlineHoverDelta: 24,
-    neutralOutlineActiveDelta: 18,
+    neutralOutlineRestDelta: 18,
+    neutralOutlineHoverDelta: 12,
+    neutralOutlineActiveDelta: 24,
 };
 
 /**

--- a/packages/fast-components-styles-msft/src/patterns/input-field.ts
+++ b/packages/fast-components-styles-msft/src/patterns/input-field.ts
@@ -1,11 +1,14 @@
 import { horizontalSpacing } from "../utilities/density";
 import { CSSRules } from "@microsoft/fast-jss-manager";
-import { DesignSystem, ensureDesignSystemDefaults } from "../design-system";
+import { DesignSystem } from "../design-system";
 import { format, toPx } from "@microsoft/fast-jss-utilities";
 import {
+    neutralFillActive,
+    neutralFillHover,
     neutralFillInputActive,
     neutralFillInputHover,
     neutralFillInputRest,
+    neutralFillRest,
     neutralFocus,
     neutralForegroundHint,
     neutralForegroundRest,
@@ -37,12 +40,7 @@ export function inputFieldStyles(
         color: neutralForegroundRest,
         fontFamily: "inherit",
         boxSizing: "border-box",
-        padding: ensureDesignSystemDefaults(
-            (designSystem: DesignSystem): string =>
-                format("0 {0}", horizontalSpacing(designSystem.outlineWidth))(
-                    designSystem
-                )
-        ),
+        padding: format("0 {0}", horizontalSpacing(outlineWidth)),
         ...applyCornerRadius(),
         margin: "0",
         transition: "all 0.2s ease-in-out",
@@ -54,7 +52,7 @@ export function inputFieldStyles(
             background: neutralFillInputActive,
             borderColor: neutralOutlineActive,
         },
-        "&:focus": {
+        "&:focus:enabled": {
             boxShadow: format<DesignSystem>("0 0 0 1px {0} inset", neutralFocus),
             borderColor: neutralFocus,
             outline: "none",
@@ -63,7 +61,26 @@ export function inputFieldStyles(
             ...applyDisabledState(),
         },
         "&::placeholder": {
-            color: neutralForegroundHint,
+            color: neutralForegroundHint(neutralFillInputRest),
+        },
+    };
+}
+
+export function filledInputFieldStyles(): CSSRules<{}> {
+    return {
+        ...inputFieldStyles(),
+        background: neutralFillRest,
+        border: format("{0} solid transparent", toPx(outlineWidth)),
+        "&:hover:enabled": {
+            background: neutralFillHover,
+            borderColor: "transparent",
+        },
+        "&:active:enabled": {
+            background: neutralFillActive,
+            borderColor: "transparent",
+        },
+        "&::placeholder": {
+            color: neutralForegroundHint(neutralFillRest),
         },
     };
 }

--- a/packages/fast-components-styles-msft/src/text-action/index.ts
+++ b/packages/fast-components-styles-msft/src/text-action/index.ts
@@ -5,9 +5,12 @@ import { directionSwitch, format, subtract, toPx } from "@microsoft/fast-jss-uti
 import { DesignSystem } from "../design-system";
 import { applyCornerRadius } from "../utilities/border";
 import {
+    neutralFillActive,
+    neutralFillHover,
     neutralFillInputActive,
     neutralFillInputHover,
     neutralFillInputRest,
+    neutralFillRest,
     neutralFocus,
     neutralForegroundRest,
     neutralOutlineActive,
@@ -18,7 +21,7 @@ import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 import { applyDisabledState } from "../utilities/disabled";
 
-// Since MSFT button is already styled, we need to override in this way to alter button classes
+// Since MSFT text field is already styled, we need to override in this way to alter text field classes
 export const textFieldOverrides: ComponentStyles<
     Partial<TextFieldClassNameContract>,
     DesignSystem
@@ -30,7 +33,8 @@ export const textFieldOverrides: ComponentStyles<
         flex: "1 0 0",
         background: "transparent",
         minWidth: "inherit",
-        "&:hover, &:disabled, &:active, &:focus": {
+        "&:hover, &:hover:enabled, &:disabled, &:active, &:active:enabled, &:focus, &:focus:enabled": {
+            background: "none",
             border: "none",
             boxShadow: "none",
         },
@@ -70,14 +74,31 @@ const styles: ComponentStyles<TextActionClassNameContract, DesignSystem> = {
             borderColor: neutralOutlineActive,
         },
     },
+    textAction__filled: {
+        background: neutralFillRest,
+        border: format("{0} solid transparent", toPx<DesignSystem>(outlineWidth)),
+        "&:hover": {
+            background: neutralFillHover,
+            borderColor: "transparent",
+        },
+        "&:active": {
+            background: neutralFillActive,
+            borderColor: "transparent",
+        },
+    },
+    textAction__outline: {},
     textAction__focus: {
         "&, &:hover": {
             boxShadow: format(
                 "0 0 0 {0} {1} inset",
-                toPx(subtract(focusOutlineWidth, outlineWidth)),
+                toPx<DesignSystem>(subtract(focusOutlineWidth, outlineWidth)),
                 neutralFocus
             ),
-            border: format("{0} solid {1}", toPx(outlineWidth), neutralFocus),
+            border: format(
+                "{0} solid {1}",
+                toPx<DesignSystem>(outlineWidth),
+                neutralFocus
+            ),
         },
     },
     textAction__disabled: {

--- a/packages/fast-components-styles-msft/src/text-field/index.ts
+++ b/packages/fast-components-styles-msft/src/text-field/index.ts
@@ -1,13 +1,16 @@
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
+import { DesignSystem } from "../design-system";
 import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { height } from "../utilities/density";
-import { inputFieldStyles } from "../patterns/input-field";
+import { filledInputFieldStyles, inputFieldStyles } from "../patterns/input-field";
 
 const styles: ComponentStyles<TextFieldClassNameContract, DesignSystem> = {
     textField: {
         ...inputFieldStyles(),
         height: height(),
+    },
+    textField__filled: {
+        ...filledInputFieldStyles(),
     },
 };
 

--- a/packages/fast-components-styles-msft/src/utilities/color/accent-foreground.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/accent-foreground.spec.ts
@@ -25,6 +25,31 @@ describe("accentForeground", (): void => {
         expect(accentForegroundLargeActive({} as DesignSystem)).toBe(accentPalette[23]);
     });
 
+    // TODO: Needed for code coverage settings. Replace tests above if/when experimental mode is permanent
+    test("should opperate on experimental design system defaults", (): void => {
+        const experimentalDesignSystem: DesignSystem = Object.assign(
+            {},
+            designSystemDefaults,
+            {
+                accentForegroundRestDelta: 100,
+                accentForegroundHoverDelta: -102,
+                accentForegroundActiveDelta: 102,
+            }
+        );
+        expect(accentForegroundRest(experimentalDesignSystem)).toBe(accentPalette[33]);
+        expect(accentForegroundHover(experimentalDesignSystem)).toBe(accentPalette[31]);
+        expect(accentForegroundActive(experimentalDesignSystem)).toBe(accentPalette[35]);
+        expect(accentForegroundLargeRest(experimentalDesignSystem)).toBe(
+            accentPalette[31]
+        );
+        expect(accentForegroundLargeHover(experimentalDesignSystem)).toBe(
+            accentPalette[29]
+        );
+        expect(accentForegroundLargeActive(experimentalDesignSystem)).toBe(
+            accentPalette[33]
+        );
+    });
+
     test("should accept a function that resolves a background swatch", (): void => {
         expect(typeof accentForegroundRest(() => "#FFF")).toBe("function");
         expect(accentForegroundRest(() => "#000")({} as DesignSystem)).toBe(

--- a/packages/fast-components-styles-msft/src/utilities/color/accent-foreground.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/accent-foreground.spec.ts
@@ -6,12 +6,11 @@ import {
     accentForegroundLargeRest,
     accentForegroundRest,
 } from "./accent-foreground";
-import designSystemDefaults, {
-    createColorPalette,
-    DesignSystem,
-} from "../../design-system";
+import designSystemDefaults, { DesignSystem } from "../../design-system";
 import { palette, Palette, PaletteType } from "./palette";
-import { contrast, parseColorString, Swatch } from "./common";
+import { contrast, Swatch } from "./common";
+import { accentPaletteConfig } from "./color-constants";
+import { parseColorHexRGB } from "@microsoft/fast-colors";
 
 describe("accentForeground", (): void => {
     const neutralPalette: Palette = palette(PaletteType.neutral)(designSystemDefaults);
@@ -90,32 +89,33 @@ describe("accentForeground", (): void => {
         accentColors.forEach(
             (accent: Swatch): void => {
                 neutralPalette.forEach(
-                    (neutral: Swatch): void => {
+                    (swatch: Swatch): void => {
                         const designSystem: DesignSystem = Object.assign(
                             {},
                             designSystemDefaults,
                             {
-                                backgroundColor: neutral,
-                                accentBaseColor: accent,
-                                accentPalette: createColorPalette(
-                                    parseColorString(accent)
+                                backgroundColor: swatch,
+                                accentPaletteConfig: Object.assign(
+                                    {},
+                                    accentPaletteConfig,
+                                    { baseColor: parseColorHexRGB(swatch) }
                                 ),
-                            } as DesignSystem
+                            }
                         );
 
                         expect(
-                            contrast(neutral, accentForegroundRest(designSystem))
+                            contrast(swatch, accentForegroundRest(designSystem))
                             // There are a few states that are impossible to meet contrast on
                         ).toBeGreaterThanOrEqual(4.47);
                         expect(
-                            contrast(neutral, accentForegroundHover(designSystem))
+                            contrast(swatch, accentForegroundHover(designSystem))
                             // There are a few states that are impossible to meet contrast on
-                        ).toBeGreaterThanOrEqual(3.5);
+                        ).toBeGreaterThanOrEqual(3.7);
                         expect(
-                            contrast(neutral, accentForegroundLargeRest(designSystem))
+                            contrast(swatch, accentForegroundLargeRest(designSystem))
                         ).toBeGreaterThanOrEqual(3);
                         expect(
-                            contrast(neutral, accentForegroundLargeHover(designSystem))
+                            contrast(swatch, accentForegroundLargeHover(designSystem))
                         ).toBeGreaterThanOrEqual(3);
                     }
                 );

--- a/packages/fast-components-styles-msft/src/utilities/color/accent.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/accent.spec.ts
@@ -1,5 +1,10 @@
 import { accentSwatch } from "./accent";
-import designSystemDefaults, { DesignSystem } from "../../design-system";
+import designSystemDefaults, {
+    DesignSystem,
+    ensureDesignSystemDefaults,
+} from "../../design-system";
+import { accentPaletteConfig } from "./color-constants";
+import { parseColorHexRGB } from "@microsoft/fast-colors";
 
 describe("accentSwatch", (): void => {
     test("should return #0078D4 by default", (): void => {

--- a/packages/fast-components-styles-msft/src/utilities/color/accent.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/accent.ts
@@ -16,8 +16,17 @@ export const accentSwatch: SwatchResolver = (designSystem: DesignSystem): Swatch
         : accentPalette[Math.floor(accentPalette.length / 2)];
 };
 
+////////////////////
+// Any portion of the code referencing newRecipeOffset is considered experimental
+// and will be incorporated permanently or removed upon review. DO NOT use values
+// in this range unless you are temporarily evaluation this feature as they will
+// no longer produce predictable results once removed.
+////////////////////
+const newRecipeOffset: number = 100;
+
 /**
  * Returns indexes for accent UI states that are accessible against an input reference color.
+ * @param stateDeltas The offsets for each state, which are offsets from the closest accessible color.
  */
 export function findAccessibleAccentSwatchIndexes(
     designSystem: DesignSystem,
@@ -33,6 +42,16 @@ export function findAccessibleAccentSwatchIndexes(
     hover: number;
     active: number;
 } {
+    function largestDelta(a: number, b: number): number {
+        return Math.abs(a) > Math.abs(b) ? a : b;
+    }
+    function adjustDelta(a: number): number {
+        if (Math.abs(a) >= newRecipeOffset) {
+            return a < 0 ? a + newRecipeOffset : a - newRecipeOffset;
+        }
+        return a;
+    }
+
     const accentColor: Swatch = accentSwatch(designSystem);
     const accentPalette: Palette = palette(PaletteType.accent)(designSystem);
     const darkTheme: boolean = isDarkMode(designSystem);
@@ -44,6 +63,104 @@ export function findAccessibleAccentSwatchIndexes(
         PaletteType.accent,
         accentColor
     )(designSystem);
+
+    /* Begin new recipe calculations */
+    if (stateDeltas.rest >= newRecipeOffset) {
+        // Get the furthest distance we need to go from the base accent color
+        const accessibilityDelta: number = largestDelta(
+            adjustDelta(stateDeltas.rest),
+            adjustDelta(stateDeltas.hover)
+        );
+        let testDirection: number = 1;
+        let accessibleLighterOffset: number = 0;
+
+        // Check the furthest distance to the _lighter_ side for contrast requirements
+        while (
+            inRange(
+                accessibleAccentIndex + accessibleLighterOffset + accessibilityDelta,
+                0,
+                paletteLength
+            ) &&
+            contrast(
+                accentPalette[
+                    accessibleAccentIndex + accessibleLighterOffset + accessibilityDelta
+                ],
+                referenceColor
+            ) < contrastTarget &&
+            inRange(
+                accessibleAccentIndex +
+                    accessibleLighterOffset +
+                    accessibilityDelta +
+                    testDirection,
+                0,
+                maxIndex
+            )
+        ) {
+            accessibleLighterOffset += testDirection;
+        }
+
+        // Check the furthest distance to the _darker_ side for contrast requirements
+        testDirection = -1;
+        let accessibleDarkerOffset: number = 0;
+        while (
+            contrast(
+                accentPalette[
+                    accessibleAccentIndex + accessibleDarkerOffset + accessibilityDelta
+                ],
+                referenceColor
+            ) < contrastTarget &&
+            inRange(
+                accessibleAccentIndex +
+                    accessibleDarkerOffset +
+                    accessibilityDelta +
+                    testDirection,
+                0,
+                maxIndex
+            )
+        ) {
+            accessibleDarkerOffset += testDirection;
+        }
+
+        // Find the closest offset to the base accent color that meets contrast (lighter or darker)
+        const lightContrastValue: number = contrast(
+            accentPalette[
+                accessibleAccentIndex + accessibleLighterOffset + accessibilityDelta
+            ],
+            referenceColor
+        );
+        const darkContrastValue: number = contrast(
+            accentPalette[
+                accessibleAccentIndex + accessibleDarkerOffset + accessibilityDelta
+            ],
+            referenceColor
+        );
+        const accessibleOffset: number =
+            lightContrastValue > darkContrastValue
+                ? accessibleLighterOffset
+                : accessibleDarkerOffset;
+
+        // Return the adjusted indexes
+        return {
+            rest: clamp(
+                accessibleAccentIndex + accessibleOffset + adjustDelta(stateDeltas.rest),
+                0,
+                maxIndex
+            ),
+            hover: clamp(
+                accessibleAccentIndex + accessibleOffset + adjustDelta(stateDeltas.hover),
+                0,
+                maxIndex
+            ),
+            active: clamp(
+                accessibleAccentIndex +
+                    accessibleOffset +
+                    adjustDelta(stateDeltas.active),
+                0,
+                maxIndex
+            ),
+        };
+    }
+    /* End new recipe calculations */
 
     while (
         inRange(
@@ -78,7 +195,3 @@ export function findAccessibleAccentSwatchIndexes(
         ),
     };
 }
-/**
- * @deprecated - please use findAccessibleAccentSwatchIndexes
- */
-export const findAccessibleAccentSwatchIndexs: typeof findAccessibleAccentSwatchIndexes = findAccessibleAccentSwatchIndexes;

--- a/packages/fast-components-styles-msft/src/utilities/color/accent.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/accent.ts
@@ -1,7 +1,7 @@
 import { DesignSystem } from "../../design-system";
 import { Palette, palette, PaletteType } from "./palette";
 import { accent } from "./color-constants";
-import { findClosestSwatchIndex, isDarkMode } from "./palette";
+import { findClosestSwatchIndex } from "./palette";
 import { contrast, Swatch, SwatchResolver } from "./common";
 import { clamp, inRange } from "lodash-es";
 
@@ -15,14 +15,6 @@ export const accentSwatch: SwatchResolver = (designSystem: DesignSystem): Swatch
         ? accent
         : accentPalette[Math.floor(accentPalette.length / 2)];
 };
-
-////////////////////
-// Any portion of the code referencing newRecipeOffset is considered experimental
-// and will be incorporated permanently or removed upon review. DO NOT use values
-// in this range unless you are temporarily evaluation this feature as they will
-// no longer produce predictable results once removed.
-////////////////////
-const newRecipeOffset: number = 100;
 
 /**
  * Returns indexes for accent UI states that are accessible against an input reference color.
@@ -45,151 +37,100 @@ export function findAccessibleAccentSwatchIndexes(
     function largestDelta(a: number, b: number): number {
         return Math.abs(a) > Math.abs(b) ? a : b;
     }
-    function adjustDelta(a: number): number {
-        if (Math.abs(a) >= newRecipeOffset) {
-            return a < 0 ? a + newRecipeOffset : a - newRecipeOffset;
-        }
-        return a;
-    }
 
     const accentColor: Swatch = accentSwatch(designSystem);
     const accentPalette: Palette = palette(PaletteType.accent)(designSystem);
-    const darkTheme: boolean = isDarkMode(designSystem);
-    const stateDirection: 1 | -1 = darkTheme ? 1 : -1;
-    const accessibleTextDirection: 1 | -1 = darkTheme ? -1 : 1;
     const paletteLength: number = accentPalette.length;
     const maxIndex: number = paletteLength - 1;
-    let accessibleAccentIndex: number = findClosestSwatchIndex(
+    const accessibleAccentIndex: number = findClosestSwatchIndex(
         PaletteType.accent,
         accentColor
     )(designSystem);
 
-    /* Begin new recipe calculations */
-    if (stateDeltas.rest >= newRecipeOffset) {
-        // Get the furthest distance we need to go from the base accent color
-        const accessibilityDelta: number = largestDelta(
-            adjustDelta(stateDeltas.rest),
-            adjustDelta(stateDeltas.hover)
-        );
-        let testDirection: number = 1;
-        let accessibleLighterOffset: number = 0;
+    // Get the furthest distance we need to go from the base accent color
+    const accessibilityDelta: number = largestDelta(stateDeltas.rest, stateDeltas.hover);
+    let testDirection: number = 1;
+    let accessibleLighterOffset: number = 0;
 
-        // Check the furthest distance to the _lighter_ side for contrast requirements
-        while (
-            inRange(
-                accessibleAccentIndex + accessibleLighterOffset + accessibilityDelta,
-                0,
-                paletteLength
-            ) &&
-            contrast(
-                accentPalette[
-                    accessibleAccentIndex + accessibleLighterOffset + accessibilityDelta
-                ],
-                referenceColor
-            ) < contrastTarget &&
-            inRange(
-                accessibleAccentIndex +
-                    accessibleLighterOffset +
-                    accessibilityDelta +
-                    testDirection,
-                0,
-                maxIndex
-            )
-        ) {
-            accessibleLighterOffset += testDirection;
-        }
-
-        // Check the furthest distance to the _darker_ side for contrast requirements
-        testDirection = -1;
-        let accessibleDarkerOffset: number = 0;
-        while (
-            contrast(
-                accentPalette[
-                    accessibleAccentIndex + accessibleDarkerOffset + accessibilityDelta
-                ],
-                referenceColor
-            ) < contrastTarget &&
-            inRange(
-                accessibleAccentIndex +
-                    accessibleDarkerOffset +
-                    accessibilityDelta +
-                    testDirection,
-                0,
-                maxIndex
-            )
-        ) {
-            accessibleDarkerOffset += testDirection;
-        }
-
-        // Find the closest offset to the base accent color that meets contrast (lighter or darker)
-        const lightContrastValue: number = contrast(
-            accentPalette[
-                accessibleAccentIndex + accessibleLighterOffset + accessibilityDelta
-            ],
-            referenceColor
-        );
-        const darkContrastValue: number = contrast(
-            accentPalette[
-                accessibleAccentIndex + accessibleDarkerOffset + accessibilityDelta
-            ],
-            referenceColor
-        );
-        const accessibleOffset: number =
-            lightContrastValue > darkContrastValue
-                ? accessibleLighterOffset
-                : accessibleDarkerOffset;
-
-        // Return the adjusted indexes
-        return {
-            rest: clamp(
-                accessibleAccentIndex + accessibleOffset + adjustDelta(stateDeltas.rest),
-                0,
-                maxIndex
-            ),
-            hover: clamp(
-                accessibleAccentIndex + accessibleOffset + adjustDelta(stateDeltas.hover),
-                0,
-                maxIndex
-            ),
-            active: clamp(
-                accessibleAccentIndex +
-                    accessibleOffset +
-                    adjustDelta(stateDeltas.active),
-                0,
-                maxIndex
-            ),
-        };
-    }
-    /* End new recipe calculations */
-
+    // Check the furthest distance to the _lighter_ side for contrast requirements
     while (
         inRange(
-            accessibleAccentIndex + stateDirection * stateDeltas.hover,
+            accessibleAccentIndex + accessibleLighterOffset + accessibilityDelta,
             0,
             paletteLength
         ) &&
         contrast(
-            accentPalette[accessibleAccentIndex + stateDirection * stateDeltas.hover],
+            accentPalette[
+                accessibleAccentIndex + accessibleLighterOffset + accessibilityDelta
+            ],
             referenceColor
         ) < contrastTarget &&
-        inRange(accessibleAccentIndex + accessibleTextDirection, 0, maxIndex)
+        inRange(
+            accessibleAccentIndex +
+                accessibleLighterOffset +
+                accessibilityDelta +
+                testDirection,
+            0,
+            maxIndex
+        )
     ) {
-        accessibleAccentIndex += accessibleTextDirection;
+        accessibleLighterOffset += testDirection;
     }
 
+    // Check the furthest distance to the _darker_ side for contrast requirements
+    testDirection = -1;
+    let accessibleDarkerOffset: number = 0;
+    while (
+        contrast(
+            accentPalette[
+                accessibleAccentIndex + accessibleDarkerOffset + accessibilityDelta
+            ],
+            referenceColor
+        ) < contrastTarget &&
+        inRange(
+            accessibleAccentIndex +
+                accessibleDarkerOffset +
+                accessibilityDelta +
+                testDirection,
+            0,
+            maxIndex
+        )
+    ) {
+        accessibleDarkerOffset += testDirection;
+    }
+
+    // Find the closest offset to the base accent color that meets contrast (lighter or darker)
+    const lightContrastValue: number = contrast(
+        accentPalette[
+            accessibleAccentIndex + accessibleLighterOffset + accessibilityDelta
+        ],
+        referenceColor
+    );
+    const darkContrastValue: number = contrast(
+        accentPalette[
+            accessibleAccentIndex + accessibleDarkerOffset + accessibilityDelta
+        ],
+        referenceColor
+    );
+    const accessibleOffset: number =
+        lightContrastValue > darkContrastValue
+            ? accessibleLighterOffset
+            : accessibleDarkerOffset;
+
+    // Return the adjusted indexes
     return {
         rest: clamp(
-            accessibleAccentIndex + stateDirection * stateDeltas.rest,
+            accessibleAccentIndex + accessibleOffset + stateDeltas.rest,
             0,
             maxIndex
         ),
         hover: clamp(
-            accessibleAccentIndex + stateDirection * stateDeltas.hover,
+            accessibleAccentIndex + accessibleOffset + stateDeltas.hover,
             0,
             maxIndex
         ),
         active: clamp(
-            accessibleAccentIndex + stateDirection * stateDeltas.active,
+            accessibleAccentIndex + accessibleOffset + stateDeltas.active,
             0,
             maxIndex
         ),

--- a/packages/fast-components-styles-msft/src/utilities/color/accent.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/accent.ts
@@ -1,6 +1,6 @@
 import { DesignSystem } from "../../design-system";
-import { accentBaseColor } from "../design-system";
 import { Palette, palette, PaletteType } from "./palette";
+import { accent } from "./color-constants";
 import { findClosestSwatchIndex, isDarkMode } from "./palette";
 import { contrast, Swatch, SwatchResolver } from "./common";
 import { clamp, inRange } from "lodash-es";
@@ -12,7 +12,7 @@ export const accentSwatch: SwatchResolver = (designSystem: DesignSystem): Swatch
     const accentPalette: Palette | null = palette(PaletteType.accent)(designSystem);
 
     return accentPalette === null
-        ? accentBaseColor(designSystem)
+        ? accent
         : accentPalette[Math.floor(accentPalette.length / 2)];
 };
 

--- a/packages/fast-components-styles-msft/src/utilities/color/color-constants.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/color-constants.ts
@@ -2,6 +2,7 @@ import { ColorPaletteConfig, parseColorHexRGB } from "@microsoft/fast-colors";
 
 export const white: string = "#FFFFFF";
 export const black: string = "#000000";
+export const accent: string = "#0078D4";
 
 export const paletteConstants: Partial<ColorPaletteConfig> = {
     steps: 63,
@@ -11,16 +12,12 @@ export const paletteConstants: Partial<ColorPaletteConfig> = {
 
 /**
  * Default palette sources
- * @deprecated
  */
 export const neutralPaletteConfig: ColorPaletteConfig = {
     ...paletteConstants,
 };
 
-/**
- * @deprecated
- */
 export const accentPaletteConfig: ColorPaletteConfig = {
     ...paletteConstants,
-    baseColor: parseColorHexRGB("#0078D4"),
+    baseColor: parseColorHexRGB(accent),
 };

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-stealth.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-stealth.spec.ts
@@ -49,6 +49,60 @@ describe("neutralFillStealth", (): void => {
         ).toBe(neutralPalette[4 - designSystemDefaults.neutralFillStealthHoverDelta]);
     });
 
+    // TODO: Needed for code coverage settings. Replace tests above if/when experimental mode is permanent
+    test("should switch from dark to light after 5 swatches in experimental mode", (): void => {
+        const experimentalDesignSystem: DesignSystem = Object.assign(
+            {},
+            designSystemDefaults,
+            {
+                neutralFillRestDelta: 104,
+                neutralFillHoverDelta: 103,
+                neutralFillActiveDelta: 105,
+                neutralFillStealthRestDelta: 100,
+                neutralFillStealthHoverDelta: 103,
+                neutralFillStealthActiveDelta: 105,
+            }
+        );
+        expect(neutralFillStealthHover(experimentalDesignSystem)).toBe(
+            neutralPalette[experimentalDesignSystem.neutralFillStealthHoverDelta - 100]
+        );
+        expect(
+            neutralFillStealthHover(() => neutralPalette[1])(experimentalDesignSystem)
+        ).toBe(
+            neutralPalette[
+                experimentalDesignSystem.neutralFillStealthHoverDelta - 100 + 1
+            ]
+        );
+        expect(
+            neutralFillStealthHover(() => neutralPalette[2])(experimentalDesignSystem)
+        ).toBe(
+            neutralPalette[
+                experimentalDesignSystem.neutralFillStealthHoverDelta - 100 + 2
+            ]
+        );
+        expect(
+            neutralFillStealthHover(() => neutralPalette[3])(experimentalDesignSystem)
+        ).toBe(
+            neutralPalette[
+                experimentalDesignSystem.neutralFillStealthHoverDelta - 100 + 3
+            ]
+        );
+        expect(
+            neutralFillStealthHover(() => neutralPalette[4])(experimentalDesignSystem)
+        ).toBe(
+            neutralPalette[
+                experimentalDesignSystem.neutralFillStealthHoverDelta - 100 + 4
+            ]
+        );
+        expect(
+            neutralFillStealthHover(() => neutralPalette[5])(experimentalDesignSystem)
+        ).toBe(
+            neutralPalette[
+                3 - (experimentalDesignSystem.neutralFillStealthHoverDelta - 100)
+            ]
+        );
+    });
+
     test("should return the same color from both implementations", (): void => {
         neutralPalette.concat(accentPalette).forEach(
             (swatch: Swatch): void => {

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-stealth.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-stealth.ts
@@ -1,6 +1,5 @@
 import { DesignSystem, DesignSystemResolver } from "../../design-system";
 import {
-    backgroundColor,
     neutralFillActiveDelta,
     neutralFillHoverDelta,
     neutralFillRestDelta,
@@ -17,12 +16,7 @@ import {
     FillSwatchFamily,
     Swatch,
 } from "./common";
-import {
-    findClosestBackgroundIndex,
-    getSwatch,
-    isDarkMode,
-    PaletteType,
-} from "./palette";
+import { findClosestBackgroundIndex, getSwatch } from "./palette";
 
 const neutralFillStealthSwapThreshold: DesignSystemResolver<
     number
@@ -42,67 +36,41 @@ enum FillType {
     selected = "selected",
 }
 
-////////////////////
-// Any portion of the code referencing newRecipeOffset is considered experimental
-// and will be incorporated permanently or removed upon review. DO NOT use values
-// in this range unless you are temporarily evaluation this feature as they will
-// no longer produce predictable results once removed.
-////////////////////
-const newRecipeOffset: number = 100;
-
 function neutralFillStealthAlogrithm(
     deltaResolver: DesignSystemResolver<number>,
     fillType: FillType
 ): DesignSystemResolver<Swatch> {
     return (designSystem: DesignSystem): Swatch => {
         const backgroundIndex: number = findClosestBackgroundIndex(designSystem);
-        let swapThreshold: number = neutralFillStealthSwapThreshold(designSystem);
-
-        if (swapThreshold >= newRecipeOffset) {
-            swapThreshold -= newRecipeOffset;
-        }
+        const swapThreshold: number = neutralFillStealthSwapThreshold(designSystem);
 
         const direction: 1 | -1 = backgroundIndex >= swapThreshold ? -1 : 1;
 
         const value: number = deltaResolver(designSystem);
 
-        if (value >= newRecipeOffset) {
-            const restDelta: number =
-                neutralFillStealthRestDelta(designSystem) - newRecipeOffset;
-            const restIndex: number = backgroundIndex + direction * restDelta;
-            const restDeltaSymbolic: number =
-                restDelta === 0
-                    ? neutralFillRestDelta(designSystem) - newRecipeOffset
-                    : restDelta;
-            const restIndexSymbolic: number =
-                backgroundIndex +
-                direction * (neutralFillRestDelta(designSystem) - newRecipeOffset);
-            switch (fillType) {
-                case FillType.rest:
-                    return getSwatch(restIndex, neutralPalette(designSystem));
-                case FillType.hover:
-                    const hoverDelta: number =
-                        neutralFillStealthHoverDelta(designSystem) - newRecipeOffset;
-                    const hoverIndex: number =
-                        restIndexSymbolic + hoverDelta - restDeltaSymbolic;
-                    return getSwatch(hoverIndex, neutralPalette(designSystem));
-                case FillType.active:
-                    const activeDelta: number =
-                        neutralFillStealthActiveDelta(designSystem) - newRecipeOffset;
-                    const activeIndex: number =
-                        restIndexSymbolic + activeDelta - restDeltaSymbolic;
-                    return getSwatch(activeIndex, neutralPalette(designSystem));
-                case FillType.selected:
-                    const selectedIndex: number =
-                        backgroundIndex + direction * (value - newRecipeOffset);
-                    return getSwatch(selectedIndex, neutralPalette(designSystem));
-            }
+        const restDelta: number = neutralFillStealthRestDelta(designSystem);
+        const restIndex: number = backgroundIndex + direction * restDelta;
+        const restDeltaSymbolic: number =
+            restDelta === 0 ? neutralFillRestDelta(designSystem) : restDelta;
+        const restIndexSymbolic: number =
+            backgroundIndex + direction * neutralFillRestDelta(designSystem);
+        switch (fillType) {
+            case FillType.rest:
+                return getSwatch(restIndex, neutralPalette(designSystem));
+            case FillType.hover:
+                const hoverDelta: number = neutralFillStealthHoverDelta(designSystem);
+                const hoverIndex: number =
+                    restIndexSymbolic + hoverDelta - restDeltaSymbolic;
+                return getSwatch(hoverIndex, neutralPalette(designSystem));
+            case FillType.active:
+                const activeDelta: number = neutralFillStealthActiveDelta(designSystem);
+                const activeIndex: number =
+                    restIndexSymbolic + activeDelta - restDeltaSymbolic;
+                return getSwatch(activeIndex, neutralPalette(designSystem));
+            case FillType.selected:
+                const selectedIndex: number = backgroundIndex + direction * value;
+                return getSwatch(selectedIndex, neutralPalette(designSystem));
         }
-
-        return getSwatch(
-            backgroundIndex + direction * value,
-            neutralPalette(designSystem)
-        );
     };
 }
 
@@ -128,19 +96,9 @@ export const neutralFillStealthActive: ColorRecipe<Swatch> = colorRecipeFactory(
 );
 export const neutralFillStealthSelected: ColorRecipe<Swatch> = colorRecipeFactory(
     (designSystem: DesignSystem): Swatch => {
-        const delta: number = neutralFillStealthSelectedDelta(designSystem);
-
-        if (delta >= newRecipeOffset) {
-            return neutralFillStealthAlogrithm(
-                neutralFillStealthSelectedDelta,
-                FillType.selected
-            )(designSystem);
-        }
-
-        return getSwatch(
-            neutralPalette(designSystem).indexOf(neutralFillStealthRest(designSystem)) +
-                (isDarkMode(designSystem) ? delta * -1 : delta),
-            neutralPalette(designSystem)
-        );
+        return neutralFillStealthAlogrithm(
+            neutralFillStealthSelectedDelta,
+            FillType.selected
+        )(designSystem);
     }
 );

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-stealth.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-stealth.ts
@@ -35,16 +35,72 @@ const neutralFillStealthSwapThreshold: DesignSystemResolver<
     neutralFillStealthActiveDelta
 );
 
+enum FillType {
+    rest = "rest",
+    hover = "hover",
+    active = "active",
+    selected = "selected",
+}
+
+////////////////////
+// Any portion of the code referencing newRecipeOffset is considered experimental
+// and will be incorporated permanently or removed upon review. DO NOT use values
+// in this range unless you are temporarily evaluation this feature as they will
+// no longer produce predictable results once removed.
+////////////////////
+const newRecipeOffset: number = 100;
+
 function neutralFillStealthAlogrithm(
-    deltaResolver: DesignSystemResolver<number>
+    deltaResolver: DesignSystemResolver<number>,
+    fillType: FillType
 ): DesignSystemResolver<Swatch> {
     return (designSystem: DesignSystem): Swatch => {
         const backgroundIndex: number = findClosestBackgroundIndex(designSystem);
-        const direction: 1 | -1 =
-            backgroundIndex >= neutralFillStealthSwapThreshold(designSystem) ? -1 : 1;
+        let swapThreshold: number = neutralFillStealthSwapThreshold(designSystem);
+
+        if (swapThreshold >= newRecipeOffset) {
+            swapThreshold -= newRecipeOffset;
+        }
+
+        const direction: 1 | -1 = backgroundIndex >= swapThreshold ? -1 : 1;
+
+        const value: number = deltaResolver(designSystem);
+
+        if (value >= newRecipeOffset) {
+            const restDelta: number =
+                neutralFillStealthRestDelta(designSystem) - newRecipeOffset;
+            const restIndex: number = backgroundIndex + direction * restDelta;
+            const restDeltaSymbolic: number =
+                restDelta === 0
+                    ? neutralFillRestDelta(designSystem) - newRecipeOffset
+                    : restDelta;
+            const restIndexSymbolic: number =
+                backgroundIndex +
+                direction * (neutralFillRestDelta(designSystem) - newRecipeOffset);
+            switch (fillType) {
+                case FillType.rest:
+                    return getSwatch(restIndex, neutralPalette(designSystem));
+                case FillType.hover:
+                    const hoverDelta: number =
+                        neutralFillStealthHoverDelta(designSystem) - newRecipeOffset;
+                    const hoverIndex: number =
+                        restIndexSymbolic + hoverDelta - restDeltaSymbolic;
+                    return getSwatch(hoverIndex, neutralPalette(designSystem));
+                case FillType.active:
+                    const activeDelta: number =
+                        neutralFillStealthActiveDelta(designSystem) - newRecipeOffset;
+                    const activeIndex: number =
+                        restIndexSymbolic + activeDelta - restDeltaSymbolic;
+                    return getSwatch(activeIndex, neutralPalette(designSystem));
+                case FillType.selected:
+                    const selectedIndex: number =
+                        backgroundIndex + direction * (value - newRecipeOffset);
+                    return getSwatch(selectedIndex, neutralPalette(designSystem));
+            }
+        }
 
         return getSwatch(
-            backgroundIndex + direction * deltaResolver(designSystem),
+            backgroundIndex + direction * value,
             neutralPalette(designSystem)
         );
     };
@@ -62,17 +118,24 @@ export const neutralFillStealth: ColorRecipe<FillSwatchFamily> = colorRecipeFact
 );
 
 export const neutralFillStealthRest: ColorRecipe<Swatch> = colorRecipeFactory(
-    neutralFillStealthAlogrithm(neutralFillStealthRestDelta)
+    neutralFillStealthAlogrithm(neutralFillStealthRestDelta, FillType.rest)
 );
 export const neutralFillStealthHover: ColorRecipe<Swatch> = colorRecipeFactory(
-    neutralFillStealthAlogrithm(neutralFillStealthHoverDelta)
+    neutralFillStealthAlogrithm(neutralFillStealthHoverDelta, FillType.hover)
 );
 export const neutralFillStealthActive: ColorRecipe<Swatch> = colorRecipeFactory(
-    neutralFillStealthAlogrithm(neutralFillStealthActiveDelta)
+    neutralFillStealthAlogrithm(neutralFillStealthActiveDelta, FillType.active)
 );
 export const neutralFillStealthSelected: ColorRecipe<Swatch> = colorRecipeFactory(
     (designSystem: DesignSystem): Swatch => {
         const delta: number = neutralFillStealthSelectedDelta(designSystem);
+
+        if (delta >= newRecipeOffset) {
+            return neutralFillStealthAlogrithm(
+                neutralFillStealthSelectedDelta,
+                FillType.selected
+            )(designSystem);
+        }
 
         return getSwatch(
             neutralPalette(designSystem).indexOf(neutralFillStealthRest(designSystem)) +

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-fill.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-fill.spec.ts
@@ -55,6 +55,43 @@ describe("neutralFill", (): void => {
         );
     });
 
+    // TODO: Needed for code coverage settings. Replace tests above if/when experimental mode is permanent
+    test("should switch from dark to light after 5 swatches", (): void => {
+        const experimentalDesignSystem: DesignSystem = Object.assign(
+            {},
+            designSystemDefaults,
+            {
+                neutralFillRestDelta: 104,
+                neutralFillHoverDelta: 103,
+                neutralFillActiveDelta: 105,
+            }
+        );
+        expect(neutralFillRest(experimentalDesignSystem)).toBe(
+            neutralPalette[experimentalDesignSystem.neutralFillRestDelta - 100]
+        );
+        expect(neutralFillHover(experimentalDesignSystem)).toBe(
+            neutralPalette[experimentalDesignSystem.neutralFillHoverDelta - 100]
+        );
+        expect(neutralFillActive(experimentalDesignSystem)).toBe(
+            neutralPalette[experimentalDesignSystem.neutralFillActiveDelta - 100]
+        );
+        expect(neutralFillRest(() => neutralPalette[1])(experimentalDesignSystem)).toBe(
+            neutralPalette[experimentalDesignSystem.neutralFillRestDelta - 100 + 1]
+        );
+        expect(neutralFillRest(() => neutralPalette[2])(experimentalDesignSystem)).toBe(
+            neutralPalette[experimentalDesignSystem.neutralFillRestDelta - 100 + 2]
+        );
+        expect(neutralFillRest(() => neutralPalette[3])(experimentalDesignSystem)).toBe(
+            neutralPalette[experimentalDesignSystem.neutralFillRestDelta - 100 + 3]
+        );
+        expect(neutralFillRest(() => neutralPalette[4])(experimentalDesignSystem)).toBe(
+            neutralPalette[experimentalDesignSystem.neutralFillRestDelta - 100 + 4]
+        );
+        expect(neutralFillRest(() => neutralPalette[5])(experimentalDesignSystem)).toBe(
+            neutralPalette[1]
+        );
+    });
+
     test("should return the same color from both implementations", (): void => {
         neutralPalette.concat(accentPalette).forEach(
             (swatch: Swatch): void => {

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-fill.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-fill.ts
@@ -22,16 +22,63 @@ const neutralFillThreshold: DesignSystemResolver<number> = designSystemResolverM
     neutralFillActiveDelta
 );
 
+enum FillType {
+    rest = "rest",
+    hover = "hover",
+    active = "active",
+    selected = "selected",
+}
+
+////////////////////
+// Any portion of the code referencing newRecipeOffset is considered experimental
+// and will be incorporated permanently or removed upon review. DO NOT use values
+// in this range unless you are temporarily evaluation this feature as they will
+// no longer produce predictable results once removed.
+////////////////////
+const newRecipeOffset: number = 100;
+
 function neutralFillAlgorithm(
-    indexResolver: DesignSystemResolver<number>
+    deltaResolver: DesignSystemResolver<number>,
+    fillType: FillType
 ): DesignSystemResolver<Swatch> {
     return (designSystem: DesignSystem): Swatch => {
         const backgroundIndex: number = findClosestBackgroundIndex(designSystem);
-        const swapThreshold: number = neutralFillThreshold(designSystem);
-        const direction: number = backgroundIndex >= swapThreshold ? -1 : 1;
+        let swapThreshold: number = neutralFillThreshold(designSystem);
+
+        if (swapThreshold >= newRecipeOffset) {
+            swapThreshold -= newRecipeOffset;
+        }
+
+        const direction: 1 | -1 = backgroundIndex >= swapThreshold ? -1 : 1;
+
+        const value: number = deltaResolver(designSystem);
+
+        if (value >= newRecipeOffset) {
+            const restDelta: number =
+                neutralFillRestDelta(designSystem) - newRecipeOffset;
+            const restIndex: number = backgroundIndex + direction * restDelta;
+            switch (fillType) {
+                case FillType.rest:
+                    return getSwatch(restIndex, neutralPalette(designSystem));
+                case FillType.hover:
+                    const hoverDelta: number =
+                        neutralFillHoverDelta(designSystem) - newRecipeOffset;
+                    const hoverIndex: number = restIndex + hoverDelta - restDelta;
+                    return getSwatch(hoverIndex, neutralPalette(designSystem));
+                case FillType.active:
+                    const activeDelta: number =
+                        neutralFillActiveDelta(designSystem) - newRecipeOffset;
+                    const activeIndex: number = restIndex + activeDelta - restDelta;
+                    return getSwatch(activeIndex, neutralPalette(designSystem));
+                case FillType.selected:
+                    const selectedIndex: number =
+                        backgroundIndex + direction * (value - newRecipeOffset);
+                    return getSwatch(selectedIndex, neutralPalette(designSystem));
+            }
+        }
 
         return getSwatch(
-            backgroundIndex + direction * indexResolver(designSystem),
+            backgroundIndex + direction * value,
             neutralPalette(designSystem)
         );
     };
@@ -49,17 +96,23 @@ export const neutralFill: ColorRecipe<FillSwatchFamily> = colorRecipeFactory(
 );
 
 export const neutralFillRest: SwatchRecipe = colorRecipeFactory(
-    neutralFillAlgorithm(neutralFillRestDelta)
+    neutralFillAlgorithm(neutralFillRestDelta, FillType.rest)
 );
 export const neutralFillHover: SwatchRecipe = colorRecipeFactory(
-    neutralFillAlgorithm(neutralFillHoverDelta)
+    neutralFillAlgorithm(neutralFillHoverDelta, FillType.hover)
 );
 export const neutralFillActive: SwatchRecipe = colorRecipeFactory(
-    neutralFillAlgorithm(neutralFillActiveDelta)
+    neutralFillAlgorithm(neutralFillActiveDelta, FillType.active)
 );
 export const neutralFillSelected: SwatchRecipe = colorRecipeFactory(
     (designSystem: DesignSystem): Swatch => {
         const delta: number = neutralFillSelectedDelta(designSystem);
+
+        if (delta >= newRecipeOffset) {
+            return neutralFillAlgorithm(neutralFillSelectedDelta, FillType.selected)(
+                designSystem
+            );
+        }
 
         return getSwatch(
             neutralPalette(designSystem).indexOf(neutralFillRest(designSystem)) +

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-outline.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-outline.ts
@@ -10,7 +10,6 @@ import {
 import {
     ColorRecipe,
     colorRecipeFactory,
-    Swatch,
     SwatchFamily,
     SwatchFamilyResolver,
     swatchFamilyToSwatchRecipeFactory,
@@ -24,14 +23,6 @@ import {
     neutralOutlineRestDelta,
 } from "../design-system";
 
-////////////////////
-// Any portion of the code referencing newRecipeOffset is considered experimental
-// and will be incorporated permanently or removed upon review. DO NOT use values
-// in this range unless you are temporarily evaluation this feature as they will
-// no longer produce predictable results once removed.
-////////////////////
-const newRecipeOffset: number = 100;
-
 const neutralOutlineAlgorithm: SwatchFamilyResolver = (
     designSystem: DesignSystem
 ): SwatchFamily => {
@@ -42,35 +33,14 @@ const neutralOutlineAlgorithm: SwatchFamilyResolver = (
     )(designSystem);
     const direction: 1 | -1 = isDarkMode(designSystem) ? -1 : 1;
 
-    let restDelta: number = neutralOutlineRestDelta(designSystem);
-
-    if (restDelta >= newRecipeOffset) {
-        restDelta -= newRecipeOffset;
-        const hoverDelta: number =
-            neutralOutlineHoverDelta(designSystem) - newRecipeOffset;
-        const activeDelta: number =
-            neutralOutlineActiveDelta(designSystem) - newRecipeOffset;
-        const restIndex: number = backgroundIndex + direction * restDelta;
-        return {
-            rest: getSwatch(restIndex, neutralPalette),
-            hover: getSwatch(restIndex + hoverDelta - restDelta, neutralPalette),
-            active: getSwatch(restIndex + activeDelta - restDelta, neutralPalette),
-        };
-    }
-
+    const restDelta: number = neutralOutlineRestDelta(designSystem);
+    const hoverDelta: number = neutralOutlineHoverDelta(designSystem);
+    const activeDelta: number = neutralOutlineActiveDelta(designSystem);
+    const restIndex: number = backgroundIndex + direction * restDelta;
     return {
-        rest: getSwatch(
-            backgroundIndex + direction * neutralOutlineRestDelta(designSystem),
-            neutralPalette
-        ),
-        hover: getSwatch(
-            backgroundIndex + direction * neutralOutlineHoverDelta(designSystem),
-            neutralPalette
-        ),
-        active: getSwatch(
-            backgroundIndex + direction * neutralOutlineActiveDelta(designSystem),
-            neutralPalette
-        ),
+        rest: getSwatch(restIndex, neutralPalette),
+        hover: getSwatch(restIndex + hoverDelta - restDelta, neutralPalette),
+        active: getSwatch(restIndex + activeDelta - restDelta, neutralPalette),
     };
 };
 

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-outline.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-outline.ts
@@ -24,6 +24,14 @@ import {
     neutralOutlineRestDelta,
 } from "../design-system";
 
+////////////////////
+// Any portion of the code referencing newRecipeOffset is considered experimental
+// and will be incorporated permanently or removed upon review. DO NOT use values
+// in this range unless you are temporarily evaluation this feature as they will
+// no longer produce predictable results once removed.
+////////////////////
+const newRecipeOffset: number = 100;
+
 const neutralOutlineAlgorithm: SwatchFamilyResolver = (
     designSystem: DesignSystem
 ): SwatchFamily => {
@@ -33,6 +41,22 @@ const neutralOutlineAlgorithm: SwatchFamilyResolver = (
         backgroundColor(designSystem)
     )(designSystem);
     const direction: 1 | -1 = isDarkMode(designSystem) ? -1 : 1;
+
+    let restDelta: number = neutralOutlineRestDelta(designSystem);
+
+    if (restDelta >= newRecipeOffset) {
+        restDelta -= newRecipeOffset;
+        const hoverDelta: number =
+            neutralOutlineHoverDelta(designSystem) - newRecipeOffset;
+        const activeDelta: number =
+            neutralOutlineActiveDelta(designSystem) - newRecipeOffset;
+        const restIndex: number = backgroundIndex + direction * restDelta;
+        return {
+            rest: getSwatch(restIndex, neutralPalette),
+            hover: getSwatch(restIndex + hoverDelta - restDelta, neutralPalette),
+            active: getSwatch(restIndex + activeDelta - restDelta, neutralPalette),
+        };
+    }
 
     return {
         rest: getSwatch(

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
@@ -9,8 +9,10 @@ import {
     swatchByMode,
 } from "./palette";
 import designSystemDefaults, { DesignSystem } from "../../design-system";
+import { accent } from "./color-constants";
 import { Swatch } from "./common";
-import { accentBaseColor, neutralPalette } from "../design-system";
+import { neutralForeground } from "./neutral-foreground";
+import { neutralPalette } from "../design-system";
 
 describe("palette", (): void => {
     test("should return a function", (): void => {
@@ -59,11 +61,7 @@ describe("palette", (): void => {
 describe("findSwatchIndex", (): void => {
     test("should impelment design-system defaults", (): void => {
         expect(findSwatchIndex(PaletteType.neutral, "#FFF")({} as DesignSystem)).toBe(0);
-        expect(
-            findSwatchIndex(PaletteType.accent, accentBaseColor({} as DesignSystem))(
-                {} as DesignSystem
-            )
-        ).toBe(31);
+        expect(findSwatchIndex(PaletteType.accent, accent)({} as DesignSystem)).toBe(31);
     });
 
     test("should return -1 if the color is not found", (): void => {
@@ -102,11 +100,9 @@ describe("findSwatchIndex", (): void => {
     });
 
     test("should find accent", (): void => {
-        expect(
-            findSwatchIndex(PaletteType.accent, accentBaseColor(designSystemDefaults))(
-                designSystemDefaults
-            )
-        ).toBe(31);
+        expect(findSwatchIndex(PaletteType.accent, accent)(designSystemDefaults)).toBe(
+            31
+        );
         expect(
             findSwatchIndex(PaletteType.accent, "rgb(0, 120, 212)")(designSystemDefaults)
         ).toBe(31);

--- a/packages/fast-components-styles-msft/src/utilities/design-system.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.ts
@@ -10,20 +10,6 @@ export const backgroundColor: DesignSystemResolver<string> = getDesignSystemValu
 );
 
 /**
- * Retrieve the base neutral color from the design system
- */
-export const neutralBaseColor: DesignSystemResolver<string> = getDesignSystemValue(
-    "neutralBaseColor"
-);
-
-/**
- * Retrieve the base accent color from the design system
- */
-export const accentBaseColor: DesignSystemResolver<string> = getDesignSystemValue(
-    "accentBaseColor"
-);
-
-/**
  * Retrieve the backgroundColor when invoked with a DesignSystem
  */
 export const cornerRadius: DesignSystemResolver<number> = getDesignSystemValue(
@@ -38,7 +24,7 @@ export const neutralPalette: DesignSystemResolver<Palette> = getDesignSystemValu
 );
 
 /**
- * Retrieve the accent palette from the design system
+ * Retrieve the accent  palette from the design system
  */
 export const accentPalette: DesignSystemResolver<Palette> = getDesignSystemValue(
     "accentPalette"

--- a/packages/fast-jss-manager-react/src/design-system-provider.tsx
+++ b/packages/fast-jss-manager-react/src/design-system-provider.tsx
@@ -11,13 +11,16 @@ import {
     mergeDesignSystem,
 } from "@microsoft/fast-jss-manager";
 
-export type DesignSystem<T> = T extends { [key: string]: unknown } ? T : never;
+/**
+ * @deprecated
+ */
+export type DesignSystem<T> = T;
 /**
  * Describes the props that the DesignSystemProvider uses. It accepts a single prop "designSystem"
  * that gets exposed to all downstream components of the DesignSystemProvider
  */
 export interface DesignSystemProviderProps<T> {
-    designSystem: DesignSystem<T>;
+    designSystem: T;
     designSystemMergingFunction?: DesignSystemMergingFunction<T>;
 }
 

--- a/packages/fast-jss-manager-react/src/jss-manager.tsx
+++ b/packages/fast-jss-manager-react/src/jss-manager.tsx
@@ -1,14 +1,8 @@
+import { ComponentStyles, ManagedClasses } from "@microsoft/fast-jss-manager";
+import { mergeWith } from "lodash-es";
 import React from "react";
-import { jss, stylesheetManager, stylesheetRegistry } from "./jss";
-import SheetManager from "./sheet-manager";
-import { DesignSystem } from "./design-system-provider";
-import {
-    ComponentStyles,
-    ComponentStyleSheet,
-    ManagedClasses,
-} from "@microsoft/fast-jss-manager";
-import { isEqual, mergeWith } from "lodash-es";
 import { designSystemContext } from "./context";
+import SheetManager from "./sheet-manager";
 
 /**
  * Describes an interface for adjusting a styled component


### PR DESCRIPTION
# Description

Updated color recipes such that hover is *always* lighter than rest.

## Motivation & context

We want to update the design guidance for buttons to go lighter on hover and darker on active. The current algorithm did an equal flip and didn't allow for one state to consistently be the same offset lighter or darker than another.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

This does not break interface or design. Tested by comparing the new and old algorithm with the current design system deltas.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->