### PR TITLE
chore: update typo in tests

### DIFF
--- a/packages/fast-components-styles-msft/src/utilities/color/accent-foreground.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/accent-foreground.spec.ts
@@ -16,7 +16,7 @@ describe("accentForeground", (): void => {
     const neutralPalette: Palette = palette(PaletteType.neutral)(designSystemDefaults);
     const accentPalette: Palette = palette(PaletteType.accent)(designSystemDefaults);
 
-    test("should opperate on design system defaults", (): void => {
+    test("should operate on design system defaults", (): void => {
         expect(accentForegroundRest({} as DesignSystem)).toBe(accentPalette[35]);
         expect(accentForegroundHover({} as DesignSystem)).toBe(accentPalette[31]);
         expect(accentForegroundActive({} as DesignSystem)).toBe(accentPalette[27]);

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-card.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-card.spec.ts
@@ -4,7 +4,7 @@ import { neutralFillCard } from "./neutral-fill-card";
 import defaultDesignSystem, { DesignSystem } from "../../design-system";
 
 describe("neutralFillCard", (): void => {
-    test("should opperate on design system defaults", (): void => {
+    test("should operate on design system defaults", (): void => {
         expect(neutralFillCard({} as DesignSystem)).toBe(
             defaultDesignSystem.neutralPalette[defaultDesignSystem.neutralFillCardDelta]
         );

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-input.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-input.spec.ts
@@ -14,7 +14,7 @@ describe("neutralFillInput", (): void => {
     const neutralPalette: Palette = palette(PaletteType.neutral)(designSystemDefaults);
     const accentPalette: Palette = palette(PaletteType.accent)(designSystemDefaults);
 
-    test("should opperate on design system defaults", (): void => {
+    test("should operate on design system defaults", (): void => {
         expect(neutralFillInputRest({} as DesignSystem)).toBe(neutralPalette[0]);
         expect(neutralFillInputHover({} as DesignSystem)).toBe(neutralPalette[0]);
         expect(neutralFillInputActive({} as DesignSystem)).toBe(neutralPalette[0]);

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-stealth.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-stealth.spec.ts
@@ -13,7 +13,7 @@ describe("neutralFillStealth", (): void => {
     const neutralPalette: Palette = palette(PaletteType.neutral)(designSystemDefaults);
     const accentPalette: Palette = palette(PaletteType.accent)(designSystemDefaults);
 
-    test("should opperate on design system defaults", (): void => {
+    test("should operate on design system defaults", (): void => {
         expect(neutralFillStealthRest({} as DesignSystem)).toBe(
             neutralPalette[designSystemDefaults.neutralFillStealthRestDelta]
         );

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-fill.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-fill.spec.ts
@@ -13,7 +13,7 @@ describe("neutralFill", (): void => {
     const neutralPalette: Palette = palette(PaletteType.neutral)(designSystemDefaults);
     const accentPalette: Palette = palette(PaletteType.accent)(designSystemDefaults);
 
-    test("should opperate on design system defaults", (): void => {
+    test("should operate on design system defaults", (): void => {
         expect(neutralFillRest({} as DesignSystem)).toBe(
             neutralPalette[designSystemDefaults.neutralFillRestDelta]
         );

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
@@ -115,7 +115,7 @@ describe("findClosestSwatchIndex", (): void => {
             findClosestSwatchIndex(PaletteType.neutral, "pewpewpew")({} as DesignSystem)
         ).toBe(0);
     });
-    test("should opperate with designSystemDefaults", (): void => {
+    test("should operate on design system defaults", (): void => {
         expect(
             findClosestSwatchIndex(PaletteType.neutral, "#FFFFFF")({} as DesignSystem)
         ).toBe(0);
@@ -155,7 +155,7 @@ describe("getSwatch", (): void => {
 });
 
 describe("swatchByMode", (): void => {
-    test("should opperate on designSystemDefaults", (): void => {
+    test("should operate on designSystemDefaults", (): void => {
         expect(swatchByMode(PaletteType.neutral)(0, 0)({} as DesignSystem)).toBe(
             designSystemDefaults.neutralPalette[0]
         );

--- a/packages/fast-components-styles-msft/src/utilities/design-system.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.spec.ts
@@ -9,7 +9,7 @@ Object.keys(designSystemUtils).forEach(
         describe(
             key,
             (): void => {
-                test("should opperate on designSystemDefaults", (): void => {
+                test("should operate on design system defaults", (): void => {
                     expect(designSystemUtils[key]({} as DesignSystem)).toBe(
                         defaultDesignSystem[key]
                     );


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Just a little typo I found going through some tests.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->