### PR TITLE
chore: dropdown in Explorer from going behind the iframe

### DIFF
--- a/packages/fast-component-explorer/app/explorer.tsx
+++ b/packages/fast-component-explorer/app/explorer.tsx
@@ -56,6 +56,7 @@ import {
     Pivot,
     PivotClassNameContract,
     Select,
+    SelectClassNameContract,
     SelectOption,
     Toggle,
     ToggleClassNameContract,
@@ -165,6 +166,15 @@ class Explorer extends Foundation<ExplorerHandledProps, {}, ExplorerState> {
                     horizontalSpacing()(designSystem)
                 );
             },
+        },
+    };
+
+    private selectStyleOverrides: ComponentStyleSheet<
+        Partial<SelectClassNameContract>,
+        DesignSystem
+    > = {
+        select: {
+            zIndex: "1",
         },
     };
 
@@ -466,6 +476,7 @@ class Explorer extends Foundation<ExplorerHandledProps, {}, ExplorerState> {
         if (Array.isArray(scenarioOptions)) {
             return (
                 <Select
+                    jssStyleSheet={this.selectStyleOverrides}
                     onValueChange={this.handleUpdateScenario}
                     defaultSelection={[scenarioOptions[0].displayName]}
                 >


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
set z-index on Select component to "1"

closes #2033 

## Motivation & context
When opening the scenario option, the drop down goes behind the iframe. The solution fixes that issue.

![image](https://user-images.githubusercontent.com/37851220/62172478-34879100-b2e7-11e9-87b0-45eeda419f1c.png)

<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->