### PR TITLE
fix: remove unnecessary z-index value in select menu styling

### DIFF
--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -63,7 +63,6 @@ const styles: ComponentStyles<SelectClassNameContract, DesignSystem> = {
         background: neutralFillStealthRest,
         ...applyElevatedCornerRadius(),
         ...applyElevation(ElevationMultiplier.e11),
-        zIndex: "1",
         position: "relative",
         width: "100%",
         margin: "0",


### PR DESCRIPTION
# Description
An apparently unnecessary z-index = 1 css style was being applied to the select menu and was causing z-index issues with some layouts.

It is unlikely but possible that this style change could impact some layouts.  If that is an issue the fix is to add a stylesheet override for the "select_menu" classname which applies the desired z-index to the menu.

## Motivation & context
Fixes this bug (the first two issues in the bug were already fixed by updating fast-dna):
https://github.com/microsoft/fast-dna/issues/1958

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.