### PR TITLE
fix:  high contrast disabled on toggle

### DIFF
--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -136,16 +136,16 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             }),
             "&:disabled": {
                 "@media (-ms-high-contrast:active)": {
-                    background: "graytext",
-                    borderColor: "graytext",
+                    background: "GrayText",
+                    borderColor: "GrayText",
                     "& + span": {
                         background: "Background",
                     },
                 },
                 "&:hover": {
                     "@media (-ms-high-contrast:active)": {
-                        background: "graytext",
-                        borderColor: "graytext",
+                        background: "GrayText",
+                        borderColor: "GrayText",
                         "& + span": {
                             background: "Background",
                         },
@@ -191,21 +191,21 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             borderColor: neutralFillSelected,
             "@media (-ms-high-contrast:active)": {
                 background: "Background",
-                borderColor: "graytext",
+                borderColor: "GrayText",
                 "&:active": {
                     "@media (-ms-high-contrast:active)": {
                         background: "Background",
                         "& + span": {
-                            background: "graytext",
+                            background: "GrayText",
                         },
                     },
                 },
                 "&:hover": {
                     "@media (-ms-high-contrast:active)": {
                         background: "Background",
-                        borderColor: "graytext",
+                        borderColor: "GrayText",
                         "& + span": {
-                            background: "graytext",
+                            background: "GrayText",
                         },
                     },
                 },
@@ -214,15 +214,17 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         "& $toggle_stateIndicator": {
             background: neutralForegroundRest,
             "@media (-ms-high-contrast:active)": {
-                background: "graytext",
+                background: "GrayText",
             },
         },
         "& $toggle_input, & $toggle_label, & $toggle_statusMessage": {
             ...applyCursorDisabled(),
+            "@media (-ms-high-contrast:active)": {
+                color: "GrayText",
+            },
         },
         "@media (-ms-high-contrast:active)": {
             opacity: "1",
-            color: "graytext",
         },
     },
     toggle_statusMessage: {

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -52,6 +52,9 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         display: "inline-block",
         color: neutralForegroundRest,
         transition: "all 0.2s ease-in-out",
+        "@media (-ms-high-contrast:active)": {
+            color: "ButtonText",
+        },
     },
     toggle_label: {
         ...applyCursorPointer(),
@@ -101,7 +104,7 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             "@media (-ms-high-contrast:active)": {
                 background: "Highlight",
                 "& + span": {
-                    background: "Background",
+                    background: "HighlightText",
                 },
             },
         },
@@ -131,6 +134,24 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
                 boxShadow: format<DesignSystem>("0 0 0 1px {0} inset", neutralFocus),
                 borderColor: neutralFocus,
             }),
+            "&:disabled": {
+                "@media (-ms-high-contrast:active)": {
+                    background: "graytext",
+                    borderColor: "graytext",
+                    "& + span": {
+                        background: "Background",
+                    },
+                },
+                "&:hover": {
+                    "@media (-ms-high-contrast:active)": {
+                        background: "graytext",
+                        borderColor: "graytext",
+                        "& + span": {
+                            background: "Background",
+                        },
+                    },
+                },
+            },
             "@media (-ms-high-contrast:active)": {
                 background: "Highlight",
                 borderColor: "Highlight",
@@ -138,13 +159,13 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
                     "@media (-ms-high-contrast:active)": {
                         background: "Highlight",
                         "& + span": {
-                            background: "Background",
+                            background: "HighlightText",
                         },
                     },
                 },
                 "&:hover": {
                     "@media (-ms-high-contrast:active)": {
-                        background: "Background",
+                        background: "HighlightText",
                         borderColor: "Highlight",
                     },
                 },
@@ -154,7 +175,12 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             left: toPx(indicatorCheckedLeft),
             background: accentForegroundCut,
             "@media (-ms-high-contrast:active)": {
-                background: "Background",
+                background: "HighlightText",
+                "&:hover": {
+                    "@media (-ms-high-contrast:active)": {
+                        background: "Highlight",
+                    },
+                },
             },
         },
     },
@@ -163,12 +189,40 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         "& $toggle_input": {
             background: neutralFillSelected,
             borderColor: neutralFillSelected,
+            "@media (-ms-high-contrast:active)": {
+                background: "Background",
+                borderColor: "graytext",
+                "&:active": {
+                    "@media (-ms-high-contrast:active)": {
+                        background: "Background",
+                        "& + span": {
+                            background: "graytext",
+                        },
+                    },
+                },
+                "&:hover": {
+                    "@media (-ms-high-contrast:active)": {
+                        background: "Background",
+                        borderColor: "graytext",
+                        "& + span": {
+                            background: "graytext",
+                        },
+                    },
+                },
+            },
         },
         "& $toggle_stateIndicator": {
             background: neutralForegroundRest,
+            "@media (-ms-high-contrast:active)": {
+                background: "graytext",
+            },
         },
         "& $toggle_input, & $toggle_label, & $toggle_statusMessage": {
             ...applyCursorDisabled(),
+        },
+        "@media (-ms-high-contrast:active)": {
+            opacity: "1",
+            color: "graytext",
         },
     },
     toggle_statusMessage: {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
- Add high contrast media query to `toggle__disabled` and set the style values to use "GrayText"
- Update the toggle indicator to use  "HighlightText" instead of "Background"

closes #2100 

disabled, in high contrast white
unhandled
![image](https://user-images.githubusercontent.com/37851220/62440376-ad7e5280-b704-11e9-93dc-a87d850418c1.png)
handled
![image](https://user-images.githubusercontent.com/37851220/62440388-bcfd9b80-b704-11e9-8221-1b08ae57f60c.png)

## Motivation & context

<!--- What problem does this change solve? -->
In high contrast, the disabled state is not using disabled high contrast color and it is too dim.
<!--- Provide a link if you are addressing an open issue. -->
This will also resolve Bug 23035696 "Disabled toggles are not the disabled high contrast color"

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->