### PR TITLE
fix: allow typing in spinal case for the CSS property name

### DIFF
--- a/packages/fast-tooling-react/src/css-property-editor/property-editor-row.props.ts
+++ b/packages/fast-tooling-react/src/css-property-editor/property-editor-row.props.ts
@@ -7,6 +7,14 @@ export interface CSSPropertyEditorRowClassNameContract {
     cssPropertyEditorRow_inputValue?: string;
 }
 
+export interface CSSPropertyEditorRowState {
+    /**
+     * Retain a check on whether the last key in the property
+     * key is a dash
+     */
+    propertyKeyLastCharacterIsDash: boolean;
+}
+
 export interface CSSPropertyEditorRowUnhandledProps
     extends React.HTMLAttributes<HTMLDivElement> {}
 

--- a/packages/fast-tooling-react/src/css-property-editor/property-editor.spec.tsx
+++ b/packages/fast-tooling-react/src/css-property-editor/property-editor.spec.tsx
@@ -109,6 +109,25 @@ describe("CSSPropertyEditor", () => {
         expect(inputs.at(0).prop("value")).toEqual("padding-top");
     });
 
+    test("should convert a dash separated key that ends in a dash into a camelCased key when the onChange callback is fired", () => {
+        const callback: any = jest.fn();
+        const data: { [key: string]: string } = {
+            margin: "10px",
+        };
+        const rendered: any = mount(
+            <CSSPropertyEditor data={data} onChange={callback} />
+        );
+        const inputs: any = rendered.find("input");
+
+        inputs.at(0).simulate("focus");
+        inputs.at(0).simulate("change", { target: { value: "padding-" } });
+        inputs.at(0).simulate("blur");
+
+        const updatedDataKeys: string[] = Object.keys(callback.mock.calls[0][0]);
+
+        expect(updatedDataKeys[0]).toEqual("padding");
+    });
+
     test("should convert a dash separated key into a camelCased key when the onChange callback is fired", () => {
         const callback: any = jest.fn();
         const data: { [key: string]: string } = {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
This allows the typing of CSS properties in spinal case.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Resolves #2045 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->