### PR TITLE
fix: add flag to autosuggest onValueChange event to label when change is from a suggested option

### DIFF
--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.props.ts
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.props.ts
@@ -51,7 +51,7 @@ export interface AutoSuggestHandledProps extends AutoSuggestManagedClasses {
      * The onValueChanged event handler
      * called when text changes in the input region
      */
-    onValueChange?: (value: string) => void;
+    onValueChange?: (value: string, isFromSuggestedOption?: boolean) => void;
 
     /**
      * The onInvoked event handler

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
@@ -288,7 +288,7 @@ describe("auto suggest", (): void => {
 
         expect(onValueChange).toHaveBeenCalledTimes(0);
         const input: any = rendered.find("input");
-        input.simulate("keydown", { keyCode: KeyCodes.colon});
+        input.simulate("keydown", { keyCode: KeyCodes.colon });
         expect(onValueChange).toHaveBeenCalledTimes(1);
         expect(onValueChange.mock.calls[0][1]).toEqual(false);
         document.body.removeChild(container);

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
@@ -290,10 +290,11 @@ describe("auto suggest", (): void => {
         const input: any = rendered.find("input");
         input.simulate("keydown", { keyCode: KeyCodes.colon});
         expect(onValueChange).toHaveBeenCalledTimes(1);
+        expect(onValueChange.mock.calls[0][1]).toEqual(false);
         document.body.removeChild(container);
     });
 
-    test("onValueChanged event handler not called when focus changes in menu", (): void => {
+    test("onValueChanged event handler called with 'isFromSuggestedOption' flag when focus changes in menu", (): void => {
         const container: HTMLDivElement = document.createElement("div");
         document.body.appendChild(container);
 
@@ -312,7 +313,8 @@ describe("auto suggest", (): void => {
         const input: any = rendered.find("input");
         input.simulate("keydown", { keyCode: KeyCodes.arrowDown });
         expect(rendered.state("value")).toBe("a");
-        expect(onValueChange).toHaveBeenCalledTimes(0);
+        expect(onValueChange).toHaveBeenCalledTimes(1);
+        expect(onValueChange.mock.calls[0][1]).toEqual(true);
 
         document.body.removeChild(container);
     });

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
@@ -287,11 +287,32 @@ describe("auto suggest", (): void => {
         );
 
         expect(onValueChange).toHaveBeenCalledTimes(0);
+        const input: any = rendered.find("input");
+        input.simulate("keydown", { keyCode: KeyCodes.colon});
+        expect(onValueChange).toHaveBeenCalledTimes(1);
+        document.body.removeChild(container);
+    });
+
+    test("onValueChanged event handler not called when focus changes in menu", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const onValueChange: any = jest.fn();
+        const rendered: any = mount(
+            <AutoSuggest listboxId="listboxId" onValueChange={onValueChange}>
+                {itemA}
+                {itemB}
+                {itemC}
+            </AutoSuggest>,
+            { attachTo: container }
+        );
+
+        expect(onValueChange).toHaveBeenCalledTimes(0);
         expect(rendered.state("value")).toBe("");
         const input: any = rendered.find("input");
         input.simulate("keydown", { keyCode: KeyCodes.arrowDown });
         expect(rendered.state("value")).toBe("a");
-        expect(onValueChange).toHaveBeenCalledTimes(1);
+        expect(onValueChange).toHaveBeenCalledTimes(0);
 
         document.body.removeChild(container);
     });

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
@@ -245,7 +245,7 @@ class AutoSuggest extends Foundation<
             this.setState({
                 focusedItem: newSelection[0],
             });
-            this.updateValue(newSelection[0].value, false);
+            this.updateValue(newSelection[0].value, true);
         }
     };
 
@@ -281,7 +281,7 @@ class AutoSuggest extends Foundation<
      */
     private handleChange = (e: React.ChangeEvent): void => {
         const newValue: string = (e.target as HTMLInputElement).value;
-        this.updateValue(newValue, true);
+        this.updateValue(newValue, false);
     };
 
     /**
@@ -289,13 +289,12 @@ class AutoSuggest extends Foundation<
      */
     private updateValue = (
             newValue: string,
-            broadcastChange: boolean
+            isFromSuggestedOption: boolean
         ): void => {
         if (
-            broadcastChange &&
             typeof this.props.onValueChange === "function"
         ) {
-            this.props.onValueChange(newValue);
+            this.props.onValueChange(newValue, isFromSuggestedOption);
         }
 
         if (this.props.value !== undefined || newValue !== this.state.value) {
@@ -336,7 +335,7 @@ class AutoSuggest extends Foundation<
             default:
                 if (e.target instanceof HTMLInputElement) {
                     const newValue: string = (e.target as HTMLInputElement).value;
-                    this.updateValue(newValue, true);
+                    this.updateValue(newValue, false);
                     this.focusOnInput();
                     break;
                 }

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
@@ -287,13 +287,8 @@ class AutoSuggest extends Foundation<
     /**
      * Update the currentValue of the component
      */
-    private updateValue = (
-            newValue: string,
-            isFromSuggestedOption: boolean
-        ): void => {
-        if (
-            typeof this.props.onValueChange === "function"
-        ) {
+    private updateValue = (newValue: string, isFromSuggestedOption: boolean): void => {
+        if (typeof this.props.onValueChange === "function") {
             this.props.onValueChange(newValue, isFromSuggestedOption);
         }
 

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
@@ -245,7 +245,7 @@ class AutoSuggest extends Foundation<
             this.setState({
                 focusedItem: newSelection[0],
             });
-            this.updateValue(newSelection[0].value);
+            this.updateValue(newSelection[0].value, false);
         }
     };
 
@@ -281,14 +281,20 @@ class AutoSuggest extends Foundation<
      */
     private handleChange = (e: React.ChangeEvent): void => {
         const newValue: string = (e.target as HTMLInputElement).value;
-        this.updateValue(newValue);
+        this.updateValue(newValue, true);
     };
 
     /**
      * Update the currentValue of the component
      */
-    private updateValue = (newValue: string): void => {
-        if (typeof this.props.onValueChange === "function") {
+    private updateValue = (
+            newValue: string,
+            broadcastChange: boolean
+        ): void => {
+        if (
+            broadcastChange &&
+            typeof this.props.onValueChange === "function"
+        ) {
             this.props.onValueChange(newValue);
         }
 
@@ -330,7 +336,7 @@ class AutoSuggest extends Foundation<
             default:
                 if (e.target instanceof HTMLInputElement) {
                     const newValue: string = (e.target as HTMLInputElement).value;
-                    this.updateValue(newValue);
+                    this.updateValue(newValue, true);
                     this.focusOnInput();
                     break;
                 }


### PR DESCRIPTION
# Description
Added a flag to Autosuggest's onValueChange event to indicate that the change was due to focus on a suggested option.

## Motivation & context
Without something like this page authors are unable to tell whether they should repopulate options as a user navigates the list of options.  This allows them to choose not to refresh the options but still react to changes if they desire.  This is an optional param so not a breaking change.

https://github.com/microsoft/fast-dna/issues/1989

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
