### PR TITLE
feat: update lightweight button and hyperlink underline size

### DIFF
--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -56,6 +56,7 @@ const applyTransparentBackplateStyles: CSSRules<DesignSystem> = {
         boxShadow: "none",
         "& $button_contentRegion::before": {
             background: neutralForegroundRest,
+            height: toPx<DesignSystem>(focusOutlineWidth),
         },
     }),
     // Underline
@@ -234,7 +235,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         "&::before": {
             content: "''",
             display: "block",
-            height: toPx<DesignSystem>(focusOutlineWidth),
+            height: toPx<DesignSystem>(outlineWidth),
             position: "absolute",
             bottom: "-3px",
             width: "100%",

--- a/packages/fast-components-styles-msft/src/hypertext/index.ts
+++ b/packages/fast-components-styles-msft/src/hypertext/index.ts
@@ -1,4 +1,4 @@
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
+import { DesignSystem } from "../design-system";
 import {
     accentForegroundActive,
     accentForegroundHover,
@@ -6,13 +6,10 @@ import {
     neutralFocus,
     neutralForegroundRest,
 } from "../utilities/color";
-import {
-    ComponentStyles,
-    ComponentStyleSheet,
-    CSSRules,
-} from "@microsoft/fast-jss-manager";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { HypertextClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { applyFocusVisible, format } from "@microsoft/fast-jss-utilities";
+import { applyFocusVisible, format, toPx } from "@microsoft/fast-jss-utilities";
+import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 
 const styles: ComponentStyles<HypertextClassNameContract, DesignSystem> = {
     hypertext: {
@@ -21,24 +18,26 @@ const styles: ComponentStyles<HypertextClassNameContract, DesignSystem> = {
         color: neutralForegroundRest,
         transition: "all 0.2s ease-in-out, border 0.03s ease-in-out",
         "&:link, &:visited": {
-            borderBottom: format<DesignSystem>("1px solid {0}", accentForegroundRest),
+            borderBottom: format<DesignSystem>(
+                "{0} solid {1}",
+                toPx(outlineWidth),
+                accentForegroundRest
+            ),
             color: accentForegroundRest,
             "&:hover": {
-                borderBottom: format<DesignSystem>(
-                    "2px solid {0}",
-                    accentForegroundHover
-                ),
+                borderBottomColor: accentForegroundHover,
                 color: accentForegroundHover,
             },
             "&:active": {
-                borderBottom: format<DesignSystem>(
-                    "2px solid {0}",
-                    accentForegroundActive
-                ),
+                borderBottomColor: accentForegroundActive,
                 color: accentForegroundActive,
             },
             ...applyFocusVisible({
-                borderBottom: format<DesignSystem>("2px solid {0}", neutralFocus),
+                borderBottom: format<DesignSystem>(
+                    "{0} solid {1}",
+                    toPx(focusOutlineWidth),
+                    neutralFocus
+                ),
             }),
         },
     },

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -8,7 +8,8 @@ import {
     accentForegroundRest,
     neutralForegroundRest,
 } from "../utilities/color";
-import { applyFocusVisible } from "@microsoft/fast-jss-utilities";
+import { applyFocusVisible, toPx } from "@microsoft/fast-jss-utilities";
+import { focusOutlineWidth } from "../utilities/design-system";
 
 const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> = {
     ...baseButton,
@@ -25,6 +26,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             boxShadow: "none",
             "& $button_contentRegion::before": {
                 background: neutralForegroundRest,
+                height: toPx<DesignSystem>(focusOutlineWidth),
             },
         }),
         "a&, button&": {},

--- a/packages/fast-components-styles-msft/src/patterns/button.ts
+++ b/packages/fast-components-styles-msft/src/patterns/button.ts
@@ -3,7 +3,7 @@ import { DesignSystem, ensureDesignSystemDefaults } from "../design-system";
 import { directionSwitch, format, toPx } from "@microsoft/fast-jss-utilities";
 import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
 import { applyCursorPointer } from "../utilities/cursor";
-import { focusOutlineWidth } from "../utilities/design-system";
+import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import { applyDisabledState } from "../utilities/disabled";
@@ -46,7 +46,7 @@ export const baseButton: ComponentStyles<ButtonBaseClassNameContract, DesignSyst
         "&::before": {
             content: "''",
             display: "block",
-            height: toPx<DesignSystem>(focusOutlineWidth),
+            height: toPx<DesignSystem>(outlineWidth),
             position: "absolute",
             bottom: "-3px",
             width: "100%",


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Updated lightweight button underline to 1px on hover/active, 2px on focus.
Updated hyperlink underline to 1px on rest/hover/active, 2px on focus.

## Motivation & context

The hover and active underline should match with normal outline widths (1px), only focus should use the focus width (2px).

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->