### PR TITLE
fix: normalize data locations of plugins

### DIFF
--- a/packages/fast-tooling-react/src/data-utilities/location.ts
+++ b/packages/fast-tooling-react/src/data-utilities/location.ts
@@ -166,7 +166,10 @@ export function getDataLocationsOfPlugins(
                             : `${schemaLocation}.${typeKeyword}`
                     }`
                 ) === DataType.children;
-            const childrenProps: any = get(data, `${normalizedDataLocation}.${propsKeyword}`);
+            const childrenProps: any = get(
+                data,
+                `${normalizedDataLocation}.${propsKeyword}`
+            );
             const isNotAnArrayOfChildren: boolean =
                 (isChildComponent &&
                     (typeof childrenProps !== "undefined" ||

--- a/packages/fast-tooling-react/src/data-utilities/location.ts
+++ b/packages/fast-tooling-react/src/data-utilities/location.ts
@@ -121,7 +121,7 @@ export function getDataLocationsOfChildren(
     });
 
     return dataLocationsOfChildren.map((dataLocationOfChildren: string) => {
-        return arrayItemsToBracketNotation(dataLocationOfChildren, data);
+        return normalizeDataLocation(dataLocationOfChildren, data);
     });
 }
 
@@ -166,11 +166,11 @@ export function getDataLocationsOfPlugins(
                             : `${schemaLocation}.${typeKeyword}`
                     }`
                 ) === DataType.children;
-            const childrenProps: any = get(data, `${dataLocation}.${propsKeyword}`);
+            const childrenProps: any = get(data, `${normalizedDataLocation}.${propsKeyword}`);
             const isNotAnArrayOfChildren: boolean =
                 (isChildComponent &&
                     (typeof childrenProps !== "undefined" ||
-                        isPrimitiveReactNode(get(data, dataLocation)))) ||
+                        isPrimitiveReactNode(get(data, normalizedDataLocation)))) ||
                 !isChildComponent;
 
             // check to see if the data location matches with the current schema and includes a plugin identifier
@@ -189,7 +189,7 @@ export function getDataLocationsOfPlugins(
                         relativeDataLocation: normalizedDataLocation,
                     });
                 } else {
-                    const subData: any = get(data, dataLocation);
+                    const subData: any = get(data, normalizedDataLocation);
 
                     if (Array.isArray(subData)) {
                         const childrenLength: number = subData.length;
@@ -211,13 +211,13 @@ export function getDataLocationsOfPlugins(
             if (isChildComponent) {
                 // resolve the child id with a child option
                 const childOption: ChildOptionItem = getChildOptionBySchemaId(
-                    get(data, dataLocation).id,
+                    get(data, normalizedDataLocation).id,
                     childOptions
                 );
                 const updatedDataLocationPrefix: string =
                     dataLocationPrefix === ""
                         ? dataLocation
-                        : `${dataLocationPrefix}.${propsKeyword}.${dataLocation}`;
+                        : `${dataLocationPrefix}.${propsKeyword}.${normalizedDataLocation}`;
 
                 if (childOption !== undefined) {
                     dataLocationsOfPlugins = dataLocationsOfPlugins.concat(


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Utilize normalized data locations in plugin location resolution so we don't get miss-matches.
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->