### PR TITLE
fix: addresses incorrect after-glyph margin in text action

### DIFF
--- a/packages/fast-components-styles-msft/src/text-action/index.ts
+++ b/packages/fast-components-styles-msft/src/text-action/index.ts
@@ -134,8 +134,8 @@ const styles: ComponentStyles<TextActionClassNameContract, DesignSystem> = {
     },
     textAction_afterGlyph: {
         ...glyphStyles,
-        marginLeft: directionSwitch(horizontalSpacing(1), ""),
-        marginRight: directionSwitch("", horizontalSpacing(1)),
+        marginLeft: directionSwitch("", horizontalSpacing(1)),
+        marginRight: directionSwitch(horizontalSpacing(1), ""),
     },
 };
 


### PR DESCRIPTION
Closes [#1854](https://github.com/microsoft/fast-dna/issues/1854)

# Description

TextAction after glyph margins were incorrect, causing it to appear with no spacing from the end edge of the container. Now fixed.

<img width="347" alt="Screen Shot 2019-06-12 at 11 54 34 AM" src="https://user-images.githubusercontent.com/22480660/59378333-f3242d80-8d08-11e9-83ea-39313b3744b6.png">
<img width="345" alt="Screen Shot 2019-06-12 at 11 54 44 AM" src="https://user-images.githubusercontent.com/22480660/59378346-f5868780-8d08-11e9-995f-9dad32c044cf.png">


## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://microsoft.github.io/fast-dna/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://microsoft.github.io/fast-dna/docs/en/contributing/working
-->