### PR TITLE
feat: add ability to avoid tag rendering for background component

### DIFF
--- a/packages/fast-components-react-msft/src/background/background.props.ts
+++ b/packages/fast-components-react-msft/src/background/background.props.ts
@@ -36,8 +36,9 @@ export enum DarkModeBackgrounds {
 export interface BackgroundHandledProps {
     /**
      * The HTML element to create
+     * If tag is set to null, no HTML element will be created.
      */
-    tag?: keyof React.ReactHTML;
+    tag?: keyof React.ReactHTML | null;
 
     /**
      * The value of the background to set. When set to a number, the value will be

--- a/packages/fast-components-react-msft/src/background/background.spec.tsx
+++ b/packages/fast-components-react-msft/src/background/background.spec.tsx
@@ -25,6 +25,9 @@ describe("Background", (): void => {
     test("should create a div by default", (): void => {
         expect(mount(<Background />).find("div")).toHaveLength(1);
     });
+    test("should not create a div with tag = null", (): void => {
+        expect(mount(<Background tag={null} />).find("div")).toHaveLength(0);
+    });
     test("should accept unhandled props", (): void => {
         expect(
             mount(<Background aria-label="wee" />)

--- a/packages/fast-components-react-msft/src/background/background.tsx
+++ b/packages/fast-components-react-msft/src/background/background.tsx
@@ -76,9 +76,12 @@ export default class Background extends Foundation<
                 designSystem={this.getDesignSystemOverrides(color)}
                 designSystemMergingFunction={this.props.designSystemMergingFunction}
             >
-                <this.tag {...this.unhandledProps()} style={style}>
-                    {this.props.children}
-                </this.tag>
+                {(this.tag && (
+                    <this.tag {...this.unhandledProps()} style={style}>
+                        {this.props.children}
+                    </this.tag>
+                )) ||
+                    this.props.children}
             </DesignSystemProvider>
         );
     };


### PR DESCRIPTION
# Description
Change to background component which allows to avoid tag rendering if tag property is set to null.

## Motivation & context
Avoid of creation of redundant div elements if <background> is used only as background context provider.
https://github.com/microsoft/fast-dna/issues/1982

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [x] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.