### PR TITLE
fix: Navigation arrows should only tip 45 degrees

### DIFF
--- a/packages/fast-tooling-react/src/navigation/navigation.style.ts
+++ b/packages/fast-tooling-react/src/navigation/navigation.style.ts
@@ -58,10 +58,11 @@ const styles: ComponentStyles<NavigationClassNameContract, {}> = {
             borderBottom: "3px solid transparent",
         },
         '&[aria-expanded="true"] > $navigation_itemContent::before': {
-            borderTop: `3px solid ${foreground300}`,
-            borderLeft: "3px solid transparent",
+            borderTop: "3px solid transparent",
+            borderLeft: `3px solid ${foreground300}`,
             borderRight: "3px solid transparent",
             borderBottom: "3px solid transparent",
+            transform: "rotate(45deg)",
         },
     },
     navigation_item__childItem: {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
expanded arrow does not match design.

after:
![image](https://user-images.githubusercontent.com/37851214/61156742-001f7280-a4a9-11e9-8ee1-0448d04e2be1.png)

Closes: #1933 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->