### PR TITLE
fix: high contrast on toggle component

### DIFF
--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -95,6 +95,16 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         borderRadius: toPx(height),
         appearance: "none",
         outline: "none",
+        "&:active": {
+            background: neutralFillInputActive,
+            borderColor: neutralOutlineActive,
+            "@media (-ms-high-contrast:active)": {
+                background: "Highlight",
+                "& + span": {
+                    background: "Background",
+                },
+            },
+        },
         "&:hover": {
             background: neutralFillInputHover,
             borderColor: neutralOutlineHover,
@@ -104,10 +114,6 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
                     background: "Highlight",
                 },
             },
-        },
-        "&:active": {
-            background: neutralFillInputActive,
-            borderColor: neutralOutlineActive,
         },
         ...applyFocusVisible({
             boxShadow: format<DesignSystem>("0 0 0 1px {0} inset", neutralFocus),
@@ -128,6 +134,14 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             "@media (-ms-high-contrast:active)": {
                 background: "Highlight",
                 borderColor: "Highlight",
+                "&:active": {
+                    "@media (-ms-high-contrast:active)": {
+                        background: "Highlight",
+                        "& + span": {
+                            background: "Background",
+                        },
+                    },
+                },
                 "&:hover": {
                     "@media (-ms-high-contrast:active)": {
                         background: "Background",

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -148,14 +148,14 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
                         borderColor: "Highlight",
                     },
                 },
-            }
+            },
         },
         "& $toggle_stateIndicator": {
             left: toPx(indicatorCheckedLeft),
             background: accentForegroundCut,
             "@media (-ms-high-contrast:active)": {
                 background: "Background",
-            }
+            },
         },
     },
     toggle__disabled: {

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -77,7 +77,7 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         height: toPx(indicatorSize),
         background: neutralForegroundRest,
         "@media (-ms-high-contrast:active)": {
-            backgroundColor: "ButtonHighlight",
+            background: "ButtonText",
         },
     },
     toggle_input: {
@@ -98,6 +98,12 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         "&:hover": {
             background: neutralFillInputHover,
             borderColor: neutralOutlineHover,
+            "@media (-ms-high-contrast:active)": {
+                borderColor: "Highlight",
+                "& + span": {
+                    background: "Highlight",
+                },
+            },
         },
         "&:active": {
             background: neutralFillInputActive,
@@ -107,6 +113,9 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             boxShadow: format<DesignSystem>("0 0 0 1px {0} inset", neutralFocus),
             borderColor: neutralFocus,
         }),
+        "@media (-ms-high-contrast:active)": {
+            borderColor: "ButtonText",
+        },
     },
     toggle__checked: {
         "& $toggle_input": {
@@ -116,10 +125,23 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
                 boxShadow: format<DesignSystem>("0 0 0 1px {0} inset", neutralFocus),
                 borderColor: neutralFocus,
             }),
+            "@media (-ms-high-contrast:active)": {
+                background: "Highlight",
+                borderColor: "Highlight",
+                "&:hover": {
+                    "@media (-ms-high-contrast:active)": {
+                        background: "Background",
+                        borderColor: "Highlight",
+                    },
+                },
+            }
         },
         "& $toggle_stateIndicator": {
             left: toPx(indicatorCheckedLeft),
             background: accentForegroundCut,
+            "@media (-ms-high-contrast:active)": {
+                background: "Background",
+            }
         },
     },
     toggle__disabled: {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Add high contrast media queries to the `input` and `stateIndicator` in both unselected and selected state.

The different states in high contrast mode.
Unselected (High contrast black theme)
rest/hover/active
![image](https://user-images.githubusercontent.com/37851220/61550577-a7e7f380-aa07-11e9-9483-3eef7b211e8e.png)
 
Selected (High contrast black theme)
rest/hover/active
![image](https://user-images.githubusercontent.com/37851220/61550822-5c821500-aa08-11e9-97ca-46a741b47d12.png)

What toggle looks like on selected state, in other high contrast theme.
Selected (High contrast 1 theme)
![image](https://user-images.githubusercontent.com/37851220/61550900-9521ee80-aa08-11e9-9427-fff838206c9e.png)

Selected (High contrast 2 theme)
![image](https://user-images.githubusercontent.com/37851220/61550940-b551ad80-aa08-11e9-8e77-f1d8ae16d224.png)

Selected (High contrast white theme)
![image](https://user-images.githubusercontent.com/37851220/61550946-b84c9e00-aa08-11e9-81a8-dcf826d275ad.png)


## Motivation & context

This solves the issue for when a user sets the toggle to "selected" there is no visual queue letting the user know the toggle is on "selected".

closes #1985 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->