### PR TITLE
feat: add regex pattern for HEX value in design system schema

### DIFF
--- a/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
+++ b/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
@@ -232,18 +232,6 @@ export default {
             type: "number",
             default: 18,
         },
-        neutralPalette: {
-            title: "Neutral palette",
-            type: "string",
-            pattern: "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
-            default: "#808080"
-        },
-        accentPalette: {
-            title: "Accent palette",
-            type: "string",
-            pattern: "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
-            default: "#0078D4"
-        },
         accentBaseColor: {
             title: "Accent base color",
             type: "string",

--- a/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
+++ b/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
@@ -8,6 +8,7 @@ export default {
         backgroundColor: {
             title: "Background color",
             type: "string",
+            pattern: "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
             default: "#FFFFFF",
             disabled: true,
         },
@@ -231,5 +232,23 @@ export default {
             type: "number",
             default: 18,
         },
+        neutralPalette: {
+            title: "Neutral palette",
+            type: "string",
+            pattern: "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+            default: "#808080"
+        },
+        accentPalette: {
+            title: "Accent palette",
+            type: "string",
+            pattern: "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+            default: "#0078D4"
+        },
+        accentBaseColor: {
+            title: "Accent base color",
+            type: "string",
+            pattern: "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+            default: "#0078D4"
+        }
     },
 };

--- a/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
+++ b/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
@@ -236,7 +236,7 @@ export default {
             title: "Accent base color",
             type: "string",
             pattern: "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
-            default: "#0078D4"
-        }
+            default: "#0078D4",
+        },
     },
 };


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Added HEX value `pattern` property to schema for `backgroundColor` and `accentBaseColor`

closes #1945 

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->