### PR TITLE
fix: cancel any callbacks queued by raf-throttle on componentWillUnmount

### DIFF
--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -198,6 +198,10 @@ class HorizontalOverflow extends Foundation<
                 this.resizeObserver.disconnect();
                 this.resizeObserver = null;
             }
+
+            // Cancel any pending calls
+            this.throttledResize.cancel();
+            this.throttledScroll.cancel();
         }
     }
 


### PR DESCRIPTION
# Description
Cancel any queued callbacks to the resize and scroll handlers when the component unmounts

## Motivation & context

Fix for issue #2022

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
    - No changes are necessary
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.