### PR TITLE
fix: resolve plugins against objects without props

### DIFF
--- a/packages/fast-tooling-react/src/data-utilities/location.spec.ts
+++ b/packages/fast-tooling-react/src/data-utilities/location.spec.ts
@@ -380,14 +380,18 @@ describe("getDataLocationsOfPlugins", () => {
             };
         }
 
-        ["", 1, true].map((value: unknown) => getDataLocationsOfPlugins(
-            childrenSchema,
-            factory(value),
-            childOptions
-        )).forEach((pluginLocation: PluginLocation[]): void => {
-            expect(pluginLocation.length).toBe(1);
-            expect(pluginLocation[0].dataLocation).toBe("children.props.children.props.children.props.render");
-        });
+        ["", 1, true]
+            .map((value: unknown) =>
+                getDataLocationsOfPlugins(childrenSchema, factory(value), childOptions)
+            )
+            .forEach(
+                (pluginLocation: PluginLocation[]): void => {
+                    expect(pluginLocation.length).toBe(1);
+                    expect(pluginLocation[0].dataLocation).toBe(
+                        "children.props.children.props.children.props.render"
+                    );
+                }
+            );
     });
     test("should return the data location of a nested react child", () => {
         const data: any = {

--- a/packages/fast-tooling-react/src/data-utilities/location.spec.ts
+++ b/packages/fast-tooling-react/src/data-utilities/location.spec.ts
@@ -358,6 +358,46 @@ describe("getDataLocationsOfPlugins", () => {
         expect(dataLocationsOfPlugins.length).toBe(1);
         expect(dataLocationsOfPlugins[0].dataLocation).toBe("render");
     });
+    test("should return the data location when children is a primitive type", () => {
+        function factory(type: unknown): any {
+            return {
+                children: {
+                    id: childrenSchema.id,
+                    props: {
+                        children: {
+                            id: childrenSchema.id,
+                            props: {
+                                children: {
+                                    id: childrenWithPluginPropsSchema.id,
+                                    props: {
+                                        render: type,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        ["", 1, true].map((value: unknown) => getDataLocationsOfPlugins(
+            childrenSchema,
+            factory(value),
+            childOptions
+        )).forEach((pluginLocation: PluginLocation[]): void => {
+            expect(pluginLocation.length).toBe(1);
+            expect(pluginLocation[0].dataLocation).toBe("children.props.children.props.children.props.render");
+        });
+
+        //        const dataLocationsOfPluginsWithStringChild: PluginLocation[] = getDataLocationsOfPlugins(
+        //            childrenSchema,
+        //            factory("string"),
+        //            childOptions
+        //        );
+        //
+        //        expect(dataLocationsOfPluginsWithStringChild.length).toBe(1);
+        //        expect(dataLocationsOfPluginsWithStringChild[0].dataLocation).toBe("children.props.children.props.children.props.render");
+    });
     test("should return the data location of a nested react child", () => {
         const data: any = {
             children: {

--- a/packages/fast-tooling-react/src/data-utilities/location.spec.ts
+++ b/packages/fast-tooling-react/src/data-utilities/location.spec.ts
@@ -388,15 +388,6 @@ describe("getDataLocationsOfPlugins", () => {
             expect(pluginLocation.length).toBe(1);
             expect(pluginLocation[0].dataLocation).toBe("children.props.children.props.children.props.render");
         });
-
-        //        const dataLocationsOfPluginsWithStringChild: PluginLocation[] = getDataLocationsOfPlugins(
-        //            childrenSchema,
-        //            factory("string"),
-        //            childOptions
-        //        );
-        //
-        //        expect(dataLocationsOfPluginsWithStringChild.length).toBe(1);
-        //        expect(dataLocationsOfPluginsWithStringChild[0].dataLocation).toBe("children.props.children.props.children.props.render");
     });
     test("should return the data location of a nested react child", () => {
         const data: any = {

--- a/packages/fast-tooling-react/src/data-utilities/location.ts
+++ b/packages/fast-tooling-react/src/data-utilities/location.ts
@@ -166,10 +166,20 @@ export function getDataLocationsOfPlugins(
                     }`
                 ) === DataType.children;
             // BUG: this evaluates to `undefined` when data is { children: "foobar" }. This will also fail
-            // when data is { children: [ /* any react node goes here */ ] }
+            // when data is { children: [ /* any primitive react node goes here */ ] }
+            const renderableReactPrimitives: string[] = [
+                true,
+                "",
+                1,
+            ].map((val: unknown) => typeof val);
+
             const childrenProps: any = get(data, `${dataLocation}.${propsKeyword}`);
             const isNotAnArrayOfChildren: boolean =
-                (isChildComponent && typeof childrenProps !== "undefined") ||
+                (isChildComponent &&
+                    (typeof childrenProps !== "undefined" ||
+                        renderableReactPrimitives.includes(
+                            typeof get(data, dataLocation)
+                        ))) ||
                 !isChildComponent;
 
             // check to see if the data location matches with the current schema and includes a plugin identifier

--- a/packages/fast-tooling-react/src/data-utilities/location.ts
+++ b/packages/fast-tooling-react/src/data-utilities/location.ts
@@ -165,8 +165,6 @@ export function getDataLocationsOfPlugins(
                             : `${schemaLocation}.${typeKeyword}`
                     }`
                 ) === DataType.children;
-            // BUG: this evaluates to `undefined` when data is { children: "foobar" }. This will also fail
-            // when data is { children: [ /* any primitive react node goes here */ ] }
             const renderableReactPrimitives: string[] = [
                 true,
                 "",

--- a/packages/fast-tooling-react/src/data-utilities/location.ts
+++ b/packages/fast-tooling-react/src/data-utilities/location.ts
@@ -165,11 +165,9 @@ export function getDataLocationsOfPlugins(
                             : `${schemaLocation}.${typeKeyword}`
                     }`
                 ) === DataType.children;
-            const renderableReactPrimitives: string[] = [
-                true,
-                "",
-                1,
-            ].map((val: unknown) => typeof val);
+            const renderableReactPrimitives: string[] = [true, "", 1].map(
+                (val: unknown) => typeof val
+            );
 
             const childrenProps: any = get(data, `${dataLocation}.${propsKeyword}`);
             const isNotAnArrayOfChildren: boolean =

--- a/packages/fast-tooling-react/src/data-utilities/location.ts
+++ b/packages/fast-tooling-react/src/data-utilities/location.ts
@@ -165,6 +165,8 @@ export function getDataLocationsOfPlugins(
                             : `${schemaLocation}.${typeKeyword}`
                     }`
                 ) === DataType.children;
+            // BUG: this evaluates to `undefined` when data is { children: "foobar" }. This will also fail
+            // when data is { children: [ /* any react node goes here */ ] }
             const childrenProps: any = get(data, `${dataLocation}.${propsKeyword}`);
             const isNotAnArrayOfChildren: boolean =
                 (isChildComponent && typeof childrenProps !== "undefined") ||


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Plugins were only being resolve against data structures that had a "props" key. This meant that a react child would not have a plugin resolved if `children` was of a type other than object, meaning strings, booleans, and numbers could would not be correctly resolved. This fixes that issue.
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->