### PR TITLE
fix: define defaultProps type of radio correctly

### DIFF
--- a/packages/fast-components-react-base/src/radio/radio.props.ts
+++ b/packages/fast-components-react-base/src/radio/radio.props.ts
@@ -28,7 +28,7 @@ export interface RadioHandledProps extends RadioManagedClasses {
     /**
      * The onChange event
      */
-    onChange?: RadioOnChange;
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
 
     /**
      * The radio content
@@ -42,6 +42,9 @@ export interface RadioHandledProps extends RadioManagedClasses {
 }
 
 export interface RadioUnhandledProps extends React.HTMLAttributes<HTMLDivElement> {}
+/**
+ * @deprecated
+ */
 export type RadioOnChange = (event?: React.ChangeEvent<HTMLInputElement>) => void;
 export interface RadioManagedClasses extends ManagedClasses<RadioClassNameContract> {}
 export type RadioProps = RadioHandledProps & RadioUnhandledProps;

--- a/packages/fast-components-react-base/src/radio/radio.spec.tsx
+++ b/packages/fast-components-react-base/src/radio/radio.spec.tsx
@@ -6,6 +6,7 @@ import Radio, {
     RadioHandledProps,
     RadioProps,
     RadioSlot,
+    RadioUnhandledProps,
 } from "./radio";
 import Label from "../label";
 import { DisplayNamePrefix } from "../utilities";
@@ -28,6 +29,22 @@ describe("radio", (): void => {
 
     test("should have a displayName that matches the component name", () => {
         expect(`${DisplayNamePrefix}${(Radio as any).name}`).toBe(Radio.displayName);
+    });
+
+    test("should accept unhandledProps", () => {
+        const handledProps: RadioHandledProps = {
+            inputId: "foo",
+        };
+
+        const unhandledProps: RadioUnhandledProps = {
+            "aria-hidden": true,
+        };
+
+        const props: RadioProps = { ...handledProps, ...unhandledProps };
+
+        const rendered: any = mount(<Radio {...props} />);
+
+        expect(rendered.find("span").prop("aria-hidden")).toEqual(true);
     });
 
     test("should have correct input type attribute 'radio'", () => {

--- a/packages/fast-components-react-base/src/radio/radio.spec.tsx
+++ b/packages/fast-components-react-base/src/radio/radio.spec.tsx
@@ -44,7 +44,7 @@ describe("radio", (): void => {
 
         const rendered: any = mount(<Radio {...props} />);
 
-        expect(rendered.find("span").prop("aria-hidden")).toEqual(true);
+        expect(rendered.find("div").prop("aria-hidden")).toEqual(true);
     });
 
     test("should have correct input type attribute 'radio'", () => {

--- a/packages/fast-components-react-base/src/radio/radio.tsx
+++ b/packages/fast-components-react-base/src/radio/radio.tsx
@@ -18,7 +18,7 @@ interface RadioState {
 
 class Radio extends Foundation<RadioHandledProps, RadioUnhandledProps, RadioState> {
     public static displayName: string = `${DisplayNamePrefix}Radio`;
-    public static defaultProps: Partial<RadioHandledProps> = {
+    public static defaultProps: Partial<RadioProps> = {
         managedClasses: {},
     };
 
@@ -60,7 +60,7 @@ class Radio extends Foundation<RadioHandledProps, RadioUnhandledProps, RadioStat
         };
     }
 
-    public render(): React.ReactElement<HTMLElement> {
+    public render(): JSX.Element {
         const {
             radio_input,
             radio_stateIndicator,


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Fixes type issue when assigning className unhandled prop
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->