### PR TITLE
feat: add neutral divider color recipe.

### DIFF
--- a/packages/fast-color-explorer/app/color-blocks.tsx
+++ b/packages/fast-color-explorer/app/color-blocks.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { ButtonClassNameContract } from "@microsoft/fast-components-react-base";
+import {
+    ButtonClassNameContract,
+    DividerClassNameContract,
+} from "@microsoft/fast-components-react-base";
 import {
     accentFillActive,
     accentFillHover,
@@ -11,6 +14,7 @@ import {
     accentForegroundRest,
     backgroundColor,
     fontWeight,
+    neutralDivider,
     neutralFillActive,
     neutralFillHover,
     neutralFillInputRest,
@@ -23,7 +27,6 @@ import {
     neutralFocus,
     neutralForegroundActive,
     neutralForegroundHint,
-    neutralForegroundHintLarge,
     neutralForegroundHover,
     neutralForegroundRest,
     neutralOutlineActive,
@@ -40,6 +43,7 @@ import {
     Caption,
     CaptionClassNameContract,
     Checkbox,
+    Divider,
     Hypertext,
     Paragraph,
     ParagraphClassNameContract,
@@ -212,6 +216,16 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
             color: neutralForegroundHint,
         },
     };
+
+    private dividerStyleOverrides: ComponentStyleSheet<
+        DividerClassNameContract,
+        ColorsDesignSystem
+    > = {
+        divider: {
+            width: "150px",
+        },
+    };
+
     constructor(props: ColorBlocksProps) {
         super(props);
 
@@ -552,6 +566,16 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
                     recipeName="neutralOutlineHover"
                 />
                 <FocusSwatch fillRecipe={accentFillRest} />
+                {this.renderExample(
+                    <Divider jssStyleSheet={this.dividerStyleOverrides} />
+                )}
+                <Swatch
+                    type={SwatchTypes.outline}
+                    fillRecipe={backgroundColor}
+                    foregroundRecipe={neutralForegroundRest}
+                    outlineRecipe={neutralDivider}
+                    recipeName="neutralDivider"
+                />
             </React.Fragment>
         );
     }

--- a/packages/fast-color-explorer/app/color-blocks.tsx
+++ b/packages/fast-color-explorer/app/color-blocks.tsx
@@ -14,7 +14,7 @@ import {
     accentForegroundRest,
     backgroundColor,
     fontWeight,
-    neutralDivider,
+    neutralDividerRest,
     neutralFillActive,
     neutralFillHover,
     neutralFillInputRest,
@@ -573,8 +573,8 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
                     type={SwatchTypes.outline}
                     fillRecipe={backgroundColor}
                     foregroundRecipe={neutralForegroundRest}
-                    outlineRecipe={neutralDivider}
-                    recipeName="neutralDivider"
+                    outlineRecipe={neutralDividerRest}
+                    recipeName="neutralDividerRest"
                 />
             </React.Fragment>
         );

--- a/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
+++ b/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
@@ -211,6 +211,11 @@ export default {
             type: "number",
             default: 16,
         },
+        neutralDividerDelta: {
+            title: "Neutral divider delta",
+            type: "number",
+            default: 6,
+        },
         neutralOutlineRestDelta: {
             title: "Neutral outline rest delta",
             type: "number",

--- a/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
+++ b/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
@@ -211,8 +211,8 @@ export default {
             type: "number",
             default: 16,
         },
-        neutralDividerDelta: {
-            title: "Neutral divider delta",
+        neutralDividerRestDelta: {
+            title: "Neutral divider rest delta",
             type: "number",
             default: 6,
         },

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -160,6 +160,11 @@ export interface DesignSystem {
     neutralForegroundActiveDelta: number;
 
     /**
+     * Color swatch delta for the neutral-divider recipe.
+     */
+    neutralDividerDelta: number;
+
+    /**
      * Color swatch deltas for the neutral-outline recipe.
      */
     neutralOutlineRestDelta: number;
@@ -225,6 +230,8 @@ const designSystemDefaults: DesignSystem = {
 
     neutralForegroundHoverDelta: 0,
     neutralForegroundActiveDelta: 0,
+
+    neutralDividerDelta: 6,
 
     neutralOutlineRestDelta: 25,
     neutralOutlineHoverDelta: 40,

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -162,7 +162,7 @@ export interface DesignSystem {
     /**
      * Color swatch delta for the neutral-divider recipe.
      */
-    neutralDividerDelta: number;
+    neutralDividerRestDelta: number;
 
     /**
      * Color swatch deltas for the neutral-outline recipe.
@@ -231,7 +231,7 @@ const designSystemDefaults: DesignSystem = {
     neutralForegroundHoverDelta: 0,
     neutralForegroundActiveDelta: 0,
 
-    neutralDividerDelta: 6,
+    neutralDividerRestDelta: 6,
 
     neutralOutlineRestDelta: 25,
     neutralOutlineHoverDelta: 40,

--- a/packages/fast-components-styles-msft/src/divider/index.ts
+++ b/packages/fast-components-styles-msft/src/divider/index.ts
@@ -3,7 +3,7 @@ import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { DividerClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { format, toPx } from "@microsoft/fast-jss-utilities";
 import { outlineWidth } from "../utilities/design-system";
-import { neutralDivider } from "../utilities/color/neutral-divider";
+import { neutralDividerRest } from "../utilities/color/neutral-divider";
 
 const styles: ComponentStyles<DividerClassNameContract, DesignSystem> = {
     divider: {
@@ -14,7 +14,7 @@ const styles: ComponentStyles<DividerClassNameContract, DesignSystem> = {
         borderTop: format<DesignSystem>(
             "{0} solid {1}",
             toPx(outlineWidth),
-            neutralDivider
+            neutralDividerRest
         ),
         transition: "all 0.2s ease-in-out",
     },

--- a/packages/fast-components-styles-msft/src/divider/index.ts
+++ b/packages/fast-components-styles-msft/src/divider/index.ts
@@ -1,11 +1,9 @@
-import designSystemDefaults, {
-    DesignSystem,
-    withDesignSystemDefaults,
-} from "../design-system";
-import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
-import { neutralOutlineRest } from "../utilities/color";
+import { DesignSystem } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { DividerClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { format } from "@microsoft/fast-jss-utilities";
+import { format, toPx } from "@microsoft/fast-jss-utilities";
+import { outlineWidth } from "../utilities/design-system";
+import { neutralDivider } from "../utilities/color/neutral-divider";
 
 const styles: ComponentStyles<DividerClassNameContract, DesignSystem> = {
     divider: {
@@ -13,7 +11,11 @@ const styles: ComponentStyles<DividerClassNameContract, DesignSystem> = {
         height: "0",
         margin: "0",
         border: "none",
-        borderTop: format<DesignSystem>("1px solid {0}", neutralOutlineRest),
+        borderTop: format<DesignSystem>(
+            "{0} solid {1}",
+            toPx(outlineWidth),
+            neutralDivider
+        ),
         transition: "all 0.2s ease-in-out",
     },
 };

--- a/packages/fast-components-styles-msft/src/utilities/color/index.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/index.ts
@@ -78,6 +78,8 @@ export {
     neutralOutlineActive,
 } from "./neutral-outline";
 
+export { neutralDivider } from "./neutral-divider";
+
 /**
  * App layer exports
  */

--- a/packages/fast-components-styles-msft/src/utilities/color/index.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/index.ts
@@ -78,7 +78,7 @@ export {
     neutralOutlineActive,
 } from "./neutral-outline";
 
-export { neutralDivider } from "./neutral-divider";
+export { neutralDividerRest } from "./neutral-divider";
 
 /**
  * App layer exports

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-divider.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-divider.spec.ts
@@ -1,0 +1,12 @@
+import designSystemDefaults from "../../design-system";
+import { neutralDividerRest } from "./neutral-divider";
+
+describe("neutralDividerRest", (): void => {
+    test("should return a string when invoked with an object", (): void => {
+        expect(typeof neutralDividerRest(designSystemDefaults)).toBe("string");
+    });
+
+    test("should return a function when invoked with a function", (): void => {
+        expect(typeof neutralDividerRest(() => "#FFF")).toBe("function");
+    });
+});

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-divider.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-divider.ts
@@ -1,5 +1,5 @@
-import { DesignSystem, DesignSystemResolver } from "../../design-system";
-import { neutralDividerDelta } from "../design-system";
+import { DesignSystem } from "../../design-system";
+import { neutralDividerRestDelta } from "../design-system";
 import {
     findClosestBackgroundIndex,
     getSwatch,
@@ -7,16 +7,19 @@ import {
     Palette,
     PaletteType,
 } from "./palette";
+import { colorRecipeFactory, Swatch, SwatchRecipe, SwatchResolver } from "./common";
 
-export const neutralDivider: DesignSystemResolver<string> = (
-    designSystem: DesignSystem
-): string => {
+const neutralDividerAlgorithm: SwatchResolver = (designSystem: DesignSystem): Swatch => {
     const neutralPalette: Palette = palette(PaletteType.neutral)(designSystem);
     const backgroundIndex: number = findClosestBackgroundIndex(designSystem);
-    const delta: number = neutralDividerDelta(designSystem);
+    const delta: number = neutralDividerRestDelta(designSystem);
     const swapThreshold: number = neutralPalette.length - delta;
     const direction: 1 | -1 = backgroundIndex >= swapThreshold ? -1 : 1;
 
     const index: number = backgroundIndex + direction * delta;
     return getSwatch(index, neutralPalette);
 };
+
+export const neutralDividerRest: SwatchRecipe = colorRecipeFactory<Swatch>(
+    neutralDividerAlgorithm
+);

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-divider.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-divider.ts
@@ -1,0 +1,22 @@
+import { DesignSystem, DesignSystemResolver } from "../../design-system";
+import { neutralDividerDelta } from "../design-system";
+import {
+    findClosestBackgroundIndex,
+    getSwatch,
+    palette,
+    Palette,
+    PaletteType,
+} from "./palette";
+
+export const neutralDivider: DesignSystemResolver<string> = (
+    designSystem: DesignSystem
+): string => {
+    const neutralPalette: Palette = palette(PaletteType.neutral)(designSystem);
+    const backgroundIndex: number = findClosestBackgroundIndex(designSystem);
+    const delta: number = neutralDividerDelta(designSystem);
+    const swapThreshold: number = neutralPalette.length - delta;
+    const direction: 1 | -1 = backgroundIndex >= swapThreshold ? -1 : 1;
+
+    const index: number = backgroundIndex + direction * delta;
+    return getSwatch(index, neutralPalette);
+};

--- a/packages/fast-components-styles-msft/src/utilities/design-system.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.ts
@@ -183,6 +183,10 @@ export const neutralForegroundActiveDelta: DesignSystemResolver<
     number
 > = getDesignSystemValue("neutralForegroundActiveDelta");
 
+export const neutralDividerDelta: DesignSystemResolver<number> = getDesignSystemValue(
+    "neutralDividerDelta"
+);
+
 export const neutralOutlineRestDelta: DesignSystemResolver<number> = getDesignSystemValue(
     "neutralOutlineRestDelta"
 );

--- a/packages/fast-components-styles-msft/src/utilities/design-system.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.ts
@@ -183,8 +183,8 @@ export const neutralForegroundActiveDelta: DesignSystemResolver<
     number
 > = getDesignSystemValue("neutralForegroundActiveDelta");
 
-export const neutralDividerDelta: DesignSystemResolver<number> = getDesignSystemValue(
-    "neutralDividerDelta"
+export const neutralDividerRestDelta: DesignSystemResolver<number> = getDesignSystemValue(
+    "neutralDividerRestDelta"
 );
 
 export const neutralOutlineRestDelta: DesignSystemResolver<number> = getDesignSystemValue(


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Added neutral divider color recipe.

## Motivation & context

The outline recipe is too strong for use as a divider line in many places. This can be thought of as an alternative to a drop shadow for separating content areas. Like a drop shadow, it stays dark as long as possible, even in dark mode.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->