### PR TITLE
fix: various perf improvements to stylesheets

### DIFF
--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -1,34 +1,9 @@
 import { ButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
-import {
-    applyFocusVisible,
-    directionSwitch,
-    format,
-    toPx,
-} from "@microsoft/fast-jss-utilities";
-import { DesignSystem, ensureDesignSystemDefaults } from "../design-system";
+import { applyFocusVisible, directionSwitch, format, toPx } from "@microsoft/fast-jss-utilities";
+import { DesignSystem, DesignSystemResolver, getDesignSystemValue } from "../design-system";
 import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
-import {
-    accentFillActive,
-    accentFillHover,
-    accentFillRest,
-    accentForegroundActive,
-    accentForegroundCut,
-    accentForegroundHover,
-    accentForegroundRest,
-    neutralFillActive,
-    neutralFillHover,
-    neutralFillRest,
-    neutralFillStealthActive,
-    neutralFillStealthHover,
-    neutralFillStealthRest,
-    neutralFocus,
-    neutralFocusInnerAccent,
-    neutralForegroundRest,
-    neutralOutlineActive,
-    neutralOutlineHover,
-    neutralOutlineRest,
-} from "../utilities/color";
+import { accentFillActive, accentFillHover, accentFillRest, accentForegroundActive, accentForegroundCut, accentForegroundHover, accentForegroundRest, neutralFillActive, neutralFillHover, neutralFillRest, neutralFillStealthActive, neutralFillStealthHover, neutralFillStealthRest, neutralFocus, neutralFocusInnerAccent, neutralForegroundRest, neutralOutlineActive, neutralOutlineHover, neutralOutlineRest } from "../utilities/color";
 import { applyCursorPointer } from "../utilities/cursor";
 import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
@@ -38,6 +13,12 @@ import { applyScaledTypeRamp } from "../utilities/typography";
 const transparentBackground: CSSRules<DesignSystem> = {
     backgroundColor: "transparent",
 };
+
+
+const density: DesignSystemResolver<number> = getDesignSystemValue(
+    "density"
+);
+
 
 const applyTransparentBackplateStyles: CSSRules<DesignSystem> = {
     color: accentForegroundRest,
@@ -90,10 +71,10 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         ...applyCursorPointer(),
         boxSizing: "border-box",
         maxWidth: "374px",
-        minWidth: ensureDesignSystemDefaults(
+        minWidth:
             (designSystem: DesignSystem): string =>
-                designSystem.density <= -2 ? "28px" : "32px"
-        ),
+                density(designSystem) <= -2 ? "28px" : "32px"
+        ,
         padding: format("0 {0}", horizontalSpacing(focusOutlineWidth)),
         display: "inline-flex",
         justifyContent: "center",
@@ -172,13 +153,13 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             ),
         },
         ...applyFocusVisible<DesignSystem>({
-            boxShadow: ensureDesignSystemDefaults(
+            boxShadow: 
                 (designSystem: DesignSystem): string => {
                     return `0 0 0 ${toPx(
-                        designSystem.focusOutlineWidth - designSystem.outlineWidth
+                        focusOutlineWidth(designSystem) - outlineWidth(designSystem)
                     )} ${neutralFocus(designSystem)} inset`;
                 }
-            ),
+            ,
             borderColor: neutralFocus,
         }),
     },

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -30,8 +30,8 @@ import {
 import {
     DesignSystem,
     DesignSystemResolver,
-    getDesignSystemValue,
 } from "../design-system";
+import { getDesignSystemValue } from "../utilities/design-system";
 import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import { applyCursorPointer } from "../utilities/cursor";

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -27,10 +27,7 @@ import {
     subtract,
     toPx,
 } from "@microsoft/fast-jss-utilities";
-import {
-    DesignSystem,
-    DesignSystemResolver,
-} from "../design-system";
+import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { getDesignSystemValue } from "../utilities/design-system";
 import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -1,18 +1,3 @@
-import { ButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
-import {
-    applyFocusVisible,
-    directionSwitch,
-    format,
-    toPx,
-    subtract,
-} from "@microsoft/fast-jss-utilities";
-import {
-    DesignSystem,
-    DesignSystemResolver,
-    getDesignSystemValue,
-} from "../design-system";
-import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
 import {
     accentFillActive,
     accentFillHover,
@@ -34,6 +19,21 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
+import { ButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import {
+    applyFocusVisible,
+    directionSwitch,
+    format,
+    subtract,
+    toPx,
+} from "@microsoft/fast-jss-utilities";
+import {
+    DesignSystem,
+    DesignSystemResolver,
+    getDesignSystemValue,
+} from "../design-system";
+import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
+import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import { applyCursorPointer } from "../utilities/cursor";
 import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
@@ -177,7 +177,11 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             ),
         },
         ...applyFocusVisible<DesignSystem>({
-            boxShadow: format("0 0 0 {0} {1} inset", toPx(subtract(focusOutlineWidth, outlineWidth)), neutralFocus),
+            boxShadow: format(
+                "0 0 0 {0} {1} inset",
+                toPx(subtract(focusOutlineWidth, outlineWidth)),
+                neutralFocus
+            ),
             borderColor: neutralFocus,
         }),
     },

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -1,9 +1,38 @@
 import { ButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
-import { applyFocusVisible, directionSwitch, format, toPx } from "@microsoft/fast-jss-utilities";
-import { DesignSystem, DesignSystemResolver, getDesignSystemValue } from "../design-system";
+import {
+    applyFocusVisible,
+    directionSwitch,
+    format,
+    toPx,
+} from "@microsoft/fast-jss-utilities";
+import {
+    DesignSystem,
+    DesignSystemResolver,
+    getDesignSystemValue,
+} from "../design-system";
 import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
-import { accentFillActive, accentFillHover, accentFillRest, accentForegroundActive, accentForegroundCut, accentForegroundHover, accentForegroundRest, neutralFillActive, neutralFillHover, neutralFillRest, neutralFillStealthActive, neutralFillStealthHover, neutralFillStealthRest, neutralFocus, neutralFocusInnerAccent, neutralForegroundRest, neutralOutlineActive, neutralOutlineHover, neutralOutlineRest } from "../utilities/color";
+import {
+    accentFillActive,
+    accentFillHover,
+    accentFillRest,
+    accentForegroundActive,
+    accentForegroundCut,
+    accentForegroundHover,
+    accentForegroundRest,
+    neutralFillActive,
+    neutralFillHover,
+    neutralFillRest,
+    neutralFillStealthActive,
+    neutralFillStealthHover,
+    neutralFillStealthRest,
+    neutralFocus,
+    neutralFocusInnerAccent,
+    neutralForegroundRest,
+    neutralOutlineActive,
+    neutralOutlineHover,
+    neutralOutlineRest,
+} from "../utilities/color";
 import { applyCursorPointer } from "../utilities/cursor";
 import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
@@ -14,11 +43,7 @@ const transparentBackground: CSSRules<DesignSystem> = {
     backgroundColor: "transparent",
 };
 
-
-const density: DesignSystemResolver<number> = getDesignSystemValue(
-    "density"
-);
-
+const density: DesignSystemResolver<number> = getDesignSystemValue("density");
 
 const applyTransparentBackplateStyles: CSSRules<DesignSystem> = {
     color: accentForegroundRest,
@@ -71,10 +96,8 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         ...applyCursorPointer(),
         boxSizing: "border-box",
         maxWidth: "374px",
-        minWidth:
-            (designSystem: DesignSystem): string =>
-                density(designSystem) <= -2 ? "28px" : "32px"
-        ,
+        minWidth: (designSystem: DesignSystem): string =>
+            density(designSystem) <= -2 ? "28px" : "32px",
         padding: format("0 {0}", horizontalSpacing(focusOutlineWidth)),
         display: "inline-flex",
         justifyContent: "center",
@@ -153,13 +176,11 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             ),
         },
         ...applyFocusVisible<DesignSystem>({
-            boxShadow: 
-                (designSystem: DesignSystem): string => {
-                    return `0 0 0 ${toPx(
-                        focusOutlineWidth(designSystem) - outlineWidth(designSystem)
-                    )} ${neutralFocus(designSystem)} inset`;
-                }
-            ,
+            boxShadow: (designSystem: DesignSystem): string => {
+                return `0 0 0 ${toPx(
+                    focusOutlineWidth(designSystem) - outlineWidth(designSystem)
+                )} ${neutralFocus(designSystem)} inset`;
+            },
             borderColor: neutralFocus,
         }),
     },

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -5,6 +5,7 @@ import {
     directionSwitch,
     format,
     toPx,
+    subtract,
 } from "@microsoft/fast-jss-utilities";
 import {
     DesignSystem,
@@ -176,11 +177,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             ),
         },
         ...applyFocusVisible<DesignSystem>({
-            boxShadow: (designSystem: DesignSystem): string => {
-                return `0 0 0 ${toPx(
-                    focusOutlineWidth(designSystem) - outlineWidth(designSystem)
-                )} ${neutralFocus(designSystem)} inset`;
-            },
+            boxShadow: format("0 0 0 {0} {1} inset", toPx(subtract(focusOutlineWidth, outlineWidth)), neutralFocus),
             borderColor: neutralFocus,
         }),
     },

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -285,6 +285,7 @@ export function checkDesignSystemResolver<T>(
 
 /**
  * Returns a function that calls the callback with designSystemDefaults ensured.
+ * @deprecated - use design system property accesseor functions instead
  */
 export function ensureDesignSystemDefaults<T>(
     callback: (designSystem: DesignSystem) => T

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -256,19 +256,6 @@ export function getDesignSystemProperty(key: string): DesignSystemResolver<strin
 }
 
 /**
- * Safely retrieves the value from a key of the DesignSystem.
- */
-export function getDesignSystemValue<T extends DesignSystem, K extends keyof T>(
-    key: K
-): (designSystem?: T) => T[K] {
-    return (designSystem?: T): T[K] => {
-        return designSystem && designSystem[key] !== undefined
-            ? designSystem[key]
-            : (designSystemDefaults as T)[key];
-    };
-}
-
-/**
  * Returns the argument if basic, otherwise calls the DesignSystemResolver function.
  *
  * @param arg A value or a DesignSystemResolver function

--- a/packages/fast-components-styles-msft/src/flyout/index.ts
+++ b/packages/fast-components-styles-msft/src/flyout/index.ts
@@ -1,15 +1,14 @@
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { FlyoutClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { DesignSystem, ensureDesignSystemDefaults } from "../design-system";
+import { DesignSystem } from "../design-system";
 import { applyFloatingCornerRadius } from "../utilities/border";
 import { applyElevation, ElevationMultiplier } from "../utilities/elevation";
+import { backgroundColor } from "../utilities/design-system"
 
 const styles: ComponentStyles<FlyoutClassNameContract, DesignSystem> = {
     flyout: {
         display: "none",
-        background: ensureDesignSystemDefaults(
-            (designSystem: DesignSystem): string => designSystem.backgroundColor
-        ),
+        background: backgroundColor,
         ...applyFloatingCornerRadius(),
         ...applyElevation(ElevationMultiplier.e14),
         zIndex: "1",

--- a/packages/fast-components-styles-msft/src/flyout/index.ts
+++ b/packages/fast-components-styles-msft/src/flyout/index.ts
@@ -3,7 +3,7 @@ import { FlyoutClassNameContract } from "@microsoft/fast-components-class-name-c
 import { DesignSystem } from "../design-system";
 import { applyFloatingCornerRadius } from "../utilities/border";
 import { applyElevation, ElevationMultiplier } from "../utilities/elevation";
-import { backgroundColor } from "../utilities/design-system"
+import { backgroundColor } from "../utilities/design-system";
 
 const styles: ComponentStyles<FlyoutClassNameContract, DesignSystem> = {
     flyout: {

--- a/packages/fast-components-styles-msft/src/heading/index.ts
+++ b/packages/fast-components-styles-msft/src/heading/index.ts
@@ -5,25 +5,7 @@ import { applyFontWeightSemiBold } from "../utilities/fonts";
 
 const styles: ComponentStyles<HeadingClassNameContract, DesignSystem> = {
     heading: {
-        "&$heading__1": {
-            ...applyFontWeightSemiBold(),
-        },
-        "&$heading__2": {
-            ...applyFontWeightSemiBold(),
-        },
-        "&$heading__3": {
-            ...applyFontWeightSemiBold(),
-        },
-        "&$heading__4": {
-            ...applyFontWeightSemiBold(),
-        },
-        "&$heading__5": {
-            ...applyFontWeightSemiBold(),
-        },
-        "&$heading__6": {
-            ...applyFontWeightSemiBold(),
-        },
-        "&$heading__7": {
+        "&$heading__1, &$heading__2, &$heading__3, &$heading__4, &$heading__5, &$heading__6, &$heading__7": {
             ...applyFontWeightSemiBold(),
         },
     },

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -1,6 +1,6 @@
 import { ButtonBaseClassNameContract as LightweightButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
-import { DesignSystem, ensureDesignSystemDefaults } from "../design-system";
+import { DesignSystem } from "../design-system";
 import { baseButton, buttonStyles } from "../patterns/button";
 import {
     neutralFocus,
@@ -10,7 +10,7 @@ import {
     neutralOutlineRest,
 } from "../utilities/color";
 import { horizontalSpacing } from "../utilities/density";
-import { outlineWidth } from "../utilities/design-system";
+import { outlineWidth, focusOutlineWidth } from "../utilities/design-system";
 import { applyFocusVisible, format, toPx } from "@microsoft/fast-jss-utilities";
 
 const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> = {
@@ -43,13 +43,13 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             ),
         },
         ...applyFocusVisible<DesignSystem>({
-            boxShadow: ensureDesignSystemDefaults(
+            boxShadow: 
                 (designSystem: DesignSystem): string => {
                     return `0 0 0 ${toPx(
-                        designSystem.focusOutlineWidth - designSystem.outlineWidth
+                        focusOutlineWidth(designSystem) - outlineWidth(designSystem)
                     )} ${neutralFocus(designSystem)} inset`;
                 }
-            ),
+            ,
             borderColor: neutralFocus,
         }),
     },

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -10,8 +10,8 @@ import {
     neutralOutlineRest,
 } from "../utilities/color";
 import { horizontalSpacing } from "../utilities/density";
-import { outlineWidth, focusOutlineWidth } from "../utilities/design-system";
-import { applyFocusVisible, format, toPx } from "@microsoft/fast-jss-utilities";
+import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
+import { applyFocusVisible, format, subtract, toPx } from "@microsoft/fast-jss-utilities";
 
 const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> = {
     ...baseButton,
@@ -43,11 +43,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             ),
         },
         ...applyFocusVisible<DesignSystem>({
-            boxShadow: (designSystem: DesignSystem): string => {
-                return `0 0 0 ${toPx(
-                    focusOutlineWidth(designSystem) - outlineWidth(designSystem)
-                )} ${neutralFocus(designSystem)} inset`;
-            },
+            boxShadow: format("0 0 0 {0} {1} inset", toPx(subtract(focusOutlineWidth, outlineWidth)), neutralFocus),
             borderColor: neutralFocus,
         }),
     },

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -43,13 +43,11 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             ),
         },
         ...applyFocusVisible<DesignSystem>({
-            boxShadow: 
-                (designSystem: DesignSystem): string => {
-                    return `0 0 0 ${toPx(
-                        focusOutlineWidth(designSystem) - outlineWidth(designSystem)
-                    )} ${neutralFocus(designSystem)} inset`;
-                }
-            ,
+            boxShadow: (designSystem: DesignSystem): string => {
+                return `0 0 0 ${toPx(
+                    focusOutlineWidth(designSystem) - outlineWidth(designSystem)
+                )} ${neutralFocus(designSystem)} inset`;
+            },
             borderColor: neutralFocus,
         }),
     },

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -43,7 +43,11 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             ),
         },
         ...applyFocusVisible<DesignSystem>({
-            boxShadow: format("0 0 0 {0} {1} inset", toPx(subtract(focusOutlineWidth, outlineWidth)), neutralFocus),
+            boxShadow: format(
+                "0 0 0 {0} {1} inset",
+                toPx(subtract(focusOutlineWidth, outlineWidth)),
+                neutralFocus
+            ),
             borderColor: neutralFocus,
         }),
     },

--- a/packages/fast-components-styles-msft/src/patterns/button.ts
+++ b/packages/fast-components-styles-msft/src/patterns/button.ts
@@ -1,5 +1,5 @@
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
-import { DesignSystem, ensureDesignSystemDefaults } from "../design-system";
+import { DesignSystem } from "../design-system";
 import { directionSwitch, format, toPx } from "@microsoft/fast-jss-utilities";
 import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
 import { applyCursorPointer } from "../utilities/cursor";
@@ -8,6 +8,11 @@ import { applyScaledTypeRamp } from "../utilities/typography";
 import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import { applyDisabledState } from "../utilities/disabled";
 import { ButtonBaseClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import { DesignSystemResolver, getDesignSystemValue, } from "../design-system"
+
+const density: DesignSystemResolver<number> = getDesignSystemValue(
+    "density"
+);
 
 export function buttonStyles(): CSSRules<{}> {
     return {
@@ -18,10 +23,10 @@ export function buttonStyles(): CSSRules<{}> {
         fontFamily: "inherit",
         boxSizing: "border-box",
         maxWidth: "374px",
-        minWidth: ensureDesignSystemDefaults(
+        minWidth:
             (designSystem: DesignSystem): string =>
-                designSystem.density <= -2 ? "28px" : "32px"
-        ),
+                density(designSystem) <= -2 ? "28px" : "32px"
+        ,
         padding: format("0 {0}", horizontalSpacing(focusOutlineWidth)),
         display: "inline-flex",
         justifyContent: "center",

--- a/packages/fast-components-styles-msft/src/patterns/button.ts
+++ b/packages/fast-components-styles-msft/src/patterns/button.ts
@@ -8,11 +8,9 @@ import { applyScaledTypeRamp } from "../utilities/typography";
 import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import { applyDisabledState } from "../utilities/disabled";
 import { ButtonBaseClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { DesignSystemResolver, getDesignSystemValue, } from "../design-system"
+import { DesignSystemResolver, getDesignSystemValue } from "../design-system";
 
-const density: DesignSystemResolver<number> = getDesignSystemValue(
-    "density"
-);
+const density: DesignSystemResolver<number> = getDesignSystemValue("density");
 
 export function buttonStyles(): CSSRules<{}> {
     return {
@@ -23,10 +21,8 @@ export function buttonStyles(): CSSRules<{}> {
         fontFamily: "inherit",
         boxSizing: "border-box",
         maxWidth: "374px",
-        minWidth:
-            (designSystem: DesignSystem): string =>
-                density(designSystem) <= -2 ? "28px" : "32px"
-        ,
+        minWidth: (designSystem: DesignSystem): string =>
+            density(designSystem) <= -2 ? "28px" : "32px",
         padding: format("0 {0}", horizontalSpacing(focusOutlineWidth)),
         display: "inline-flex",
         justifyContent: "center",

--- a/packages/fast-components-styles-msft/src/patterns/button.ts
+++ b/packages/fast-components-styles-msft/src/patterns/button.ts
@@ -8,7 +8,8 @@ import { applyScaledTypeRamp } from "../utilities/typography";
 import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import { applyDisabledState } from "../utilities/disabled";
 import { ButtonBaseClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { DesignSystemResolver, getDesignSystemValue } from "../design-system";
+import { DesignSystemResolver } from "../design-system";
+import { getDesignSystemValue } from "../utilities/design-system";
 
 const density: DesignSystemResolver<number> = getDesignSystemValue("density");
 

--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -1,10 +1,9 @@
 import DesignSystemDefaults, {
     DesignSystem,
-    ensureDesignSystemDefaults,
 } from "../design-system";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import {
-    applyLocalizedProperty,
+    directionSwitch,
     ellipsis,
     format,
     localizeSpacing,
@@ -42,10 +41,7 @@ const styles: ComponentStyles<SelectClassNameContract, DesignSystem> = {
     },
     select_buttonDisplayText: {
         ...ellipsis(),
-        textAlign: ensureDesignSystemDefaults(
-            (designSystem: DesignSystem): string =>
-                applyLocalizedProperty("left", "right", designSystem.direction)
-        ),
+        textAlign: directionSwitch("left", "right"),
         width: "100%",
     },
     select_toggleGlyph: {

--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -1,6 +1,4 @@
-import DesignSystemDefaults, {
-    DesignSystem,
-} from "../design-system";
+import DesignSystemDefaults, { DesignSystem } from "../design-system";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import {
     directionSwitch,

--- a/packages/fast-components-styles-msft/src/subheading/index.ts
+++ b/packages/fast-components-styles-msft/src/subheading/index.ts
@@ -5,27 +5,9 @@ import { applyFontWeightNormal } from "../utilities/fonts";
 
 const styles: ComponentStyles<SubheadingClassNameContract, DesignSystem> = {
     subheading: {
-        "&$subheading__1": {
+        "&$subheading__1, &$subheading__2, &$subheading__3, &$subheading__4, &$subheading__5, &$subheading__6, &$subheading__7": {
             ...applyFontWeightNormal(),
-        },
-        "&$subheading__2": {
-            ...applyFontWeightNormal(),
-        },
-        "&$subheading__3": {
-            ...applyFontWeightNormal(),
-        },
-        "&$subheading__4": {
-            ...applyFontWeightNormal(),
-        },
-        "&$subheading__5": {
-            ...applyFontWeightNormal(),
-        },
-        "&$subheading__6": {
-            ...applyFontWeightNormal(),
-        },
-        "&$subheading__7": {
-            ...applyFontWeightNormal(),
-        },
+        }
     },
     subheading__1: {},
     subheading__2: {},

--- a/packages/fast-components-styles-msft/src/subheading/index.ts
+++ b/packages/fast-components-styles-msft/src/subheading/index.ts
@@ -7,7 +7,7 @@ const styles: ComponentStyles<SubheadingClassNameContract, DesignSystem> = {
     subheading: {
         "&$subheading__1, &$subheading__2, &$subheading__3, &$subheading__4, &$subheading__5, &$subheading__6, &$subheading__7": {
             ...applyFontWeightNormal(),
-        }
+        },
     },
     subheading__1: {},
     subheading__2: {},

--- a/packages/fast-components-styles-msft/src/utilities/color/common.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/common.ts
@@ -81,7 +81,7 @@ export type ColorRecipe<T> = DesignSystemResolver<T> &
 
 export function colorRecipeFactory<T>(recipe: DesignSystemResolver<T>): ColorRecipe<T> {
     const memoizedRecipe: typeof recipe = memoize(recipe);
-    
+
     function curryRecipe(designSystem: DesignSystem): T;
     function curryRecipe(
         backgroundResolver: SwatchResolver

--- a/packages/fast-components-styles-msft/src/utilities/color/common.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/common.ts
@@ -80,6 +80,8 @@ export type ColorRecipe<T> = DesignSystemResolver<T> &
     DesignSystemResolverFromSwatchResolver<T>;
 
 export function colorRecipeFactory<T>(recipe: DesignSystemResolver<T>): ColorRecipe<T> {
+    const memoizedRecipe: typeof recipe = memoize(recipe);
+    
     function curryRecipe(designSystem: DesignSystem): T;
     function curryRecipe(
         backgroundResolver: SwatchResolver
@@ -87,14 +89,14 @@ export function colorRecipeFactory<T>(recipe: DesignSystemResolver<T>): ColorRec
     function curryRecipe(arg: any): any {
         if (typeof arg === "function") {
             return (designSystem: DesignSystem): T => {
-                return recipe(
+                return memoizedRecipe(
                     Object.assign({}, designSystem, {
                         backgroundColor: arg(designSystem),
                     })
                 );
             };
         } else {
-            return recipe(arg);
+            return memoizedRecipe(arg);
         }
     }
 
@@ -119,17 +121,18 @@ export function swatchFamilyToSwatchRecipeFactory<T extends SwatchFamily>(
     type: keyof T,
     callback: SwatchFamilyResolver<T>
 ): SwatchRecipe {
+    const memoizedRecipe: typeof callback = memoize(callback);
     return (arg: DesignSystem | SwatchResolver): any => {
         if (typeof arg === "function") {
             return (designSystem: DesignSystem): Swatch => {
-                return callback(
+                return memoizedRecipe(
                     Object.assign({}, designSystem, {
                         backgroundColor: arg(designSystem),
                     })
                 )[type as string];
             };
         } else {
-            return callback(arg)[type];
+            return memoizedRecipe(arg)[type];
         }
     };
 }

--- a/packages/fast-components-styles-msft/src/utilities/density.ts
+++ b/packages/fast-components-styles-msft/src/utilities/density.ts
@@ -2,8 +2,8 @@ import {
     checkDesignSystemResolver,
     DesignSystem,
     DesignSystemResolver,
-    getDesignSystemValue,
 } from "../design-system";
+import { getDesignSystemValue } from "../utilities/design-system";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import {
     baseHeightMultiplier,

--- a/packages/fast-components-styles-msft/src/utilities/design-system.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.spec.ts
@@ -4,22 +4,25 @@ import defaultDesignSystem, {
 } from "../design-system";
 import * as designSystemUtils from "./design-system";
 
-Object.keys(designSystemUtils).forEach(
+
+Object.keys(designSystemUtils).filter((key: string) => key !== "getDesignSystemValue").forEach(
     (key: string): void => {
         describe(
             key,
             (): void => {
+                const designSystemKey: string = key === "getFontWeight" ? "fontWeight" : key;
+
                 test("should operate on design system defaults", (): void => {
                     expect(designSystemUtils[key]({} as DesignSystem)).toBe(
-                        defaultDesignSystem[key]
+                        defaultDesignSystem[designSystemKey]
                     );
                 });
                 test(`should return the ${key} property of the provided designSystem if it exists`, (): void => {
                     const customDesignSystem: DesignSystem = withDesignSystemDefaults({
-                        [key]: "custom value" as any,
+                        [designSystemKey]: "custom value" as any,
                     });
                     expect(designSystemUtils[key](customDesignSystem)).toBe(
-                        customDesignSystem[key]
+                        customDesignSystem[designSystemKey]
                     );
                 });
             }

--- a/packages/fast-components-styles-msft/src/utilities/design-system.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.spec.ts
@@ -4,28 +4,32 @@ import defaultDesignSystem, {
 } from "../design-system";
 import * as designSystemUtils from "./design-system";
 
+Object.keys(designSystemUtils)
+    .filter((key: string) => key !== "getDesignSystemValue")
+    .forEach(
+        (key: string): void => {
+            describe(
+                key,
+                (): void => {
+                    const designSystemKey: string =
+                        key === "getFontWeight" ? "fontWeight" : key;
 
-Object.keys(designSystemUtils).filter((key: string) => key !== "getDesignSystemValue").forEach(
-    (key: string): void => {
-        describe(
-            key,
-            (): void => {
-                const designSystemKey: string = key === "getFontWeight" ? "fontWeight" : key;
-
-                test("should operate on design system defaults", (): void => {
-                    expect(designSystemUtils[key]({} as DesignSystem)).toBe(
-                        defaultDesignSystem[designSystemKey]
-                    );
-                });
-                test(`should return the ${key} property of the provided designSystem if it exists`, (): void => {
-                    const customDesignSystem: DesignSystem = withDesignSystemDefaults({
-                        [designSystemKey]: "custom value" as any,
+                    test("should operate on design system defaults", (): void => {
+                        expect(designSystemUtils[key]({} as DesignSystem)).toBe(
+                            defaultDesignSystem[designSystemKey]
+                        );
                     });
-                    expect(designSystemUtils[key](customDesignSystem)).toBe(
-                        customDesignSystem[designSystemKey]
-                    );
-                });
-            }
-        );
-    }
-);
+                    test(`should return the ${key} property of the provided designSystem if it exists`, (): void => {
+                        const customDesignSystem: DesignSystem = withDesignSystemDefaults(
+                            {
+                                [designSystemKey]: "custom value" as any,
+                            }
+                        );
+                        expect(designSystemUtils[key](customDesignSystem)).toBe(
+                            customDesignSystem[designSystemKey]
+                        );
+                    });
+                }
+            );
+        }
+    );

--- a/packages/fast-components-styles-msft/src/utilities/design-system.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.ts
@@ -1,6 +1,7 @@
 import { DesignSystemResolver, getDesignSystemValue } from "../design-system";
 import { Palette } from "../utilities/color/palette";
 import { Direction } from "@microsoft/fast-web-utilities";
+import { FontWeight } from "./fonts";
 
 /**
  * Retrieve the backgroundColor when invoked with a DesignSystem
@@ -90,6 +91,7 @@ export const outlineWidth: DesignSystemResolver<number> = getDesignSystemValue(
 export const focusOutlineWidth: DesignSystemResolver<number> = getDesignSystemValue(
     "focusOutlineWidth"
 );
+
 /**
  * Retrieve the direction from the design system
  */

--- a/packages/fast-components-styles-msft/src/utilities/design-system.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.ts
@@ -1,6 +1,23 @@
-import { DesignSystemResolver, getDesignSystemValue } from "../design-system";
+import  designSystemDefaults, {
+    DesignSystem,
+    DesignSystemResolver,
+} from "../design-system";
 import { Palette } from "../utilities/color/palette";
 import { Direction } from "@microsoft/fast-web-utilities";
+import { FontWeight } from "./fonts";
+
+/**
+ * Safely retrieves the value from a key of the DesignSystem.
+ */
+export function getDesignSystemValue<T extends DesignSystem, K extends keyof T>(
+    key: K
+): (designSystem?: T) => T[K] {
+    return (designSystem?: T): T[K] => {
+        return designSystem && designSystem[key] !== undefined
+            ? designSystem[key]
+            : (designSystemDefaults as T)[key];
+    };
+}
 
 /**
  * Retrieve the backgroundColor when invoked with a DesignSystem
@@ -196,3 +213,4 @@ export const neutralOutlineHoverDelta: DesignSystemResolver<
 export const neutralOutlineActiveDelta: DesignSystemResolver<
     number
 > = getDesignSystemValue("neutralOutlineActiveDelta");
+export const getFontWeight: DesignSystemResolver<FontWeight> = getDesignSystemValue("fontWeight")

--- a/packages/fast-components-styles-msft/src/utilities/design-system.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.ts
@@ -1,4 +1,4 @@
-import  designSystemDefaults, {
+import designSystemDefaults, {
     DesignSystem,
     DesignSystemResolver,
 } from "../design-system";
@@ -213,4 +213,6 @@ export const neutralOutlineHoverDelta: DesignSystemResolver<
 export const neutralOutlineActiveDelta: DesignSystemResolver<
     number
 > = getDesignSystemValue("neutralOutlineActiveDelta");
-export const getFontWeight: DesignSystemResolver<FontWeight> = getDesignSystemValue("fontWeight")
+export const getFontWeight: DesignSystemResolver<FontWeight> = getDesignSystemValue(
+    "fontWeight"
+);

--- a/packages/fast-components-styles-msft/src/utilities/design-system.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.ts
@@ -1,7 +1,6 @@
 import { DesignSystemResolver, getDesignSystemValue } from "../design-system";
 import { Palette } from "../utilities/color/palette";
 import { Direction } from "@microsoft/fast-web-utilities";
-import { FontWeight } from "./fonts";
 
 /**
  * Retrieve the backgroundColor when invoked with a DesignSystem
@@ -91,7 +90,6 @@ export const outlineWidth: DesignSystemResolver<number> = getDesignSystemValue(
 export const focusOutlineWidth: DesignSystemResolver<number> = getDesignSystemValue(
     "focusOutlineWidth"
 );
-
 /**
  * Retrieve the direction from the design system
  */

--- a/packages/fast-components-styles-msft/src/utilities/fonts.ts
+++ b/packages/fast-components-styles-msft/src/utilities/fonts.ts
@@ -2,7 +2,7 @@ import { CSSRules } from "@microsoft/fast-jss-manager";
 import {
     DesignSystem,
     DesignSystemResolver,
-    ensureDesignSystemDefaults,
+    getDesignSystemValue
 } from "../design-system";
 
 export interface FontWeight {
@@ -26,12 +26,17 @@ export const defaultFontWeights: FontWeight = {
  */
 export const fontWeight: FontWeight = defaultFontWeights;
 
+/**
+ * Retrieve the focusOutlineWidth from the design system
+ */
+const getDesignSystemFontWeight: DesignSystemResolver<FontWeight> = getDesignSystemValue(
+    "fontWeight"
+);
+
 function weight(index: keyof FontWeight): DesignSystemResolver<string> {
-    return ensureDesignSystemDefaults(
-        (designSystem: DesignSystem): string => {
-            return `${designSystem.fontWeight[index]}`;
-        }
-    );
+    return (designSystem: DesignSystem): string => {
+            return `${getDesignSystemFontWeight(designSystem)[index]}`;
+        };
 }
 
 export function applyFontWeightLight(): CSSRules<DesignSystem> {

--- a/packages/fast-components-styles-msft/src/utilities/fonts.ts
+++ b/packages/fast-components-styles-msft/src/utilities/fonts.ts
@@ -1,5 +1,8 @@
 import { CSSRules } from "@microsoft/fast-jss-manager";
-import designSystemDefaults, { DesignSystem, DesignSystemResolver } from "../design-system";
+import designSystemDefaults, {
+    DesignSystem,
+    DesignSystemResolver,
+} from "../design-system";
 import { getFontWeight } from "./design-system";
 
 export interface FontWeight {

--- a/packages/fast-components-styles-msft/src/utilities/fonts.ts
+++ b/packages/fast-components-styles-msft/src/utilities/fonts.ts
@@ -2,7 +2,7 @@ import { CSSRules } from "@microsoft/fast-jss-manager";
 import {
     DesignSystem,
     DesignSystemResolver,
-    getDesignSystemValue
+    getDesignSystemValue,
 } from "../design-system";
 
 export interface FontWeight {
@@ -35,8 +35,8 @@ const getDesignSystemFontWeight: DesignSystemResolver<FontWeight> = getDesignSys
 
 function weight(index: keyof FontWeight): DesignSystemResolver<string> {
     return (designSystem: DesignSystem): string => {
-            return `${getDesignSystemFontWeight(designSystem)[index]}`;
-        };
+        return `${getDesignSystemFontWeight(designSystem)[index]}`;
+    };
 }
 
 export function applyFontWeightLight(): CSSRules<DesignSystem> {

--- a/packages/fast-components-styles-msft/src/utilities/fonts.ts
+++ b/packages/fast-components-styles-msft/src/utilities/fonts.ts
@@ -1,9 +1,6 @@
 import { CSSRules } from "@microsoft/fast-jss-manager";
-import {
-    DesignSystem,
-    DesignSystemResolver,
-    getDesignSystemValue,
-} from "../design-system";
+import designSystemDefaults, { DesignSystem, DesignSystemResolver } from "../design-system";
+import { getFontWeight } from "./design-system";
 
 export interface FontWeight {
     light: number;
@@ -29,13 +26,10 @@ export const fontWeight: FontWeight = defaultFontWeights;
 /**
  * Retrieve the focusOutlineWidth from the design system
  */
-const getDesignSystemFontWeight: DesignSystemResolver<FontWeight> = getDesignSystemValue(
-    "fontWeight"
-);
 
 function weight(index: keyof FontWeight): DesignSystemResolver<string> {
     return (designSystem: DesignSystem): string => {
-        return `${getDesignSystemFontWeight(designSystem)[index]}`;
+        return getFontWeight(designSystem)[index].toString();
     };
 }
 

--- a/packages/fast-components-styles-msft/src/utilities/typography.ts
+++ b/packages/fast-components-styles-msft/src/utilities/typography.ts
@@ -3,7 +3,6 @@ import { CSSRules } from "@microsoft/fast-jss-manager";
 import {
     DesignSystem,
     DesignSystemResolver,
-    ensureDesignSystemDefaults,
 } from "../design-system";
 import { densityCategorySwitch } from "./density";
 import { clamp } from "lodash-es";
@@ -83,14 +82,12 @@ export const typeRamp: TypeRamp = {
  * Scales a typeramp ID by density
  */
 function scaleTypeRampId(key: keyof TypeRamp): DesignSystemResolver<keyof TypeRamp> {
-    return ensureDesignSystemDefaults(
-        (designSystem: DesignSystem): keyof TypeRamp => {
+    return (designSystem: DesignSystem): keyof TypeRamp => {
             const typeConfigNumber: number = parseInt(key.replace("t", ""), 10);
             const densityOffset: number = densityCategorySwitch(-1, 0, 1)(designSystem);
             const size: number = clamp(typeConfigNumber - densityOffset, 1, 9);
             return sanitizeTypeRampId("t".concat(size.toString()) as keyof TypeRamp);
         }
-    );
 }
 
 /*

--- a/packages/fast-components-styles-msft/src/utilities/typography.ts
+++ b/packages/fast-components-styles-msft/src/utilities/typography.ts
@@ -1,9 +1,6 @@
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { CSSRules } from "@microsoft/fast-jss-manager";
-import {
-    DesignSystem,
-    DesignSystemResolver,
-} from "../design-system";
+import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { densityCategorySwitch } from "./density";
 import { clamp } from "lodash-es";
 
@@ -83,11 +80,11 @@ export const typeRamp: TypeRamp = {
  */
 function scaleTypeRampId(key: keyof TypeRamp): DesignSystemResolver<keyof TypeRamp> {
     return (designSystem: DesignSystem): keyof TypeRamp => {
-            const typeConfigNumber: number = parseInt(key.replace("t", ""), 10);
-            const densityOffset: number = densityCategorySwitch(-1, 0, 1)(designSystem);
-            const size: number = clamp(typeConfigNumber - densityOffset, 1, 9);
-            return sanitizeTypeRampId("t".concat(size.toString()) as keyof TypeRamp);
-        }
+        const typeConfigNumber: number = parseInt(key.replace("t", ""), 10);
+        const densityOffset: number = densityCategorySwitch(-1, 0, 1)(designSystem);
+        const size: number = clamp(typeConfigNumber - densityOffset, 1, 9);
+        return sanitizeTypeRampId("t".concat(size.toString()) as keyof TypeRamp);
+    };
 }
 
 /*

--- a/packages/fast-jss-utilities/src/acrylic.ts
+++ b/packages/fast-jss-utilities/src/acrylic.ts
@@ -19,9 +19,16 @@ export interface AcrylicConfig {
 /*
  * Check for backdrop-filter support within the current browser
  */
-export const backdropFilterSupport: boolean =
-    "backdrop-filter" in document.documentElement.style ||
-    "-webkit-backdrop-filter" in document.documentElement.style;
+let backdropFilterSupport: boolean;
+try {
+    backdropFilterSupport =
+        "backdrop-filter" in document.documentElement.style ||
+        "-webkit-backdrop-filter" in document.documentElement.style;
+} catch (e) {
+    backdropFilterSupport = false;
+}
+
+export { backdropFilterSupport }
 
 /*
  * Applies a partially transparent "acrylic" background to an element

--- a/packages/fast-jss-utilities/src/acrylic.ts
+++ b/packages/fast-jss-utilities/src/acrylic.ts
@@ -28,7 +28,7 @@ try {
     backdropFilterSupport = false;
 }
 
-export { backdropFilterSupport }
+export { backdropFilterSupport };
 
 /*
  * Applies a partially transparent "acrylic" background to an element

--- a/packages/fast-web-utilities/src/dom.ts
+++ b/packages/fast-web-utilities/src/dom.ts
@@ -21,16 +21,15 @@ export function canUseFocusVisible(): boolean {
     }
 
     // Check to see if the document supports the focus-visible elemtn
-    const styleElement: HTMLStyleElement = document.createElement("style");
-    document.head.appendChild(styleElement);
 
     try {
+        const styleElement: HTMLStyleElement = document.createElement("style");
+        document.head.appendChild(styleElement);
         (styleElement.sheet as any).insertRule("foo:focus-visible {color:inherit}", 0);
         _canUseFocusVisible = true;
+        document.head.removeChild(styleElement);
     } catch (e) {
         _canUseFocusVisible = false;
-    } finally {
-        document.head.removeChild(styleElement);
     }
 
     return _canUseFocusVisible as boolean;


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Memoize colors, various selector adjustments, and removal of `ensureDesignSystemDefaults`
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->