### PR TITLE
feat: color explorer default state and base color marker

### DIFF
--- a/packages/fast-color-explorer/app/app.tsx
+++ b/packages/fast-color-explorer/app/app.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Canvas, Container, Pane, Row } from "@microsoft/fast-layouts-react";
+import { Canvas, Container, Row } from "@microsoft/fast-layouts-react";
 import { DesignSystemProvider } from "@microsoft/fast-jss-manager-react";
 import { ColorsDesignSystem } from "./design-system";
 import { Gradient } from "./gradient";
@@ -11,9 +11,12 @@ import { connect } from "react-redux";
 import { Background, DarkModeBackgrounds } from "@microsoft/fast-components-react-msft";
 import { FixedSizeList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
+import { Swatch } from "@microsoft/fast-components-styles-msft/dist/utilities/color/common";
 
 interface AppProps {
     designSystem: ColorsDesignSystem;
+    neutralBaseColor: Swatch;
+    accentBaseColor: Swatch;
 }
 /* tslint:disable:jsx-no-lambda */
 /* tslint:disable:no-empty */
@@ -41,6 +44,7 @@ class App extends React.Component<AppProps, {}> {
                                         colors={palette(PaletteType.neutral)(
                                             this.props.designSystem
                                         )}
+                                        markedColor={this.props.neutralBaseColor}
                                         createAnchors={true}
                                         scrollToItem={this.handleGradientScroll}
                                     />
@@ -50,6 +54,7 @@ class App extends React.Component<AppProps, {}> {
                                         colors={palette(PaletteType.accent)(
                                             this.props.designSystem
                                         )}
+                                        markedColor={this.props.accentBaseColor}
                                         createAnchors={false}
                                     />
                                 </Row>
@@ -117,6 +122,8 @@ class App extends React.Component<AppProps, {}> {
 function mapStateToProps(state: AppState): Partial<AppProps> {
     return {
         designSystem: state.designSystem,
+        neutralBaseColor: state.neutralBaseColor,
+        accentBaseColor: state.accentBaseColor,
     };
 }
 

--- a/packages/fast-color-explorer/app/color-blocks.tsx
+++ b/packages/fast-color-explorer/app/color-blocks.tsx
@@ -21,8 +21,10 @@ import {
     neutralFillStealthRest,
     neutralFillStealthSelected,
     neutralFocus,
+    neutralForegroundActive,
     neutralForegroundHint,
     neutralForegroundHintLarge,
+    neutralForegroundHover,
     neutralForegroundRest,
     neutralOutlineActive,
     neutralOutlineHover,
@@ -40,6 +42,7 @@ import {
     Checkbox,
     Hypertext,
     Paragraph,
+    ParagraphClassNameContract,
     TextField,
 } from "@microsoft/fast-components-react-msft";
 import { connect } from "react-redux";
@@ -184,6 +187,21 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
         ColorsDesignSystem
     > = {
         button: {},
+    };
+
+    private neutralTextStyleOverrides: ComponentStyleSheet<
+        ParagraphClassNameContract,
+        ColorsDesignSystem
+    > = {
+        paragraph: {
+            cursor: "pointer !important",
+            "&:hover": {
+                color: neutralForegroundHover,
+            },
+            "&:active": {
+                color: neutralForegroundActive,
+            },
+        },
     };
 
     private hintTextStyleOverrides: ComponentStyleSheet<
@@ -406,12 +424,28 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
     private renderTextComponents(): React.ReactNode {
         return (
             <React.Fragment>
-                {this.renderExample(<Paragraph>Neutral</Paragraph>)}
+                {this.renderExample(
+                    <Paragraph jssStyleSheet={this.neutralTextStyleOverrides}>
+                        Neutral
+                    </Paragraph>
+                )}
                 <Swatch
                     type={SwatchTypes.foreground}
                     fillRecipe={backgroundColor}
                     foregroundRecipe={neutralForegroundRest}
                     recipeName="neutralForegroundRest"
+                />
+                <Swatch
+                    type={SwatchTypes.foreground}
+                    fillRecipe={backgroundColor}
+                    foregroundRecipe={neutralForegroundHover}
+                    recipeName="neutralForegroundHover"
+                />
+                <Swatch
+                    type={SwatchTypes.foreground}
+                    fillRecipe={backgroundColor}
+                    foregroundRecipe={neutralForegroundActive}
+                    recipeName="neutralForegroundActive"
                 />
 
                 {this.renderExample(

--- a/packages/fast-color-explorer/app/colors.ts
+++ b/packages/fast-color-explorer/app/colors.ts
@@ -19,3 +19,6 @@ export const neutralColors: string[] = [
     "#5C2D91",
     "#D83B01",
 ];
+
+export const defaultAccentColor: string = AccentColors.blue;
+export const defaultNeutralColor: string = neutralColors[0];

--- a/packages/fast-color-explorer/app/control-pane.tsx
+++ b/packages/fast-color-explorer/app/control-pane.tsx
@@ -30,7 +30,12 @@ import { get, values } from "lodash-es";
 import React from "react";
 import { SketchPicker } from "react-color";
 import { connect } from "react-redux";
-import { AccentColors, neutralColors } from "./colors";
+import {
+    AccentColors,
+    defaultAccentColor,
+    defaultNeutralColor,
+    neutralColors,
+} from "./colors";
 import { ColorsDesignSystem } from "./design-system";
 import {
     AppState,
@@ -154,24 +159,13 @@ class ControlPaneBase extends React.Component<ControlPaneProps, ControlPaneState
         marginBottom: "18px",
         width: "100%",
     };
+
     constructor(props: ControlPaneProps) {
         super(props);
-        const defaultAccentBase: ColorRGBA64 | null = this.getBaseColor(
-            this.props.designSystem.accentPalette
-        );
-        const defaultNeutralBase: ColorRGBA64 | null = this.getBaseColor(
-            this.props.designSystem.neutralPalette
-        );
 
         this.state = {
-            accentColorBase:
-                defaultAccentBase instanceof ColorRGBA64
-                    ? defaultAccentBase.toStringHexRGB()
-                    : AccentColors.blue,
-            neutralColorBase:
-                defaultNeutralBase instanceof ColorRGBA64
-                    ? defaultNeutralBase.toStringHexRGB()
-                    : neutralColors[0],
+            accentColorBase: defaultAccentColor,
+            neutralColorBase: defaultNeutralColor,
         };
     }
 
@@ -200,10 +194,6 @@ class ControlPaneBase extends React.Component<ControlPaneProps, ControlPaneState
         );
     }
 
-    private getBaseColor(palette: string[]): ColorRGBA64 | null {
-        return parseColorHexRGB(palette[Math.floor(palette.length / 2)]);
-    }
-
     private handleFormSubmit(e: React.FormEvent<HTMLFormElement>): void {
         e.preventDefault();
     }
@@ -225,6 +215,7 @@ class ControlPaneBase extends React.Component<ControlPaneProps, ControlPaneState
             </div>
         );
     };
+
     private renderComponentSelector(): JSX.Element {
         const items: JSX.Element[] = Object.keys(ComponentTypes).map(
             (key: string): JSX.Element => {
@@ -343,6 +334,7 @@ class ControlPaneBase extends React.Component<ControlPaneProps, ControlPaneState
             </div>
         );
     }
+
     private handleColorChange(
         palette: "neutralColorBase" | "accentColorBase",
         callback: (color: ColorRGBA64) => void

--- a/packages/fast-color-explorer/app/design-system.ts
+++ b/packages/fast-color-explorer/app/design-system.ts
@@ -4,17 +4,19 @@ import {
 } from "@microsoft/fast-components-styles-msft";
 import { createColorPalette } from "@microsoft/fast-components-styles-msft";
 import { ColorRGBA64, parseColorHexRGB } from "@microsoft/fast-colors";
-import { AccentColors } from "./colors";
+import { defaultAccentColor, defaultNeutralColor } from "./colors";
 
 export type ColorsDesignSystem = DesignSystem;
 export const colorsDesignSystem: ColorsDesignSystem = Object.assign(
     {},
     DesignSystemDefaults,
     {
-        neutralPalette: createColorPalette(new ColorRGBA64(0.5, 0.5, 0.5, 1)),
-        accentPalette: createColorPalette(parseColorHexRGB(
-            AccentColors.blue
+        neutralPalette: createColorPalette(parseColorHexRGB(
+            defaultNeutralColor
         ) as ColorRGBA64),
-        accentBaseColor: AccentColors.blue,
+        accentPalette: createColorPalette(parseColorHexRGB(
+            defaultAccentColor
+        ) as ColorRGBA64),
+        accentBaseColor: defaultAccentColor,
     }
 );

--- a/packages/fast-color-explorer/app/gradient.tsx
+++ b/packages/fast-color-explorer/app/gradient.tsx
@@ -1,25 +1,38 @@
 import React from "react";
 import manageJss from "@microsoft/fast-jss-manager-react";
-import { ColorsDesignSystem } from "./design-system";
 import { isEqual } from "lodash-es";
 
-const styles: any = (designSystem: ColorsDesignSystem): any => {
-    return {
-        gradient: {
-            display: "flex",
-            width: "100%",
-        },
-        gradient_item: {
+const styles: any = {
+    gradient: {
+        display: "flex",
+        width: "100%",
+    },
+    gradient_item: {
+        display: "flex",
+        flex: "1",
+        height: "100%",
+    },
+    gradient_item__marked: {
+        position: "relative",
+        "&::before": {
+            width: "6px",
+            height: "6px",
+            margin: "0 auto",
+            content: "''",
+            opacity: "0.5",
+            position: "relative",
+            border: "solid 1px white",
+            borderRadius: "50%",
             display: "block",
-            flex: "1",
-            height: "100%",
+            alignSelf: "center",
         },
-    };
+    },
 };
 
 interface GradientProps {
     managedClasses: any;
     colors: string[];
+    markedColor?: string;
     createAnchors?: boolean;
     scrollToItem?: (index: number, align: string) => void;
 }
@@ -38,10 +51,21 @@ class BaseGradient extends React.Component<GradientProps, {}> {
 
     private createItems(): React.ReactNode {
         return this.props.colors.map((item: string, index: number) => {
+            let classNames: string = this.props.managedClasses.gradient_item;
+
+            if (
+                this.props.markedColor !== undefined &&
+                item.toUpperCase() === this.props.markedColor.toUpperCase()
+            ) {
+                classNames = `${classNames} ${
+                    this.props.managedClasses.gradient_item__marked
+                }`;
+            }
+
             return (
                 <a
                     key={index}
-                    className={this.props.managedClasses.gradient_item}
+                    className={classNames}
                     style={{
                         background: this.props.colors[index],
                     }}

--- a/packages/fast-color-explorer/app/state.ts
+++ b/packages/fast-color-explorer/app/state.ts
@@ -1,9 +1,9 @@
 import { Action, createStore } from "redux";
 import { ColorsDesignSystem, colorsDesignSystem } from "./design-system";
 import { ColorRGBA64 } from "@microsoft/fast-colors";
-import { merge } from "lodash-es";
-import { Color } from "csstype";
 import { createColorPalette } from "@microsoft/fast-components-styles-msft";
+import { Swatch } from "@microsoft/fast-components-styles-msft/dist/utilities/color/common";
+import { defaultNeutralColor } from "./colors";
 
 export enum ComponentTypes {
     backplate = "backplate",
@@ -28,6 +28,10 @@ export interface AppState {
      * The component type being displayed
      */
     componentType: ComponentTypes;
+
+    neutralBaseColor: Swatch;
+
+    accentBaseColor: Swatch;
 }
 
 export interface Action {
@@ -40,6 +44,8 @@ export interface Action {
 function setPalette(
     palette: "accentPalette" | "neutralPalette"
 ): (state: AppState, value: ColorRGBA64) => AppState {
+    const baseColor: string =
+        palette === "accentPalette" ? "accentBaseColor" : "neutralBaseColor";
     return (state: AppState, value: ColorRGBA64): AppState => {
         const designSystem: ColorsDesignSystem = {
             ...state.designSystem,
@@ -52,6 +58,7 @@ function setPalette(
         return {
             ...state,
             designSystem,
+            [baseColor]: value.toStringHexRGB(),
         };
     };
 }
@@ -75,6 +82,8 @@ function rootReducer(state: AppState, action: any): AppState {
 export const store: any = createStore(rootReducer, {
     designSystem: colorsDesignSystem,
     componentType: ComponentTypes.backplate,
+    neutralBaseColor: defaultNeutralColor,
+    accentBaseColor: colorsDesignSystem.accentBaseColor,
 });
 
 interface ColorExplorerAction<S, T = any> extends Action<T> {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

-Added a marker on the gradients for the base input color
-Added hover and active to the neutral foreground example

## Motivation & context

Part of the color algorithm update, to support visualizing the base ramp color in its position.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->