### PR TITLE
fix: accent color inner focus

### DIFF
--- a/packages/fast-color-explorer/app/color-blocks.tsx
+++ b/packages/fast-color-explorer/app/color-blocks.tsx
@@ -25,6 +25,7 @@ import {
     neutralFillStealthRest,
     neutralFillStealthSelected,
     neutralFocus,
+    neutralFocusInnerAccent,
     neutralForegroundActive,
     neutralForegroundHint,
     neutralForegroundHover,
@@ -144,12 +145,13 @@ function AccentFillSwatch(
 }
 
 function FocusSwatch(
-    props: Omit<SwatchProps, "type" | "foregroundRecipe" | "recipeName">
+    props: Omit<SwatchProps, "type" | "fillRecipe" | "foregroundRecipe" | "recipeName">
 ): JSX.Element {
     return (
         <Swatch
             {...props}
             type={SwatchTypes.outline}
+            fillRecipe={backgroundColor}
             foregroundRecipe={neutralFocus}
             outlineRecipe={neutralFocus}
             recipeName="neutralFocus"
@@ -320,7 +322,14 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
                     foregroundRecipe={accentForegroundCut}
                     recipeName="accentForegroundCut"
                 />
-                <FocusSwatch fillRecipe={accentFillRest} />
+                <Swatch
+                    type={SwatchTypes.outline}
+                    fillRecipe={neutralFocus}
+                    foregroundRecipe={neutralFocusInnerAccent(accentFillRest)}
+                    outlineRecipe={neutralFocusInnerAccent(accentFillRest)}
+                    recipeName="neutralFocusInnerAccent"
+                />
+                <FocusSwatch />
 
                 {/* Neutral component */}
                 {this.renderExample(<Button>Neutral</Button>)}
@@ -346,7 +355,7 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
                     foregroundRecipe={neutralForegroundRest}
                     recipeName="neutralForegroundRest"
                 />
-                <FocusSwatch fillRecipe={accentFillRest} />
+                <FocusSwatch />
 
                 {/* Outline component */}
                 {this.renderExample(
@@ -395,7 +404,7 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
                     foregroundRecipe={neutralForegroundRest}
                     recipeName="neutralForegroundRest"
                 />
-                <FocusSwatch fillRecipe={accentFillRest} />
+                <FocusSwatch />
 
                 {/* Outline component */}
                 {this.renderExample(
@@ -430,7 +439,7 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
                     foregroundRecipe={neutralForegroundRest}
                     recipeName="neutralForegroundRest"
                 />
-                <FocusSwatch fillRecipe={accentFillRest} />
+                <FocusSwatch />
             </React.Fragment>
         );
     }
@@ -492,7 +501,7 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
                     foregroundRecipe={accentForegroundActive}
                     recipeName="accentForegroundActive"
                 />
-                <FocusSwatch fillRecipe={accentFillRest} />
+                <FocusSwatch />
             </React.Fragment>
         );
     }
@@ -533,7 +542,7 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
                     outlineRecipe={neutralOutlineHover}
                     recipeName="neutralOutlineHover"
                 />
-                <FocusSwatch fillRecipe={accentFillRest} />
+                <FocusSwatch />
                 {this.renderExample(
                     <Checkbox inputId={uniqueId()}>
                         <label slot="label">Checkbox</label>
@@ -565,7 +574,7 @@ class ColorBlocksBase extends React.Component<ColorBlocksProps, ColorBlocksState
                     outlineRecipe={neutralOutlineHover}
                     recipeName="neutralOutlineHover"
                 />
-                <FocusSwatch fillRecipe={accentFillRest} />
+                <FocusSwatch />
                 {this.renderExample(
                     <Divider jssStyleSheet={this.dividerStyleOverrides} />
                 )}

--- a/packages/fast-color-explorer/app/swatch.tsx
+++ b/packages/fast-color-explorer/app/swatch.tsx
@@ -202,11 +202,9 @@ function iconFactoryByType(type: SwatchTypes): SwatchIconFactory {
                     : type === SwatchTypes.outline && typeof outlineRecipe === "function"
                         ? outlineRecipe
                         : fillRecipe,
-                type === SwatchTypes.foreground
+                type === SwatchTypes.foreground || type === SwatchTypes.outline
                     ? fillRecipe
-                    : type === SwatchTypes.outline && typeof fillRecipe === "function"
-                        ? fillRecipe
-                        : backgroundColor
+                    : backgroundColor
             )(designSystem);
             const tooltip: string =
                 type === SwatchTypes.fill && typeof foregroundRecipe === "function"

--- a/packages/fast-color-explorer/app/swatch.tsx
+++ b/packages/fast-color-explorer/app/swatch.tsx
@@ -147,7 +147,7 @@ function iconStyleOverrides(
                           ? outlineRecipe(designSystem)
                           : fillRecipe(designSystem)
                   }`,
-                  backgroundColor: "transparent",
+                  backgroundColor: fillRecipe(designSystem),
               }
             : type === SwatchTypes.foreground
                 ? {
@@ -202,7 +202,11 @@ function iconFactoryByType(type: SwatchTypes): SwatchIconFactory {
                     : type === SwatchTypes.outline && typeof outlineRecipe === "function"
                         ? outlineRecipe
                         : fillRecipe,
-                type === SwatchTypes.foreground ? fillRecipe : backgroundColor
+                type === SwatchTypes.foreground
+                    ? fillRecipe
+                    : type === SwatchTypes.outline && typeof fillRecipe === "function"
+                        ? fillRecipe
+                        : backgroundColor
             )(designSystem);
             const tooltip: string =
                 type === SwatchTypes.fill && typeof foregroundRecipe === "function"

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-focus.ts
@@ -62,12 +62,7 @@ function neutralFocusInnerAccentDirectionResolver(
     palette: string[],
     designSystem: DesignSystem
 ): 1 | -1 {
-    return isDarkMode({
-        ...designSystem,
-        backgroundColor: palette[referenceIndex],
-    })
-        ? -1
-        : 1;
+    return isDarkMode(designSystem) ? 1 : -1;
 }
 
 export function neutralFocusInnerAccent(


### PR DESCRIPTION
# Description

Fixed accent color inner focus to work with container light/dark mode.
Added swatch for inner accent color.
Updated contrast calculation to support this different relationship.

## Motivation & context

The inner focus ring for accent color was correctly 3.5 : 1 against the outer ring, but going darker on very light backgrounds instead of lighter. Updated to fit desired styling.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->