### PR TITLE
feat: refine css prop editor create row behavior

### DIFF
--- a/packages/fast-tooling-react/src/css-property-editor/property-editor.style.ts
+++ b/packages/fast-tooling-react/src/css-property-editor/property-editor.style.ts
@@ -16,12 +16,15 @@ const styles: ComponentStyles<CSSPropertyEditorClassNameContract, {}> = {
         height: "100%",
         padding: "0",
         margin: "0",
+        outlineWidth: "0",
         fontFamily: "Consolas, monaco, monospace, monospace",
         fontSize: "12px",
     },
     cssPropertyEditor_propertyRegion: {
         display: "inline-block",
         paddingLeft: "20px",
+        width:"100%",
+        outlineWidth: "0",
         "&::before, &::after": {
             marginLeft: "-20px",
         },
@@ -31,6 +34,9 @@ const styles: ComponentStyles<CSSPropertyEditorClassNameContract, {}> = {
         "&::after": {
             content: "'}'",
         },
+    },
+    cssPropertyEditor_row: {
+        outlineWidth: "0"
     },
     cssPropertyEditor_input: {
         background: "transparent",

--- a/packages/fast-tooling-react/src/css-property-editor/property-editor.style.ts
+++ b/packages/fast-tooling-react/src/css-property-editor/property-editor.style.ts
@@ -23,7 +23,7 @@ const styles: ComponentStyles<CSSPropertyEditorClassNameContract, {}> = {
     cssPropertyEditor_propertyRegion: {
         display: "inline-block",
         paddingLeft: "20px",
-        width:"100%",
+        width: "100%",
         outlineWidth: "0",
         "&::before, &::after": {
             marginLeft: "-20px",
@@ -36,7 +36,7 @@ const styles: ComponentStyles<CSSPropertyEditorClassNameContract, {}> = {
         },
     },
     cssPropertyEditor_row: {
-        outlineWidth: "0"
+        outlineWidth: "0",
     },
     cssPropertyEditor_input: {
         background: "transparent",

--- a/packages/fast-tooling-react/src/css-property-editor/property-editor.tsx
+++ b/packages/fast-tooling-react/src/css-property-editor/property-editor.tsx
@@ -294,14 +294,13 @@ export default class CSSPropertyEditor extends Foundation<
         if (e.defaultPrevented) {
             return;
         }
-        if (
+
+        this.createRow(
             !isNil(this.propertyEditorRef.current) &&
             e.nativeEvent.offsetY < this.propertyEditorRef.current.clientHeight / 2
-        ) {
-            this.createRow(0);
-        } else {
-            this.createRow(Object.keys(this.editData).length);
-        }
+                ? 0
+                : Object.keys(this.editData).length
+        );
     };
 
     /**

--- a/packages/fast-tooling-react/src/css-property-editor/property-editor.tsx
+++ b/packages/fast-tooling-react/src/css-property-editor/property-editor.tsx
@@ -120,7 +120,7 @@ export default class CSSPropertyEditor extends Foundation<
                 rowIndex={index}
                 onValueChange={this.handleValueChange}
                 onPropertyNameChange={this.handleKeyChange}
-                onClickOutside={this.handleClickToInsert}
+                onClickOutside={this.handleClickOutside}
                 onCommitPropertyNameEdit={this.handleCommitKeyEdit}
                 onRowBlur={this.handleRowBlur}
                 onRowFocus={this.handleRowFocus}
@@ -283,7 +283,7 @@ export default class CSSPropertyEditor extends Foundation<
     /**
      * Clicks on a row outside the inputs add a row following that row
      */
-    private handleClickToInsert = (rowKey: string, rowIndex: number): void => {
+    private handleClickOutside = (rowKey: string, rowIndex: number): void => {
         this.createRow(rowIndex + 1);
     };
 
@@ -294,7 +294,14 @@ export default class CSSPropertyEditor extends Foundation<
         if (e.defaultPrevented) {
             return;
         }
-        this.createRow(Object.keys(this.editData).length);
+        if (
+            !isNil(this.propertyEditorRef.current) &&
+            e.nativeEvent.offsetY < this.propertyEditorRef.current.clientHeight / 2
+        ) {
+            this.createRow(0);
+        } else {
+            this.createRow(Object.keys(this.editData).length);
+        }
     };
 
     /**


### PR DESCRIPTION
# Description
Some minor tweaks to the css property editor's "click to create row" behavior.  Rows extend to the width of the component to more reliably insert after the click, also check for top/bottom insertion when clicking outside rows.  Hide outlines that could show up on click.

## Motivation & context
Getting closer to matching behavior of edge css prop editor

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.