### PR TITLE
fix: select menu closes on blur event

### DIFF
--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -110,8 +110,6 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
     }
 
     public componentDidMount(): void {
-        window.addEventListener("click", this.handleWindowClick);
-
         this.toggleMenu(this.checkPropsForMenuState());
         if (
             this.props.autoFocus &&
@@ -120,10 +118,6 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         ) {
             this.focusTriggerElement();
         }
-    }
-
-    public componentWillUnmount(): void {
-        window.removeEventListener("click", this.handleWindowClick);
     }
 
     /**
@@ -253,6 +247,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
                 defaultSelection={this.state.selectedItems}
                 selectedItems={this.props.selectedItems}
                 onSelectedItemsChanged={this.updateSelection}
+                onBlur={this.handleMenuBlur}
                 managedClasses={{
                     listbox: get(this.props.managedClasses, "select_menu", ""),
                     listbox__disabled: get(
@@ -500,13 +495,14 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
     };
 
     /**
-     * Close the menu when when there are clicks outside
+     * handle menu blur
      */
-    private handleWindowClick = (event: MouseEvent): void => {
+    private handleMenuBlur = (event: React.FocusEvent): void => {
         if (
             this.state.isMenuOpen &&
+            !this.props.multiselectable &&
             this.rootElement.current !== null &&
-            !this.rootElement.current.contains(event.target as Element)
+            !this.rootElement.current.contains(event.relatedTarget as Element)
         ) {
             this.toggleMenu(false);
         }


### PR DESCRIPTION
# Description
Select menu could remain open when focus was put outside of the menu.

## Motivation & context
The expected user interaction for this type of menu is that it does not remain open when focus is elsewhere.  Our previous mechanism only caught loss of focus as a result of a mouse click.

Fixes:
https://github.com/microsoft/fast-dna/issues/1814

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [X] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
