### PR TITLE
fix: enumerate collapseWidth and collapseHeight as handled props

### DIFF
--- a/packages/fast-layouts-react/src/pane/pane.tsx
+++ b/packages/fast-layouts-react/src/pane/pane.tsx
@@ -114,19 +114,20 @@ export class Pane extends Foundation<PaneHandledProps, PaneUnhandledProps, PaneS
     /**
      * All handled props
      */
-    protected handledProps: HandledProps<PaneHandledProps> = {
-        initialWidth: void 0,
-        minWidth: void 0,
-        maxWidth: void 0,
-        width: void 0,
-        resizable: void 0,
-        id: void 0,
+    protected handledProps: HandledProps<Required<PaneHandledProps>> = {
         collapsed: void 0,
-        overlay: void 0,
+        collapsedWidth: void 0,
         hidden: void 0,
-        resizeFrom: void 0,
+        id: void 0,
+        initialWidth: void 0,
         managedClasses: void 0,
+        maxWidth: void 0,
+        minWidth: void 0,
         onResize: void 0,
+        overlay: void 0,
+        resizable: void 0,
+        resizeFrom: void 0,
+        width: void 0,
     };
     /**
      * Stores a reference to the pane HTML element

--- a/packages/fast-layouts-react/src/row/row.tsx
+++ b/packages/fast-layouts-react/src/row/row.tsx
@@ -132,20 +132,21 @@ export class Row extends Foundation<
         hidden: false,
     };
 
-    protected handledProps: HandledProps<RowHandledProps> = {
-        fill: void 0,
-        minHeight: void 0,
-        maxHeight: void 0,
-        height: void 0,
-        resizable: void 0,
-        id: void 0,
+    protected handledProps: HandledProps<Required<RowHandledProps>> = {
         collapsed: void 0,
-        overlay: void 0,
+        collapsedHeight: void 0,
+        fill: void 0,
+        height: void 0,
         hidden: void 0,
-        resizeFrom: void 0,
-        managedClasses: void 0,
+        id: void 0,
         initialHeight: void 0,
+        managedClasses: void 0,
+        maxHeight: void 0,
+        minHeight: void 0,
         onResize: void 0,
+        overlay: void 0,
+        resizable: void 0,
+        resizeFrom: void 0,
     };
 
     /**


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
`collapsedWidth` and `collapsedHeight` were being added to the DOM via unhandled props because they were not enumerated as handled props. This change adds those properties to the handled props property of `Row` and `Pane`
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->