### PR TITLE
feat: allow children in the React default children prop to be directly nested in the Navigation component

### DIFF
--- a/packages/fast-tooling-react/app/configs/children.schema.json
+++ b/packages/fast-tooling-react/app/configs/children.schema.json
@@ -11,6 +11,13 @@
             "defaults": [
                 "text"
             ]
+        },
+        "otherChildren": {
+            "title": "Children",
+            "type": "children",
+            "defaults": [
+                "text"
+            ]
         }
     },
     "properties": {

--- a/packages/fast-tooling-react/src/navigation/navigation-tree-item.props.ts
+++ b/packages/fast-tooling-react/src/navigation/navigation-tree-item.props.ts
@@ -44,21 +44,6 @@ export interface NavigationTreeItemProps
     handleKeyUp: React.KeyboardEventHandler<HTMLElement>;
 
     /**
-     * The level, used for the tree items aria-level
-     */
-    level: number;
-
-    /**
-     * The length of the navigation, used for the tree items aria-setsize
-     */
-    navigationLength: number;
-
-    /**
-     * The position of the tree item in the navigation, used for the tree items aria-posinset
-     */
-    positionInNavigation: number;
-
-    /**
      * The text used for the tree item
      */
     text: string;

--- a/packages/fast-tooling-react/src/navigation/navigation-tree-item.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation-tree-item.tsx
@@ -183,10 +183,7 @@ const NavigationTreeItem: React.RefForwardingComponent<
                     {props.children}
                 </div>
             ) : (
-                <div
-                    className={props.className}
-                    ref={elementRef}
-                >
+                <div className={props.className} ref={elementRef}>
                     <a
                         className={`${props.contentClassName}${getDragHoverClassName()}`}
                         role={"treeitem"}

--- a/packages/fast-tooling-react/src/navigation/navigation-tree-item.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation-tree-item.tsx
@@ -167,9 +167,6 @@ const NavigationTreeItem: React.RefForwardingComponent<
                     className={props.className}
                     role={"treeitem"}
                     ref={elementRef}
-                    aria-level={props.level}
-                    aria-setsize={props.navigationLength}
-                    aria-posinset={props.positionInNavigation}
                     aria-expanded={props.expanded}
                     onClick={props.handleClick}
                     onKeyUp={props.handleKeyUp}
@@ -186,14 +183,14 @@ const NavigationTreeItem: React.RefForwardingComponent<
                     {props.children}
                 </div>
             ) : (
-                <div className={props.className} role={"none"} ref={elementRef}>
+                <div
+                    className={props.className}
+                    ref={elementRef}
+                >
                     <a
                         className={`${props.contentClassName}${getDragHoverClassName()}`}
                         role={"treeitem"}
                         data-location={props.dataLocation}
-                        aria-level={props.level}
-                        aria-setsize={props.navigationLength}
-                        aria-posinset={props.positionInNavigation}
                         href={"#"}
                         onClick={props.handleClick}
                         onKeyUp={props.handleKeyUp}

--- a/packages/fast-tooling-react/src/navigation/navigation.spec.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation.spec.tsx
@@ -335,7 +335,7 @@ describe("Navigation", () => {
                     {
                         id: childOptions[0].schema.id,
                         props: {},
-                    }
+                    },
                 ],
             },
             managedClasses,

--- a/packages/fast-tooling-react/src/navigation/navigation.spec.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation.spec.tsx
@@ -117,47 +117,8 @@ describe("Navigation", () => {
         const item: any = rendered.find(treeItemEndPointSelector);
         expect(item).toHaveLength(1);
         const triggerItem: any = rendered.find(treeItemExpandListTriggerSelector);
-        expect(triggerItem).toHaveLength(2);
+        expect(triggerItem).toHaveLength(1);
         expect(item.props().className).toEqual(managedClasses.navigation_itemContent);
-        expect(item.props()["aria-level"]).toEqual(3);
-        expect(item.props()["aria-setsize"]).toEqual(1);
-        expect(item.props()["aria-posinset"]).toEqual(1);
-        expect(
-            triggerItem
-                .at(0)
-                .parent()
-                .props()["aria-level"]
-        ).toEqual(1);
-        expect(
-            triggerItem
-                .at(0)
-                .parent()
-                .props()["aria-setsize"]
-        ).toEqual(1);
-        expect(
-            triggerItem
-                .at(0)
-                .parent()
-                .props()["aria-posinset"]
-        ).toEqual(1);
-        expect(
-            triggerItem
-                .at(1)
-                .parent()
-                .props()["aria-level"]
-        ).toEqual(2);
-        expect(
-            triggerItem
-                .at(1)
-                .parent()
-                .props()["aria-setsize"]
-        ).toEqual(1);
-        expect(
-            triggerItem
-                .at(1)
-                .parent()
-                .props()["aria-posinset"]
-        ).toEqual(1);
     });
     test("should render multiple items if multiple children have been passed", () => {
         const props: NavigationProps = {
@@ -181,19 +142,45 @@ describe("Navigation", () => {
         const item: any = rendered.find(treeItemEndPointSelector);
         const itemTriggers: any = rendered.find(treeItemExpandListTriggerSelector);
         expect(item).toHaveLength(2);
-        expect(itemTriggers).toHaveLength(2);
+        expect(itemTriggers).toHaveLength(1);
         expect(item.at(0).props().className).toEqual(
             managedClasses.navigation_itemContent
         );
-        expect(item.at(0).props()["aria-level"]).toEqual(3);
-        expect(item.at(0).props()["aria-setsize"]).toEqual(2);
-        expect(item.at(0).props()["aria-posinset"]).toEqual(1);
         expect(item.at(1).props().className).toEqual(
             managedClasses.navigation_itemContent
         );
-        expect(item.at(1).props()["aria-level"]).toEqual(3);
-        expect(item.at(1).props()["aria-setsize"]).toEqual(2);
-        expect(item.at(1).props()["aria-posinset"]).toEqual(2);
+    });
+    test("should not render a children data type for props using the React default children prop", () => {
+        const props: NavigationProps = {
+            ...navigationProps,
+            data: {
+                children: {
+                    id: childOptions[0].schema.id,
+                    props: {},
+                },
+            },
+            managedClasses,
+        };
+
+        const rendered: any = mount(<DragDropNavigation {...props} />);
+        const triggerItem: any = rendered.find(treeItemExpandListTriggerSelector);
+        expect(triggerItem).toHaveLength(1);
+    });
+    test("should render a children data type for props not using the React default children prop", () => {
+        const props: NavigationProps = {
+            ...navigationProps,
+            data: {
+                otherChildren: {
+                    id: childOptions[0].schema.id,
+                    props: {},
+                },
+            },
+            managedClasses,
+        };
+
+        const rendered: any = mount(<DragDropNavigation {...props} />);
+        const triggerItem: any = rendered.find(treeItemExpandListTriggerSelector);
+        expect(triggerItem).toHaveLength(2);
     });
     test("should render a nested item if nested children have been passed", () => {
         const props: NavigationProps = {
@@ -220,14 +207,8 @@ describe("Navigation", () => {
         expect(triggerItem.props().className).toEqual(
             managedClasses.navigation_itemContent
         );
-        expect(triggerItem.parent().props()["aria-level"]).toEqual(2);
-        expect(triggerItem.parent().props()["aria-setsize"]).toEqual(1);
-        expect(triggerItem.parent().props()["aria-posinset"]).toEqual(1);
         expect(linkItem).toHaveLength(1);
         expect(linkItem.props().className).toEqual(managedClasses.navigation_itemContent);
-        expect(linkItem.props()["aria-level"]).toEqual(5);
-        expect(linkItem.props()["aria-setsize"]).toEqual(1);
-        expect(linkItem.props()["aria-posinset"]).toEqual(1);
     });
     test("should render multiple nested items if multiple nested children have been passed", () => {
         const props: NavigationProps = {
@@ -260,22 +241,13 @@ describe("Navigation", () => {
         expect(triggerItem.props().className).toEqual(
             managedClasses.navigation_itemContent
         );
-        expect(triggerItem.parent().props()["aria-level"]).toEqual(2);
-        expect(triggerItem.parent().props()["aria-setsize"]).toEqual(1);
-        expect(triggerItem.parent().props()["aria-posinset"]).toEqual(1);
         expect(linkItem).toHaveLength(2);
         expect(linkItem.at(0).props().className).toEqual(
             managedClasses.navigation_itemContent
         );
-        expect(linkItem.at(0).props()["aria-level"]).toEqual(5);
-        expect(linkItem.at(0).props()["aria-setsize"]).toEqual(2);
-        expect(linkItem.at(0).props()["aria-posinset"]).toEqual(1);
         expect(linkItem.at(1).props().className).toEqual(
             managedClasses.navigation_itemContent
         );
-        expect(linkItem.at(1).props()["aria-level"]).toEqual(5);
-        expect(linkItem.at(1).props()["aria-setsize"]).toEqual(2);
-        expect(linkItem.at(1).props()["aria-posinset"]).toEqual(2);
     });
     test("should render multiple items if multiple children with nested children have been passed", () => {
         const props: NavigationProps = {
@@ -315,107 +287,8 @@ describe("Navigation", () => {
         const linkItem: any = rendered.find(treeItemEndPointSelector);
         const triggerItem: any = rendered.find(treeItemExpandListTriggerSelector);
 
-        expect(triggerItem).toHaveLength(6);
-        expect(
-            triggerItem
-                .at(1)
-                .parent()
-                .props()["aria-level"]
-        ).toEqual(2);
-        expect(
-            triggerItem
-                .at(1)
-                .parent()
-                .props()["aria-setsize"]
-        ).toEqual(1);
-        expect(
-            triggerItem
-                .at(1)
-                .parent()
-                .props()["aria-posinset"]
-        ).toEqual(1);
-        expect(
-            triggerItem
-                .at(2)
-                .parent()
-                .props()["aria-level"]
-        ).toEqual(3);
-        expect(
-            triggerItem
-                .at(2)
-                .parent()
-                .props()["aria-setsize"]
-        ).toEqual(2);
-        expect(
-            triggerItem
-                .at(2)
-                .parent()
-                .props()["aria-posinset"]
-        ).toEqual(1);
-        expect(
-            triggerItem
-                .at(3)
-                .parent()
-                .props()["aria-level"]
-        ).toEqual(4);
-        expect(
-            triggerItem
-                .at(3)
-                .parent()
-                .props()["aria-setsize"]
-        ).toEqual(1);
-        expect(
-            triggerItem
-                .at(3)
-                .parent()
-                .props()["aria-posinset"]
-        ).toEqual(1);
-        expect(
-            triggerItem
-                .at(4)
-                .parent()
-                .props()["aria-level"]
-        ).toEqual(3);
-        expect(
-            triggerItem
-                .at(4)
-                .parent()
-                .props()["aria-setsize"]
-        ).toEqual(2);
-        expect(
-            triggerItem
-                .at(4)
-                .parent()
-                .props()["aria-posinset"]
-        ).toEqual(2);
-        expect(
-            triggerItem
-                .at(5)
-                .parent()
-                .props()["aria-level"]
-        ).toEqual(4);
-        expect(
-            triggerItem
-                .at(5)
-                .parent()
-                .props()["aria-setsize"]
-        ).toEqual(1);
-        expect(
-            triggerItem
-                .at(5)
-                .parent()
-                .props()["aria-posinset"]
-        ).toEqual(1);
+        expect(triggerItem).toHaveLength(3);
         expect(linkItem).toHaveLength(3);
-        expect(linkItem.at(0).props()["aria-level"]).toEqual(5);
-        expect(linkItem.at(0).props()["aria-setsize"]).toEqual(2);
-        expect(linkItem.at(0).props()["aria-posinset"]).toEqual(1);
-        expect(linkItem.at(1).props()["aria-level"]).toEqual(5);
-        expect(linkItem.at(1).props()["aria-setsize"]).toEqual(2);
-        expect(linkItem.at(1).props()["aria-posinset"]).toEqual(2);
-        expect(linkItem.at(2).props()["aria-level"]).toEqual(5);
-        expect(linkItem.at(2).props()["aria-setsize"]).toEqual(1);
-        expect(linkItem.at(2).props()["aria-posinset"]).toEqual(1);
     });
     test("should fire a callback when a link has been clicked", () => {
         const onLocationUpdate: any = jest.fn();
@@ -457,7 +330,14 @@ describe("Navigation", () => {
         const onLocationUpdate: any = jest.fn();
         const props: any = {
             ...navigationProps,
-            data: standardData,
+            data: {
+                otherChildren: [
+                    {
+                        id: childOptions[0].schema.id,
+                        props: {},
+                    }
+                ],
+            },
             managedClasses,
             onLocationUpdate,
         };

--- a/packages/fast-tooling-react/src/navigation/navigation.style.ts
+++ b/packages/fast-tooling-react/src/navigation/navigation.style.ts
@@ -5,6 +5,7 @@ import { accent, background300, background800, foreground300 } from "../style/co
 export interface NavigationClassNameContract {
     navigation?: string;
     navigation_item?: string;
+    navigation_item__childItem?: string;
     navigation_itemContent?: string;
     navigation_itemContent__active?: string;
     navigation_itemContent__dragHover?: string;
@@ -46,9 +47,15 @@ const styles: ComponentStyles<NavigationClassNameContract, {}> = {
             borderBottom: "3px solid transparent",
         },
     },
+    navigation_item__childItem: {
+        "& > $navigation_itemContent": {
+            fontStyle: "normal"
+        }
+    },
     navigation_itemContent: {
         ...applyTriggerStyle(foreground300),
         textDecoration: "none",
+        fontStyle: "italic",
         "&:focus": {
             ...insetStrongBoxShadow(accent),
         },

--- a/packages/fast-tooling-react/src/navigation/navigation.style.ts
+++ b/packages/fast-tooling-react/src/navigation/navigation.style.ts
@@ -49,8 +49,8 @@ const styles: ComponentStyles<NavigationClassNameContract, {}> = {
     },
     navigation_item__childItem: {
         "& > $navigation_itemContent": {
-            fontStyle: "normal"
-        }
+            fontStyle: "normal",
+        },
     },
     navigation_itemContent: {
         ...applyTriggerStyle(foreground300),

--- a/packages/fast-tooling-react/src/navigation/navigation.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation.tsx
@@ -138,7 +138,7 @@ export default class Navigation extends Foundation<
         const dataLocation: string = navigation.dataLocation;
         const dataType: NavigationDataType = navigation.type;
         const props: NavigationTreeItemProps = {
-            className: this.props.managedClasses.navigation_item,
+            className: this.getItemClassName(dataType),
             contentClassName: this.getItemContentClassName(dataLocation),
             getContentDragHoverClassName: this.getItemContentDragHoverClassName,
             dataLocation,
@@ -148,9 +148,6 @@ export default class Navigation extends Foundation<
             expanded: this.isExpanded(dataLocation),
             handleClick: this.handleTreeItemClick(dataLocation, dataType),
             handleKeyUp: this.handleTreeItemKeyUp(dataLocation, dataType),
-            level,
-            navigationLength,
-            positionInNavigation,
             text: navigation.text,
             type: dataType,
             onChange: this.handleChange,
@@ -160,6 +157,13 @@ export default class Navigation extends Foundation<
             Array.isArray(navigation.items) && navigationLength > 0
                 ? this.renderTreeItemContainer(navigation.items, level)
                 : void 0;
+
+        // Directly nest React children which use the "children" property
+        if (dataLocation === "children" || dataLocation.endsWith("props.children")) {
+            if (Array.isArray(navigation.items) && navigationLength > 0) {
+                return this.renderTreeItems(navigation.items, level + 1);
+            }
+        }
 
         if (this.props.dragAndDropReordering) {
             return (
@@ -240,7 +244,12 @@ export default class Navigation extends Foundation<
         navigation: TreeNavigation[],
         level: number
     ): React.ReactNode {
-        return navigation.map((navigationItem: TreeNavigation, index: number) => {
+        // Sort items so that childrenItems are weighted towards the top
+        const sortedNavigation: TreeNavigation[] = navigation.sort((a: TreeNavigation) => {
+            return a.type === NavigationDataType.children ? 1 : -1;
+        });
+
+        return sortedNavigation.map((navigationItem: TreeNavigation, index: number) => {
             const navigationLength: number = navigation.length;
             const positionInNavigation: number = index + 1;
 
@@ -353,6 +362,20 @@ export default class Navigation extends Foundation<
                 nodes[currentIndex - 1].focus();
             }
         }
+    }
+
+    private getItemClassName(dataType: NavigationDataType): string {
+        let classes: string = this.props.managedClasses.navigation_item;
+
+        if (dataType === NavigationDataType.childrenItem) {
+            classes = `${classes} ${get(
+                this.props,
+                "managedClasses.navigation_item__childItem",
+                ""
+            )}`;
+        }
+
+        return classes;
     }
 
     private getItemContentClassName(dataLocation: string): string {

--- a/packages/fast-tooling-react/src/navigation/navigation.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation.tsx
@@ -245,9 +245,11 @@ export default class Navigation extends Foundation<
         level: number
     ): React.ReactNode {
         // Sort items so that childrenItems are weighted towards the top
-        const sortedNavigation: TreeNavigation[] = navigation.sort((a: TreeNavigation) => {
-            return a.type === NavigationDataType.children ? 1 : -1;
-        });
+        const sortedNavigation: TreeNavigation[] = navigation.sort(
+            (a: TreeNavigation) => {
+                return a.type === NavigationDataType.children ? 1 : -1;
+            }
+        );
 
         return sortedNavigation.map((navigationItem: TreeNavigation, index: number) => {
             const navigationLength: number = navigation.length;


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Adds the following:
- Direct nesting of default React children
- Adds distinction between children items and other complex objects by italicizing non-children items
- Sorts items to nest non-children before children

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Resolves #1831 #1832

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->