### PR TITLE
feat: added collapsed measurements as props instead of constants

### DIFF
--- a/packages/fast-layouts-react/src/pane/pane.props.ts
+++ b/packages/fast-layouts-react/src/pane/pane.props.ts
@@ -21,6 +21,11 @@ export interface PaneHandledProps extends PaneManagedClasses {
     initialWidth?: number;
 
     /**
+     * The width of a pane when it is collapsed
+     */
+    collapsedWidth?: number;
+
+    /**
      * The minimum width of the pane
      */
     minWidth?: number;

--- a/packages/fast-layouts-react/src/pane/pane.tsx
+++ b/packages/fast-layouts-react/src/pane/pane.tsx
@@ -102,6 +102,7 @@ export class Pane extends Foundation<PaneHandledProps, PaneUnhandledProps, PaneS
      */
     public static defaultProps: Partial<PaneProps> = {
         initialWidth: 300,
+        collapsedWidth: 40,
         minWidth: 100,
         maxWidth: 800,
         resizable: false,
@@ -109,11 +110,6 @@ export class Pane extends Foundation<PaneHandledProps, PaneUnhandledProps, PaneS
         overlay: false,
         hidden: false,
     };
-
-    /**
-     * The width of a pane when it is collapsed
-     */
-    private static collapsedWidth: number = 40;
 
     /**
      * All handled props
@@ -197,7 +193,7 @@ export class Pane extends Foundation<PaneHandledProps, PaneUnhandledProps, PaneS
      */
     public getWidth(): number {
         if (this.props.collapsed) {
-            return Pane.collapsedWidth;
+            return this.props.collapsedWidth;
         } else if (this.width() < this.props.minWidth) {
             return this.props.minWidth;
         } else if (this.width() > this.props.maxWidth) {
@@ -215,7 +211,7 @@ export class Pane extends Foundation<PaneHandledProps, PaneUnhandledProps, PaneS
         const styles: React.CSSProperties = {};
 
         styles.minWidth = this.props.collapsed
-            ? Pane.collapsedWidth
+            ? this.props.collapsedWidth
             : this.props.resizable
                 ? toPx(this.props.minWidth)
                 : width;

--- a/packages/fast-layouts-react/src/row/row.props.ts
+++ b/packages/fast-layouts-react/src/row/row.props.ts
@@ -24,6 +24,11 @@ export interface RowHandledProps extends RowManagedClasses {
     initialHeight?: number;
 
     /**
+     * The height of a row when it is collapsed
+     */
+    collapsedHeight?: number;
+
+    /**
      * Causes the row to fill all available vertical space
      */
     fill?: boolean;

--- a/packages/fast-layouts-react/src/row/row.tsx
+++ b/packages/fast-layouts-react/src/row/row.tsx
@@ -123,6 +123,7 @@ export class Row extends Foundation<
     public static defaultProps: Partial<RowProps> = {
         fill: false,
         initialHeight: 40,
+        collapsedHeight: 40,
         minHeight: 40,
         maxHeight: 800,
         resizable: false,
@@ -130,11 +131,6 @@ export class Row extends Foundation<
         overlay: false,
         hidden: false,
     };
-
-    /**
-     * The height of a row when it is collapsed
-     */
-    private static collapsedHeight: number = 40;
 
     protected handledProps: HandledProps<RowHandledProps> = {
         fill: void 0,
@@ -198,7 +194,7 @@ export class Row extends Foundation<
      */
     public getHeight(): number {
         if (this.props.collapsed) {
-            return Row.collapsedHeight;
+            return this.props.collapsedHeight;
         } else if (this.height() <= this.props.minHeight) {
             return this.props.minHeight;
         } else if (this.height() >= this.props.maxHeight) {
@@ -216,7 +212,7 @@ export class Row extends Foundation<
         const styles: React.CSSProperties = {};
 
         styles.minHeight = this.props.collapsed
-            ? Row.collapsedHeight
+            ? this.props.collapsedHeight
             : this.props.resizable
                 ? toPx(this.props.minHeight)
                 : height;


### PR DESCRIPTION
# Description

Added collapsed measurements as props instead of constants.

## Motivation & context

The layout package was built before density was added to the components. There was a fixed assumption to the minimum size a pane could be when collapsed, that doesn't coordinate well with density other than the default. Also, this is beneficial for many other design reasons allowing complete flexibility in sizing.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->