### PR TITLE
feat: add unique design system value for elevated corner radius

### DIFF
--- a/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
+++ b/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
@@ -81,6 +81,11 @@ export default {
             type: "number",
             default: 2,
         },
+        elevatedCornerRadius: {
+            title: "Elevated corner radius",
+            type: "number",
+            default: 4,
+        },
         outlineWidth: {
             title: "Outline width",
             type: "number",

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -67,9 +67,14 @@ export interface DesignSystem {
     fontWeight?: FontWeight;
 
     /**
-     * The corner default radius applied to controls.
+     * The corner radius applied to controls.
      */
     cornerRadius?: number;
+
+    /**
+     * The corner radius applied to elevated surfaces or controls.
+     */
+    elevatedCornerRadius?: number;
 
     /**
      * The width of the outline in pixels applied to outline components.
@@ -174,6 +179,7 @@ const designSystemDefaults: DesignSystem = {
     baseHorizontalSpacingMultiplier: 3,
     direction: Direction.ltr,
     cornerRadius: 2,
+    elevatedCornerRadius: 4,
     focusOutlineWidth: 2,
     fontWeight: defaultFontWeights,
     disabledOpacity: 0.3,

--- a/packages/fast-components-styles-msft/src/utilities/border.ts
+++ b/packages/fast-components-styles-msft/src/utilities/border.ts
@@ -6,14 +6,14 @@ import {
     ensureDesignSystemDefaults,
     withDesignSystemDefaults,
 } from "../design-system";
-import { cornerRadius } from "../utilities/design-system";
+import { cornerRadius, elevatedCornerRadius } from "../utilities/design-system";
 
 export function applyCornerRadius(): CSSRules<DesignSystem> {
     return { borderRadius: toPx(cornerRadius) };
 }
 
 export function applyFloatingCornerRadius(): CSSRules<DesignSystem> {
-    return { borderRadius: toPx(multiply(cornerRadius, 2)) };
+    return { borderRadius: toPx(elevatedCornerRadius) };
 }
 
 /**

--- a/packages/fast-components-styles-msft/src/utilities/design-system.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.ts
@@ -17,10 +17,17 @@ export const accentBaseColor: DesignSystemResolver<string> = getDesignSystemValu
 );
 
 /**
- * Retrieve the backgroundColor when invoked with a DesignSystem
+ * Retrieve the cornerRadius when invoked with a DesignSystem
  */
 export const cornerRadius: DesignSystemResolver<number> = getDesignSystemValue(
     "cornerRadius"
+);
+
+/**
+ * Retrieve the elevatedCornerRadius when invoked with a DesignSystem
+ */
+export const elevatedCornerRadius: DesignSystemResolver<number> = getDesignSystemValue(
+    "elevatedCornerRadius"
 );
 
 /**


### PR DESCRIPTION
## Motivation & context
This change adds a new design system value for elevated corner radius instances. Previously this was calculated to be twice the size of the corner radius; however, when working with larger numbers the delta becomes extreme, and a separate property provides greater flexibility.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->