### PR TITLE
fix: :bangbang: single mode select menu changes selection on invoke, not focus

### DIFF
--- a/packages/fast-components-react-base/src/select/select.props.ts
+++ b/packages/fast-components-react-base/src/select/select.props.ts
@@ -80,6 +80,11 @@ export interface SelectHandledProps extends SelectManagedClasses {
     ) => void;
 
     /**
+     * The onMenuSelectionChange event handler
+     */
+    onMenuSelectionChange?: (selectedItems: ListboxItemProps[]) => void;
+
+    /**
      * Whether a listitem should automatically get focus when this component is mounted
      * (multi-select only)
      */

--- a/packages/fast-components-react-base/src/select/select.spec.tsx
+++ b/packages/fast-components-react-base/src/select/select.spec.tsx
@@ -110,7 +110,7 @@ describe("select", (): void => {
         expect(rendered.state("selectedItems").length).toBe(1);
     });
 
-    test("provided callback function is called and value changes when selection changes", (): void => {
+    test("onValueChange callback function is called and value changes when selection changes", (): void => {
         const onValueChange: any = jest.fn();
         const rendered: any = mount(
             <Select onValueChange={onValueChange} defaultSelection={["b"]}>
@@ -134,7 +134,7 @@ describe("select", (): void => {
         expect(onValueChange).toHaveBeenCalledTimes(1);
     });
 
-    test("provided callback function is called and value does not change when selection changes in controlled mode", (): void => {
+    test("onValueChange callback function is called and value does not change when selection changes in controlled mode", (): void => {
         const onValueChange: any = jest.fn();
         const rendered: any = mount(
             <Select onValueChange={onValueChange} selectedItems={["b"]}>
@@ -158,10 +158,14 @@ describe("select", (): void => {
         expect(onValueChange).toHaveBeenCalledTimes(1);
     });
 
-    test("provided callback function is not called when selected item is reselected", (): void => {
+    test("onValueChange callback function is not called when selected item is reselected", (): void => {
         const onValueChange: any = jest.fn();
         const rendered: any = mount(
-            <Select onValueChange={onValueChange} defaultSelection={["b"]}>
+            <Select
+                onValueChange={onValueChange}
+                defaultSelection={["a"]}
+                isMenuOpen={true}
+            >
                 {itemA}
                 {itemB}
                 {itemC}
@@ -171,14 +175,50 @@ describe("select", (): void => {
         expect(rendered.state("selectedItems").length).toBe(1);
         expect(onValueChange).toHaveBeenCalledTimes(0);
 
-        rendered.simulate("click");
-        expect(rendered.state("isMenuOpen")).toBe(true);
+        rendered
+            .find('[displayString="ab"]')
+            .simulate("keydown", { keyCode: keyCodeSpace });
+        expect(rendered.state("selectedItems").length).toBe(1);
+        expect(onValueChange).toHaveBeenCalledTimes(1);
 
         rendered
             .find('[displayString="ab"]')
             .simulate("keydown", { keyCode: keyCodeSpace });
         expect(rendered.state("selectedItems").length).toBe(1);
-        expect(onValueChange).toHaveBeenCalledTimes(0);
+        expect(onValueChange).toHaveBeenCalledTimes(1);
+    });
+
+    test("onMenuSelectionChange callback function is called when menu focus changes", (): void => {
+        const onMenuSelectionChange: any = jest.fn();
+        const rendered: any = mount(
+            <Select
+                onMenuSelectionChange={onMenuSelectionChange}
+                defaultSelection={["a"]}
+                isMenuOpen={true}
+            >
+                {itemA}
+                {itemB}
+                {itemC}
+            </Select>
+        );
+
+        expect(rendered.state("selectedItems").length).toBe(1);
+        expect(onMenuSelectionChange).toHaveBeenCalledTimes(0);
+
+        rendered
+            .find('[displayString="a"]')
+            .simulate("keydown", { keyCode: keyCodeSpace });
+        expect(onMenuSelectionChange).toHaveBeenCalledTimes(0);
+
+        rendered
+            .find('[displayString="ab"]')
+            .simulate("keydown", { keyCode: keyCodeSpace });
+        expect(onMenuSelectionChange).toHaveBeenCalledTimes(1);
+
+        rendered
+            .find('[displayString="a"]')
+            .simulate("keydown", { keyCode: keyCodeSpace });
+        expect(onMenuSelectionChange).toHaveBeenCalledTimes(2);
     });
 
     test("Arrow keys should increment selection without opening menu in single select mode", (): void => {

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -55,6 +55,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         onValueChange: void 0,
         placeholder: void 0,
         autoFocus: void 0,
+        onMenuSelectionChange: void 0,
     };
 
     private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
@@ -247,7 +248,8 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
                 multiselectable={this.props.multiselectable}
                 defaultSelection={this.state.selectedItems}
                 selectedItems={this.props.selectedItems}
-                onSelectedItemsChanged={this.updateSelection}
+                onSelectedItemsChanged={this.menuSelectionChange}
+                onItemInvoked={this.menuItemInvoked}
                 onBlur={this.handleMenuBlur}
                 managedClasses={{
                     listbox: get(this.props.managedClasses, "select_menu", ""),
@@ -264,12 +266,39 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
     }
 
     /**
+     * Handles selection changes from menu
+     */
+    private menuSelectionChange = (newSelection: ListboxItemProps[]): void => {
+        if (typeof this.props.onMenuSelectionChange === "function") {
+            this.props.onMenuSelectionChange(newSelection);
+        }
+        if (this.props.multiselectable) {
+            this.updateSelection(newSelection);
+        }
+    };
+
+    /**
+     * Handles selection changes from menu
+     */
+    private menuItemInvoked = (newSelection: ListboxItemProps): void => {
+        if (!this.props.multiselectable) {
+            this.updateSelection([newSelection]);
+        }
+    };
+
+    /**
      * Updates selection state and associated values
      */
     private updateSelection = (newSelection: ListboxItemProps[]): void => {
         newSelection = this.trimSelection(newSelection);
 
         const newValue: string | string[] = this.getValueFromSelection(newSelection);
+
+        if (this.state.value === newValue) {
+            // no change, abort
+            return;
+        }
+
         const newDisplayString: string = this.getFormattedDisplayString(newSelection);
         if (
             typeof this.props.onValueChange === "function" &&

--- a/packages/fast-components-react-msft/src/select/select.stories.tsx
+++ b/packages/fast-components-react-msft/src/select/select.stories.tsx
@@ -81,4 +81,32 @@ storiesOf("Select", module)
                 displayString="Select option 4"
             />
         </Select>
+    ))
+    .add("Multi", () => (
+        <Select
+            placeholder="Select an option"
+            onValueChange={action("onValueChange")}
+            multiselectable={true}
+        >
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 1"
+                displayString="Select option 1"
+            />
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 2"
+                displayString="Select option 2"
+            />
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 3"
+                displayString="Select option 3"
+            />
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 4"
+                displayString="Select option 4"
+            />
+        </Select>
     ));


### PR DESCRIPTION
# Description
Previously the select menu changed the selected state of the select as options got focus, now this only happens when an item is invoked by a click or keyboard enter or space.  A new callback has been added for those that may want to act on menu focus changes.

!!! NOTE: It is possible that some implementations based on the old behavior may not behave as expected with this change.  Please test your Select implementations  !!!

## Motivation & context
https://github.com/microsoft/fast-dna/issues/2181

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
