### PR TITLE
fix: dialog elements clipped when zoomed

### DIFF
--- a/packages/fast-components-styles-msft/src/dialog/index.ts
+++ b/packages/fast-components-styles-msft/src/dialog/index.ts
@@ -22,7 +22,6 @@ const styles: ComponentStyles<DialogClassNameContract, DesignSystem> = (
         dialog_positioningRegion: {
             display: "flex",
             justifyContent: "center",
-            alignItems: "center",
             position: "fixed",
             top: "0",
             bottom: "0",
@@ -39,6 +38,8 @@ const styles: ComponentStyles<DialogClassNameContract, DesignSystem> = (
             ...applyAcrylicMaterial(backgroundColor, 0.6, 0.9, true),
         },
         dialog_contentRegion: {
+            marginTop: "auto",
+            marginBottom: "auto",
             background: backgroundColor,
             ...applyElevatedCornerRadius(),
             ...applyElevation(ElevationMultiplier.e14),


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Dialog was content gets clipped zoomed.

Closes: #1871 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->