### PR TITLE
fix: allows the navigation to update using the active location when new props are passed

### DIFF
--- a/packages/fast-tooling-react/app/pages/form.tsx
+++ b/packages/fast-tooling-react/app/pages/form.tsx
@@ -11,7 +11,7 @@ import {
     FormProps,
 } from "../../src/form/form/form.props";
 import * as testConfigs from "./form/";
-import { StringUpdateSchemaPlugin } from "./form/plugin/plugin";
+import { OneOfUpdateSchemaPlugin, StringUpdateSchemaPlugin } from "./form/plugin/plugin";
 
 export type componentDataOnChange = (e: React.ChangeEvent<HTMLFormElement>) => void;
 
@@ -64,6 +64,9 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
         this.plugins = [
             new StringUpdateSchemaPlugin({
                 id: "plugins/pluginModifiedString",
+            }),
+            new OneOfUpdateSchemaPlugin({
+                id: "oneOfs/plugins/pluginModifiedString",
             }),
         ];
 

--- a/packages/fast-tooling-react/app/pages/form/plugin/plugin.ts
+++ b/packages/fast-tooling-react/app/pages/form/plugin/plugin.ts
@@ -1,5 +1,6 @@
 import { FormPlugin, FormPluginProps } from "../../../../src";
 
+/* tslint:disable:max-classes-per-file */
 export class StringUpdateSchemaPlugin extends FormPlugin<FormPluginProps> {
     public resolver(schema: any, data: any): any {
         switch (data.pluginModifiedNumber) {
@@ -12,5 +13,26 @@ export class StringUpdateSchemaPlugin extends FormPlugin<FormPluginProps> {
         }
 
         return Object.assign({}, schema, { enum: ["red", "green", "blue"] });
+    }
+}
+
+export class OneOfUpdateSchemaPlugin extends FormPlugin<FormPluginProps> {
+    public resolver(schema: any, data: any): any {
+        const testSchema: any = {
+            oneOf: [
+                {
+                    description: "string option",
+                    title: "string option",
+                    type: "string",
+                },
+                {
+                    description: "number option",
+                    title: "number option",
+                    type: "number",
+                },
+            ],
+        };
+
+        return Object.assign({}, schema, testSchema);
     }
 }

--- a/packages/fast-tooling-react/src/__tests__/schemas/plugin.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/plugin.schema.json
@@ -143,6 +143,7 @@
             "title": "oneOfs",
             "oneOf": [
                 {
+                    "title": "Contains a nested plugin oneOf",
                     "type": "object",
                     "properties": {
                         "pluginModifiedString": {
@@ -161,12 +162,13 @@
                     ]
                 },
                 {
+                    "title": "Contains a plugin modified number",
                     "type": "object",
                     "properties": {
                         "pluginModifiedNumber": {
                             "title": "Plugin modified number",
                             "type": "number",
-                            "formPluginId": "plugins/pluginModifiedNumber"
+                            "formPluginId": "oneOfs/plugins/pluginModifiedNumber"
                         },
                         "object": {
                             "title": "Object",

--- a/packages/fast-tooling-react/src/form/form/form.tsx
+++ b/packages/fast-tooling-react/src/form/form/form.tsx
@@ -157,14 +157,18 @@ class Form extends React.Component<
     /**
      * Update the state when a new schema is given
      */
-    /* tslint:disable-next-line */
     private updateStateForNewProps(
         props: FormProps,
         updateData: boolean,
         updateSchema: boolean,
         updateLocation: boolean
     ): Partial<FormState> {
-        let state: Partial<FormState> = {};
+        let state: Partial<FormState> = Object.assign(
+            {},
+            {
+                activeDataLocation: updateSchema ? "" : this.state.activeDataLocation,
+            }
+        );
         const updatedSchema: any = mapPluginsToSchema(
             props.schema,
             props.data,

--- a/packages/fast-tooling-react/src/form/utilities/form.spec.ts
+++ b/packages/fast-tooling-react/src/form/utilities/form.spec.ts
@@ -672,6 +672,44 @@ describe("getNavigation", () => {
             "propertyKey.propertyKey1.propertyKey2"
         );
     });
+    test("should return navigation items for directly nested oneOfs", () => {
+        const navigation: NavigationItem[] = getNavigation(
+            "propertyKey",
+            {
+                propertyKey: 42,
+            },
+            {
+                type: "object",
+                oneOf: [
+                    {
+                        oneOf: [
+                            {
+                                properties: {
+                                    propertyKey: {
+                                        type: "string",
+                                    },
+                                },
+                                required: ["propertyKey"],
+                            },
+                            {
+                                properties: {
+                                    propertyKey: {
+                                        type: "number",
+                                    },
+                                },
+                                required: ["propertyKey"],
+                            },
+                        ],
+                    },
+                ],
+            },
+            []
+        );
+
+        expect(navigation).toHaveLength(2);
+        expect(navigation[0].dataLocation).toEqual("");
+        expect(navigation[1].dataLocation).toEqual("propertyKey");
+    });
     test("should return navigation items with default values", () => {
         const defaultValue: string = "bar";
         const navigation: NavigationItem[] = getNavigation(


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
This fixes the generated navigation when using tightly nested oneOfs.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->