### PR TITLE
chore: style selection state of navigation menu

### DIFF
--- a/packages/fast-tooling-react/src/navigation-menu/navigation-menu.style.ts
+++ b/packages/fast-tooling-react/src/navigation-menu/navigation-menu.style.ts
@@ -1,6 +1,13 @@
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager-react";
 import { applyTriggerStyle, insetStrongBoxShadow } from "../style";
-import { accent, background800, foreground300, neutralLayerL4 } from "../style/constants";
+import { applyFocusVisible } from "@microsoft/fast-jss-utilities";
+import {
+    accent,
+    background800,
+    foreground300,
+    neutralFillStealthSelected,
+    neutralLayerL4,
+} from "../style/constants";
 import { NavigationMenuItemClassNameContract } from "./navigation-menu-item.props";
 
 export interface NavigationMenuClassNameContract
@@ -37,6 +44,7 @@ const styles: ComponentStyles<NavigationMenuClassNameContract, {}> = {
         fontFamily: "inherit",
         textIndent: "inherit",
         cursor: "pointer",
+        position: "relative",
         '&[aria-expanded="false"]::before, &[aria-expanded="true"]::before': {
             content: "''",
             display: "inline-block",
@@ -55,12 +63,22 @@ const styles: ComponentStyles<NavigationMenuClassNameContract, {}> = {
             borderRight: "3px solid transparent",
             borderBottom: "3px solid transparent",
         },
-        "&:focus": {
+        ...applyFocusVisible({
             ...insetStrongBoxShadow(accent),
-        },
+        }),
     },
     navigationMenuItem_listItem__active: {
-        background: background800,
+        background: neutralFillStealthSelected,
+        "&::after": {
+            content: "''",
+            position: "absolute",
+            background: accent,
+            borderRadius: "2px",
+            width: "2px",
+            height: "calc(100% - 4px)",
+            top: "2px",
+            left: "2px",
+        },
     },
 };
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Add selection state to `<NavigationMenu/>`

Closes: #2035 

After:
<img width="432" alt="Screen Shot 2019-08-13 at 9 33 16 PM" src="https://user-images.githubusercontent.com/37851214/62994750-6255f500-be12-11e9-8f64-fd6414026b6a.png">

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->