### PR TITLE
fix: address formatting issue with self closing children and multiple children components

### DIFF
--- a/packages/fast-tooling-react/app/pages/code-preview/examples.data.ts
+++ b/packages/fast-tooling-react/app/pages/code-preview/examples.data.ts
@@ -41,10 +41,51 @@ const exampleData: any[] = [
                 props: {
                     children: {
                         id: badgeSchema.id,
+                        props: {},
+                    },
+                },
+            },
+            childOptions,
+        },
+    },
+    {
+        exampleName: "Nested with props",
+        config: {
+            data: {
+                id: childrenSchema.id,
+                props: {
+                    children: {
+                        id: badgeSchema.id,
                         props: {
+                            string: "bar",
                             children: "foo",
                         },
                     },
+                },
+            },
+            childOptions,
+        },
+    },
+    {
+        exampleName: "Nested with multiple",
+        config: {
+            data: {
+                id: childrenSchema.id,
+                props: {
+                    children: [
+                        {
+                            id: badgeSchema.id,
+                            props: {
+                                children: "foo",
+                            },
+                        },
+                        {
+                            id: badgeSchema.id,
+                            props: {
+                                children: "bar",
+                            },
+                        },
+                    ],
                 },
             },
             childOptions,

--- a/packages/fast-tooling-react/src/data-utilities/mapping.spec.ts
+++ b/packages/fast-tooling-react/src/data-utilities/mapping.spec.ts
@@ -365,6 +365,54 @@ describe("mapDataToCodePreview", () => {
             `<${badgeJSXName}>\n${tabIndent}foobar\n</${badgeJSXName}>`
         );
     });
+    test("should return a string containing a JSX element with multiple component children", () => {
+        const mappedData: string = mapDataToCodePreview({
+            data: {
+                id: badgeSchema.id,
+                props: {
+                    children: [
+                        {
+                            id: badgeSchema.id,
+                            props: {
+                                children: "foo",
+                            },
+                        },
+                        {
+                            id: badgeSchema.id,
+                            props: {
+                                children: "bar",
+                            },
+                        },
+                    ],
+                },
+            },
+            childOptions,
+        });
+
+        expect(mappedData).toEqual(
+            `<${badgeJSXName}>\n${tabIndent}<${badgeJSXName}>\n${tabIndent +
+                tabIndent}foo\n${tabIndent}</${badgeJSXName}>\n${tabIndent}<${badgeJSXName}>\n${tabIndent +
+                tabIndent}bar\n${tabIndent}</${badgeJSXName}>\n</${badgeJSXName}>`
+        );
+    });
+    test("should return a string containing a JSX element with a self closing component child", () => {
+        const mappedData: string = mapDataToCodePreview({
+            data: {
+                id: childrenSchema.id,
+                props: {
+                    children: {
+                        id: badgeSchema.id,
+                        props: {},
+                    },
+                },
+            },
+            childOptions,
+        });
+
+        expect(mappedData).toEqual(
+            `<${childrenJSXName}>\n${tabIndent}<${badgeJSXName} />\n</${childrenJSXName}>`
+        );
+    });
     test("should return a string containing a JSX element with component children", () => {
         const mappedData: string = mapDataToCodePreview({
             data: {

--- a/packages/fast-tooling-react/src/data-utilities/mapping.ts
+++ b/packages/fast-tooling-react/src/data-utilities/mapping.ts
@@ -450,7 +450,7 @@ class ComponentCodePreview {
                   }${codePreviewConfig.tabIndent}${nestedChildren}\n${
                       codePreviewConfig.tabIndent
                   }</${component.name}>`
-                : `${codePreviewConfig.tabIndent}/>`;
+                : `${componentAttributes !== "" ? codePreviewConfig.tabIndent : ""}/>`;
         }
 
         return componentJSX;
@@ -463,7 +463,7 @@ class ComponentCodePreview {
         const componentPropValue: any = Array.isArray(value) ? value : [value];
 
         return componentPropValue.reduce(
-            (accumulatedChildrenValue: any, childrenValue: any): any => {
+            (accumulatedChildrenValue: any, childrenValue: any): string => {
                 const childrenDataType: string = typeof childrenValue;
 
                 if (
@@ -475,15 +475,20 @@ class ComponentCodePreview {
                 }
 
                 const component: CodePreviewChildOption = this.getChildOptionById(
-                    get(value, "id"),
+                    get(childrenValue, "id"),
                     this.childOptions
                 );
 
                 if (component) {
                     return (
                         accumulatedChildrenValue +
+                        `${
+                            accumulatedChildrenValue !== ""
+                                ? `\n${tabIndent + this.tabIndent}`
+                                : ""
+                        }` +
                         this.getComponentCodePreview({
-                            data: value,
+                            data: childrenValue,
                             tabIndent: tabIndent + this.tabIndent,
                         })
                     );


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Fixes an issue where nested children components that were self closing without attributes showed an indent and multiple children components would not display.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->