### PR TITLE
fix: ensure enter does not 'click' buttons

### DIFF
--- a/packages/fast-tooling-react/src/form/form/form-item.children.tsx
+++ b/packages/fast-tooling-react/src/form/form/form-item.children.tsx
@@ -165,6 +165,7 @@ class FormItemChildren extends FormItemBase<
                         ref={this.filteredChildrenInput}
                     />
                     <button
+                        type="button" // Ensure the form doesn't see this as a submit button
                         className={
                             this.props.managedClasses.formItemChildren_childrenListTrigger
                         }
@@ -286,6 +287,7 @@ class FormItemChildren extends FormItemBase<
     private renderExistingChildDelete(index: number): JSX.Element {
         return (
             <button
+                type="button" // Ensure the form doesn't see this as a submit button
                 aria-label={"Select to remove"}
                 className={this.props.managedClasses.formItemChildren_deleteButton}
                 onClick={this.clickDeleteComponentFactory(index)}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
The form from form-generator was interpreting the children button controls as submit button, causing weird behavior when the users pressed the "enter" key.
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->