### PR TITLE
fix: set opacity to 1 on high contrast

### DIFF
--- a/packages/fast-components-styles-msft/src/utilities/disabled.ts
+++ b/packages/fast-components-styles-msft/src/utilities/disabled.ts
@@ -10,5 +10,8 @@ export function applyDisabledState(
     return {
         opacity: toString(disabledOpacity),
         ...applyCursorDisabled(),
+        "@media (-ms-high-contrast:active)": {
+            opacity: "1",
+        },
     };
 }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
All of our components, when disabled, in high contrast, are hard to see.  
Setting opacity to 1 on `-ms-high-contrast:active` media query.

**Note:** 
This only resolves the issue of making disabled easy to read. I have issues, assigned to me, to make sure the components are using the correct "disabled" keyword.

closes #2104 

![image](https://user-images.githubusercontent.com/37851220/62426455-0369e080-b69a-11e9-90e9-ec347a82b23a.png)
![image](https://user-images.githubusercontent.com/37851220/62426467-1977a100-b69a-11e9-8d26-7a9a9194188f.png)
![image](https://user-images.githubusercontent.com/37851220/62426474-25636300-b69a-11e9-95d2-125a7e2d7473.png)


## Motivation & context
When we lower opacity in high contrast we are making it worst for users to see.

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->