### PR TITLE
fix: enable viewport postioner to correct for base position offset from anchor

### DIFF
--- a/packages/fast-components-react-base/src/viewport-positioner/README.md
+++ b/packages/fast-components-react-base/src/viewport-positioner/README.md
@@ -40,6 +40,8 @@ The "AlwaysInView" props (i.e. "horizontalAlwaysInView" and "verticalAlwaysInVie
 
 The "fixedAfterInitialPlacement" prop is set the component will not adjust positioning after the initial render.
 
+The "verticalLocktoDefault" and "horizontalLocktoDefault" properties force placement to specified default positions regardless of available space.  Note that this has no effect when an axis is in "uncontrolled" mode.
+
 The not fully supported [ResizeObserver](https://developers.google.com/web/updates/2016/10/resizeobserver) and [IntersectionObserver](https://developers.google.com/web/updates/2016/04/intersectionobserver) are used (supported in Chrome), so it is necessary to apply a polyfill if more thorough browser support is needed (Safari and Firefox). Full adaptation is expected soon.
 
 

--- a/packages/fast-components-react-base/src/viewport-positioner/README.md
+++ b/packages/fast-components-react-base/src/viewport-positioner/README.md
@@ -8,6 +8,8 @@ The *viewport positioner* and the anchor element it is attached to must both be 
 
 If no "anchor" is specified the component will be disabled and not attempt to adjust layout. If no viewport is specified the component will assume the viewport is the root document element of the page.
 
+Authors should ensure that the positioner element has fixed dimensions, most likely coming from css styles, sizing forced by a parent element (i.e. grid cell), etc....  
+
 Authors can specify a positioning mode for each axis or leave it "uncontrolled" and use other means (i.e. their own css) to manage the positioner's layout on that axis.  The "adjacent" positioning mode ensures that the positioner does not overlap with the anchor on that axis and butts up against the outer edges of the anchor element.  With the "inset" positioning mode set the positioner will overlap with the anchor on the axis specified but will only extend beyond the anchor on the side with the most available space.
 
 Adjacent:
@@ -32,6 +34,8 @@ Inset:
  
  If a default position is specified for a particular axis and there is enough space that position will be set.  Whether there is enough space is determined by comparing the threshold size for the axis (or the height/width of the positioner if no threshold specified) to the available space for that position. If there is not enough space, or if no default position is specified, the positioner chooses the position with the most available space.
 
+ The "verticalLocktoDefault" and "horizontalLocktoDefault" properties force placement to specified default positions regardless of available space.  Note that this has no effect when an axis is in "uncontrolled" mode.
+
 The chosen position determines which side of the positioner is fixed to the anchor.  For example if the chosen position for the horizontal axis is "left" the positioner will have its "right" property set to a value corresponding to the left edge of the anchor and the "left" propertly will be unset.
 
 The *viewport positioner* adds css classes to itself based on the chosen positions (i.e. "viewportPositioner__left", "viewportPositioner__right", etc.) to enable authors to style the positioner and its contents based on relative position.
@@ -39,8 +43,6 @@ The *viewport positioner* adds css classes to itself based on the chosen positio
 The "AlwaysInView" props (i.e. "horizontalAlwaysInView" and "verticalAlwaysInView") for each axis allows authors to specify whether the positioner should remain on screen when the anchor element is scrolled off.  The *viewport positioner* accomplishes this by setting the translate transform and translate origin properties of the component.
 
 The "fixedAfterInitialPlacement" prop is set the component will not adjust positioning after the initial render.
-
-The "verticalLocktoDefault" and "horizontalLocktoDefault" properties force placement to specified default positions regardless of available space.  Note that this has no effect when an axis is in "uncontrolled" mode.
 
 The not fully supported [ResizeObserver](https://developers.google.com/web/updates/2016/10/resizeobserver) and [IntersectionObserver](https://developers.google.com/web/updates/2016/04/intersectionobserver) are used (supported in Chrome), so it is necessary to apply a polyfill if more thorough browser support is needed (Safari and Firefox). Full adaptation is expected soon.
 

--- a/packages/fast-components-react-base/src/viewport-positioner/README.md
+++ b/packages/fast-components-react-base/src/viewport-positioner/README.md
@@ -6,7 +6,7 @@ The *viewport positioner* component is a container that positions itself relativ
 
 The *viewport positioner* and the anchor element it is attached to must both be children of the specified viewport element. There should also be no other scrollable elements in the DOM hierarchy between these elements and the viewport.  The *viewport positioner* element will have its position attribute programmatically set to "relative" and the component also writes in values for the top, right, bottom, left, transform-origin and tranform attributes. 
 
-If no "anchor" is specified the component will be disabled and not attempt to adjust layout. If no viewport is specified the component will assume the viewport is the root document element of the page. 
+If no "anchor" is specified the component will be disabled and not attempt to adjust layout. If no viewport is specified the component will assume the viewport is the root document element of the page.
 
 Authors can specify a positioning mode for each axis or leave it "uncontrolled" and use other means (i.e. their own css) to manage the positioner's layout on that axis.  The "adjacent" positioning mode ensures that the positioner does not overlap with the anchor on that axis and butts up against the outer edges of the anchor element.  With the "inset" positioning mode set the positioner will overlap with the anchor on the axis specified but will only extend beyond the anchor on the side with the most available space.
 
@@ -32,7 +32,7 @@ Inset:
  
  If a default position is specified for a particular axis and there is enough space that position will be set.  Whether there is enough space is determined by comparing the threshold size for the axis (or the height/width of the positioner if no threshold specified) to the available space for that position. If there is not enough space, or if no default position is specified, the positioner chooses the position with the most available space.
 
- The "verticalLocktoDefault" and "horizontalLocktoDefault" properties force placement to specified default positions regardless of available space.  Note that this has no effect when an axis is in "uncontrolled" mode.
+ The "verticalLockToDefault" and "horizontalLockToDefault" properties force placement to specified default positions regardless of available space.  Note that this has no effect when an axis is in "uncontrolled" mode.
 
 The chosen position determines which side of the positioner is fixed to the anchor.  For example if the chosen position for the horizontal axis is "left" the positioner will have its "right" property set to a value corresponding to the left edge of the anchor and the "left" propertly will be unset.
 
@@ -42,15 +42,11 @@ The "AlwaysInView" props (i.e. "horizontalAlwaysInView" and "verticalAlwaysInVie
 
 The "fixedAfterInitialPlacement" prop is set the component will not adjust positioning after the initial render.
 
-Authors should be mindful that instanciating a flyout positioner can cause layout changes as it is actually inserted into the dom and can cause parent containers to expand, move siblings down the page, etc...  It is up to authors to place the component such that it does not cause unwanted layout changes.  
+Authors should be mindful that instanciating a flyout positioner can cause layout changes as it is actually inserted into the DOM and can cause parent containers to expand, move siblings down the page, etc.  It is up to authors to place the component such that it does not cause unwanted layout changes.  
 
 Authors should ensure that the positioner element has fixed dimensions. If these are dynamic this can cause incorrect positioning to be calculated.   
 
 The not fully supported [ResizeObserver](https://developers.google.com/web/updates/2016/10/resizeobserver) and [IntersectionObserver](https://developers.google.com/web/updates/2016/04/intersectionobserver) are used (supported in Chrome), so it is necessary to apply a polyfill if more thorough browser support is needed (Safari and Firefox). Full adaptation is expected soon.
-
-
-
-
 
 
 

--- a/packages/fast-components-react-base/src/viewport-positioner/README.md
+++ b/packages/fast-components-react-base/src/viewport-positioner/README.md
@@ -6,9 +6,7 @@ The *viewport positioner* component is a container that positions itself relativ
 
 The *viewport positioner* and the anchor element it is attached to must both be children of the specified viewport element. There should also be no other scrollable elements in the DOM hierarchy between these elements and the viewport.  The *viewport positioner* element will have its position attribute programmatically set to "relative" and the component also writes in values for the top, right, bottom, left, transform-origin and tranform attributes. 
 
-If no "anchor" is specified the component will be disabled and not attempt to adjust layout. If no viewport is specified the component will assume the viewport is the root document element of the page.
-
-Authors should ensure that the positioner element has fixed dimensions, most likely coming from css styles, sizing forced by a parent element (i.e. grid cell), etc....  
+If no "anchor" is specified the component will be disabled and not attempt to adjust layout. If no viewport is specified the component will assume the viewport is the root document element of the page. 
 
 Authors can specify a positioning mode for each axis or leave it "uncontrolled" and use other means (i.e. their own css) to manage the positioner's layout on that axis.  The "adjacent" positioning mode ensures that the positioner does not overlap with the anchor on that axis and butts up against the outer edges of the anchor element.  With the "inset" positioning mode set the positioner will overlap with the anchor on the axis specified but will only extend beyond the anchor on the side with the most available space.
 
@@ -43,6 +41,10 @@ The *viewport positioner* adds css classes to itself based on the chosen positio
 The "AlwaysInView" props (i.e. "horizontalAlwaysInView" and "verticalAlwaysInView") for each axis allows authors to specify whether the positioner should remain on screen when the anchor element is scrolled off.  The *viewport positioner* accomplishes this by setting the translate transform and translate origin properties of the component.
 
 The "fixedAfterInitialPlacement" prop is set the component will not adjust positioning after the initial render.
+
+Authors should be mindful that instanciating a flyout positioner can cause layout changes as it is actually inserted into the dom and can cause parent containers to expand, move siblings down the page, etc...  It is up to authors to place the component such that it does not cause unwanted layout changes.  
+
+Authors should ensure that the positioner element has fixed dimensions. If these are dynamic this can cause incorrect positioning to be calculated.   
 
 The not fully supported [ResizeObserver](https://developers.google.com/web/updates/2016/10/resizeobserver) and [IntersectionObserver](https://developers.google.com/web/updates/2016/04/intersectionobserver) are used (supported in Chrome), so it is necessary to apply a polyfill if more thorough browser support is needed (Safari and Firefox). Full adaptation is expected soon.
 

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
@@ -59,6 +59,11 @@ export interface ViewportPositionerHandledProps extends ViewportPositionerManage
     horizontalAlwaysInView?: boolean;
 
     /**
+     *  Locks horizontal axis to default position
+     */
+    horizontalLocktoDefault?: boolean;
+
+    /**
      *  The positioning mode for the vertical axis, default is uncontrolled
      */
     verticalPositioningMode?: AxisPositioningMode;
@@ -77,6 +82,11 @@ export interface ViewportPositionerHandledProps extends ViewportPositionerManage
      *  When enabled the positioner will not move out of the viewport on the vertical axis
      */
     verticalAlwaysInView?: boolean;
+
+    /**
+     *  Locks vertical axis to default position
+     */
+    verticalLocktoDefault?: boolean;
 
     /**
      * The disabled state

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
@@ -61,7 +61,7 @@ export interface ViewportPositionerHandledProps extends ViewportPositionerManage
     /**
      *  Locks horizontal axis to default position
      */
-    horizontalLocktoDefault?: boolean;
+    horizontalLockToDefault?: boolean;
 
     /**
      *  The positioning mode for the vertical axis, default is uncontrolled
@@ -86,7 +86,7 @@ export interface ViewportPositionerHandledProps extends ViewportPositionerManage
     /**
      *  Locks vertical axis to default position
      */
-    verticalLocktoDefault?: boolean;
+    verticalLockToDefault?: boolean;
 
     /**
      * The disabled state

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -951,4 +951,94 @@ describe("viewport positioner", (): void => {
             ViewportPositionerVerticalPosition.bottom
         );
     });
+
+    test("Positioner stays fixed on default position when LocktoDefault set in props", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div
+                style={{
+                    height: "100px",
+                    width: "100px",
+                }}
+                ref={viewportElement}
+            >
+                <div
+                    style={{
+                        height: "10px",
+                        width: "10px",
+                    }}
+                    ref={anchorElement}
+                />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.adjacent}
+                    defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
+                    horizontalLockToDefault={true}
+                    horizontalThreshold={20}
+                    verticalPositioningMode={AxisPositioningMode.adjacent}
+                    defaultVerticalPosition={ViewportPositionerVerticalPosition.top}
+                    verticalLockToDefault={true}
+                    verticalThreshold={20}
+                    anchor={anchorElement}
+                    viewport={viewportElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        positioner.instance().viewportRect = viewportRect;
+        positioner.instance().positionerRect = positionerRectX70Y70;
+        positioner.instance().anchorTop = 80;
+        positioner.instance().anchorRight = 90;
+        positioner.instance().anchorBottom = 90;
+        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorWidth = 10;
+        positioner.instance().anchorHeight = 10;
+        positioner.instance().scrollTop = 0;
+        positioner.instance().scrollLeft = 0;
+
+        positioner.instance()["updateLayout"]();
+
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            ViewportPositionerHorizontalPosition.left
+        );
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            ViewportPositionerVerticalPosition.top
+        );
+
+        positioner.instance().anchorTop = 20;
+        positioner.instance().anchorRight = 30;
+        positioner.instance().anchorBottom = 30;
+        positioner.instance().anchorLeft = 20;
+
+        positioner.instance()["updateLayout"]();
+
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            ViewportPositionerHorizontalPosition.left
+        );
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            ViewportPositionerVerticalPosition.top
+        );
+
+        positioner.instance().anchorTop = 10;
+        positioner.instance().anchorRight = 20;
+        positioner.instance().anchorBottom = 20;
+        positioner.instance().anchorLeft = 10;
+
+        positioner.instance()["updateLayout"]();
+
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            ViewportPositionerHorizontalPosition.left
+        );
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            ViewportPositionerVerticalPosition.top
+        );
+    });
 });

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -1041,4 +1041,117 @@ describe("viewport positioner", (): void => {
             ViewportPositionerVerticalPosition.top
         );
     });
+
+    test("Positioner base position offset from anchor is accounted for", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div
+                style={{
+                    height: "100px",
+                    width: "100px",
+                }}
+                ref={viewportElement}
+            >
+                <div
+                    style={{
+                        height: "10px",
+                        width: "10px",
+                    }}
+                    ref={anchorElement}
+                />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.adjacent}
+                    verticalPositioningMode={AxisPositioningMode.adjacent}
+                    anchor={anchorElement}
+                    viewport={viewportElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        positioner.instance().viewportRect = viewportRect;
+        positioner.instance().positionerRect = positionerRectX70Y70;
+        positioner.instance().anchorTop = 80;
+        positioner.instance().anchorRight = 90;
+        positioner.instance().anchorBottom = 90;
+        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorWidth = 10;
+        positioner.instance().anchorHeight = 10;
+        positioner.instance().scrollTop = 0;
+        positioner.instance().scrollLeft = 0;
+        positioner.instance().baseHorizontalOffset = 10;
+        positioner.instance().baseVerticalOffset = 10;
+
+        expect(
+            positioner
+                .instance()
+                ["getHorizontalPositioningState"](
+                    ViewportPositionerHorizontalPositionLabel.right
+                )["left"]
+        ).toBe(20);
+
+        expect(
+            positioner
+                .instance()
+                ["getHorizontalPositioningState"](
+                    ViewportPositionerHorizontalPositionLabel.left
+                )["right"]
+        ).toBe(0);
+
+        expect(
+            positioner
+                .instance()
+                ["getHorizontalPositioningState"](
+                    ViewportPositionerHorizontalPositionLabel.insetRight
+                )["left"]
+        ).toBe(10);
+
+        expect(
+            positioner
+                .instance()
+                ["getHorizontalPositioningState"](
+                    ViewportPositionerHorizontalPositionLabel.insetLeft
+                )["right"]
+        ).toBe(-10);
+
+        expect(
+            positioner
+                .instance()
+                ["getVerticalPositioningState"](
+                    ViewportPositionerVerticalPositionLabel.top
+                )["bottom"]
+        ).toBe(10);
+
+        expect(
+            positioner
+                .instance()
+                ["getVerticalPositioningState"](
+                    ViewportPositionerVerticalPositionLabel.bottom
+                )["top"]
+        ).toBe(10);
+
+        expect(
+            positioner
+                .instance()
+                ["getVerticalPositioningState"](
+                    ViewportPositionerVerticalPositionLabel.insetTop
+                )["bottom"]
+        ).toBe(0);
+
+        expect(
+            positioner
+                .instance()
+                ["getVerticalPositioningState"](
+                    ViewportPositionerVerticalPositionLabel.insetBottom
+                )["top"]
+        ).toBe(0);
+    });
 });

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -105,8 +105,8 @@ class ViewportPositioner extends Foundation<
         defaultVerticalPosition: ViewportPositionerVerticalPosition.bottom,
         horizontalAlwaysInView: false,
         verticalAlwaysInView: false,
-        verticalLocktoDefault: false,
-        horizontalLocktoDefault: false,
+        verticalLockToDefault: false,
+        horizontalLockToDefault: false,
         fixedAfterInitialPlacement: false,
     };
 
@@ -118,12 +118,12 @@ class ViewportPositioner extends Foundation<
         defaultHorizontalPosition: void 0,
         horizontalThreshold: void 0,
         horizontalAlwaysInView: void 0,
-        horizontalLocktoDefault: void 0,
+        horizontalLockToDefault: void 0,
         verticalPositioningMode: void 0,
         defaultVerticalPosition: void 0,
         verticalThreshold: void 0,
         verticalAlwaysInView: void 0,
-        verticalLocktoDefault: void 0,
+        verticalLockToDefault: void 0,
         fixedAfterInitialPlacement: void 0,
         disabled: void 0,
     };
@@ -784,7 +784,7 @@ class ViewportPositioner extends Foundation<
             if (
                 desiredHorizontalPosition ===
                     ViewportPositionerHorizontalPositionLabel.undefined ||
-                (!this.props.horizontalLocktoDefault &&
+                (!this.props.horizontalLockToDefault &&
                     this.getHorizontalPositionAvailableWidth(desiredHorizontalPosition) <
                         horizontalThreshold)
             ) {
@@ -808,7 +808,7 @@ class ViewportPositioner extends Foundation<
             if (
                 desiredVerticalPosition ===
                     ViewportPositionerVerticalPositionLabel.undefined ||
-                (!this.props.verticalLocktoDefault &&
+                (!this.props.verticalLockToDefault &&
                     this.getVerticalPositionAvailableHeight(desiredVerticalPosition) <
                         verticalThreshold)
             ) {

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -105,6 +105,8 @@ class ViewportPositioner extends Foundation<
         defaultVerticalPosition: ViewportPositionerVerticalPosition.bottom,
         horizontalAlwaysInView: false,
         verticalAlwaysInView: false,
+        verticalLocktoDefault: false,
+        horizontalLocktoDefault: false,
         fixedAfterInitialPlacement: false,
     };
 
@@ -116,10 +118,12 @@ class ViewportPositioner extends Foundation<
         defaultHorizontalPosition: void 0,
         horizontalThreshold: void 0,
         horizontalAlwaysInView: void 0,
+        horizontalLocktoDefault: void 0,
         verticalPositioningMode: void 0,
         defaultVerticalPosition: void 0,
         verticalThreshold: void 0,
         verticalAlwaysInView: void 0,
+        verticalLocktoDefault: void 0,
         fixedAfterInitialPlacement: void 0,
         disabled: void 0,
     };
@@ -144,6 +148,12 @@ class ViewportPositioner extends Foundation<
 
     private scrollTop: number = 0;
     private scrollLeft: number = 0;
+
+    /**
+     * base offsets between the positioner's base position and the anchor's
+     */
+    private baseHorizontalOffset: number = 0;
+    private baseVerticalOffset: number = 0;
 
     /**
      * constructor
@@ -637,6 +647,7 @@ class ViewportPositioner extends Foundation<
         this.anchorTop = anchorEntry.boundingClientRect.top;
         this.anchorRight = anchorEntry.boundingClientRect.right;
         this.anchorBottom = anchorEntry.boundingClientRect.bottom;
+        this.anchorLeft = anchorEntry.boundingClientRect.left;
         this.anchorHeight = anchorEntry.boundingClientRect.height;
         this.anchorWidth = anchorEntry.boundingClientRect.width;
     };
@@ -737,6 +748,23 @@ class ViewportPositioner extends Foundation<
             return;
         }
 
+        // on the first layout pass we determine the base offset between the positioner and the anchor
+        if (
+            this.props.horizontalPositioningMode !== AxisPositioningMode.uncontrolled &&
+            this.state.currentHorizontalPosition ===
+                ViewportPositionerHorizontalPositionLabel.undefined
+        ) {
+            this.baseHorizontalOffset = this.anchorLeft - this.positionerRect.left;
+        }
+
+        if (
+            this.props.verticalPositioningMode !== AxisPositioningMode.uncontrolled &&
+            this.state.currentVerticalPosition ===
+                ViewportPositionerVerticalPositionLabel.undefined
+        ) {
+            this.baseVerticalOffset = this.anchorBottom - this.positionerRect.top;
+        }
+
         this.updateForScrolling();
 
         let desiredVerticalPosition: ViewportPositionerVerticalPositionLabel =
@@ -756,8 +784,9 @@ class ViewportPositioner extends Foundation<
             if (
                 desiredHorizontalPosition ===
                     ViewportPositionerHorizontalPositionLabel.undefined ||
-                this.getHorizontalPositionAvailableWidth(desiredHorizontalPosition) <
-                    horizontalThreshold
+                (!this.props.horizontalLocktoDefault &&
+                    this.getHorizontalPositionAvailableWidth(desiredHorizontalPosition) <
+                        horizontalThreshold)
             ) {
                 desiredHorizontalPosition =
                     this.getHorizontalPositionAvailableWidth(horizontalOptions[0]) >
@@ -779,8 +808,9 @@ class ViewportPositioner extends Foundation<
             if (
                 desiredVerticalPosition ===
                     ViewportPositionerVerticalPositionLabel.undefined ||
-                this.getVerticalPositionAvailableHeight(desiredVerticalPosition) <
-                    verticalThreshold
+                (!this.props.verticalLocktoDefault &&
+                    this.getVerticalPositionAvailableHeight(desiredVerticalPosition) <
+                        verticalThreshold)
             ) {
                 desiredVerticalPosition =
                     this.getVerticalPositionAvailableHeight(verticalOptions[0]) >
@@ -814,22 +844,25 @@ class ViewportPositioner extends Foundation<
         switch (desiredHorizontalPosition) {
             case ViewportPositionerHorizontalPositionLabel.left:
                 xTransformOrigin = Location.right;
-                right = this.positionerRect.width;
+                right = this.positionerRect.width - this.baseHorizontalOffset;
                 break;
 
             case ViewportPositionerHorizontalPositionLabel.insetLeft:
                 xTransformOrigin = Location.right;
-                right = 0;
+                right =
+                    this.positionerRect.width -
+                    this.anchorWidth -
+                    this.baseHorizontalOffset;
                 break;
 
             case ViewportPositionerHorizontalPositionLabel.insetRight:
                 xTransformOrigin = Location.left;
-                left = 0;
+                left = this.baseHorizontalOffset;
                 break;
 
             case ViewportPositionerHorizontalPositionLabel.right:
                 xTransformOrigin = Location.left;
-                left = this.anchorWidth;
+                left = this.anchorWidth + this.baseHorizontalOffset;
                 break;
         }
 
@@ -854,22 +887,25 @@ class ViewportPositioner extends Foundation<
         switch (desiredVerticalPosition) {
             case ViewportPositionerVerticalPositionLabel.top:
                 yTransformOrigin = Location.bottom;
-                bottom = this.positionerRect.height + this.anchorHeight;
+                bottom =
+                    this.positionerRect.height +
+                    this.anchorHeight -
+                    this.baseVerticalOffset;
                 break;
 
             case ViewportPositionerVerticalPositionLabel.insetTop:
                 yTransformOrigin = Location.bottom;
-                bottom = this.positionerRect.height;
+                bottom = this.positionerRect.height - this.baseVerticalOffset;
                 break;
 
             case ViewportPositionerVerticalPositionLabel.insetBottom:
                 yTransformOrigin = Location.top;
-                top = -this.anchorHeight;
+                top = this.baseVerticalOffset - this.anchorHeight;
                 break;
 
             case ViewportPositionerVerticalPositionLabel.bottom:
                 yTransformOrigin = Location.top;
-                top = 0;
+                top = this.baseVerticalOffset;
                 break;
         }
         return {


### PR DESCRIPTION
# Description
The viewport positioner placement logic did not account for cases where the positioner was not initially placed immediately below the anchor element.  This change adds logic to do that.  Also added "verticalLocktoDefault" and "horizontalLocktoDefault" props to enable authors to use the component to place a flyout without adjusting for available space.

## Motivation & context
That the positioner didn't adjust for offset between the anchor and the positioner was an oversight interfering with partner implementations.  

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.