### PR TITLE
fix: updates fill being applied to flipper svg in dark slide theme in carousel

### DIFF
--- a/packages/fast-components-styles-msft/src/carousel/index.ts
+++ b/packages/fast-components-styles-msft/src/carousel/index.ts
@@ -149,6 +149,9 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                     borderColor: darkModeNeutralForegroundRest,
                 },
             },
+            "& > svg": {
+                fill: darkModeNeutralForegroundRest,
+            },
         },
         "& $carousel_sequenceIndicator": {
             "&::before": {
@@ -184,6 +187,9 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                 "& span::before": {
                     borderColor: lightModeNeutralForegroundRest,
                 },
+            },
+            "& > svg": {
+                fill: lightModeNeutralForegroundRest,
             },
         },
         "& $carousel_sequenceIndicator": {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Addresses fill being applied to flipper svg in dark slide theme in carousel.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->