### PR TITLE
feat: update neutral foreground recipes to be based on contrast

### DIFF
--- a/packages/fast-color-explorer/app/color-blocks.tsx
+++ b/packages/fast-color-explorer/app/color-blocks.tsx
@@ -233,7 +233,7 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
             >
                 <Caption
                     className={this.props.managedClasses.colorBlocks_backgroundColor}
-                    jssStyleSheet={{ caption: { color: neutralForegroundHintLarge } }}
+                    jssStyleSheet={{ caption: { color: neutralForegroundHint } }}
                 >
                     BACKGROUND {this.props.index} -{" "}
                     {this.state.designSystem.backgroundColor.toUpperCase()}

--- a/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
+++ b/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
@@ -196,16 +196,6 @@ export default {
             type: "number",
             default: 2,
         },
-        neutralForegroundDarkIndex: {
-            title: "Neutral foreground dark index",
-            type: "number",
-            default: 58,
-        },
-        neutralForegroundLightIndex: {
-            title: "Neutral foreground light index",
-            type: "number",
-            default: 0,
-        },
         neutralForegroundHoverDelta: {
             title: "Neutral foreground hover delta",
             type: "number",

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -133,7 +133,13 @@ export interface DesignSystem {
     /**
      * Color swatch deltas for neutral-foreground
      */
+    /**
+     * @deprecated Neutral foreground is now based on contrast and this is no longer used.
+     */
     neutralForegroundDarkIndex: number;
+    /**
+     * @deprecated Neutral foreground is now based on contrast and this is no longer used.
+     */
     neutralForegroundLightIndex: number;
     neutralForegroundHoverDelta: number;
     neutralForegroundActiveDelta: number;

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.spec.ts
@@ -1,8 +1,5 @@
-import { neutralForegroundRest } from "./neutral-foreground";
-import { palette, PaletteType } from "./palette";
 import designSystemDefaults, { DesignSystem } from "../../design-system";
 import { neutralFocus } from "./neutral-focus";
-import { Swatch } from "./common";
 
 describe("neutralFocus", (): void => {
     test("should return a string when invoked with an object", (): void => {
@@ -15,17 +12,5 @@ describe("neutralFocus", (): void => {
 
     test("should operate on default design system if no design system is supplied", (): void => {
         expect(neutralFocus({} as DesignSystem)).toBe("#101010");
-    });
-
-    test("should always match neutralForegroundRest", (): void => {
-        palette(PaletteType.neutral)(designSystemDefaults)
-            .concat(palette(PaletteType.accent)(designSystemDefaults))
-            .forEach(
-                (swatch: Swatch): void => {
-                    expect(neutralFocus((): Swatch => swatch)({} as DesignSystem)).toBe(
-                        neutralForegroundRest((): Swatch => swatch)({} as DesignSystem)
-                    );
-                }
-            );
     });
 });

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
@@ -1,12 +1,11 @@
 import { isDarkMode } from "./palette";
-import { neutralForegroundDark, neutralForegroundLight } from "./neutral-foreground";
 import { ColorRecipe, colorRecipeFactory, Swatch, SwatchResolver } from "./common";
 import { DesignSystem } from "../../design-system";
 
+// These literal values are to remove the dependency on neutralForegroundLight and Dark,
+// and are very temporary as focus is being updated to contrast-based as well.
 export const neutralFocus: ColorRecipe<Swatch> = colorRecipeFactory(
     (designSystem: DesignSystem): Swatch => {
-        return isDarkMode(designSystem)
-            ? neutralForegroundLight(designSystem)
-            : neutralForegroundDark(designSystem);
+        return isDarkMode(designSystem) ? "#FFFFFF" : "#101010";
     }
 );

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
@@ -1,11 +1,15 @@
-import { isDarkMode } from "./palette";
-import { ColorRecipe, colorRecipeFactory, Swatch, SwatchResolver } from "./common";
+import { getSwatch, isDarkMode, Palette, palette, PaletteType } from "./palette";
+import { ColorRecipe, colorRecipeFactory, Swatch } from "./common";
 import { DesignSystem } from "../../design-system";
 
 // These literal values are to remove the dependency on neutralForegroundLight and Dark,
 // and are very temporary as focus is being updated to contrast-based as well.
 export const neutralFocus: ColorRecipe<Swatch> = colorRecipeFactory(
     (designSystem: DesignSystem): Swatch => {
-        return isDarkMode(designSystem) ? "#FFFFFF" : "#101010";
+        const neutralPalette: Palette = palette(PaletteType.neutral)(designSystem);
+
+        return isDarkMode(designSystem)
+            ? getSwatch(neutralPalette.length - 5, neutralPalette)
+            : getSwatch(0, neutralPalette);
     }
 );

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
@@ -9,7 +9,7 @@ export const neutralFocus: ColorRecipe<Swatch> = colorRecipeFactory(
         const neutralPalette: Palette = palette(PaletteType.neutral)(designSystem);
 
         return isDarkMode(designSystem)
-            ? getSwatch(neutralPalette.length - 5, neutralPalette)
-            : getSwatch(0, neutralPalette);
+            ? getSwatch(0, neutralPalette)
+            : getSwatch(neutralPalette.length - 5, neutralPalette);
     }
 );

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.ts
@@ -1,22 +1,12 @@
 import { DesignSystem } from "../../design-system";
 import {
     findClosestSwatchIndex,
-    findSwatchIndex,
     isDarkMode,
     Palette,
-    palette,
     PaletteType,
     swatchByContrast,
 } from "./palette";
-import { neutralForegroundRest } from "./neutral-foreground";
-import { inRange } from "lodash-es";
-import {
-    colorRecipeFactory,
-    contrast,
-    Swatch,
-    SwatchRecipe,
-    SwatchResolver,
-} from "./common";
+import { colorRecipeFactory, SwatchRecipe } from "./common";
 import { backgroundColor, neutralPalette } from "../design-system";
 
 /**
@@ -35,9 +25,10 @@ function neutralForegroundHintInitialIndexResolver(
  */
 function neturalForegroundHintDirectionResolver(
     referenceIndex: number,
-    sourcePalette: Palette
+    sourcePalette: Palette,
+    designSystem: DesignSystem
 ): 1 | -1 {
-    return referenceIndex > Math.ceil(sourcePalette.length / 2) ? -1 : 1;
+    return isDarkMode(designSystem) ? -1 : 1;
 }
 
 const neutralForegroundHintAlgorithm: ReturnType<

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.spec.ts
@@ -1,11 +1,10 @@
 import {
     neutralForegroundActive,
-    neutralForegroundDark,
     neutralForegroundHover,
     neutralForegroundRest,
 } from "./neutral-foreground";
-import { palette, Palette, PaletteType } from "./palette";
 import designSystemDefaults from "../../design-system";
+import { contrast } from "./common";
 
 describe("neutralForeground", (): void => {
     test("should return a string when invoked with an object", (): void => {
@@ -21,85 +20,71 @@ describe("neutralForeground", (): void => {
     });
 
     test("should operate on default design system if no design system is supplied", (): void => {
-        const neutralPalette: Palette = palette(PaletteType.neutral)(
-            designSystemDefaults
-        );
-        expect(neutralForegroundRest(undefined as any)).toBe(
-            neutralForegroundDark(undefined)
-        );
-        expect(neutralForegroundRest(() => undefined as any)(undefined as any)).toBe(
-            neutralForegroundDark(undefined)
-        );
-        expect(neutralForegroundRest(() => "#FFF")(undefined as any)).toBe(
-            neutralForegroundDark(undefined)
-        );
-        expect(neutralForegroundRest(() => "#FFFFFF")(undefined as any)).toBe(
-            neutralForegroundDark(undefined)
-        );
+        expect(
+            contrast(neutralForegroundRest(undefined as any), "#FFF")
+        ).toBeGreaterThanOrEqual(14);
+        expect(
+            contrast(
+                neutralForegroundRest(() => undefined as any)(undefined as any),
+                "#FFF"
+            )
+        ).toBeGreaterThanOrEqual(14);
+        expect(
+            contrast(neutralForegroundRest(() => "#FFF")(undefined as any), "#FFF")
+        ).toBeGreaterThanOrEqual(14);
+        expect(
+            contrast(neutralForegroundRest(() => "#FFFFFF")(undefined as any), "#FFF")
+        ).toBeGreaterThanOrEqual(14);
 
-        expect(neutralForegroundHover(undefined! as any)).toBe(
-            neutralPalette[
-                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
-                    designSystemDefaults.neutralForegroundHoverDelta
-            ]
-        );
-        expect(neutralForegroundHover(() => undefined as any)(undefined as any)).toBe(
-            neutralPalette[
-                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
-                    designSystemDefaults.neutralForegroundHoverDelta
-            ]
-        );
-        expect(neutralForegroundHover(() => "#FFF")(undefined as any)).toBe(
-            neutralPalette[
-                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
-                    designSystemDefaults.neutralForegroundHoverDelta
-            ]
-        );
-        expect(neutralForegroundHover(() => "#FFFFFF")(undefined as any)).toBe(
-            neutralPalette[
-                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
-                    designSystemDefaults.neutralForegroundHoverDelta
-            ]
-        );
-        expect(neutralForegroundActive(undefined! as any)).toBe(
-            neutralPalette[
-                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
-                    designSystemDefaults.neutralForegroundActiveDelta
-            ]
-        );
-        expect(neutralForegroundActive(() => undefined as any)(undefined as any)).toBe(
-            neutralPalette[
-                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
-                    designSystemDefaults.neutralForegroundActiveDelta
-            ]
-        );
-        expect(neutralForegroundActive(() => "#FFF")(undefined as any)).toBe(
-            neutralPalette[
-                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
-                    designSystemDefaults.neutralForegroundActiveDelta
-            ]
-        );
-        expect(neutralForegroundActive(() => "#FFFFFF")(undefined as any)).toBe(
-            neutralPalette[
-                neutralPalette.indexOf(neutralForegroundDark(undefined)) -
-                    designSystemDefaults.neutralForegroundActiveDelta
-            ]
-        );
+        expect(
+            contrast(neutralForegroundHover(undefined as any), "#FFF")
+        ).toBeGreaterThanOrEqual(14);
+        expect(
+            contrast(
+                neutralForegroundHover(() => undefined as any)(undefined as any),
+                "#FFF"
+            )
+        ).toBeGreaterThanOrEqual(14);
+        expect(
+            contrast(neutralForegroundHover(() => "#FFF")(undefined as any), "#FFF")
+        ).toBeGreaterThanOrEqual(14);
+        expect(
+            contrast(neutralForegroundHover(() => "#FFFFFF")(undefined as any), "#FFF")
+        ).toBeGreaterThanOrEqual(14);
+
+        expect(
+            contrast(neutralForegroundActive(undefined as any), "#FFF")
+        ).toBeGreaterThanOrEqual(14);
+        expect(
+            contrast(
+                neutralForegroundActive(() => undefined as any)(undefined as any),
+                "#FFF"
+            )
+        ).toBeGreaterThanOrEqual(14);
+        expect(
+            contrast(neutralForegroundActive(() => "#FFF")(undefined as any), "#FFF")
+        ).toBeGreaterThanOrEqual(14);
+        expect(
+            contrast(neutralForegroundActive(() => "#FFFFFF")(undefined as any), "#FFF")
+        ).toBeGreaterThanOrEqual(14);
     });
 
-    test("should return #101010 with default design system values", (): void => {
-        expect(neutralForegroundRest(designSystemDefaults)).toBe(
-            neutralForegroundDark(undefined)
-        );
+    test("should return correct result with default design system values", (): void => {
+        expect(
+            contrast(neutralForegroundRest(designSystemDefaults), "#FFF")
+        ).toBeGreaterThanOrEqual(14);
     });
 
     test("should return #FFFFFF with a dark background", (): void => {
         expect(
-            neutralForegroundRest(
-                Object.assign({}, designSystemDefaults, {
-                    backgroundColor: "#000",
-                })
+            contrast(
+                neutralForegroundRest(
+                    Object.assign({}, designSystemDefaults, {
+                        backgroundColor: "#000",
+                    })
+                ),
+                "#000"
             )
-        ).toBe("#FFFFFF");
+        ).toBeGreaterThanOrEqual(14);
     });
 });

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.ts
@@ -1,20 +1,46 @@
 import { DesignSystem, DesignSystemResolver } from "../../design-system";
 import {
+    backgroundColor,
     neutralForegroundActiveDelta,
-    neutralForegroundDarkIndex,
     neutralForegroundHoverDelta,
-    neutralForegroundLightIndex,
-    neutralPalette,
 } from "../design-system";
 import {
-    ColorRecipe,
     colorRecipeFactory,
     Swatch,
     SwatchFamily,
+    SwatchFamilyResolver,
+    swatchFamilyToSwatchRecipeFactory,
+    SwatchFamilyType,
     SwatchRecipe,
-    SwatchResolver,
 } from "./common";
-import { getSwatch, isDarkMode, Palette } from "./palette";
+import {
+    findClosestSwatchIndex,
+    findSwatchIndex,
+    getSwatch,
+    isDarkMode,
+    Palette,
+    palette,
+    PaletteType,
+    swatchByContrast,
+} from "./palette";
+import { clamp } from "@microsoft/fast-colors";
+
+/**
+ * Resolves the index that the contrast serach algorithm should start at
+ */
+function neutralForegroundInitialIndexResolver(
+    referenceColor: string,
+    sourcePalette: Palette,
+    designSystem: DesignSystem
+): number {
+    return findClosestSwatchIndex(PaletteType.neutral, referenceColor)(designSystem);
+}
+
+function contrastTargetFactory(
+    targetContrast: number
+): (instanceContrast: number) => boolean {
+    return (instanceContrast: number): boolean => instanceContrast >= targetContrast;
+}
 
 /**
  * Function to derive neutralForeground from color inputs.
@@ -22,61 +48,83 @@ import { getSwatch, isDarkMode, Palette } from "./palette";
  * the color that has the most contrast against the background. If contrast
  * cannot be retrieved correctly, function returns black.
  */
-function neutralForegroundAlgorithm(
-    deltaResolver: DesignSystemResolver<number>
-): DesignSystemResolver<Swatch> {
-    return (designSystem: DesignSystem): Swatch => {
-        const palette: Palette = neutralPalette(designSystem);
-        const isDark: boolean = isDarkMode(designSystem);
-        const direction: 1 | -1 = isDark ? 1 : -1;
-        const restColor: Swatch = isDark
-            ? neutralForegroundLight(designSystem)
-            : neutralForegroundDark(designSystem);
-        const restIndex: number = palette.indexOf(restColor);
-        return getSwatch(restIndex + deltaResolver(designSystem) * direction, palette);
+function neutralForegroundAlgorithm(): DesignSystemResolver<SwatchFamily> {
+    return (designSystem: DesignSystem): SwatchFamily => {
+        const neutralPalette: Palette = palette(PaletteType.neutral)(designSystem);
+        const paletteLength: number = neutralPalette.length;
+        const maxIndex: number = paletteLength - 1;
+
+        const stateDeltas: any = {
+            rest: 0,
+            hover: neutralForegroundHoverDelta(designSystem),
+            active: neutralForegroundActiveDelta(designSystem),
+        };
+
+        const direction: 1 | -1 = isDarkMode(designSystem) ? -1 : 1;
+
+        const accessibleSwatch: Swatch = swatchByContrast(
+            backgroundColor // Compare swatches against the background
+        )(
+            palette(PaletteType.neutral) // Use the neutral palette
+        )(
+            neutralForegroundInitialIndexResolver // Begin searching based on neutral index, direction, and deltas
+        )(
+            () => direction // Search direction based on light/dark mode
+        )(
+            contrastTargetFactory(14) // A swatch is only valid if the contrast is greater than indicated
+        )(
+            designSystem // Pass the design system
+        );
+
+        // One of these will be rest, the other will be hover. Depends on the offsets and the direction.
+        const accessibleIndex1: number = findSwatchIndex(
+            PaletteType.neutral,
+            accessibleSwatch
+        )(designSystem);
+        const accessibleIndex2: number =
+            accessibleIndex1 + direction * Math.abs(stateDeltas.rest - stateDeltas.hover);
+
+        const indexOneIsRestState: boolean =
+            direction === 1
+                ? stateDeltas.rest < stateDeltas.hover
+                : direction * stateDeltas.rest > direction * stateDeltas.hover;
+
+        const restIndex: number = indexOneIsRestState
+            ? accessibleIndex1
+            : accessibleIndex2;
+        const hoverIndex: number = indexOneIsRestState
+            ? accessibleIndex2
+            : accessibleIndex1;
+
+        const restClamped: number = clamp(restIndex, 0, maxIndex);
+        const hoverClamped: number = clamp(hoverIndex, 0, maxIndex);
+        const activeIndex: number = clamp(
+            restIndex + direction * stateDeltas.active,
+            0,
+            maxIndex
+        );
+
+        return {
+            rest: getSwatch(restClamped, neutralPalette),
+            hover: getSwatch(hoverClamped, neutralPalette),
+            active: getSwatch(activeIndex, neutralPalette),
+        };
     };
 }
 
-/**
- * Retrieve light neutral-foreground color for use on dark backgrounds
- */
-export const neutralForegroundLight: SwatchResolver = (
-    designSystem: DesignSystem
-): Swatch => {
-    return getSwatch(
-        neutralForegroundLightIndex(designSystem),
-        neutralPalette(designSystem)
-    );
-};
-
-/**
- * Retrieve dark neutral-foreground color for use on light backgrounds
- */
-export const neutralForegroundDark: SwatchResolver = (
-    designSystem: DesignSystem
-): Swatch => {
-    return getSwatch(
-        neutralForegroundDarkIndex(designSystem),
-        neutralPalette(designSystem)
-    );
-};
-
-export const neutralForeground: ColorRecipe<SwatchFamily> = colorRecipeFactory(
-    (designSystem: DesignSystem): SwatchFamily => {
-        return {
-            rest: neutralForegroundRest(designSystem),
-            hover: neutralForegroundHover(designSystem),
-            active: neutralForegroundActive(designSystem),
-        };
-    }
+export const neutralForeground: SwatchFamilyResolver = colorRecipeFactory(
+    neutralForegroundAlgorithm()
 );
 
-export const neutralForegroundRest: SwatchRecipe = colorRecipeFactory(
-    neutralForegroundAlgorithm(() => 0)
+export const neutralForegroundRest: SwatchRecipe = swatchFamilyToSwatchRecipeFactory(
+    SwatchFamilyType.rest,
+    neutralForeground
 );
-export const neutralForegroundHover: SwatchRecipe = colorRecipeFactory(
-    neutralForegroundAlgorithm(neutralForegroundHoverDelta)
+export const neutralForegroundHover: SwatchRecipe = swatchFamilyToSwatchRecipeFactory(
+    SwatchFamilyType.hover,
+    neutralForeground
 );
-export const neutralForegroundActive: SwatchRecipe = colorRecipeFactory(
-    neutralForegroundAlgorithm(neutralForegroundActiveDelta)
+export const neutralForegroundActive: SwatchRecipe = swatchFamilyToSwatchRecipeFactory(
+    SwatchFamilyType.active,
+    neutralForeground
 );

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.ts
@@ -23,7 +23,6 @@ import {
     PaletteType,
     swatchByContrast,
 } from "./palette";
-import { clamp } from "@microsoft/fast-colors";
 
 /**
  * Resolves the index that the contrast serach algorithm should start at
@@ -51,8 +50,6 @@ function contrastTargetFactory(
 function neutralForegroundAlgorithm(): DesignSystemResolver<SwatchFamily> {
     return (designSystem: DesignSystem): SwatchFamily => {
         const neutralPalette: Palette = palette(PaletteType.neutral)(designSystem);
-        const paletteLength: number = neutralPalette.length;
-        const maxIndex: number = paletteLength - 1;
 
         const stateDeltas: any = {
             rest: 0,
@@ -96,17 +93,11 @@ function neutralForegroundAlgorithm(): DesignSystemResolver<SwatchFamily> {
             ? accessibleIndex2
             : accessibleIndex1;
 
-        const restClamped: number = clamp(restIndex, 0, maxIndex);
-        const hoverClamped: number = clamp(hoverIndex, 0, maxIndex);
-        const activeIndex: number = clamp(
-            restIndex + direction * stateDeltas.active,
-            0,
-            maxIndex
-        );
+        const activeIndex: number = restIndex + direction * stateDeltas.active;
 
         return {
-            rest: getSwatch(restClamped, neutralPalette),
-            hover: getSwatch(hoverClamped, neutralPalette),
+            rest: getSwatch(restIndex, neutralPalette),
+            hover: getSwatch(hoverIndex, neutralPalette),
             active: getSwatch(activeIndex, neutralPalette),
         };
     };

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -13,7 +13,7 @@ import {
     Swatch,
     SwatchResolver,
 } from "./common";
-import { neutralForegroundDark, neutralForegroundLight } from "./neutral-foreground";
+import { black, white } from "./color-constants";
 
 /**
  * The named palettes of the MSFT design system
@@ -134,10 +134,7 @@ export function findClosestSwatchIndex(
 export function isDarkMode(designSystem: DesignSystem): boolean {
     const bg: string = backgroundColor(designSystem);
 
-    return (
-        contrast(neutralForegroundLight(designSystem), bg) >=
-        contrast(neutralForegroundDark(designSystem), bg)
-    );
+    return contrast(white, bg) >= contrast(black, bg);
 }
 
 /**

--- a/packages/fast-components-styles-msft/src/utilities/design-system.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.ts
@@ -156,12 +156,19 @@ export const neutralFillCardDelta: DesignSystemResolver<number> = getDesignSyste
     "neutralFillCardDelta"
 );
 
+/**
+ * @deprecated Neutral foreground is now based on contrast and this is no longer used.
+ */
 export const neutralForegroundDarkIndex: DesignSystemResolver<
     number
 > = getDesignSystemValue("neutralForegroundDarkIndex");
+/**
+ * @deprecated Neutral foreground is now based on contrast and this is no longer used.
+ */
 export const neutralForegroundLightIndex: DesignSystemResolver<
     number
 > = getDesignSystemValue("neutralForegroundLightIndex");
+
 export const neutralForegroundHoverDelta: DesignSystemResolver<
     number
 > = getDesignSystemValue("neutralForegroundHoverDelta");


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Updated neutral foreground recipes to be based on contrast instead of offset.
Deprecated references to "light" or "dark" offsets or recipes.

## Motivation & context

This is to address the design when there are multiple app layers with increasing color depth, and the contrast increases between the layers because the foreground text was fixed white or almost black.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->