### PR TITLE
fix: [toggle] make selected & unselected messages optional 

### DIFF
--- a/packages/fast-components-react-base/src/toggle/toggle.props.ts
+++ b/packages/fast-components-react-base/src/toggle/toggle.props.ts
@@ -40,17 +40,17 @@ export interface ToggleHandledProps extends ToggleManagedClasses {
     /**
      * The text to display when selected
      */
-    selectedMessage: string;
+    selectedMessage?: string;
 
     /**
      * The status label HTML id attribute
      */
-    statusMessageId: string;
+    statusMessageId?: string;
 
     /**
      * The text to display when unselected
      */
-    unselectedMessage: string;
+    unselectedMessage?: string;
 }
 
 export type ToggleProps = ToggleHandledProps & ToggleUnhandledProps;

--- a/packages/fast-components-react-base/src/toggle/toggle.schema.ts
+++ b/packages/fast-components-react-base/src/toggle/toggle.schema.ts
@@ -43,5 +43,5 @@ export default {
             defaults: ["text"],
         },
     },
-    required: ["id", "selectedMessage", "statusMessageId", "unselectedMessage"],
+    required: ["id"],
 };

--- a/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
@@ -24,6 +24,7 @@ describe("toggle", (): void => {
         toggle_toggleButton: "toggle-wrapper-class",
         toggle_input: "toggle-input-class",
         toggle_stateIndicator: "toggle-button-class",
+        toggle_statusMessage: "toggle_statusMessage-class",
     };
     const handledProps: ToggleHandledProps = {
         managedClasses,
@@ -123,4 +124,17 @@ describe("toggle", (): void => {
         rendered.find(inputSelector).simulate("change");
         expect(rendered.state("selected")).toEqual(true);
     });
+
+    test("should render status message when unselected or selected message prop is passed", () => {
+        const rendered: any = shallow(<Toggle inputId="id" {...handledProps} selected={false} />);
+
+        expect(rendered.exists("span.toggle_statusMessage-class")).toBe(true);
+        // expect(rendered.exists("div.breadcrumb-separator-class")).toBe(true);
+    })
+
+    test("should not render status message when unselected and selected message prop is not passed", () => {
+        const rendered: any = shallow(<Toggle inputId="id" managedClasses={managedClasses} selected={false} />);
+
+        expect(rendered.exists("span.toggle_statusMessage-class")).toBe(false);
+    })
 });

--- a/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
@@ -126,15 +126,19 @@ describe("toggle", (): void => {
     });
 
     test("should render status message when unselected or selected message prop is passed", () => {
-        const rendered: any = shallow(<Toggle inputId="id" {...handledProps} selected={false} />);
+        const rendered: any = shallow(
+            <Toggle inputId="id" {...handledProps} selected={false} />
+        );
 
         expect(rendered.exists("span.toggle_statusMessage-class")).toBe(true);
         // expect(rendered.exists("div.breadcrumb-separator-class")).toBe(true);
-    })
+    });
 
     test("should not render status message when unselected and selected message prop is not passed", () => {
-        const rendered: any = shallow(<Toggle inputId="id" managedClasses={managedClasses} selected={false} />);
+        const rendered: any = shallow(
+            <Toggle inputId="id" managedClasses={managedClasses} selected={false} />
+        );
 
         expect(rendered.exists("span.toggle_statusMessage-class")).toBe(false);
-    })
+    });
 });

--- a/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
@@ -131,7 +131,6 @@ describe("toggle", (): void => {
         );
 
         expect(rendered.exists("span.toggle_statusMessage-class")).toBe(true);
-        // expect(rendered.exists("div.breadcrumb-separator-class")).toBe(true);
     });
 
     test("should not render status message when unselected and selected message prop is not passed", () => {

--- a/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
@@ -147,7 +147,7 @@ describe("toggle", (): void => {
         );
 
         const span: any = rendered.find("span.toggle_statusMessage-class");
-        const input: any = rendered.find("input.toggle-input-class")
+        const input: any = rendered.find("input.toggle-input-class");
 
         expect(span.prop("id")).toEqual("status-message-id");
         expect(input.prop("aria-describedby")).toEqual("status-message-id");

--- a/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.spec.tsx
@@ -140,4 +140,16 @@ describe("toggle", (): void => {
 
         expect(rendered.exists("span.toggle_statusMessage-class")).toBe(false);
     });
+
+    test("should set id on span and aria-describedby on input when statusMessageId is passed", () => {
+        const rendered: any = shallow(
+            <Toggle inputId="id" {...handledProps} selected={false} />
+        );
+
+        const span: any = rendered.find("span.toggle_statusMessage-class");
+        const input: any = rendered.find("input.toggle-input-class")
+
+        expect(span.prop("id")).toEqual("status-message-id");
+        expect(input.prop("aria-describedby")).toEqual("status-message-id");
+    });
 });

--- a/packages/fast-components-react-base/src/toggle/toggle.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.tsx
@@ -98,12 +98,7 @@ class Toggle extends Foundation<ToggleHandledProps, ToggleUnhandledProps, Toggle
                         )}
                     />
                 </div>
-                <span
-                    id={this.props.statusMessageId}
-                    className={get(this.props, "managedClasses.toggle_statusMessage")}
-                >
-                    {this.generateToggleStateLabel()}
-                </span>
+                {this.renderStatusMessage()}
             </div>
         );
     }
@@ -169,6 +164,19 @@ class Toggle extends Foundation<ToggleHandledProps, ToggleUnhandledProps, Toggle
                     {this.props.children}
                 </label>
             );
+        }
+    }
+
+    private renderStatusMessage(): React.ReactNode {
+        if (this.props.selectedMessage || this.props.unselectedMessage) {
+            return (
+                <span
+                    id={this.props.statusMessageId}
+                    className={get(this.props, "managedClasses.toggle_statusMessage")}
+                >
+                    {this.generateToggleStateLabel()}
+                </span>
+            )
         }
     }
 }

--- a/packages/fast-components-react-base/src/toggle/toggle.tsx
+++ b/packages/fast-components-react-base/src/toggle/toggle.tsx
@@ -176,7 +176,7 @@ class Toggle extends Foundation<ToggleHandledProps, ToggleUnhandledProps, Toggle
                 >
                     {this.generateToggleStateLabel()}
                 </span>
-            )
+            );
         }
     }
 }

--- a/packages/fast-components-react-msft/src/toggle/README.md
+++ b/packages/fast-components-react-msft/src/toggle/README.md
@@ -4,6 +4,6 @@
 
 ## Usage
 
-Only replace the **on** and **off** labels if there are more specific labels for the setting. If there are short, 3-4 character labels that represent binary opposites that are more appropriate for a particular setting, use them. For example, you might use **show** or **hide** if the setting is "Show images." Using more specific labels can help when dealing with different languages.
+Though optional, you should aleways provide a `selectedMessage`, `unselectedMessage` and `statusMessageId` prop. For most cases this should be an **on** and **off** label. If there are short, 3-4 character labels that represent binary opposites that are more appropriate for a particular setting, use them. For example, you might use **show** or **hide** if the setting is "Show images." Using more specific labels can help when dealing with different languages.
 
 If any extra step is required for changes to be effective, you should use *checkbox* and corresponding "Apply" button instead of *toggle*. Users shouldn’t do something else or go somewhere else in order to experience the *toggle's* effect.

--- a/packages/fast-components-react-msft/src/toggle/README.md
+++ b/packages/fast-components-react-msft/src/toggle/README.md
@@ -4,6 +4,6 @@
 
 ## Usage
 
-Though optional, you should aleways provide a `selectedMessage`, `unselectedMessage` and `statusMessageId` prop. For most cases this should be an **on** and **off** label. If there are short, 3-4 character labels that represent binary opposites that are more appropriate for a particular setting, use them. For example, you might use **show** or **hide** if the setting is "Show images." Using more specific labels can help when dealing with different languages.
+Though optional, you should always provide a `selectedMessage`, `unselectedMessage` and `statusMessageId` prop. For most cases this should be an **on** and **off** label. If there are short, 3-4 character labels that represent binary opposites that are more appropriate for a particular setting, use them. For example, you might use **show** or **hide** if the setting is "Show images." Using more specific labels can help when dealing with different languages.
 
 If any extra step is required for changes to be effective, you should use *checkbox* and corresponding "Apply" button instead of *toggle*. Users shouldn’t do something else or go somewhere else in order to experience the *toggle's* effect.

--- a/packages/fast-components-react-msft/src/toggle/toggle.schema.ts
+++ b/packages/fast-components-react-msft/src/toggle/toggle.schema.ts
@@ -49,5 +49,5 @@ export default {
             defaults: ["text"],
         },
     },
-    required: ["id", "selectedMessage", "statusMessageId", "unselectedMessage"],
+    required: ["id"],
 };

--- a/packages/fast-components-react-msft/src/toggle/toggle.stories.tsx
+++ b/packages/fast-components-react-msft/src/toggle/toggle.stories.tsx
@@ -48,4 +48,5 @@ storiesOf("Toggle", module)
         }
         return <ToggleStateHandler>{render}</ToggleStateHandler>;
     })
-    .add("Disabled", () => <Toggle {...toggleProps} disabled={true} />);
+    .add("Disabled", () => <Toggle {...toggleProps} disabled={true} />)
+    .add("No Label", () => <Toggle inputId={uniqueId()}/>)

--- a/packages/fast-components-react-msft/src/toggle/toggle.stories.tsx
+++ b/packages/fast-components-react-msft/src/toggle/toggle.stories.tsx
@@ -49,4 +49,4 @@ storiesOf("Toggle", module)
         return <ToggleStateHandler>{render}</ToggleStateHandler>;
     })
     .add("Disabled", () => <Toggle {...toggleProps} disabled={true} />)
-    .add("No Label", () => <Toggle inputId={uniqueId()}/>)
+    .add("No Label", () => <Toggle inputId={uniqueId()} />);


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Made `selectedMessage`, `statusMessageId` and `unselectedMessage` optional because there are design cases where we don't want a status message.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->