### PR TITLE
fix: high contrast for slider component

### DIFF
--- a/packages/fast-components-styles-msft/src/slider-label/index.ts
+++ b/packages/fast-components-styles-msft/src/slider-label/index.ts
@@ -30,6 +30,9 @@ const styles: ComponentStyles<SliderLabelClassNameContract, DesignSystem> = {
 
     sliderLabel_tickMark: {
         background: neutralOutlineRest,
+        "@media (-ms-high-contrast:active)": {
+            background: "ButtonHighlight",
+        },
     },
 
     sliderLabel__positionMin: {},

--- a/packages/fast-components-styles-msft/src/slider-label/index.ts
+++ b/packages/fast-components-styles-msft/src/slider-label/index.ts
@@ -31,7 +31,7 @@ const styles: ComponentStyles<SliderLabelClassNameContract, DesignSystem> = {
     sliderLabel_tickMark: {
         background: neutralOutlineRest,
         "@media (-ms-high-contrast:active)": {
-            background: "ButtonHighlight",
+            background: "ButtonText",
         },
     },
 

--- a/packages/fast-components-styles-msft/src/slider/index.ts
+++ b/packages/fast-components-styles-msft/src/slider/index.ts
@@ -70,6 +70,9 @@ const styles: ComponentStyles<SliderClassNameContract, DesignSystem> = {
         "&:active": {
             background: neutralForegroundActive,
         },
+        "@media (-ms-high-contrast:active)": {
+            background: "ButtonText",
+        },
     },
     slider_thumb__lowerValue: {},
     slider_thumb__upperValue: {},
@@ -77,11 +80,17 @@ const styles: ComponentStyles<SliderClassNameContract, DesignSystem> = {
     slider_backgroundTrack: {
         ...applyCornerRadius(),
         background: neutralOutlineRest,
+        "@media (-ms-high-contrast:active)": {
+            background: "ButtonShadow",
+        },
     },
     slider_foregroundTrack: {
         ...applyCornerRadius(),
         background: neutralForegroundHint,
         transition: "all 0.1s ease",
+        "@media (-ms-high-contrast:active)": {
+            background: "ButtonHighlight",
+        },
     },
     slider__disabled: {
         ...applyDisabledState(),

--- a/packages/fast-components-styles-msft/src/slider/index.ts
+++ b/packages/fast-components-styles-msft/src/slider/index.ts
@@ -72,6 +72,12 @@ const styles: ComponentStyles<SliderClassNameContract, DesignSystem> = {
         },
         "@media (-ms-high-contrast:active)": {
             background: "ButtonText",
+            "&:hover": {
+                background: "Highlight",
+            },
+            "&:active": {
+                background: "Highlight",
+            },
         },
     },
     slider_thumb__lowerValue: {},
@@ -81,7 +87,7 @@ const styles: ComponentStyles<SliderClassNameContract, DesignSystem> = {
         ...applyCornerRadius(),
         background: neutralOutlineRest,
         "@media (-ms-high-contrast:active)": {
-            background: "ButtonShadow",
+            background: "ButtonText",
         },
     },
     slider_foregroundTrack: {
@@ -89,7 +95,7 @@ const styles: ComponentStyles<SliderClassNameContract, DesignSystem> = {
         background: neutralForegroundHint,
         transition: "all 0.1s ease",
         "@media (-ms-high-contrast:active)": {
-            background: "ButtonHighlight",
+            background: "Highlight",
         },
     },
     slider__disabled: {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Set high contrast media query to slider label tick mark. slider thumb (rest, hover and active state). The background and foreground of the slider track.

High contrast 1
![image](https://user-images.githubusercontent.com/37851220/61494097-1eceaf00-a96a-11e9-8584-0dc9d71f9c95.png)
High contrast 2
![image](https://user-images.githubusercontent.com/37851220/61494111-29894400-a96a-11e9-94ac-99c7e1b7bcff.png)
High contrast black
![image](https://user-images.githubusercontent.com/37851220/61494125-3443d900-a96a-11e9-9ec7-c9b5acdceba3.png)
High contrast white
![image](https://user-images.githubusercontent.com/37851220/61494134-3c037d80-a96a-11e9-8ab0-da65d5fd54ee.png)

closes #1984 

## Motivation & context

When user turns on high contrast the slider does not show up

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->