### PR TITLE
fix: slider moves to nearest increment on click

### DIFF
--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -684,6 +684,8 @@ describe("Slider", (): void => {
             />
         );
 
+        // constrainToStep = (value: number, step: number): number 
+        // where value is the number to be constrained and step the step increment
         expect(rendered.instance()["constrainToStep"](14, 10)).toBe(10);
         expect(rendered.instance()["constrainToStep"](16, 10)).toBe(20);
     });

--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -673,6 +673,22 @@ describe("Slider", (): void => {
         document.body.removeChild(container);
     });
 
+    test("constrainToStep rounds fractions of a step properly", (): void => {
+        const rendered: any = mount(
+            <Slider
+                range={{
+                    minValue: 0,
+                    maxValue: 100,
+                }}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(rendered.instance()["constrainToStep"](14, 10)).toBe(10);
+        expect(rendered.instance()["constrainToStep"](16, 10)).toBe(20);
+
+    });
+
     // tslint:disable-next-line:no-shadowed-variable
     window.removeEventListener = jest.fn((event: string, callback: any) => {
         map[event] = callback;

--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -684,7 +684,7 @@ describe("Slider", (): void => {
             />
         );
 
-        // constrainToStep = (value: number, step: number): number 
+        // constrainToStep = (value: number, step: number): number
         // where value is the number to be constrained and step the step increment
         expect(rendered.instance()["constrainToStep"](14, 10)).toBe(10);
         expect(rendered.instance()["constrainToStep"](16, 10)).toBe(20);

--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -686,7 +686,6 @@ describe("Slider", (): void => {
 
         expect(rendered.instance()["constrainToStep"](14, 10)).toBe(10);
         expect(rendered.instance()["constrainToStep"](16, 10)).toBe(20);
-
     });
 
     // tslint:disable-next-line:no-shadowed-variable

--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -239,8 +239,8 @@ describe("Slider", (): void => {
     test("initial value respects step", (): void => {
         const rendered: any = mount(<Slider mode={SliderMode.singleValue} step={20} />);
 
-        expect(rendered.state("upperValue")).toBe(40);
-        expect(rendered.state("lowerValue")).toBe(40);
+        expect(rendered.state("upperValue")).toBe(60);
+        expect(rendered.state("lowerValue")).toBe(60);
     });
 
     test("one thumb is rendered in singleValue mode", (): void => {

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -1135,15 +1135,14 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
             return value;
         }
 
-        let constrainedValue: number = Math.floor((value - this.props.range.minValue) / step) * step;
-        constrainedValue = (((value - constrainedValue) / step) > 0.5)
-            ? constrainedValue + step
-            : constrainedValue;
+        let constrainedValue: number =
+            Math.floor((value - this.props.range.minValue) / step) * step;
+        constrainedValue =
+            (value - constrainedValue) / step > 0.5
+                ? constrainedValue + step
+                : constrainedValue;
 
-        return (
-            constrainedValue +
-            this.props.range.minValue
-        );
+        return constrainedValue + this.props.range.minValue;
     };
 
     /**

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -1138,7 +1138,7 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
         let constrainedValue: number =
             Math.floor((value - this.props.range.minValue) / step) * step;
         constrainedValue =
-            (value - constrainedValue) / step > 0.5
+            (value - constrainedValue) / step >= 0.5
                 ? constrainedValue + step
                 : constrainedValue;
 

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -1131,10 +1131,11 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
      * Ensures a value is an even multiple of the slider step increment
      */
     private constrainToStep = (value: number, step: number): number => {
-        const remainder: number = value % step;
-        const constrainedValue: number = remainder >= (step / 2) // check to see if this is over half a single step
-            ? value - remainder + step // if so add a step
-            : value - remainder;
+        let constrainedValue: number =  value - this.props.range.minValue;
+        const remainder: number = constrainedValue % step;
+        constrainedValue = remainder >= (step / 2) // check to see if this is over half a single step
+            ? constrainedValue - remainder + step // if so add a step
+            : constrainedValue - remainder;
 
         return constrainedValue + this.props.range.minValue;
     };

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -1131,6 +1131,10 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
      * Ensures a value is an even multiple of the slider step increment
      */
     private constrainToStep = (value: number, step: number): number => {
+        // we remove then restore the slider range min value to 
+        // ensure that the remainder calculates correctly in case the minValue 
+        // is not based off 0, eg. range minValue 7.5, step 2.  Slider steps increment off
+        // of the min value of the slider's range, not 0.
         let constrainedValue: number =  value - this.props.range.minValue;
         const remainder: number = constrainedValue % step;
         constrainedValue = remainder >= (step / 2) // check to see if this is over half a single step

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -1131,16 +1131,10 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
      * Ensures a value is an even multiple of the slider step increment
      */
     private constrainToStep = (value: number, step: number): number => {
-        if (step === 0) {
-            return value;
-        }
-
-        let constrainedValue: number =
-            Math.floor((value - this.props.range.minValue) / step) * step;
-        constrainedValue =
-            (value - constrainedValue) / step >= 0.5
-                ? constrainedValue + step
-                : constrainedValue;
+        const remainder: number = value % step;
+        const constrainedValue: number = remainder >= (step / 2) // check to see if this is over half a single step
+            ? value - remainder + step // if so add a step
+            : value - remainder;
 
         return constrainedValue + this.props.range.minValue;
     };

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -1131,15 +1131,16 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
      * Ensures a value is an even multiple of the slider step increment
      */
     private constrainToStep = (value: number, step: number): number => {
-        // we remove then restore the slider range min value to 
-        // ensure that the remainder calculates correctly in case the minValue 
+        // we remove then restore the slider range min value to
+        // ensure that the remainder calculates correctly in case the minValue
         // is not based off 0, eg. range minValue 7.5, step 2.  Slider steps increment off
         // of the min value of the slider's range, not 0.
-        let constrainedValue: number =  value - this.props.range.minValue;
+        let constrainedValue: number = value - this.props.range.minValue;
         const remainder: number = constrainedValue % step;
-        constrainedValue = remainder >= (step / 2) // check to see if this is over half a single step
-            ? constrainedValue - remainder + step // if so add a step
-            : constrainedValue - remainder;
+        constrainedValue =
+            remainder >= step / 2 // check to see if this is over half a single step
+                ? constrainedValue - remainder + step // if so add a step
+                : constrainedValue - remainder;
 
         return constrainedValue + this.props.range.minValue;
     };

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -1135,8 +1135,13 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
             return value;
         }
 
+        let constrainedValue: number = Math.floor((value - this.props.range.minValue) / step) * step;
+        constrainedValue = (((value - constrainedValue) / step) > 0.5)
+            ? constrainedValue + step
+            : constrainedValue;
+
         return (
-            Math.floor((value - this.props.range.minValue) / step) * step +
+            constrainedValue +
             this.props.range.minValue
         );
     };


### PR DESCRIPTION
# Description
Slider was previously always rounding down on clicks between increments, now it moves to the nearest one

## Motivation & context
Previous behavior was incorrect and made it nearly impossible to click on the track to get to the highest value increment on the track

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
