### PR TITLE
feat: add ability to duplicate component children in react "children" property using Ctrl + D in the navigation component

### DIFF
--- a/packages/fast-tooling-react/src/navigation/navigation-tree-item.props.ts
+++ b/packages/fast-tooling-react/src/navigation/navigation-tree-item.props.ts
@@ -40,9 +40,9 @@ export interface NavigationTreeItemProps
     handleClick: React.MouseEventHandler<HTMLElement>;
 
     /**
-     * The keyUp handler
+     * The keyDown handler
      */
-    handleKeyUp: React.KeyboardEventHandler<HTMLElement>;
+    handleKeyDown: React.KeyboardEventHandler<HTMLElement>;
 
     /**
      * The handler for closing dragging items

--- a/packages/fast-tooling-react/src/navigation/navigation-tree-item.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation-tree-item.tsx
@@ -188,12 +188,12 @@ const NavigationTreeItem: React.RefForwardingComponent<
                     ref={elementRef}
                     aria-expanded={props.expanded}
                     onClick={props.handleClick}
-                    onKeyUp={props.handleKeyUp}
+                    onKeyDown={props.handleKeyDown}
                 >
                     <span
                         className={`${props.contentClassName}${getDragHoverClassName()}`}
                         onClick={props.handleClick}
-                        onKeyUp={props.handleKeyUp}
+                        onKeyDown={props.handleKeyDown}
                         tabIndex={0}
                         data-location={props.dataLocation}
                     >
@@ -209,7 +209,7 @@ const NavigationTreeItem: React.RefForwardingComponent<
                         data-location={props.dataLocation}
                         href={"#"}
                         onClick={props.handleClick}
-                        onKeyUp={props.handleKeyUp}
+                        onKeyDown={props.handleKeyDown}
                         tabIndex={0}
                     >
                         {props.text}

--- a/packages/fast-tooling-react/src/navigation/navigation.spec.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation.spec.tsx
@@ -471,7 +471,7 @@ describe("Navigation", () => {
                 .props()["aria-expanded"]
         ).toEqual(false);
 
-        triggerItem.at(0).simulate("keyup", { keyCode: KeyCodes.enter });
+        triggerItem.at(0).simulate("keydown", { keyCode: KeyCodes.enter });
 
         expect(
             rendered
@@ -490,7 +490,7 @@ describe("Navigation", () => {
         const rendered: any = mount(<DragDropNavigation {...props} />);
         const triggerItem: any = rendered.find(treeItemExpandListTriggerSelector);
 
-        triggerItem.at(0).simulate("keyup", { keyCode: KeyCodes.enter });
+        triggerItem.at(0).simulate("keydown", { keyCode: KeyCodes.enter });
 
         expect(
             rendered
@@ -500,7 +500,7 @@ describe("Navigation", () => {
                 .props()["aria-expanded"]
         ).toEqual(true);
 
-        triggerItem.at(0).simulate("keyup", { keyCode: KeyCodes.enter });
+        triggerItem.at(0).simulate("keydown", { keyCode: KeyCodes.enter });
 
         expect(
             rendered
@@ -526,7 +526,7 @@ describe("Navigation", () => {
                 .props()["aria-expanded"]
         ).toEqual(false);
 
-        triggerItem.at(0).simulate("keyup", { keyCode: KeyCodes.space });
+        triggerItem.at(0).simulate("keydown", { keyCode: KeyCodes.space });
 
         expect(
             rendered
@@ -545,7 +545,7 @@ describe("Navigation", () => {
         const rendered: any = mount(<DragDropNavigation {...props} />);
         const triggerItem: any = rendered.find(treeItemExpandListTriggerSelector);
 
-        triggerItem.at(0).simulate("keyup", { keyCode: KeyCodes.space });
+        triggerItem.at(0).simulate("keydown", { keyCode: KeyCodes.space });
 
         expect(
             rendered
@@ -555,7 +555,7 @@ describe("Navigation", () => {
                 .props()["aria-expanded"]
         ).toEqual(true);
 
-        triggerItem.at(0).simulate("keyup", { keyCode: KeyCodes.space });
+        triggerItem.at(0).simulate("keydown", { keyCode: KeyCodes.space });
 
         expect(
             rendered

--- a/packages/fast-tooling-react/src/navigation/navigation.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation.tsx
@@ -14,7 +14,11 @@ import {
     NavigationUnhandledProps,
     TreeNavigation,
 } from "./navigation.props";
-import { getNavigationFromData, getUpdatedData } from "./navigation.utilities";
+import {
+    getDataWithDuplicate,
+    getNavigationFromData,
+    getUpdatedData,
+} from "./navigation.utilities";
 import { DraggableNavigationTreeItem, NavigationTreeItem } from "./navigation-tree-item";
 import {
     NavigationTreeItemProps,
@@ -504,7 +508,12 @@ export default class Navigation extends Foundation<
                     case KeyCodes.end:
                         this.focusLastTreeItem();
                         break;
+
                     default:
+                        if (e.key.toLowerCase() === "d" && e.shiftKey) {
+                            this.duplicateCurrentItem(dataLocation, type);
+                            e.preventDefault();
+                        }
                         break;
                 }
             }
@@ -591,4 +600,23 @@ export default class Navigation extends Foundation<
 
         return false;
     }
+
+    /**
+     * Duplicates the item
+     */
+    private duplicateCurrentItem = (
+        dataLocation: string,
+        type: NavigationDataType
+    ): void => {
+        if (
+            type !== NavigationDataType.component &&
+            type !== NavigationDataType.primitiveChild
+        ) {
+            return;
+        }
+
+        if (typeof this.props.onChange === "function") {
+            this.props.onChange(getDataWithDuplicate(dataLocation, this.props.data));
+        }
+    };
 }

--- a/packages/fast-tooling-react/src/navigation/navigation.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation.tsx
@@ -75,7 +75,6 @@ export default class Navigation extends Foundation<
     };
 
     private rootElement: React.RefObject<HTMLDivElement>;
-    private delayedFocusDataLocation: string = null;
 
     constructor(props: NavigationProps) {
         super(props);
@@ -110,13 +109,6 @@ export default class Navigation extends Foundation<
                 {this.renderTreeItem(this.state.navigation, 1, 1, 0)}
             </div>
         );
-    }
-
-    public componentDidUpdate(prevProps: NavigationProps): void {
-        if (this.delayedFocusDataLocation !== null) {
-            this.focusNextTreeItem(this.delayedFocusDataLocation);
-            this.delayedFocusDataLocation = null;
-        }
     }
 
     /**
@@ -160,7 +152,7 @@ export default class Navigation extends Foundation<
                 dataLocation === this.state.dragHoverAfterDataLocation,
             expanded: this.isExpanded(dataLocation),
             handleClick: this.handleTreeItemClick(dataLocation, dataType),
-            handleKeyUp: this.handleTreeItemKeyUp(dataLocation, dataType),
+            handleKeyDown: this.handleTreeItemKeyDown(dataLocation, dataType),
             handleCloseDraggingItem: this.handleCloseDraggingTreeItem,
             text: navigation.text,
             type: dataType,
@@ -483,7 +475,7 @@ export default class Navigation extends Foundation<
     /**
      * Handles key up on a tree item
      */
-    private handleTreeItemKeyUp = (
+    private handleTreeItemKeyDown = (
         dataLocation: string,
         type: NavigationDataType
     ): ((e: React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement>) => void) => {
@@ -518,9 +510,9 @@ export default class Navigation extends Foundation<
                         break;
 
                     default:
-                        if (e.key.toLowerCase() === "d" && e.shiftKey) {
-                            this.duplicateCurrentItem(dataLocation, type);
+                        if (e.key.toLowerCase() === "d" && e.ctrlKey) {
                             e.preventDefault();
+                            this.duplicateCurrentItem(dataLocation, type);
                         }
                         break;
                 }
@@ -621,12 +613,6 @@ export default class Navigation extends Foundation<
             type !== NavigationDataType.primitiveChild
         ) {
             return;
-        }
-
-        this.delayedFocusDataLocation = dataLocation;
-
-        if (this.isExpanded(dataLocation)) {
-            this.toggleItems(dataLocation, type);
         }
 
         if (typeof this.props.onChange === "function") {

--- a/packages/fast-tooling-react/src/navigation/navigation.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation.tsx
@@ -75,6 +75,7 @@ export default class Navigation extends Foundation<
     };
 
     private rootElement: React.RefObject<HTMLDivElement>;
+    private delayedFocusDataLocation: string = null;
 
     constructor(props: NavigationProps) {
         super(props);
@@ -109,6 +110,13 @@ export default class Navigation extends Foundation<
                 {this.renderTreeItem(this.state.navigation, 1, 1, 0)}
             </div>
         );
+    }
+
+    public componentDidUpdate(prevProps: NavigationProps): void {
+        if (this.delayedFocusDataLocation !== null) {
+            this.focusNextTreeItem(this.delayedFocusDataLocation);
+            this.delayedFocusDataLocation = null;
+        }
     }
 
     /**
@@ -613,6 +621,12 @@ export default class Navigation extends Foundation<
             type !== NavigationDataType.primitiveChild
         ) {
             return;
+        }
+
+        this.delayedFocusDataLocation = dataLocation;
+
+        if (this.isExpanded(dataLocation)) {
+            this.toggleItems(dataLocation, type);
         }
 
         if (typeof this.props.onChange === "function") {

--- a/packages/fast-tooling-react/src/navigation/navigation.utilities.ts
+++ b/packages/fast-tooling-react/src/navigation/navigation.utilities.ts
@@ -760,7 +760,10 @@ export function getDataWithDuplicate<T>(sourceDataLocation: string, data: T): T 
     } else {
         // check for case of single child as object
         const sourceDataLocationSegments: string[] = sourceDataLocation.split(".");
-        if (sourceDataLocationSegments[sourceDataLocationSegments.length - 2] === childrenKeyword) {
+        if (
+            sourceDataLocationSegments[sourceDataLocationSegments.length - 2] ===
+            childrenKeyword
+        ) {
             duplicateDataInArray(clonedData, normalizedSourceDataLocation);
         }
     }

--- a/packages/fast-tooling-react/src/navigation/navigation.utilities.ts
+++ b/packages/fast-tooling-react/src/navigation/navigation.utilities.ts
@@ -748,3 +748,37 @@ function setDataWhenTargetIsUndefined(
     unset(data, sourceDataLocation);
     set(data as object, targetDataLocation, sourceData);
 }
+
+export function getDataWithDuplicate<T>(sourceDataLocation: string, data: T): T {
+    const clonedData: T = cloneDeep(data) as T;
+    const normalizedSourceDataLocation: string = getDataLocationNormalized(
+        sourceDataLocation
+    );
+
+    if (isInArray(clonedData, normalizedSourceDataLocation)) {
+        duplicateDataInArray(clonedData, normalizedSourceDataLocation);
+    }
+
+    return clonedData;
+}
+
+function duplicateDataInArray(data: unknown, sourceDataLocation: string): void {
+    const sourceData: unknown = get(data as object, sourceDataLocation);
+    const sourceDataLocationSegments: string[] = sourceDataLocation.split(".");
+    const sourceDataLocationIndex: number = parseInt(
+        sourceDataLocationSegments[sourceDataLocationSegments.length - 1],
+        10
+    );
+    const parentSourceDataLocation: string = sourceDataLocationSegments
+        .slice(0, -1)
+        .join(".");
+    const parentSourceData: unknown | unknown[] = get(data, parentSourceDataLocation);
+
+    (parentSourceData as unknown[]).splice(
+        sourceDataLocationIndex + 1,
+        0,
+        cloneDeep(sourceData)
+    );
+
+    set(data as object, parentSourceDataLocation, parentSourceData as object[]);
+}

--- a/packages/fast-tooling-react/src/navigation/navigation.utilities.ts
+++ b/packages/fast-tooling-react/src/navigation/navigation.utilities.ts
@@ -757,6 +757,12 @@ export function getDataWithDuplicate<T>(sourceDataLocation: string, data: T): T 
 
     if (isInArray(clonedData, normalizedSourceDataLocation)) {
         duplicateDataInArray(clonedData, normalizedSourceDataLocation);
+    } else {
+        // check for case of single child as object
+        const sourceDataLocationSegments: string[] = sourceDataLocation.split(".");
+        if (sourceDataLocationSegments[sourceDataLocationSegments.length - 2] === childrenKeyword) {
+            duplicateDataInArray(clonedData, normalizedSourceDataLocation);
+        }
     }
 
     return clonedData;
@@ -765,14 +771,22 @@ export function getDataWithDuplicate<T>(sourceDataLocation: string, data: T): T 
 function duplicateDataInArray(data: unknown, sourceDataLocation: string): void {
     const sourceData: unknown = get(data as object, sourceDataLocation);
     const sourceDataLocationSegments: string[] = sourceDataLocation.split(".");
-    const sourceDataLocationIndex: number = parseInt(
-        sourceDataLocationSegments[sourceDataLocationSegments.length - 1],
-        10
-    );
-    const parentSourceDataLocation: string = sourceDataLocationSegments
+
+    let parentSourceDataLocation: string = sourceDataLocationSegments
         .slice(0, -1)
         .join(".");
-    const parentSourceData: unknown | unknown[] = get(data, parentSourceDataLocation);
+    let parentSourceData: unknown | unknown[] = get(data, parentSourceDataLocation);
+
+    let sourceDataLocationIndex: number = 0;
+    if (!Array.isArray(parentSourceData)) {
+        parentSourceData = [(parentSourceData as object)[childrenKeyword]];
+        parentSourceDataLocation = `${parentSourceDataLocation}.${childrenKeyword}`;
+    } else {
+        sourceDataLocationIndex = parseInt(
+            sourceDataLocationSegments[sourceDataLocationSegments.length - 1],
+            10
+        );
+    }
 
     (parentSourceData as unknown[]).splice(
         sourceDataLocationIndex + 1,


### PR DESCRIPTION
# Description
feat: add ability to duplicate items in navigation

The navigation component should log key combinations which allow duplication of data for any child items which could be components or primitive data.  The intent was for this to work with "ctrl+d" but Edge seems to be intercepting that so currently using "shift+d" while we investigate.

## Motivation & context
https://github.com/microsoft/fast-dna/issues/2032

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.