### PR TITLE
fix: tweak CSS editor styling so wrapping brackets are always on different lines

### DIFF
--- a/packages/fast-tooling-react/src/css-property-editor/property-editor.style.ts
+++ b/packages/fast-tooling-react/src/css-property-editor/property-editor.style.ts
@@ -32,6 +32,7 @@ const styles: ComponentStyles<CSSPropertyEditorClassNameContract, {}> = {
             content: "'{'",
         },
         "&::after": {
+            display: "block",
             content: "'}'",
         },
     },


### PR DESCRIPTION
# Description
Tweak CSS so wrapping brackets on css property editor are on their own lines.

## Motivation & context
Noticed that when there were no content in the editor the brackets displayed incorrectly

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
