### PR TITLE
fix: removed an unnecessary type assigned to the navigation items in Navigation

### DIFF
--- a/packages/fast-tooling-react/src/navigation/navigation-tree-item.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation-tree-item.tsx
@@ -218,7 +218,12 @@ const NavigationTreeItem: React.RefForwardingComponent<
 
 export { NavigationTreeItem };
 
-export const DraggableNavigationTreeItem: typeof NavigationTreeItem = DropTarget(
+/*
+ * The type returned by DropTarget is very complicated so we'll let the
+ * compiler infer the type instead of re-declaring just for the package export
+ */
+/* tslint:disable-next-line:typedef */
+export const DraggableNavigationTreeItem = DropTarget(
     NavigationTreeItemDragID,
     navigationTreeItemDropSource,
     navigationTreeItemDropTargetCollect
@@ -229,3 +234,4 @@ export const DraggableNavigationTreeItem: typeof NavigationTreeItem = DropTarget
         navigationTreeItemDragSourceCollect
     )(NavigationTreeItem)
 );
+type DraggableNavigationTreeItem = InstanceType<typeof DraggableNavigationTreeItem>;


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->

## Motivation & context
This fixes a build break caused by a TypeScript update where unnecessary and incorrect type declarations can take precedence over implicit types.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->