### PR TITLE
fix: add missing viewport positioner export

### DIFF
--- a/packages/fast-components-react-base/src/index.ts
+++ b/packages/fast-components-react-base/src/index.ts
@@ -105,3 +105,7 @@ export * from "./toggle";
 import Typography from "./typography";
 export { Typography };
 export * from "./typography";
+
+import ViewportPositioner from "./viewport-positioner";
+export { ViewportPositioner };
+export * from "./viewport-positioner";

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -84,7 +84,7 @@ export enum ViewportPositionerVerticalPositionLabel {
 /**
  * location enum for transform origin settings
  */
-export enum Location {
+const enum Location {
     top = "top",
     left = "left",
     right = "right",


### PR DESCRIPTION
# Description
Realized the export for the viewport positioner component got left behind with my test code

## Motivation & context
Component isn't much use if not exported

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.
