### PR TITLE
fix: correct bad slider thumb orientation modifier classnames

### DIFF
--- a/packages/fast-components-class-name-contracts-base/src/slider/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/slider/index.ts
@@ -44,6 +44,16 @@ export interface SliderClassNameContract {
     slider_thumb?: string;
 
     /**
+     * The thumb vertical orientation modifier
+     */
+    slider_thumb__vertical?: string;
+
+    /**
+     * The thumb horizontal orientation modifier
+     */
+    slider_thumb__horizontal?: string;
+
+    /**
      * The high value thumb
      */
     slider_thumb__upperValue?: string;

--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -26,6 +26,8 @@ const managedClasses: SliderClassNameContract = {
     slider_thumb: "slider_thumb",
     slider_thumb__upperValue: "slider_thumb__upperValue",
     slider_thumb__lowerValue: "slider_thumb__lowerValue",
+    slider_thumb__horizontal: "slider_thumb__horizontal",
+    slider_thumb__vertical: "slider_thumb__vertical",
     slider__disabled: "slider__disabled",
     slider__rtl: "slider__rtl",
     slider__modeSingle: "slider__modeSingle",
@@ -305,6 +307,32 @@ describe("Slider", (): void => {
             `.${managedClasses.slider_thumb__lowerValue}`
         );
         expect(lowerThumb).toHaveLength(1);
+    });
+
+    test("horizontal thumb modifier applied to thumb in horizontal orientation", (): void => {
+        const rendered: any = mount(
+            <Slider
+                managedClasses={managedClasses}
+                mode={SliderMode.singleValue}
+                orientation={SliderOrientation.horizontal}
+            />
+        );
+
+        const thumb: any = rendered.find(`.${managedClasses.slider_thumb__horizontal}`);
+        expect(thumb).toHaveLength(1);
+    });
+
+    test("vertical thumb modifier applied to thumb in vertical orientation", (): void => {
+        const rendered: any = mount(
+            <Slider
+                managedClasses={managedClasses}
+                mode={SliderMode.singleValue}
+                orientation={SliderOrientation.vertical}
+            />
+        );
+
+        const thumb: any = rendered.find(`.${managedClasses.slider_thumb__vertical}`);
+        expect(thumb).toHaveLength(1);
     });
 
     test("custom thumb render function is called", (): void => {

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -414,12 +414,12 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
                           ).concat(" ", thumbBaseClass),
                 sliderTrackItem_horizontal: get(
                     this.props,
-                    "managedClasses.sliderTrackItem_vertical",
+                    "managedClasses.slider_thumb__horizontal",
                     ""
                 ),
                 sliderTrackItem_vertical: get(
                     this.props,
-                    "managedClasses.slider_thumb__orientationVertical",
+                    "managedClasses.slider_thumb__vertical",
                     ""
                 ),
             },


### PR DESCRIPTION
# Description
Slider thumb orientation classes were not being applied

## Motivation & context
https://github.com/microsoft/fast-dna/issues/2124

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
