### PR TITLE
fix: missing outline on dialog and modal in high contrast

### DIFF
--- a/packages/fast-components-styles-msft/src/dialog/index.ts
+++ b/packages/fast-components-styles-msft/src/dialog/index.ts
@@ -12,7 +12,6 @@ const styles: ComponentStyles<DialogClassNameContract, DesignSystem> = {
         '&[aria-hidden="false"]': {
             display: "block",
         },
-        ...highContrastBorder,
     },
     dialog_positioningRegion: {
         display: "flex",
@@ -39,6 +38,7 @@ const styles: ComponentStyles<DialogClassNameContract, DesignSystem> = {
         ...applyElevatedCornerRadius(),
         ...applyElevation(ElevationMultiplier.e14),
         "z-index": "1",
+        ...highContrastBorder,
     },
 };
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Moved the the high contrast media query to `dialog_contentRegion`. The outline is set to "Text" color.

## Motivation & context
When putting a border around our dialog and modal in high contrast, will help prevent the contents inside to not look like they are floating.

![image](https://user-images.githubusercontent.com/37851220/63791769-0cbd2600-c8b1-11e9-81c5-2e7ec326762b.png)

closes #2188 

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->