### PR TITLE
fix: addresses an issue in the mapDataToComponent utility where plugins and children would not work on objects inside arrays

### DIFF
--- a/packages/fast-tooling-react/src/data-utilities/mapping.spec.ts
+++ b/packages/fast-tooling-react/src/data-utilities/mapping.spec.ts
@@ -188,6 +188,66 @@ describe("mapDataToComponent", () => {
         expect(mappedData.render[1](testClass2).type.displayName).toEqual("Children");
         expect(mappedData.render[1](testClass2).props.className).toBe(testClass2);
     });
+    test("should map children in arrays to plugins", () => {
+        const data: any = {
+            render: [
+                {
+                    children: [
+                        {
+                            id: textFieldSchema.id,
+                            props: {},
+                        },
+                        {
+                            id: childrenSchema.id,
+                            props: {},
+                        },
+                    ],
+                },
+            ],
+        };
+        const arrayPropertyPluginId: string = "myPluginId";
+        const schema: any = {
+            type: "object",
+            properties: {
+                render: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        reactProperties: {
+                            children: {
+                                type: "children",
+                                pluginId: arrayPropertyPluginId,
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const testClass1: string = "Foo";
+        const testClass2: string = "Bar";
+
+        const mappedData: any = mapDataToComponent(schema, data, childOptions, [
+            new MapChildrenPropToCallbackPassingClassName({
+                id: arrayPropertyPluginId,
+            }),
+        ]);
+        expect(mappedData.render[0].children).toHaveLength(2);
+        expect(typeof mappedData.render[0].children[0]).toBe("function");
+        expect(mappedData.render[0].children[0](testClass1).type.displayName).toEqual(
+            "Text field"
+        );
+        expect(mappedData.render[0].children[0](testClass1).props.className).toBe(
+            testClass1
+        );
+        expect(typeof mappedData.render[0].children[1]).toBe("function");
+        expect(mappedData.render[0].children[1](testClass2).type.displayName).toEqual(
+            "Children"
+        );
+        expect(mappedData.render[0].children[1](testClass2).props.className).toBe(
+            testClass2
+        );
+    });
     test("should map children to a plugin nested inside a child", () => {
         const data: any = {
             children: {

--- a/packages/fast-tooling-react/src/data-utilities/mapping.ts
+++ b/packages/fast-tooling-react/src/data-utilities/mapping.ts
@@ -176,9 +176,9 @@ function mapPluginToData(
 ): any {
     const mappedData: any = data;
     const pluginModifiedSchemaLocation: string = mapSchemaLocationFromDataLocation(
-        pluginModifiedDataLocation.relativeDataLocation.replace(squareBracketsRegex, ""),
+        pluginModifiedDataLocation.relativeDataLocation,
         pluginModifiedDataLocation.schema,
-        data
+        mappedData
     );
     const pluginId: string = get(
         pluginModifiedDataLocation.schema,
@@ -189,7 +189,7 @@ function mapPluginToData(
             return plugin.matches(pluginId);
         }
     );
-    const pluginData: any = get(data, pluginModifiedDataLocation.dataLocation);
+    const pluginData: any = get(mappedData, pluginModifiedDataLocation.dataLocation);
 
     if (pluginResolver !== undefined) {
         getPluginResolverDataMap({


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
The mapDataToComponent utility was unable to identify children inside of array objects, this has been addressed.

Resolves #1813 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->