### PR TITLE
feat: add slider display value converter

### DIFF
--- a/packages/fast-components-react-base/src/slider/README.md
+++ b/packages/fast-components-react-base/src/slider/README.md
@@ -33,5 +33,9 @@ The "value" prop is used for controlled mode.
 
 The "thumb" prop allows authors to provide custom render functions for the thumb element(s).
 
+The "valuetextStringFormatter" prop enables authors to provide a function to format the "aria-valuetext" attribute of the thumbs.
+
+The "displayValueConverter" prop enables authors to provide a function that converts the underlying slider value to one appropriate to display to the user if those differ.  A likely scenario for this is when the slider is actually selection an array index and the correct thing to report to the user is the value for that index and not the index itself.  This is currently applied to the "aria-valuemin", "aria-valuemax" and "aria-valuenow" attributes of the slider thumbs.
+
 ### Accessibility
 *Slider* implements the recommended keyboard navigation scheme described [here](http://w3c.github.io/aria-practices/examples/slider/multithumb-slider.html).

--- a/packages/fast-components-react-base/src/slider/README.md
+++ b/packages/fast-components-react-base/src/slider/README.md
@@ -35,7 +35,7 @@ The "thumb" prop allows authors to provide custom render functions for the thumb
 
 The "valuetextStringFormatter" prop enables authors to provide a function to format the "aria-valuetext" attribute of the thumbs.
 
-The "displayValueConverter" prop enables authors to provide a function that converts the underlying slider value to one appropriate to display to the user if those differ.  A likely scenario for this is when the slider is actually selection an array index and the correct thing to report to the user is the value for that index and not the index itself.  This is currently applied to the "aria-valuemin", "aria-valuemax" and "aria-valuenow" attributes of the slider thumbs.
+The "displayValueConverter" prop enables authors to provide a function that converts the underlying slider value to one that is appropriate to display to the user if those differ.  A likely scenario for this is when the slider is actually selection an array index and the correct thing to report to the user is the value for that index and not the index itself.  This is currently applied to the "aria-valuemin", "aria-valuemax" and "aria-valuenow" attributes of the slider thumbs.
 
 ### Accessibility
 *Slider* implements the recommended keyboard navigation scheme described [here](http://w3c.github.io/aria-practices/examples/slider/multithumb-slider.html).

--- a/packages/fast-components-react-base/src/slider/slider.props.ts
+++ b/packages/fast-components-react-base/src/slider/slider.props.ts
@@ -120,6 +120,15 @@ export interface SliderHandledProps extends SliderManagedClasses {
         sliderState: SliderState,
         thumb: SliderThumb
     ) => string;
+
+    /**
+     * Function which converts the underlying slider value to another value to be displayed to the user.
+     * This may be useful in scenarios such as the case where a slider is selecting indexes in an array and 
+     * the author wants aria to report the value at that index, not the index.
+     */
+    displayValueConverter?: (
+        value: number
+    ) => number;
 }
 
 export type SliderProps = SliderUnhandledProps & SliderHandledProps;

--- a/packages/fast-components-react-base/src/slider/slider.props.ts
+++ b/packages/fast-components-react-base/src/slider/slider.props.ts
@@ -123,12 +123,10 @@ export interface SliderHandledProps extends SliderManagedClasses {
 
     /**
      * Function which converts the underlying slider value to another value to be displayed to the user.
-     * This may be useful in scenarios such as the case where a slider is selecting indexes in an array and 
+     * This may be useful in scenarios such as the case where a slider is selecting indexes in an array and
      * the author wants aria to report the value at that index, not the index.
      */
-    displayValueConverter?: (
-        value: number
-    ) => number;
+    displayValueConverter?: (value: number) => number;
 }
 
 export type SliderProps = SliderUnhandledProps & SliderHandledProps;

--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -615,6 +615,64 @@ describe("Slider", (): void => {
         document.body.removeChild(container);
     });
 
+    test("valuetextStringFormatter gets called and applied", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+        const valueFormatterFn: any = jest.fn();
+        valueFormatterFn.mockReturnValue("test Value");
+
+        const rendered: any = mount(
+            <Slider
+                range={{
+                    minValue: 0,
+                    maxValue: 100,
+                }}
+                mode={SliderMode.adustUpperValue}
+                managedClasses={managedClasses}
+                valuetextStringFormatter={valueFormatterFn}
+            />,
+            {
+                attachTo: container,
+            }
+        );
+
+        expect(valueFormatterFn).toHaveBeenCalledTimes(1);
+        const thumb: any = rendered.find(`.${managedClasses.slider_thumb__upperValue}`);
+        expect(thumb.prop("aria-valuetext")).toBe("test Value");
+
+        document.body.removeChild(container);
+    });
+
+    test("displayValueConverter gets called", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+        const displayValueConverterFn: any = jest.fn();
+        displayValueConverterFn.mockReturnValue(1000);
+
+        const rendered: any = mount(
+            <Slider
+                range={{
+                    minValue: 0,
+                    maxValue: 100,
+                }}
+                mode={SliderMode.adustUpperValue}
+                managedClasses={managedClasses}
+                displayValueConverter={displayValueConverterFn}
+            />,
+            {
+                attachTo: container,
+            }
+        );
+
+        expect(displayValueConverterFn).toHaveBeenCalledTimes(3);
+        const thumb: any = rendered.find(`.${managedClasses.slider_thumb__upperValue}`);
+        expect(thumb.prop("aria-valuenow")).toBe(1000);
+        expect(thumb.prop("aria-valuemin")).toBe(1000);
+        expect(thumb.prop("aria-valuemax")).toBe(1000);
+
+        document.body.removeChild(container);
+    });
+
     // tslint:disable-next-line:no-shadowed-variable
     window.removeEventListener = jest.fn((event: string, callback: any) => {
         map[event] = callback;

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -72,6 +72,7 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
         minThumbLabel: void 0,
         maxThumbLabel: void 0,
         valuetextStringFormatter: void 0,
+        displayValueConverter: void 0,
     };
 
     private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
@@ -490,10 +491,20 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
                 tabIndex={props.disabled === true ? null : 0}
                 onKeyDown={keyDownCallback}
                 onMouseDown={mouseDownCallback}
-                aria-valuemin={props.range.minValue}
-                aria-valuemax={props.range.maxValue}
+                aria-valuemin={ 
+                    typeof props.displayValueConverter === "function"
+                        ? props.displayValueConverter(props.range.minValue)
+                        : props.range.minValue
+                }
+                aria-valuemax={
+                    typeof props.displayValueConverter === "function"
+                        ? props.displayValueConverter(props.range.maxValue)
+                        : props.range.maxValue
+                }
                 aria-valuenow={
-                    thumb === SliderThumb.lowerThumb ? state.lowerValue : state.upperValue
+                    typeof props.displayValueConverter === "function"
+                        ? props.displayValueConverter(thumb === SliderThumb.lowerThumb ? state.lowerValue : state.upperValue)
+                        : thumb === SliderThumb.lowerThumb ? state.lowerValue : state.upperValue
                 }
                 aria-valuetext={
                     typeof props.valuetextStringFormatter === "function"

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -491,7 +491,7 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
                 tabIndex={props.disabled === true ? null : 0}
                 onKeyDown={keyDownCallback}
                 onMouseDown={mouseDownCallback}
-                aria-valuemin={ 
+                aria-valuemin={
                     typeof props.displayValueConverter === "function"
                         ? props.displayValueConverter(props.range.minValue)
                         : props.range.minValue
@@ -503,8 +503,14 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
                 }
                 aria-valuenow={
                     typeof props.displayValueConverter === "function"
-                        ? props.displayValueConverter(thumb === SliderThumb.lowerThumb ? state.lowerValue : state.upperValue)
-                        : thumb === SliderThumb.lowerThumb ? state.lowerValue : state.upperValue
+                        ? props.displayValueConverter(
+                              thumb === SliderThumb.lowerThumb
+                                  ? state.lowerValue
+                                  : state.upperValue
+                          )
+                        : thumb === SliderThumb.lowerThumb
+                            ? state.lowerValue
+                            : state.upperValue
                 }
                 aria-valuetext={
                     typeof props.valuetextStringFormatter === "function"

--- a/packages/fast-components-react-msft/src/slider/README.md
+++ b/packages/fast-components-react-msft/src/slider/README.md
@@ -1,7 +1,10 @@
 # Slider
+
 The *slider* component allows the user to move one or two "thumb" elements along a vertical or horizontal axis to select a value or range. It is very similar in usage to the html input "range" element.
 
 ### Usage
+The component is not usable (or even visible) without styling as many parts have zero height or width without it.
+
 As the user moves the slider the resulting value changes can be used by developers in two ways:
 - If the *slider* component is part of a form the results will be submitted along with the form. This is because the *slider* component maintains a hidden native HTML input element in the dom and updates the "value" attribute of the native component as selection changes.
 - Developers can hook up to the *select*'s onValueChange callback.
@@ -29,6 +32,10 @@ The "pageStep" prop specifies the amount the slider increments when the page up/
 The "value" prop is used for controlled mode.
 
 The "thumb" prop allows authors to provide custom render functions for the thumb element(s).
+
+The "valuetextStringFormatter" prop enables authors to provide a function to format the "aria-valuetext" attribute of the thumbs.
+
+The "displayValueConverter" prop enables authors to provide a function that converts the underlying slider value to one that is appropriate to display to the user if those differ.  A likely scenario for this is when the slider is actually selection an array index and the correct thing to report to the user is the value for that index and not the index itself.  This is currently applied to the "aria-valuemin", "aria-valuemax" and "aria-valuenow" attributes of the slider thumbs.
 
 ### Accessibility
 *Slider* implements the recommended keyboard navigation scheme described [here](http://w3c.github.io/aria-practices/examples/slider/multithumb-slider.html).


### PR DESCRIPTION
# Description
Adds a prop by which developers can convert a slider value before it is shown to the user (through screen readers at this point as developers already have control of labels).

## Motivation & context
This was an issue dev encountered and the idea that a developper could want to use a slider to select values in an array seemed like a general use case we should support.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->