### PR TITLE
fix: set checkbox cursor to pointer on hover

### DIFF
--- a/packages/fast-components-styles-msft/src/checkbox/index.ts
+++ b/packages/fast-components-styles-msft/src/checkbox/index.ts
@@ -1,15 +1,9 @@
-import {
-    DesignSystem,
-    DesignSystemResolver,
-    withDesignSystemDefaults,
-} from "../design-system";
-import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
+import { DesignSystem, DesignSystemResolver } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { CheckboxClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import {
     add,
     applyFocusVisible,
-    applyLocalizedProperty,
-    Direction,
     directionSwitch,
     divide,
     format,
@@ -34,7 +28,7 @@ import {
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { designUnit, outlineWidth } from "../utilities/design-system";
-import { applyCursorPointer, applyCursorDefault } from "../utilities/cursor";
+import { applyCursorDefault, applyCursorPointer } from "../utilities/cursor";
 
 const inputSize: DesignSystemResolver<string> = toPx(
     add(divide(heightNumber(), 2), designUnit)

--- a/packages/fast-components-styles-msft/src/checkbox/index.ts
+++ b/packages/fast-components-styles-msft/src/checkbox/index.ts
@@ -34,6 +34,7 @@ import {
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { designUnit, outlineWidth } from "../utilities/design-system";
+import { applyCursorPointer, applyCursorDefault } from "../utilities/cursor";
 
 const inputSize: DesignSystemResolver<string> = toPx(
     add(divide(heightNumber(), 2), designUnit)
@@ -77,11 +78,14 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
             toPx<DesignSystem>(outlineWidth),
             neutralOutlineRest
         ),
+        "&:enabled": {
+            ...applyCursorPointer(),
+        },
         "&:hover:enabled": {
             background: neutralFillInputHover,
             borderColor: neutralOutlineHover,
         },
-        "&:active": {
+        "&:active:enabled": {
             background: neutralFillInputActive,
             borderColor: neutralOutlineActive,
         },
@@ -109,6 +113,7 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
         },
     },
     checkbox_label: {
+        ...applyCursorPointer(),
         color: neutralForegroundRest,
         ...applyScaledTypeRamp("t7"),
     },
@@ -142,6 +147,9 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
     },
     checkbox__disabled: {
         ...applyDisabledState(),
+        "& $checkbox_label": {
+            ...applyCursorDefault(),
+        },
     },
 };
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Set the checkbox cursor on hover, but not if disabled.

## Motivation & context

All actionable components should respond to hover with a cursor change.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->