### PR TITLE
fix: use focus visible in form items that support it

### DIFF
--- a/packages/fast-tooling-react/src/form/form/form-item.checkbox.style.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.checkbox.style.ts
@@ -1,6 +1,9 @@
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager-react";
 import { FormItemCheckboxClassNameContract } from "./form-item.checkbox.props";
 import {
+    applyFocusVisible,
+} from "@microsoft/fast-jss-utilities";
+import {
     applyControlSingleLineWrapper,
     applyFormItemDisabled,
     applyFormItemIndicator,
@@ -49,10 +52,10 @@ const styles: ComponentStyles<FormItemCheckboxClassNameContract, {}> = {
         "&:hover": {
             border: `1px solid ${foreground300}`,
         },
-        "&:focus": {
+        ...applyFocusVisible({
             outline: "none",
             ...insetStrongBoxShadow(foreground300),
-        },
+        }),
         "& + span": {
             position: "absolute",
             left: "0",

--- a/packages/fast-tooling-react/src/form/form/form-item.checkbox.style.ts
+++ b/packages/fast-tooling-react/src/form/form/form-item.checkbox.style.ts
@@ -1,8 +1,6 @@
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager-react";
 import { FormItemCheckboxClassNameContract } from "./form-item.checkbox.props";
-import {
-    applyFocusVisible,
-} from "@microsoft/fast-jss-utilities";
+import { applyFocusVisible } from "@microsoft/fast-jss-utilities";
 import {
     applyControlSingleLineWrapper,
     applyFormItemDisabled,

--- a/packages/fast-tooling-react/src/style/utilities.ts
+++ b/packages/fast-tooling-react/src/style/utilities.ts
@@ -1,5 +1,6 @@
 import { CSSRules } from "@microsoft/fast-jss-manager-react";
 import {
+    applyFocusVisible,
     Direction,
     ellipsis,
     localizeSpacing,
@@ -69,10 +70,10 @@ export function applyInteractiveFormItemIndicator(): CSSRules<{}> {
                 fill: accent,
             },
         },
-        "&:focus": {
+        ...applyFocusVisible({
             borderColor: accent,
             outline: "none",
-        },
+        }),
     };
 }
 
@@ -274,10 +275,10 @@ export function applyRemoveItemStyle(): CSSRules<{}> {
         height: "20px",
         zIndex: "1",
         borderRadius: "2px",
-        "&:focus": {
+        ...applyFocusVisible({
             ...insetStrongBoxShadow(accent),
             outline: "none",
-        },
+        }),
         "&::before": {
             position: "absolute",
             content: "''",
@@ -341,10 +342,10 @@ export function applySoftRemoveInput(): CSSRules<{}> {
         height: "20px",
         zIndex: "1",
         borderRadius: "2px",
-        "&:focus": {
+        ...applyFocusVisible({
             ...insetStrongBoxShadow(accent),
             outline: "none",
-        },
+        }),
         "& + svg": {
             fill: foreground800,
         },


### PR DESCRIPTION
# Description
fix: use focus visible in form items that support it

## Motivation & context
https://github.com/microsoft/fast-dna/issues/1950

I was unable to get the focus visible behavior to work on select elements, so these are excluded for now.

## Issue type checklist
- [] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
