### PR TITLE
fix: improve slider drag

### DIFF
--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -910,8 +910,8 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
         this.updateSliderDimensions();
         const pixelCoordinate: number =
             this.props.orientation === SliderOrientation.vertical
-                ? event.pageY
-                : event.pageX;
+                ? event.clientY
+                : event.clientX;
         const dragValue: number =
             (this.props.range.maxValue - this.props.range.minValue) *
                 this.convertPixelToPercent(pixelCoordinate) +


### PR DESCRIPTION
# Description
Previously Slider used pageX/pageY to determine cursor position during dragging, this caused odd slider behavior when cursor overlapped other i-frames during a drag operation (noticed this when dragging over the component list in the component explorer app).  Using clientX/clientY instead fixes the issue.

## Motivation & context
Odd slider behavior during dragging

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
