### PR TITLE
fix: resolve issues with viewport positioner no-observer mode

### DIFF
--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -1156,7 +1156,7 @@ describe("viewport positioner", (): void => {
         ).toBe(0);
     });
 
-    test("Positioner base position offset correctly recalculated", (): void => {
+    test("Positioner base position offset correctly calculated", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
@@ -1194,26 +1194,79 @@ describe("viewport positioner", (): void => {
         positioner.instance().viewportRect = viewportRect;
         positioner.instance().positionerRect = positionerRectX70Y70;
         positioner.instance().anchorTop = 60;
-        positioner.instance().anchorRight = 90;
+        positioner.instance().anchorRight = 70;
         positioner.instance().anchorBottom = 70;
-        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorLeft = 60;
         positioner.instance().anchorWidth = 10;
         positioner.instance().anchorHeight = 10;
         positioner.instance().scrollTop = 0;
         positioner.instance().scrollLeft = 0;
 
+        //test bottom right
+        positioner.instance().baseHorizontalOffset = 0;
+        positioner.instance().baseVerticalOffset = 0;
+        positioner.instance().setState({ 
+            currentHorizontalPosition: ViewportPositionerHorizontalPositionLabel.right,
+            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.bottom
+        });
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            ViewportPositionerHorizontalPositionLabel.right
+        );
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            ViewportPositionerVerticalPositionLabel.bottom
+        );
         positioner.instance()["updatePositionerOffset"]();
-
         expect(positioner.instance().baseHorizontalOffset).toBe(0);
         expect(positioner.instance().baseVerticalOffset).toBe(0);
 
-        positioner.instance().anchorTop = 50;
-        positioner.instance().anchorRight = 80;
-        positioner.instance().anchorBottom = 60;
-        positioner.instance().anchorLeft = 70;
-
+        //test inset bottom right
+        positioner.instance().baseHorizontalOffset = 0;
+        positioner.instance().baseVerticalOffset = 0;
+        positioner.instance().setState({ 
+            currentHorizontalPosition: ViewportPositionerHorizontalPositionLabel.insetRight,
+            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.insetBottom
+        });
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            ViewportPositionerHorizontalPositionLabel.insetRight
+        );
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            ViewportPositionerVerticalPositionLabel.insetBottom
+        );
         positioner.instance()["updatePositionerOffset"]();
+        expect(positioner.instance().baseHorizontalOffset).toBe(-10);
+        expect(positioner.instance().baseVerticalOffset).toBe(-10);
 
+        //test top left
+        positioner.instance().baseHorizontalOffset = 0;
+        positioner.instance().baseVerticalOffset = 0;
+        positioner.instance().setState({ 
+            currentHorizontalPosition: ViewportPositionerHorizontalPositionLabel.left,
+            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.top
+        });
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            ViewportPositionerHorizontalPositionLabel.left
+        );
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            ViewportPositionerVerticalPositionLabel.top
+        );
+        positioner.instance()["updatePositionerOffset"]();
+        expect(positioner.instance().baseHorizontalOffset).toBe(-20);
+        expect(positioner.instance().baseVerticalOffset).toBe(-20);
+
+        //test inset top left
+        positioner.instance().baseHorizontalOffset = 0;
+        positioner.instance().baseVerticalOffset = 0;
+        positioner.instance().setState({ 
+            currentHorizontalPosition: ViewportPositionerHorizontalPositionLabel.insetLeft,
+            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.insetTop
+        });
+        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+            ViewportPositionerHorizontalPositionLabel.insetLeft
+        );
+        expect(positioner.instance().state.currentVerticalPosition).toBe(
+            ViewportPositionerVerticalPositionLabel.insetTop
+        );
+        positioner.instance()["updatePositionerOffset"]();
         expect(positioner.instance().baseHorizontalOffset).toBe(-10);
         expect(positioner.instance().baseVerticalOffset).toBe(-10);
     });

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -114,6 +114,7 @@ describe("viewport positioner", (): void => {
         const rendered: any = mount(
             <div>
                 <ViewportPositioner
+                    viewport={document.firstElementChild as HTMLElement}
                     defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
                     managedClasses={managedClasses}
                 />
@@ -133,6 +134,7 @@ describe("viewport positioner", (): void => {
             <div>
                 <div ref={anchorElement} />
                 <ViewportPositioner
+                    viewport={document.firstElementChild as HTMLElement}
                     anchor={anchorElement}
                     managedClasses={managedClasses}
                 />
@@ -152,6 +154,7 @@ describe("viewport positioner", (): void => {
             <div>
                 <div ref={anchorElement} />
                 <ViewportPositioner
+                    viewport={document.firstElementChild as HTMLElement}
                     disabled={true}
                     anchor={anchorElement}
                     managedClasses={managedClasses}
@@ -172,6 +175,7 @@ describe("viewport positioner", (): void => {
             <div>
                 <div ref={anchorElement} />
                 <ViewportPositioner
+                    viewport={document.firstElementChild as HTMLElement}
                     horizontalPositioningMode={AxisPositioningMode.adjacent}
                     defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
                     verticalPositioningMode={AxisPositioningMode.adjacent}
@@ -183,6 +187,7 @@ describe("viewport positioner", (): void => {
         );
 
         const positioner: any = rendered.find("BaseViewportPositioner");
+        positioner.instance().updateLayout();
         expect(positioner.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.left
         );
@@ -213,6 +218,7 @@ describe("viewport positioner", (): void => {
             <div>
                 <div ref={anchorElement} />
                 <ViewportPositioner
+                    viewport={document.firstElementChild as HTMLElement}
                     horizontalPositioningMode={AxisPositioningMode.adjacent}
                     defaultHorizontalPosition={ViewportPositionerHorizontalPosition.right}
                     verticalPositioningMode={AxisPositioningMode.adjacent}
@@ -224,6 +230,7 @@ describe("viewport positioner", (): void => {
         );
 
         const positioner: any = rendered.find("BaseViewportPositioner");
+        positioner.instance().updateLayout();
         expect(positioner.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.right
         );
@@ -254,6 +261,7 @@ describe("viewport positioner", (): void => {
             <div>
                 <div ref={anchorElement} />
                 <ViewportPositioner
+                    viewport={document.firstElementChild as HTMLElement}
                     horizontalPositioningMode={AxisPositioningMode.inset}
                     defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
                     verticalPositioningMode={AxisPositioningMode.inset}
@@ -265,6 +273,7 @@ describe("viewport positioner", (): void => {
         );
 
         const positioner: any = rendered.find("BaseViewportPositioner");
+        positioner.instance().updateLayout();
         expect(positioner.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.insetLeft
         );
@@ -301,6 +310,7 @@ describe("viewport positioner", (): void => {
             <div>
                 <div ref={anchorElement} />
                 <ViewportPositioner
+                    viewport={document.firstElementChild as HTMLElement}
                     horizontalPositioningMode={AxisPositioningMode.inset}
                     defaultHorizontalPosition={ViewportPositionerHorizontalPosition.right}
                     verticalPositioningMode={AxisPositioningMode.inset}
@@ -312,6 +322,7 @@ describe("viewport positioner", (): void => {
         );
 
         const positioner: any = rendered.find("BaseViewportPositioner");
+        positioner.instance().updateLayout();
         expect(positioner.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.insetRight
         );
@@ -343,9 +354,6 @@ describe("viewport positioner", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
-        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
 
         const rendered: any = mount(
             <div
@@ -353,7 +361,6 @@ describe("viewport positioner", (): void => {
                     height: "100px",
                     width: "100px",
                 }}
-                ref={viewportElement}
             >
                 <div
                     style={{
@@ -366,7 +373,7 @@ describe("viewport positioner", (): void => {
                     horizontalPositioningMode={AxisPositioningMode.adjacent}
                     verticalPositioningMode={AxisPositioningMode.adjacent}
                     anchor={anchorElement}
-                    viewport={viewportElement}
+                    viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
                 />
             </div>
@@ -419,9 +426,6 @@ describe("viewport positioner", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
-        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
 
         const rendered: any = mount(
             <div
@@ -429,7 +433,6 @@ describe("viewport positioner", (): void => {
                     height: "100px",
                     width: "100px",
                 }}
-                ref={viewportElement}
             >
                 <div
                     style={{
@@ -442,7 +445,7 @@ describe("viewport positioner", (): void => {
                     horizontalPositioningMode={AxisPositioningMode.inset}
                     verticalPositioningMode={AxisPositioningMode.inset}
                     anchor={anchorElement}
-                    viewport={viewportElement}
+                    viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
                 />
             </div>
@@ -565,9 +568,6 @@ describe("viewport positioner", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
-        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
 
         const rendered: any = mount(
             <div
@@ -575,7 +575,6 @@ describe("viewport positioner", (): void => {
                     height: "100px",
                     width: "100px",
                 }}
-                ref={viewportElement}
             >
                 <div
                     style={{
@@ -594,7 +593,7 @@ describe("viewport positioner", (): void => {
                         ViewportPositionerVerticalPosition.uncontrolled
                     }
                     anchor={anchorElement}
-                    viewport={viewportElement}
+                    viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
                 />
             </div>
@@ -627,9 +626,6 @@ describe("viewport positioner", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
-        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
 
         const rendered: any = mount(
             <div
@@ -637,7 +633,6 @@ describe("viewport positioner", (): void => {
                     height: "100px",
                     width: "100px",
                 }}
-                ref={viewportElement}
             >
                 <div
                     style={{
@@ -650,7 +645,7 @@ describe("viewport positioner", (): void => {
                     horizontalPositioningMode={AxisPositioningMode.adjacent}
                     verticalPositioningMode={AxisPositioningMode.adjacent}
                     anchor={anchorElement}
-                    viewport={viewportElement}
+                    viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
                 />
             </div>
@@ -683,9 +678,6 @@ describe("viewport positioner", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
-        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
 
         const rendered: any = mount(
             <div
@@ -693,7 +685,6 @@ describe("viewport positioner", (): void => {
                     height: "100px",
                     width: "100px",
                 }}
-                ref={viewportElement}
             >
                 <div
                     style={{
@@ -706,7 +697,7 @@ describe("viewport positioner", (): void => {
                     horizontalPositioningMode={AxisPositioningMode.inset}
                     verticalPositioningMode={AxisPositioningMode.inset}
                     anchor={anchorElement}
-                    viewport={viewportElement}
+                    viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
                     horizontalAlwaysInView={true}
                     verticalAlwaysInView={true}
@@ -721,6 +712,8 @@ describe("viewport positioner", (): void => {
         positioner.instance().anchorRight = 210;
         positioner.instance().anchorBottom = 210;
         positioner.instance().anchorLeft = 200;
+        positioner.instance().setState({ noObserverMode: false });
+        expect(positioner.instance().state.noObserverMode).toBe(false);
 
         expect(
             positioner
@@ -750,9 +743,6 @@ describe("viewport positioner", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
-        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
 
         const rendered: any = mount(
             <div
@@ -760,7 +750,6 @@ describe("viewport positioner", (): void => {
                     height: "100px",
                     width: "100px",
                 }}
-                ref={viewportElement}
             >
                 <div
                     style={{
@@ -773,7 +762,7 @@ describe("viewport positioner", (): void => {
                     horizontalPositioningMode={AxisPositioningMode.inset}
                     verticalPositioningMode={AxisPositioningMode.inset}
                     anchor={anchorElement}
-                    viewport={viewportElement}
+                    viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
                     horizontalAlwaysInView={true}
                     verticalAlwaysInView={true}
@@ -819,9 +808,6 @@ describe("viewport positioner", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
-        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
 
         const rendered: any = mount(
             <div
@@ -829,7 +815,6 @@ describe("viewport positioner", (): void => {
                     height: "100px",
                     width: "100px",
                 }}
-                ref={viewportElement}
             >
                 <div
                     style={{
@@ -848,7 +833,7 @@ describe("viewport positioner", (): void => {
                         ViewportPositionerVerticalPosition.uncontrolled
                     }
                     anchor={anchorElement}
-                    viewport={viewportElement}
+                    viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
                 />
             </div>
@@ -866,6 +851,7 @@ describe("viewport positioner", (): void => {
         positioner.instance().anchorHeight = 10;
         positioner.instance().scrollTop = 0;
         positioner.instance().scrollLeft = 0;
+        positioner.instance().setState({ noObserverMode: false });
 
         positioner.instance()["updateLayout"]();
 
@@ -895,17 +881,12 @@ describe("viewport positioner", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
-        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
             <div
                 style={{
                     height: "100px",
                     width: "100px",
                 }}
-                ref={viewportElement}
             >
                 <div
                     style={{
@@ -922,7 +903,7 @@ describe("viewport positioner", (): void => {
                     defaultVerticalPosition={ViewportPositionerVerticalPosition.top}
                     verticalThreshold={20}
                     anchor={anchorElement}
-                    viewport={viewportElement}
+                    viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
                 />
             </div>
@@ -940,6 +921,7 @@ describe("viewport positioner", (): void => {
         positioner.instance().anchorHeight = 10;
         positioner.instance().scrollTop = 0;
         positioner.instance().scrollLeft = 0;
+        positioner.instance().setState({ noObserverMode: false });
 
         positioner.instance()["updateLayout"]();
 
@@ -983,9 +965,6 @@ describe("viewport positioner", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
-        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
 
         const rendered: any = mount(
             <div
@@ -993,7 +972,6 @@ describe("viewport positioner", (): void => {
                     height: "100px",
                     width: "100px",
                 }}
-                ref={viewportElement}
             >
                 <div
                     style={{
@@ -1012,7 +990,7 @@ describe("viewport positioner", (): void => {
                     verticalLockToDefault={true}
                     verticalThreshold={20}
                     anchor={anchorElement}
-                    viewport={viewportElement}
+                    viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
                 />
             </div>
@@ -1073,9 +1051,6 @@ describe("viewport positioner", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
-        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
 
         const rendered: any = mount(
             <div
@@ -1083,7 +1058,6 @@ describe("viewport positioner", (): void => {
                     height: "100px",
                     width: "100px",
                 }}
-                ref={viewportElement}
             >
                 <div
                     style={{
@@ -1096,7 +1070,7 @@ describe("viewport positioner", (): void => {
                     horizontalPositioningMode={AxisPositioningMode.adjacent}
                     verticalPositioningMode={AxisPositioningMode.adjacent}
                     anchor={anchorElement}
-                    viewport={viewportElement}
+                    viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
                 />
             </div>

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -1204,9 +1204,9 @@ describe("viewport positioner", (): void => {
         // test bottom right
         positioner.instance().baseHorizontalOffset = 0;
         positioner.instance().baseVerticalOffset = 0;
-        positioner.instance().setState({ 
+        positioner.instance().setState({
             currentHorizontalPosition: ViewportPositionerHorizontalPositionLabel.right,
-            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.bottom
+            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.bottom,
         });
         expect(positioner.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.right
@@ -1221,9 +1221,10 @@ describe("viewport positioner", (): void => {
         // test inset bottom right
         positioner.instance().baseHorizontalOffset = 0;
         positioner.instance().baseVerticalOffset = 0;
-        positioner.instance().setState({ 
-            currentHorizontalPosition: ViewportPositionerHorizontalPositionLabel.insetRight,
-            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.insetBottom
+        positioner.instance().setState({
+            currentHorizontalPosition:
+                ViewportPositionerHorizontalPositionLabel.insetRight,
+            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.insetBottom,
         });
         expect(positioner.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.insetRight
@@ -1238,9 +1239,9 @@ describe("viewport positioner", (): void => {
         // test top left
         positioner.instance().baseHorizontalOffset = 0;
         positioner.instance().baseVerticalOffset = 0;
-        positioner.instance().setState({ 
+        positioner.instance().setState({
             currentHorizontalPosition: ViewportPositionerHorizontalPositionLabel.left,
-            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.top
+            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.top,
         });
         expect(positioner.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.left
@@ -1255,9 +1256,10 @@ describe("viewport positioner", (): void => {
         // test inset top left
         positioner.instance().baseHorizontalOffset = 0;
         positioner.instance().baseVerticalOffset = 0;
-        positioner.instance().setState({ 
-            currentHorizontalPosition: ViewportPositionerHorizontalPositionLabel.insetLeft,
-            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.insetTop
+        positioner.instance().setState({
+            currentHorizontalPosition:
+                ViewportPositionerHorizontalPositionLabel.insetLeft,
+            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.insetTop,
         });
         expect(positioner.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.insetLeft

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -1202,7 +1202,7 @@ describe("viewport positioner", (): void => {
         positioner.instance().scrollTop = 0;
         positioner.instance().scrollLeft = 0;
 
-        //test bottom right
+        // test bottom right
         positioner.instance().baseHorizontalOffset = 0;
         positioner.instance().baseVerticalOffset = 0;
         positioner.instance().setState({ 
@@ -1219,7 +1219,7 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().baseHorizontalOffset).toBe(0);
         expect(positioner.instance().baseVerticalOffset).toBe(0);
 
-        //test inset bottom right
+        // test inset bottom right
         positioner.instance().baseHorizontalOffset = 0;
         positioner.instance().baseVerticalOffset = 0;
         positioner.instance().setState({ 
@@ -1236,7 +1236,7 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().baseHorizontalOffset).toBe(-10);
         expect(positioner.instance().baseVerticalOffset).toBe(-10);
 
-        //test top left
+        // test top left
         positioner.instance().baseHorizontalOffset = 0;
         positioner.instance().baseVerticalOffset = 0;
         positioner.instance().setState({ 
@@ -1253,7 +1253,7 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().baseHorizontalOffset).toBe(-20);
         expect(positioner.instance().baseVerticalOffset).toBe(-20);
 
-        //test inset top left
+        // test inset top left
         positioner.instance().baseHorizontalOffset = 0;
         positioner.instance().baseVerticalOffset = 0;
         positioner.instance().setState({ 

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -1170,7 +1170,6 @@ describe("viewport positioner", (): void => {
                     height: "100px",
                     width: "100px",
                 }}
-                ref={viewportElement}
             >
                 <div
                     style={{
@@ -1183,7 +1182,7 @@ describe("viewport positioner", (): void => {
                     horizontalPositioningMode={AxisPositioningMode.adjacent}
                     verticalPositioningMode={AxisPositioningMode.adjacent}
                     anchor={anchorElement}
-                    viewport={viewportElement}
+                    viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
                 />
             </div>

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -1,0 +1,46 @@
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import ViewportPositioner from "./";
+
+const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
+    HTMLDivElement
+>();
+const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+    HTMLDivElement
+>();
+
+storiesOf("Viewport Positioner", module)
+    .add("Default", () => (
+        <div
+            id="view"
+            style={{
+                position: "relative",
+                height: "1000px",
+                width: "1000px",
+                padding: "100px",
+                background: "blue"
+            }}
+        >
+            <div
+                ref={anchorElement}
+                style={{
+                    height: "100px",
+                    width: "100px",
+                    background: "green"
+                }}
+            >
+                Anchor
+            </div>
+            <ViewportPositioner
+                viewport={viewportElement}
+                anchor={anchorElement}
+                style={{
+                    height: "100px",
+                    width: "100px",
+                    background: "yellow"
+                }}
+            >
+                Positioner
+            </ViewportPositioner>
+        </div>
+));

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -1,46 +1,58 @@
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import ViewportPositioner from "./";
+import { AxisPositioningMode } from "./viewport-positioner.props";
+import Foundation from "@microsoft/fast-components-foundation-react";
 
-const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-    HTMLDivElement
->();
 const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-    HTMLDivElement
+HTMLDivElement
+>();
+
+const rootElement: React.RefObject<HTMLDivElement> = React.createRef<
+HTMLDivElement
 >();
 
 storiesOf("Viewport Positioner", module)
     .add("Default", () => (
         <div
-            id="view"
+            ref={rootElement}
             style={{
-                position: "relative",
-                height: "1000px",
-                width: "1000px",
-                padding: "100px",
-                background: "blue"
+                height: "400px",
+                width: "400px",
+                overflow: "scroll"
             }}
         >
             <div
-                ref={anchorElement}
                 style={{
-                    height: "100px",
-                    width: "100px",
-                    background: "green"
+                    height: "600px",
+                    width: "600px",
+                    padding: "250px",
+                    background: "blue",
                 }}
             >
-                Anchor
+                <div
+                    ref={anchorElement}
+                    style={{
+                        height: "100px",
+                        width: "100px",
+                        background: "green",
+                    }}
+                >
+                    Anchor
+            </div>
             </div>
             <ViewportPositioner
-                viewport={viewportElement}
-                anchor={anchorElement}
-                style={{
-                    height: "100px",
-                    width: "100px",
-                    background: "yellow"
-                }}
-            >
-                Positioner
+                    verticalPositioningMode={AxisPositioningMode.adjacent}
+                    horizontalPositioningMode={AxisPositioningMode.adjacent}
+                    anchor={anchorElement}
+                    viewport={rootElement}
+                    style={{
+                        height: "100px",
+                        width: "100px",
+                        background: "yellow"
+                    }}
+                >
+                    Positioner
             </ViewportPositioner>
         </div>
-));
+    ));

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -4,55 +4,50 @@ import ViewportPositioner from "./";
 import { AxisPositioningMode } from "./viewport-positioner.props";
 import Foundation from "@microsoft/fast-components-foundation-react";
 
-const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-HTMLDivElement
->();
+const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
 
-const rootElement: React.RefObject<HTMLDivElement> = React.createRef<
-HTMLDivElement
->();
+const rootElement: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
 
-storiesOf("Viewport Positioner", module)
-    .add("Default", () => (
+storiesOf("Viewport Positioner", module).add("Default", () => (
+    <div
+        ref={rootElement}
+        style={{
+            height: "400px",
+            width: "400px",
+            overflow: "scroll",
+        }}
+    >
         <div
-            ref={rootElement}
             style={{
-                height: "400px",
-                width: "400px",
-                overflow: "scroll"
+                height: "600px",
+                width: "600px",
+                padding: "250px",
+                background: "blue",
             }}
         >
             <div
+                ref={anchorElement}
                 style={{
-                    height: "600px",
-                    width: "600px",
-                    padding: "250px",
-                    background: "blue",
+                    height: "100px",
+                    width: "100px",
+                    background: "green",
                 }}
             >
-                <div
-                    ref={anchorElement}
-                    style={{
-                        height: "100px",
-                        width: "100px",
-                        background: "green",
-                    }}
-                >
-                    Anchor
+                Anchor
             </div>
-            </div>
-            <ViewportPositioner
-                    verticalPositioningMode={AxisPositioningMode.adjacent}
-                    horizontalPositioningMode={AxisPositioningMode.adjacent}
-                    anchor={anchorElement}
-                    viewport={rootElement}
-                    style={{
-                        height: "100px",
-                        width: "100px",
-                        background: "yellow"
-                    }}
-                >
-                    Positioner
-            </ViewportPositioner>
         </div>
-    ));
+        <ViewportPositioner
+            verticalPositioningMode={AxisPositioningMode.adjacent}
+            horizontalPositioningMode={AxisPositioningMode.adjacent}
+            anchor={anchorElement}
+            viewport={rootElement}
+            style={{
+                height: "100px",
+                width: "100px",
+                background: "yellow",
+            }}
+        >
+            Positioner
+        </ViewportPositioner>
+    </div>
+));

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -1005,7 +1005,6 @@ class ViewportPositioner extends Foundation<
     private getHorizontalTranslate = (
         horizontalPosition: ViewportPositionerHorizontalPositionLabel
     ): number => {
-        /* tslint:disable-next-line */
         if (!this.props.horizontalAlwaysInView || this.state.disabled) {
             return 0;
         }

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -392,8 +392,8 @@ class ViewportPositioner extends Foundation<
         if (
             !this.state.disabled ||
             this.props.disabled ||
-            this.getAnchorElement() === null ||
-            this.getViewportElement() === null ||
+            isNil(this.getAnchorElement()) ||
+            isNil(this.getViewportElement()) ||
             isNil(this.rootElement.current)
         ) {
             return;
@@ -1112,7 +1112,10 @@ class ViewportPositioner extends Foundation<
      */
     private getViewportElement = (): HTMLElement => {
         if (isNil(this.props.viewport)) {
-            return document.scrollingElement as HTMLElement;
+            if (document.scrollingElement instanceof HTMLElement) {
+                return document.scrollingElement as HTMLElement;
+            } 
+            return null;
         }
 
         if (this.props.viewport instanceof HTMLElement) {

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -380,6 +380,7 @@ class ViewportPositioner extends Foundation<
             !this.state.disabled ||
             this.props.disabled ||
             this.getAnchorElement() === null ||
+            this.getViewportElement() === null ||
             isNil(this.rootElement.current)
         ) {
             return;

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -64,7 +64,6 @@ export interface ViewportPositionerState {
      */
     initialLayoutComplete: boolean;
 
-    
     /**
      * how many checks for a valid viewport before we give up
      * this is primarily because during the initial layout pass
@@ -206,10 +205,10 @@ class ViewportPositioner extends Foundation<
     }
 
     public componentDidUpdate(prevProps: ViewportPositionerProps): void {
-        if(
+        if (
             prevProps.disabled !== this.props.disabled ||
             this.state.validRefChecksRemaining > 0
-        ){
+        ) {
             this.updateDisabledState();
         }
     }
@@ -369,19 +368,13 @@ class ViewportPositioner extends Foundation<
      *  Checks whether component should be disabled or not
      */
     private updateDisabledState = (): void => {
-        if (
-            !canUseDOM() ||
-            this.props.disabled === true
-        ) {
+        if (!canUseDOM() || this.props.disabled === true) {
             this.disable();
             return;
         }
 
-        if (
-            this.getAnchorElement() === null ||
-            this.getViewportElement() === null
-        ){
-            if(this.state.validRefChecksRemaining > 0){
+        if (this.getAnchorElement() === null || this.getViewportElement() === null) {
+            if (this.state.validRefChecksRemaining > 0) {
                 this.setState({
                     validRefChecksRemaining: this.state.validRefChecksRemaining - 1,
                 });
@@ -480,7 +473,7 @@ class ViewportPositioner extends Foundation<
             disabled: true,
             validRefChecksRemaining: 0,
         });
-       
+
         if (
             this.collisionDetector &&
             typeof this.collisionDetector.disconnect === "function"
@@ -496,17 +489,14 @@ class ViewportPositioner extends Foundation<
         // Revisit usage once Safari and Firefox adapt
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1272409
         // https://bugs.webkit.org/show_bug.cgi?id=157743
-        if (
-            this.resizeDetector &&
-            typeof this.resizeDetector.disconnect === "function"
-        ) {
+        if (this.resizeDetector && typeof this.resizeDetector.disconnect === "function") {
             this.resizeDetector.unobserve(this.getAnchorElement());
             this.resizeDetector.disconnect();
             this.resizeDetector = null;
         }
-        
+
         const viewPortElement: HTMLElement = this.getViewportElement();
-        if (!isNil(viewPortElement)){
+        if (!isNil(viewPortElement)) {
             viewPortElement.removeEventListener("scroll", this.handleScroll);
         }
     };

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -1114,7 +1114,7 @@ class ViewportPositioner extends Foundation<
         if (isNil(this.props.viewport)) {
             if (document.scrollingElement instanceof HTMLElement) {
                 return document.scrollingElement as HTMLElement;
-            } 
+            }
             return null;
         }
 


### PR DESCRIPTION
# Description
- no observer mode actually works now
- added missing story for viewport positioner
- Viewport positioner will attempt to reinitialize twice if dom refs are not populated which can easily happen if viewport is initialized in same render pass as the positioner.

## Motivation & context
- some functionality was broken

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.