### PR TITLE
feat: added applyElevatedCornerRadius and deprecated the 'floating' version

### DIFF
--- a/packages/fast-components-styles-msft/README.md
+++ b/packages/fast-components-styles-msft/README.md
@@ -123,7 +123,7 @@ These utility functions help you write clean and manageable style sheets.
     - [applyAcrylicMaterial](#applyacrylicmaterial)
 - [Border](#border)
     - [applyCornerRadius](#applycornerradius)
-    - [applyElevatedCornerRadius](#applyElevatedCornerRadius)
+    - [applyElevatedCornerRadius](#applyelevatedcornerradius)
     - [applyFocusPlaceholderBorder](#applyfocusplaceholderborder)
 - [Cursor](#cursor)
     - [applyCursorDefault](#applycursordefault)

--- a/packages/fast-components-styles-msft/README.md
+++ b/packages/fast-components-styles-msft/README.md
@@ -123,7 +123,7 @@ These utility functions help you write clean and manageable style sheets.
     - [applyAcrylicMaterial](#applyacrylicmaterial)
 - [Border](#border)
     - [applyCornerRadius](#applycornerradius)
-    - [applyFloatingCornerRadius](#applyfloatingcornerradius)
+    - [applyElevatedCornerRadius](#applyElevatedCornerRadius)
     - [applyFocusPlaceholderBorder](#applyfocusplaceholderborder)
 - [Cursor](#cursor)
     - [applyCursorDefault](#applycursordefault)
@@ -196,16 +196,16 @@ const styles: ComponentStyles<ClassNameContract, DesignSystem> = {
 };
 ```
 
-#### applyFloatingCornerRadius
+#### applyElevatedCornerRadius
 
-Applies a `cornerRadius` for UI elements which are elevated or outside the normal document flow.
+Applies the design system value for `elevatedCornerRadius` for UI elements which are elevated or outside the normal document flow.
 
 ```TypeScript
-import { applyFloatingCornerRadius } from "@microsoft/fast-components-styles-msft";
+import { applyElevatedCornerRadius } from "@microsoft/fast-components-styles-msft";
 
 const styles: ComponentStyles<ClassNameContract, DesignSystem> = {
     styled_component: {
-        ...applyFloatingCornerRadius(),
+        ...applyElevatedCornerRadius(),
     },
 };
 ```

--- a/packages/fast-components-styles-msft/src/auto-suggest/index.ts
+++ b/packages/fast-components-styles-msft/src/auto-suggest/index.ts
@@ -2,7 +2,7 @@ import { DesignSystem, withDesignSystemDefaults } from "../design-system";
 import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
 import { AutoSuggestClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { add, format, multiply, toPx } from "@microsoft/fast-jss-utilities";
-import { applyFloatingCornerRadius } from "../utilities/border";
+import { applyElevatedCornerRadius } from "../utilities/border";
 import { neutralFillStealthRest } from "../utilities/color";
 import { heightNumber } from "../utilities/density";
 import { applyElevation, ElevationMultiplier } from "../utilities/elevation";
@@ -27,7 +27,7 @@ const styles: ComponentStyles<AutoSuggestClassNameContract, DesignSystem> = {
         minWidth: "276px",
         maxHeight: toPx(add(heightNumber(visibleChildCount), multiply(designUnit, 2))),
         overflow: "auto",
-        ...applyFloatingCornerRadius(),
+        ...applyElevatedCornerRadius(),
     },
     autoSuggest__menuOpen: {},
 };

--- a/packages/fast-components-styles-msft/src/context-menu/index.ts
+++ b/packages/fast-components-styles-msft/src/context-menu/index.ts
@@ -2,14 +2,14 @@ import { ContextMenuClassNameContract } from "@microsoft/fast-components-class-n
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { format, toPx } from "@microsoft/fast-jss-utilities";
 import { DesignSystem } from "../design-system";
-import { applyFloatingCornerRadius } from "../utilities/border";
+import { applyElevatedCornerRadius } from "../utilities/border";
 import { backgroundColor, designUnit } from "../utilities/design-system";
 import { applyElevation, ElevationMultiplier } from "../utilities/elevation";
 
 const styles: ComponentStyles<ContextMenuClassNameContract, DesignSystem> = {
     contextMenu: {
         background: backgroundColor,
-        ...applyFloatingCornerRadius(),
+        ...applyElevatedCornerRadius(),
         ...applyElevation(ElevationMultiplier.e11),
         margin: "0",
         padding: format("{0} 0", toPx<DesignSystem>(designUnit)),

--- a/packages/fast-components-styles-msft/src/dialog/index.ts
+++ b/packages/fast-components-styles-msft/src/dialog/index.ts
@@ -2,7 +2,7 @@ import { DesignSystem, withDesignSystemDefaults } from "../design-system";
 import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
 import { DialogClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { applyAcrylicMaterial } from "../utilities/acrylic";
-import { applyFloatingCornerRadius } from "../utilities/border";
+import { applyElevatedCornerRadius } from "../utilities/border";
 import { applyElevation, ElevationMultiplier } from "../utilities/elevation";
 
 /* tslint:disable-next-line */
@@ -39,7 +39,7 @@ const styles: ComponentStyles<DialogClassNameContract, DesignSystem> = (
         },
         dialog_contentRegion: {
             background: backgroundColor,
-            ...applyFloatingCornerRadius(),
+            ...applyElevatedCornerRadius(),
             ...applyElevation(ElevationMultiplier.e14),
             zIndex: "1",
         },

--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -18,7 +18,7 @@ import {
     neutralForegroundRest,
     neutralOutlineRest,
 } from "../utilities/color";
-import { applyFloatingCornerRadius } from "../utilities/border";
+import { applyElevatedCornerRadius } from "../utilities/border";
 import { designUnit } from "../utilities/design-system";
 import { inputFieldStyles } from "../patterns/input-field";
 
@@ -59,7 +59,7 @@ const styles: ComponentStyles<SelectClassNameContract, DesignSystem> = {
     },
     select_menu: {
         background: neutralFillStealthRest,
-        ...applyFloatingCornerRadius(),
+        ...applyElevatedCornerRadius(),
         ...applyElevation(ElevationMultiplier.e11),
         zIndex: "1",
         position: "relative",

--- a/packages/fast-components-styles-msft/src/utilities/border.ts
+++ b/packages/fast-components-styles-msft/src/utilities/border.ts
@@ -1,17 +1,29 @@
 import { CSSRules } from "@microsoft/fast-jss-manager";
-import { multiply, toPx } from "@microsoft/fast-jss-utilities";
+import { format, toPx } from "@microsoft/fast-jss-utilities";
+import { DesignSystem } from "../design-system";
 import {
-    DesignSystem,
-    DesignSystemResolver,
-    ensureDesignSystemDefaults,
-    withDesignSystemDefaults,
-} from "../design-system";
-import { cornerRadius, elevatedCornerRadius } from "../utilities/design-system";
+    cornerRadius,
+    elevatedCornerRadius,
+    focusOutlineWidth,
+} from "../utilities/design-system";
 
+/**
+ * Sets the border radius for controls.
+ */
 export function applyCornerRadius(): CSSRules<DesignSystem> {
     return { borderRadius: toPx(cornerRadius) };
 }
 
+/**
+ * Sets the border radius for elevated surfaces or controls.
+ */
+export function applyElevatedCornerRadius(): CSSRules<DesignSystem> {
+    return applyFloatingCornerRadius();
+}
+
+/**
+ * @deprecated Use applyElevatedCornerRadius instead.
+ */
 export function applyFloatingCornerRadius(): CSSRules<DesignSystem> {
     return { borderRadius: toPx(elevatedCornerRadius) };
 }
@@ -23,9 +35,6 @@ export function applyFocusPlaceholderBorder(
     config?: DesignSystem /* @deprecated - this function doesn't need an argument */
 ): CSSRules<DesignSystem> {
     return {
-        border: ensureDesignSystemDefaults(
-            (designSystem: DesignSystem): string =>
-                `${toPx(designSystem.focusOutlineWidth)} solid transparent`
-        ),
+        border: format("{0} solid transparent", toPx(focusOutlineWidth)),
     };
 }


### PR DESCRIPTION
# Description

Added applyElevatedCornerRadius and deprecated the 'floating' version of the same.

## Motivation & context

The new design system property is called is called “elevated” and it is intended to be used for all elevated surfaces. “Floating” generally refers to higher elevation items like dialogs or drop-lists.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->