### PR TITLE
fix: high-contrast style in Button, AccentButton, ActionToggle, ActionTrigger, Call to Action, NeutralButton, LightweightButton, OutlineButton, and StealthButton to support Edge icon components and add more common constants to high-contrast utility file.

### DIFF
--- a/packages/fast-components-react-msft/src/button/button.stories.tsx
+++ b/packages/fast-components-react-msft/src/button/button.stories.tsx
@@ -44,9 +44,7 @@ storiesOf("Button", module)
         </Button>
     ))
     .add("Stealth", () => (
-        <Button appearance={ButtonAppearance.stealth}>
-            Stealth Button
-        </Button>
+        <Button appearance={ButtonAppearance.stealth}>Stealth Button</Button>
     ))
     .add("Stealth - disabled", () => (
         <Button appearance={ButtonAppearance.stealth} disabled={true}>

--- a/packages/fast-components-react-msft/src/button/button.stories.tsx
+++ b/packages/fast-components-react-msft/src/button/button.stories.tsx
@@ -43,9 +43,14 @@ storiesOf("Button", module)
             Justified Button
         </Button>
     ))
+    .add("Stealth", () => (
+        <Button appearance={ButtonAppearance.stealth}>
+            Stealth Button
+        </Button>
+    ))
     .add("Stealth - disabled", () => (
         <Button appearance={ButtonAppearance.stealth} disabled={true}>
-            Justified Button
+            Stealth Button
         </Button>
     ))
     .add("Before content", () => (

--- a/packages/fast-components-styles-msft/src/accent-button/index.ts
+++ b/packages/fast-components-styles-msft/src/accent-button/index.ts
@@ -12,6 +12,7 @@ import {
     neutralFocusInnerAccent,
 } from "../utilities/color";
 import {
+    highContrastAccent,
     HighContrastColor,
     highContrastDisabledBorder,
     highContrastDisabledForeground,
@@ -32,6 +33,7 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
                 background: HighContrastColor.selectedText,
                 "border-color": HighContrastColor.selectedBackground,
                 color: HighContrastColor.selectedBackground,
+                fill: HighContrastColor.selectedBackground,
             },
             "& $button_beforeContent, & $button_afterContent": {
                 [highContrastSelector]: {
@@ -62,12 +64,7 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
                 fill: "HighlightText",
             },
         },
-        [highContrastSelector]: {
-            background: HighContrastColor.selectedBackground,
-            "border-color": HighContrastColor.selectedBackground,
-            color: HighContrastColor.selectedText,
-            "-ms-high-contrast-adjust": "none",
-        },
+        ...highContrastAccent,
         "a&": {
             "&$button__disabled": {
                 ...highContrastDisabledBorder,

--- a/packages/fast-components-styles-msft/src/action-toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/action-toggle/index.ts
@@ -39,11 +39,11 @@ export const actionToggleButtonOverrides: ComponentStyles<
 const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = {
     actionToggle: {
         "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {
-            ...highContrastForeground
+            ...highContrastForeground,
         },
         "&:hover:enabled": {
             "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {
-                ...highContrastSelectionForeground
+                ...highContrastSelectionForeground,
             },
         },
         [`&$actionToggle__justified, &$actionToggle__lightweight`]: {
@@ -72,7 +72,7 @@ const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = {
     actionToggle__primary: {
         "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {
             fill: accentForegroundCut,
-            ...highContrastSelectionForeground
+            ...highContrastSelectionForeground,
         },
         "&:hover:enabled": {
             "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {

--- a/packages/fast-components-styles-msft/src/action-toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/action-toggle/index.ts
@@ -15,6 +15,8 @@ import {
 import { glyphSize, horizontalSpacing } from "../utilities/density";
 import {
     highContrastDisabledForeground,
+    highContrastForeground,
+    highContrastSelectionForeground,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -37,15 +39,11 @@ export const actionToggleButtonOverrides: ComponentStyles<
 const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = {
     actionToggle: {
         "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {
-            [highContrastSelector]: {
-                fill: "ButtonText !important",
-            },
+            ...highContrastForeground
         },
         "&:hover:enabled": {
             "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {
-                [highContrastSelector]: {
-                    fill: "HighlightText !important",
-                },
+                ...highContrastSelectionForeground
             },
         },
         [`&$actionToggle__justified, &$actionToggle__lightweight`]: {
@@ -74,9 +72,7 @@ const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = {
     actionToggle__primary: {
         "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {
             fill: accentForegroundCut,
-            [highContrastSelector]: {
-                fill: "HighlightText !important",
-            },
+            ...highContrastSelectionForeground
         },
         "&:hover:enabled": {
             "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {

--- a/packages/fast-components-styles-msft/src/action-toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/action-toggle/index.ts
@@ -16,7 +16,7 @@ import { glyphSize, horizontalSpacing } from "../utilities/density";
 import {
     highContrastDisabledForeground,
     highContrastForeground,
-    highContrastSelectionForeground,
+    highContrastSelectedForeground,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -43,7 +43,7 @@ const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = {
         },
         "&:hover:enabled": {
             "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {
-                ...highContrastSelectionForeground,
+                ...highContrastSelectedForeground,
             },
         },
         [`&$actionToggle__justified, &$actionToggle__lightweight`]: {
@@ -72,7 +72,7 @@ const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = {
     actionToggle__primary: {
         "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {
             fill: accentForegroundCut,
-            ...highContrastSelectionForeground,
+            ...highContrastSelectedForeground,
         },
         "&:hover:enabled": {
             "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {

--- a/packages/fast-components-styles-msft/src/action-trigger/index.ts
+++ b/packages/fast-components-styles-msft/src/action-trigger/index.ts
@@ -15,6 +15,8 @@ import {
 import { glyphSize, horizontalSpacing } from "../utilities/density";
 import {
     highContrastDisabledForeground,
+    highContrastForeground,
+    highContrastSelectionForeground,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -38,13 +40,13 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = {
     actionTrigger: {
         "& $actionTrigger_glyph": {
             [highContrastSelector]: {
-                fill: "ButtonText !important",
+                ...highContrastForeground
             },
         },
         "&:hover:enabled": {
             "& $actionTrigger_glyph": {
                 [highContrastSelector]: {
-                    fill: "HighlightText !important",
+                    ...highContrastSelectionForeground
                 },
             },
         },
@@ -69,7 +71,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = {
         "& $actionTrigger_glyph": {
             fill: accentForegroundCut,
             [highContrastSelector]: {
-                fill: "HighlightText !important",
+                ...highContrastSelectionForeground
             },
         },
         "&:hover:enabled": {

--- a/packages/fast-components-styles-msft/src/action-trigger/index.ts
+++ b/packages/fast-components-styles-msft/src/action-trigger/index.ts
@@ -16,7 +16,7 @@ import { glyphSize, horizontalSpacing } from "../utilities/density";
 import {
     highContrastDisabledForeground,
     highContrastForeground,
-    highContrastSelectionForeground,
+    highContrastSelectedForeground,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -39,14 +39,12 @@ export const actionTriggerButtonOverrides: ComponentStyles<
 const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = {
     actionTrigger: {
         "& $actionTrigger_glyph": {
-            [highContrastSelector]: {
-                ...highContrastForeground,
-            },
+            ...highContrastForeground,
         },
         "&:hover:enabled": {
             "& $actionTrigger_glyph": {
                 [highContrastSelector]: {
-                    ...highContrastSelectionForeground,
+                    ...highContrastSelectedForeground,
                 },
             },
         },
@@ -71,7 +69,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = {
         "& $actionTrigger_glyph": {
             fill: accentForegroundCut,
             [highContrastSelector]: {
-                ...highContrastSelectionForeground,
+                ...highContrastSelectedForeground,
             },
         },
         "&:hover:enabled": {

--- a/packages/fast-components-styles-msft/src/action-trigger/index.ts
+++ b/packages/fast-components-styles-msft/src/action-trigger/index.ts
@@ -40,13 +40,13 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = {
     actionTrigger: {
         "& $actionTrigger_glyph": {
             [highContrastSelector]: {
-                ...highContrastForeground
+                ...highContrastForeground,
             },
         },
         "&:hover:enabled": {
             "& $actionTrigger_glyph": {
                 [highContrastSelector]: {
-                    ...highContrastSelectionForeground
+                    ...highContrastSelectionForeground,
                 },
             },
         },
@@ -71,7 +71,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = {
         "& $actionTrigger_glyph": {
             fill: accentForegroundCut,
             [highContrastSelector]: {
-                ...highContrastSelectionForeground
+                ...highContrastSelectionForeground,
             },
         },
         "&:hover:enabled": {

--- a/packages/fast-components-styles-msft/src/auto-suggest-option/index.ts
+++ b/packages/fast-components-styles-msft/src/auto-suggest-option/index.ts
@@ -23,7 +23,7 @@ import { designUnit } from "../utilities/design-system";
 import {
     HighContrastColor,
     highContrastDisabled,
-    highContrastSelection,
+    highContrastSelected,
     highContrastSelector,
     highContrastStealth,
 } from "../utilities/high-contrast";
@@ -58,7 +58,7 @@ const styles: ComponentStyles<AutoSuggestOptionClassNameContract, DesignSystem> 
         }),
         "&:hover": {
             background: neutralFillStealthHover,
-            ...highContrastSelection,
+            ...highContrastSelected,
         },
         ...highContrastStealth,
     },
@@ -79,7 +79,7 @@ const styles: ComponentStyles<AutoSuggestOptionClassNameContract, DesignSystem> 
         background: neutralFillStealthSelected,
         "&:hover": {
             background: neutralFillStealthSelected,
-            ...highContrastSelection,
+            ...highContrastSelected,
         },
     },
 };

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -134,7 +134,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             ...highContrastSelectionOutline,
             "& $button_beforeContent, & $button_afterContent": {
                 fill: accentForegroundCut,
-                ...highContrastSelectionForeground
+                ...highContrastSelectionForeground,
             },
         },
         "&:active:enabled": {
@@ -145,7 +145,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             "border-color": neutralFocus,
         }),
         "&:disabled": {
-            ...highContrastDisabledBorder
+            ...highContrastDisabledBorder,
         },
         "&::-moz-focus-inner": {
             border: "0",
@@ -204,7 +204,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
                 toPx<DesignSystem>(outlineWidth),
                 neutralOutlineHover
             ),
-            ...highContrastSelectionOutline
+            ...highContrastSelectionOutline,
         },
         "&:active:enabled": {
             background: "transparent",
@@ -239,7 +239,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         background: neutralFillStealthRest,
         "&:hover:enabled": {
             "background-color": neutralFillStealthHover,
-            ...highContrastSelection
+            ...highContrastSelection,
         },
         "&:active:enabled": {
             "background-color": neutralFillStealthActive,

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -39,11 +39,16 @@ import {
 } from "../utilities/design-system";
 import { applyDisabledState } from "../utilities/disabled";
 import {
+    highContrastAccent,
     highContrastBackground,
     highContrastDisabledBorder,
     highContrastDisabledForeground,
     highContrastDoubleFocus,
+    highContrastOutline,
     highContrastOutlineFocus,
+    highContrastSelection,
+    highContrastSelectionForeground,
+    highContrastSelectionOutline,
     highContrastSelector,
     highContrastStealth,
 } from "../utilities/high-contrast";
@@ -89,6 +94,7 @@ const applyTransparentBackplateStyles: CSSRules<DesignSystem> = {
         [highContrastSelector]: {
             background: "ButtonFace !important",
             color: "ButtonText !important",
+            fill: "Highlight",
         },
     },
     "&:active:enabled": {
@@ -125,16 +131,10 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         background: neutralFillRest,
         "&:hover:enabled": {
             background: neutralFillHover,
-            [highContrastSelector]: {
-                background: "Highlight !important",
-                "border-color": "ButtonText !important",
-                color: "HighlightText !important",
-            },
+            ...highContrastSelectionOutline,
             "& $button_beforeContent, & $button_afterContent": {
                 fill: accentForegroundCut,
-                [highContrastSelector]: {
-                    fill: "HighlightText",
-                },
+                ...highContrastSelectionForeground
             },
         },
         "&:active:enabled": {
@@ -145,22 +145,12 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             "border-color": neutralFocus,
         }),
         "&:disabled": {
-            [highContrastSelector]: {
-                background: "ButtonFace",
-                "border-color": "GrayText",
-                color: "GrayText",
-            },
+            ...highContrastDisabledBorder
         },
         "&::-moz-focus-inner": {
             border: "0",
         },
-        [highContrastSelector]: {
-            background: "ButtonFace",
-            "border-color": "ButtonText",
-            color: "ButtonText",
-            fill: "ButtonText",
-            "-ms-high-contrast-adjust": "none",
-        },
+        ...highContrastOutline,
         "a&": {
             "&$button__disabled": {
                 "&:hover": {
@@ -179,6 +169,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
                 background: "HighlightText !important",
                 "border-color": "Highlight !important",
                 color: "Highlight !important",
+                fill: "Highlight",
             },
         },
         "&:active:enabled": {
@@ -196,12 +187,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         "& $button_beforeContent, & $button_afterContent": {
             fill: accentForegroundCut,
         },
-        [highContrastSelector]: {
-            background: "Highlight !important",
-            "border-color": "Highlight !important",
-            color: "HighlightText !important",
-            "-ms-high-contrast-adjust": "none",
-        },
+        ...highContrastAccent,
     },
     button__outline: {
         background: "transparent",
@@ -218,6 +204,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
                 toPx<DesignSystem>(outlineWidth),
                 neutralOutlineHover
             ),
+            ...highContrastSelectionOutline
         },
         "&:active:enabled": {
             background: "transparent",
@@ -252,6 +239,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         background: neutralFillStealthRest,
         "&:hover:enabled": {
             "background-color": neutralFillStealthHover,
+            ...highContrastSelection
         },
         "&:active:enabled": {
             "background-color": neutralFillStealthActive,

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -44,12 +44,13 @@ import {
     highContrastDisabledBorder,
     highContrastDisabledForeground,
     highContrastDoubleFocus,
+    highContrastHighlightBackground,
+    highContrastHighlightForeground,
     highContrastOutline,
     highContrastOutlineFocus,
-    highContrastSelection,
-    highContrastSelectionForeground,
-    highContrastSelectionOutline,
-    highContrastSelector,
+    highContrastSelected,
+    highContrastSelectedForeground,
+    highContrastSelectedOutline,
     highContrastStealth,
 } from "../utilities/high-contrast";
 import { applyScaledTypeRamp } from "../utilities/typography";
@@ -76,7 +77,7 @@ const applyTransparentBackplateStyles: CSSRules<DesignSystem> = {
     // Underline
     "&:hover $button_contentRegion::before": {
         background: accentForegroundHover,
-        ...highContrastBackground,
+        ...highContrastHighlightBackground,
     },
     "&:hover$button__disabled $button_contentRegion::before": {
         display: "none",
@@ -89,12 +90,11 @@ const applyTransparentBackplateStyles: CSSRules<DesignSystem> = {
     },
     "&:hover:enabled": {
         color: accentForegroundHover,
-        fill: accentForegroundHover,
         ...transparentBackground,
-        [highContrastSelector]: {
-            background: "ButtonFace !important",
-            color: "ButtonText !important",
-            fill: "Highlight",
+        ...highContrastHighlightForeground,
+        "& $button_beforeContent, & $button_afterContent": {
+            fill: accentForegroundHover,
+            ...highContrastHighlightForeground,
         },
     },
     "&:active:enabled": {
@@ -131,10 +131,10 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         background: neutralFillRest,
         "&:hover:enabled": {
             background: neutralFillHover,
-            ...highContrastSelectionOutline,
+            ...highContrastSelected,
             "& $button_beforeContent, & $button_afterContent": {
                 fill: accentForegroundCut,
-                ...highContrastSelectionForeground,
+                ...highContrastSelectedForeground,
             },
         },
         "&:active:enabled": {
@@ -165,12 +165,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         background: accentFillRest,
         "&:hover:enabled": {
             background: accentFillHover,
-            [highContrastSelector]: {
-                background: "HighlightText !important",
-                "border-color": "Highlight !important",
-                color: "Highlight !important",
-                fill: "Highlight",
-            },
+            ...highContrastSelectedOutline,
         },
         "&:active:enabled": {
             background: accentFillActive,
@@ -204,7 +199,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
                 toPx<DesignSystem>(outlineWidth),
                 neutralOutlineHover
             ),
-            ...highContrastSelectionOutline,
+            ...highContrastSelected,
         },
         "&:active:enabled": {
             background: "transparent",
@@ -239,7 +234,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         background: neutralFillStealthRest,
         "&:hover:enabled": {
             "background-color": neutralFillStealthHover,
-            ...highContrastSelection,
+            ...highContrastSelected,
         },
         "&:active:enabled": {
             "background-color": neutralFillStealthActive,

--- a/packages/fast-components-styles-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-styles-msft/src/call-to-action/index.ts
@@ -23,6 +23,8 @@ import { designUnit } from "../utilities/design-system";
 import {
     highContrastDisabledForeground,
     highContrastForeground,
+    highContrastHighlightForeground,
+    highContrastSelectedForeground,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -89,9 +91,7 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
         "&:hover": {
             "& $callToAction_glyph": {
                 ...applyGlyphTransform(),
-                [highContrastSelector]: {
-                    fill: "HighlightText !important",
-                },
+                ...highContrastSelectedForeground,
             },
         },
         ...applyFocusVisible("& $callToAction_glyph", {
@@ -113,14 +113,10 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
     callToAction__primary: {
         "& $callToAction_glyph": {
             fill: accentForegroundCut,
-            [highContrastSelector]: {
-                fill: "HighlightText !important",
-            },
+            ...highContrastSelectedForeground,
         },
         "&:hover $callToAction_glyph": {
-            [highContrastSelector]: {
-                fill: "Highlight !important",
-            },
+            ...highContrastHighlightForeground,
         },
     },
     callToAction__lightweight: {
@@ -130,7 +126,7 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
         "&:hover": {
             "& $callToAction_glyph": {
                 fill: accentForegroundHover,
-                ...highContrastForeground,
+                ...highContrastHighlightForeground,
             },
         },
         "&:active": {
@@ -148,7 +144,7 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
         "&:hover": {
             "& $callToAction_glyph": {
                 fill: accentForegroundHover,
-                ...highContrastForeground,
+                ...highContrastHighlightForeground,
             },
         },
         "&:active": {},

--- a/packages/fast-components-styles-msft/src/carousel/index.ts
+++ b/packages/fast-components-styles-msft/src/carousel/index.ts
@@ -9,7 +9,10 @@ import {
 } from "../utilities/color";
 import { CarouselClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { designUnit, outlineWidth } from "../utilities/design-system";
-import { highContrastSelector } from "../utilities/high-contrast";
+import {
+    highContrastHighlightBackground,
+    highContrastSelector,
+} from "../utilities/high-contrast";
 
 const white: string = "#FFF";
 const black: string = "#101010";
@@ -171,9 +174,7 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
             "&$carousel_sequenceIndicator__active": {
                 "&::before": {
                     background: darkModeNeutralFillStealthRest,
-                    [highContrastSelector]: {
-                        background: "Highlight",
-                    },
+                    ...highContrastHighlightBackground,
                 },
             },
         },
@@ -223,9 +224,7 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
             "&$carousel_sequenceIndicator__active": {
                 "&::before": {
                     background: lightModeNeutralFillStealthRest,
-                    [highContrastSelector]: {
-                        background: "Highlight",
-                    },
+                    ...highContrastHighlightBackground,
                 },
             },
         },

--- a/packages/fast-components-styles-msft/src/checkbox/index.ts
+++ b/packages/fast-components-styles-msft/src/checkbox/index.ts
@@ -1,9 +1,5 @@
-import {
-    densityCategorySwitch,
-    heightNumber,
-    horizontalSpacing,
-} from "../utilities/density";
 import { DesignSystem, DesignSystemResolver } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { CheckboxClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import {
     add,
@@ -24,7 +20,11 @@ import {
     neutralOutlineRest,
 } from "../utilities/color";
 import { applyCornerRadius } from "../utilities/border";
-import { ComponentStyles } from "@microsoft/fast-jss-manager";
+import {
+    densityCategorySwitch,
+    heightNumber,
+    horizontalSpacing,
+} from "../utilities/density";
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { designUnit, outlineWidth } from "../utilities/design-system";
@@ -33,6 +33,8 @@ import { ColorRecipe } from "src/utilities/color/common";
 import {
     highContrastBorderColor,
     highContrastDisabledBorder,
+    highContrastHighlightBackground,
+    highContrastSelectedBackground,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -158,13 +160,9 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
             },
         },
         "& $checkbox_input": {
-            [highContrastSelector]: {
-                background: "Highlight",
-            },
+            ...highContrastHighlightBackground,
             "&:hover": {
-                [highContrastSelector]: {
-                    background: "HighlightText",
-                },
+                ...highContrastSelectedBackground,
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/context-menu-item/index.ts
+++ b/packages/fast-components-styles-msft/src/context-menu-item/index.ts
@@ -17,7 +17,7 @@ import { applyScaledTypeRamp } from "../utilities/typography";
 import {
     highContrastDisabled,
     highContrastOutlineFocus,
-    highContrastSelection,
+    highContrastSelected,
     highContrastStealth,
 } from "../utilities/high-contrast";
 
@@ -51,7 +51,7 @@ const styles: ComponentStyles<ContextMenuItemClassNameContract, DesignSystem> = 
         }),
         "&:hover": {
             background: neutralFillStealthHover,
-            ...highContrastSelection,
+            ...highContrastSelected,
         },
         "&:active": {
             background: neutralFillStealthActive,

--- a/packages/fast-components-styles-msft/src/flipper/index.ts
+++ b/packages/fast-components-styles-msft/src/flipper/index.ts
@@ -20,7 +20,10 @@ import {
 import { glyphSize, height } from "../utilities/density";
 import { outlineWidth } from "../utilities/design-system";
 import { applyCursorPointer } from "../utilities/cursor";
-import { highContrastSelector } from "../utilities/high-contrast";
+import {
+    highContrastHighlightBackground,
+    highContrastSelector,
+} from "../utilities/high-contrast";
 
 const styles: ComponentStyles<FlipperClassNameContract, DesignSystem> = {
     flipper: {
@@ -67,9 +70,7 @@ const styles: ComponentStyles<FlipperClassNameContract, DesignSystem> = {
             "&::before": {
                 background: neutralFillStealthHover,
                 "border-color": neutralOutlineHover,
-                [highContrastSelector]: {
-                    background: "Highlight",
-                },
+                ...highContrastHighlightBackground,
             },
             "& $flipper_glyph": {
                 [highContrastSelector]: {

--- a/packages/fast-components-styles-msft/src/index.ts
+++ b/packages/fast-components-styles-msft/src/index.ts
@@ -232,5 +232,6 @@ export * from "./utilities/disabled";
 export * from "./utilities/elevation";
 export * from "./utilities/fonts";
 export * from "./utilities/high-contrast";
+export * from "./utilities/important";
 export * from "./utilities/keyof-to-type";
 export * from "./utilities/typography";

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -13,7 +13,9 @@ import { focusOutlineWidth } from "../utilities/design-system";
 import {
     highContrastBackground,
     highContrastDisabledForeground,
-    highContrastSelector,
+    highContrastForeground,
+    highContrastHighlightBackground,
+    highContrastHighlightForeground,
 } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> = {
@@ -39,7 +41,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
         // Underline
         "&:hover $button_contentRegion::before": {
             background: accentForegroundHover,
-            ...highContrastBackground,
+            ...highContrastHighlightBackground,
         },
         "&:hover$button__disabled $button_contentRegion::before": {
             display: "none",
@@ -55,18 +57,14 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             color: accentForegroundHover,
             fill: accentForegroundHover,
             "background-color": "transparent",
-            [highContrastSelector]: {
-                fill: "Highlight",
-            },
+            ...highContrastHighlightForeground,
         },
         "&:active:enabled": {
             color: accentForegroundActive,
             fill: accentForegroundActive,
             "background-color": "transparent",
         },
-        [highContrastSelector]: {
-            fill: "ButtonText",
-        },
+        ...highContrastForeground,
         "a&": {
             "&$button__disabled": {
                 ...highContrastDisabledForeground,

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -65,7 +65,6 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             "background-color": "transparent",
         },
         [highContrastSelector]: {
-            border: "none",
             fill: "ButtonText",
         },
         "a&": {

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -66,7 +66,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
         },
         ...highContrastForeground,
         "a&": {
-            "&$button__disabled": {
+            "&:hover$button__disabled": {
                 ...highContrastDisabledForeground,
             },
         },

--- a/packages/fast-components-styles-msft/src/neutral-button/index.ts
+++ b/packages/fast-components-styles-msft/src/neutral-button/index.ts
@@ -14,7 +14,7 @@ import {
     highContrastDisabledBorder,
     highContrastOutline,
     highContrastOutlineFocus,
-    highContrastSelection,
+    highContrastSelected,
 } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<NeutralButtonClassNameContract, DesignSystem> = {
@@ -26,7 +26,7 @@ const styles: ComponentStyles<NeutralButtonClassNameContract, DesignSystem> = {
         background: neutralFillRest,
         "&:hover:enabled": {
             background: neutralFillHover,
-            ...highContrastSelection,
+            ...highContrastSelected,
         },
         "&:active:enabled": {
             background: neutralFillActive,

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -16,7 +16,7 @@ import {
     highContrastDisabledBorder,
     highContrastOutline,
     highContrastOutlineFocus,
-    highContrastSelection,
+    highContrastSelected,
 } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> = {
@@ -39,7 +39,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
                 toPx<DesignSystem>(outlineWidth),
                 neutralOutlineHover
             ),
-            ...highContrastSelection,
+            ...highContrastSelected,
         },
         "&:active:enabled": {
             background: "transparent",

--- a/packages/fast-components-styles-msft/src/pivot/index.ts
+++ b/packages/fast-components-styles-msft/src/pivot/index.ts
@@ -1,5 +1,5 @@
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { PivotClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { DesignSystem } from "../design-system";
 import {
     applyFocusVisible,
     directionSwitch,
@@ -15,7 +15,7 @@ import {
     neutralForegroundHover,
     neutralForegroundRest,
 } from "../utilities/color";
-import { ComponentStyles } from "@microsoft/fast-jss-manager";
+import { DesignSystem } from "../design-system";
 import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { focusOutlineWidth } from "../utilities/design-system";
@@ -23,6 +23,7 @@ import { applyCursorPointer } from "../utilities/cursor";
 import {
     highContrastBorderColor,
     highContrastForeground,
+    highContrastHighlightBackground,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -84,9 +85,7 @@ const styles: ComponentStyles<PivotClassNameContract, DesignSystem> = {
         height: toPx(activeIndicatorHeight),
         display: "block",
         background: accentFillRest,
-        [highContrastSelector]: {
-            background: "Highlight",
-        },
+        ...highContrastHighlightBackground,
     },
     pivot_tabPanel: {
         display: "block",

--- a/packages/fast-components-styles-msft/src/radio/index.ts
+++ b/packages/fast-components-styles-msft/src/radio/index.ts
@@ -1,9 +1,9 @@
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import {
     densityCategorySwitch,
     heightNumber,
     horizontalSpacing,
 } from "../utilities/density";
-import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { RadioClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import {
     add,
@@ -23,16 +23,16 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
-import { ComponentStyles } from "@microsoft/fast-jss-manager";
+import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { designUnit, outlineWidth } from "../utilities/design-system";
 import { applyCursorDisabled, applyCursorPointer } from "../utilities/cursor";
 import {
     highContrastDisabledBorder,
+    highContrastHighlightBackground,
     highContrastSelectedBackground,
     highContrastSelector,
-    highContrastHighlightBackground,
 } from "../utilities/high-contrast";
 
 const inputSize: DesignSystemResolver<string> = toPx(

--- a/packages/fast-components-styles-msft/src/radio/index.ts
+++ b/packages/fast-components-styles-msft/src/radio/index.ts
@@ -1,5 +1,9 @@
+import {
+    densityCategorySwitch,
+    heightNumber,
+    horizontalSpacing,
+} from "../utilities/density";
 import { DesignSystem, DesignSystemResolver } from "../design-system";
-import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { RadioClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import {
     add,
@@ -19,18 +23,16 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
-import {
-    densityCategorySwitch,
-    heightNumber,
-    horizontalSpacing,
-} from "../utilities/density";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { designUnit, outlineWidth } from "../utilities/design-system";
 import { applyCursorDisabled, applyCursorPointer } from "../utilities/cursor";
 import {
     highContrastDisabledBorder,
+    highContrastSelectedBackground,
     highContrastSelector,
+    highContrastHighlightBackground,
 } from "../utilities/high-contrast";
 
 const inputSize: DesignSystemResolver<string> = toPx(
@@ -122,24 +124,16 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         "& $radio_stateIndicator": {
             "&::before": {
                 background: neutralForegroundRest,
-                [highContrastSelector]: {
-                    background: "Highlight",
-                },
+                ...highContrastHighlightBackground,
             },
         },
         "&:hover $radio_stateIndicator::before": {
-            [highContrastSelector]: {
-                background: "HighlightText",
-            },
+            ...highContrastSelectedBackground,
         },
         "& $radio_input": {
-            [highContrastSelector]: {
-                background: "HighlightText",
-            },
+            ...highContrastSelectedBackground,
             "&:hover": {
-                [highContrastSelector]: {
-                    background: "Highlight",
-                },
+                ...highContrastHighlightBackground,
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/select-option/index.ts
+++ b/packages/fast-components-styles-msft/src/select-option/index.ts
@@ -23,7 +23,7 @@ import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import {
     highContrastDisabledBorder,
-    highContrastSelection,
+    highContrastSelected,
     highContrastSelector,
     highContrastStealth,
 } from "../utilities/high-contrast";
@@ -52,7 +52,7 @@ const styles: ComponentStyles<SelectOptionClassNameContract, DesignSystem> = {
         }),
         "&:hover": {
             background: neutralFillStealthHover,
-            ...highContrastSelection,
+            ...highContrastSelected,
         },
         ...highContrastStealth,
     },

--- a/packages/fast-components-styles-msft/src/slider/index.ts
+++ b/packages/fast-components-styles-msft/src/slider/index.ts
@@ -1,5 +1,5 @@
+import { SliderClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
-import { applyCursorPointer } from "../utilities/cursor";
 import {
     add,
     applyFocusVisible,
@@ -18,7 +18,7 @@ import {
     neutralForegroundRest,
     neutralOutlineRest,
 } from "../utilities/color";
-import { SliderClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import { applyCursorPointer } from "../utilities/cursor";
 import { heightNumber } from "../utilities/density";
 import {
     backgroundColor,
@@ -29,6 +29,7 @@ import { applyDisabledState } from "../utilities/disabled";
 import { applyElevation, ElevationMultiplier } from "../utilities/elevation";
 import {
     highContrastBackground,
+    highContrastDisabledBackground,
     highContrastHighlightBackground,
     highContrastSelector,
 } from "../utilities/high-contrast";
@@ -105,9 +106,7 @@ const styles: ComponentStyles<SliderClassNameContract, DesignSystem> = {
     slider__disabled: {
         ...applyDisabledState(),
         "& $slider_thumb, & $slider_backgroundTrack": {
-            [highContrastSelector]: {
-                background: "GrayText",
-            },
+            ...highContrastDisabledBackground,
             "&:hover": {
                 background: neutralForegroundRest,
             },

--- a/packages/fast-components-styles-msft/src/slider/index.ts
+++ b/packages/fast-components-styles-msft/src/slider/index.ts
@@ -1,5 +1,5 @@
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { applyCursorPointer } from "../utilities/cursor";
-import { SliderClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import {
     add,
     applyFocusVisible,
@@ -18,7 +18,7 @@ import {
     neutralForegroundRest,
     neutralOutlineRest,
 } from "../utilities/color";
-import { ComponentStyles } from "@microsoft/fast-jss-manager";
+import { SliderClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { heightNumber } from "../utilities/density";
 import {
     backgroundColor,
@@ -27,7 +27,11 @@ import {
 } from "../utilities/design-system";
 import { applyDisabledState } from "../utilities/disabled";
 import { applyElevation, ElevationMultiplier } from "../utilities/elevation";
-import { highContrastBackground, highContrastSelector } from "../utilities/high-contrast";
+import {
+    highContrastBackground,
+    highContrastHighlightBackground,
+    highContrastSelector,
+} from "../utilities/high-contrast";
 
 const thumbSizeValue: DesignSystemResolver<number> = add(
     divide(heightNumber(), 2),
@@ -96,9 +100,7 @@ const styles: ComponentStyles<SliderClassNameContract, DesignSystem> = {
         ...applyCornerRadius(),
         background: neutralForegroundHint,
         transition: "all 0.2s ease",
-        [highContrastSelector]: {
-            background: "Highlight",
-        },
+        ...highContrastHighlightBackground,
     },
     slider__disabled: {
         ...applyDisabledState(),

--- a/packages/fast-components-styles-msft/src/stealth-button/index.ts
+++ b/packages/fast-components-styles-msft/src/stealth-button/index.ts
@@ -13,7 +13,7 @@ import { baseButton, buttonStyles } from "../patterns/button";
 import {
     highContrastDisabledBorder,
     highContrastOutlineFocus,
-    highContrastSelection,
+    highContrastSelected,
     highContrastStealth,
 } from "../utilities/high-contrast";
 
@@ -26,7 +26,7 @@ const styles: ComponentStyles<StealthButtonClassNameContract, DesignSystem> = {
         background: neutralFillStealthRest,
         "&:hover:enabled": {
             "background-color": neutralFillStealthHover,
-            ...highContrastSelection,
+            ...highContrastSelected,
         },
         "&:active:enabled": {
             "background-color": neutralFillStealthActive,

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -1,4 +1,3 @@
-import { DesignSystem, DesignSystemResolver } from "../design-system";
 import {
     accentFillRest,
     accentForegroundCut,
@@ -13,6 +12,7 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
+import { applyDisabledState } from "../utilities/disabled";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import {
     add,
@@ -25,7 +25,7 @@ import {
     toPx,
 } from "@microsoft/fast-jss-utilities";
 import { ToggleClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { applyDisabledState } from "../utilities/disabled";
+import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { densityCategorySwitch, heightNumber } from "../utilities/density";
 import { designUnit, focusOutlineWidth, outlineWidth } from "../utilities/design-system";
@@ -34,6 +34,8 @@ import {
     highContrastBackground,
     highContrastBorderColor,
     highContrastDoubleFocus,
+    highContrastHighlightBackground,
+    highContrastSelectedBackground,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -178,13 +180,9 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         "& $toggle_stateIndicator": {
             left: toPx(indicatorCheckedLeft),
             background: accentForegroundCut,
-            [highContrastSelector]: {
-                background: "HighlightText",
-            },
+            ...highContrastSelectedBackground,
             "&:hover": {
-                [highContrastSelector]: {
-                    background: "Highlight",
-                },
+                ...highContrastHighlightBackground,
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -17,7 +17,7 @@ export enum HighContrastColor {
 }
 
 function ImportantColor(color: HighContrastColor): string {
-    return color + "!important";
+    return `${color} !important`;
 }
 
 // Used to remove text backplate and borders in 'button-text' colors
@@ -107,6 +107,18 @@ export const highContrastDoubleFocus: CSSRules<DesignSystem> = {
     },
 };
 
+/**
+ * @deprecated Use 'highContrastSelected' instead
+ */
+export const highContrastSelection: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        background: HighContrastColor.selectedBackground,
+        "border-color": HighContrastColor.buttonText,
+        color: HighContrastColor.selectedText,
+        fill: HighContrastColor.selectedText,
+    },
+};
+
 // Used to set 'selected-text' color
 export const highContrastSelected: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
@@ -176,7 +188,7 @@ export const highContrastBackground: CSSRules<DesignSystem> = {
 };
 
 // Used to set background to be 'selected-text' color
-export const highContrastSelectionBackground: CSSRules<DesignSystem> = {
+export const highContrastSelectedBackground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         background: HighContrastColor.selectedText,
     },

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -16,6 +16,10 @@ export enum HighContrastColor {
     background = "Background",
 }
 
+function ImportantColor(color: HighContrastColor): string {
+    return color + "!important";
+}
+
 // Used to remove text backplate and borders in 'button-text' colors
 export const highContrastStealth: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
@@ -63,7 +67,7 @@ export const highContrastDisabled: CSSRules<DesignSystem> = {
 export const highContrastDisabledBorder: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         opacity: "1",
-        background: "ButtonFace !important",
+        background: ImportantColor(HighContrastColor.buttonBackground),
         "border-color": HighContrastColor.disabledText,
         color: HighContrastColor.disabledText,
         fill: HighContrastColor.disabledText,
@@ -94,7 +98,7 @@ export const highContrastOutlineFocus: CSSRules<DesignSystem> = {
 // Used to set double focus with keyboard focus
 export const highContrastDoubleFocus: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
-        "border-color": "ButtonText !important",
+        "border-color": ImportantColor(HighContrastColor.buttonText),
         "box-shadow": format(
             "0 0 0 {0} inset {1}",
             toPx(focusOutlineWidth),
@@ -104,7 +108,7 @@ export const highContrastDoubleFocus: CSSRules<DesignSystem> = {
 };
 
 // Used to set 'selected-text' color
-export const highContrastSelection: CSSRules<DesignSystem> = {
+export const highContrastSelected: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         background: HighContrastColor.selectedBackground,
         color: HighContrastColor.selectedText,
@@ -112,29 +116,37 @@ export const highContrastSelection: CSSRules<DesignSystem> = {
     },
 };
 
-// Used to set 'selected-text' color with an outline
-export const highContrastSelectionOutline: CSSRules<DesignSystem> = {
+// Used to set 'selected-background' color with an outline
+export const highContrastSelectedOutline: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
-        background: HighContrastColor.selectedBackground,
-        "border-color": HighContrastColor.buttonText,
-        color: HighContrastColor.selectedText,
-        fill: HighContrastColor.selectedText,
+        background: HighContrastColor.selectedText,
+        "border-color": HighContrastColor.selectedBackground,
+        color: HighContrastColor.selectedBackground,
+        fill: HighContrastColor.selectedBackground,
     },
 };
 
 // Used to set foreground and glyph to be 'button-text' color
 export const highContrastForeground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
-        color: "ButtonText !important",
-        fill: "ButtonText !important",
+        color: ImportantColor(HighContrastColor.buttonText),
+        fill: ImportantColor(HighContrastColor.buttonText),
     },
 };
 
 // Used to set foreground and glyph to be 'select-text' color
-export const highContrastSelectionForeground: CSSRules<DesignSystem> = {
+export const highContrastSelectedForeground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
-        color: "HighlightText !important",
-        fill: "HighlightText !important",
+        color: ImportantColor(HighContrastColor.selectedText),
+        fill: ImportantColor(HighContrastColor.selectedText),
+    },
+};
+
+// Used to set foreground and glyph to be 'highlight' color
+export const highContrastHighlightForeground: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        color: ImportantColor(HighContrastColor.selectedBackground),
+        fill: ImportantColor(HighContrastColor.selectedBackground),
     },
 };
 
@@ -167,5 +179,12 @@ export const highContrastBackground: CSSRules<DesignSystem> = {
 export const highContrastSelectionBackground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         background: HighContrastColor.selectedText,
+    },
+};
+
+// Used to set background to be 'highlight' color
+export const highContrastHighlightBackground: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        background: HighContrastColor.selectedBackground,
     },
 };

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -2,22 +2,19 @@ import { CSSRules } from "@microsoft/fast-jss-manager";
 import { DesignSystem } from "../design-system";
 import { format, toPx } from "@microsoft/fast-jss-utilities";
 import { focusOutlineWidth, outlineWidth } from "./design-system";
+import { importantValue } from "./important";
 
 export const highContrastSelector: string = "@media (-ms-high-contrast:active)";
 
 export enum HighContrastColor {
     text = "WindowText",
     hyperLinks = "LinkText",
-    disabledText = "GrayText !important",
+    disabledText = "GrayText",
     selectedText = "HighlightText",
     selectedBackground = "Highlight",
     buttonText = "ButtonText",
     buttonBackground = "ButtonFace",
     background = "Background",
-}
-
-function ImportantColor(color: HighContrastColor): string {
-    return `${color} !important`;
 }
 
 // Used to remove text backplate and borders in 'button-text' colors
@@ -57,9 +54,9 @@ export const highContrastAccent: CSSRules<DesignSystem> = {
 export const highContrastDisabled: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         opacity: "1",
-        background: HighContrastColor.background,
-        color: HighContrastColor.disabledText,
-        fill: HighContrastColor.disabledText,
+        background: importantValue(HighContrastColor.buttonBackground),
+        color: importantValue(HighContrastColor.disabledText),
+        fill: importantValue(HighContrastColor.disabledText),
     },
 };
 
@@ -67,10 +64,10 @@ export const highContrastDisabled: CSSRules<DesignSystem> = {
 export const highContrastDisabledBorder: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         opacity: "1",
-        background: ImportantColor(HighContrastColor.buttonBackground),
-        "border-color": HighContrastColor.disabledText,
-        color: HighContrastColor.disabledText,
-        fill: HighContrastColor.disabledText,
+        background: importantValue(HighContrastColor.buttonBackground),
+        color: importantValue(HighContrastColor.disabledText),
+        fill: importantValue(HighContrastColor.disabledText),
+        "border-color": importantValue(HighContrastColor.disabledText),
     },
 };
 
@@ -78,8 +75,16 @@ export const highContrastDisabledBorder: CSSRules<DesignSystem> = {
 export const highContrastDisabledForeground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         opacity: "1",
-        color: HighContrastColor.disabledText,
-        fill: HighContrastColor.disabledText,
+        color: importantValue(HighContrastColor.disabledText),
+        fill: importantValue(HighContrastColor.disabledText),
+    },
+};
+
+// Used to set background to disabled color
+export const highContrastDisabledBackground: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        opacity: "1",
+        background: importantValue(HighContrastColor.disabledText),
     },
 };
 
@@ -98,24 +103,12 @@ export const highContrastOutlineFocus: CSSRules<DesignSystem> = {
 // Used to set double focus with keyboard focus
 export const highContrastDoubleFocus: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
-        "border-color": ImportantColor(HighContrastColor.buttonText),
+        "border-color": importantValue(HighContrastColor.buttonText),
         "box-shadow": format(
             "0 0 0 {0} inset {1}",
             toPx(focusOutlineWidth),
             () => HighContrastColor.buttonBackground
         ),
-    },
-};
-
-/**
- * @deprecated Use 'highContrastSelected' instead
- */
-export const highContrastSelection: CSSRules<DesignSystem> = {
-    [highContrastSelector]: {
-        background: HighContrastColor.selectedBackground,
-        "border-color": HighContrastColor.buttonText,
-        color: HighContrastColor.selectedText,
-        fill: HighContrastColor.selectedText,
     },
 };
 
@@ -127,6 +120,10 @@ export const highContrastSelected: CSSRules<DesignSystem> = {
         fill: HighContrastColor.selectedText,
     },
 };
+/**
+ * @deprecated Use 'highContrastSelected' instead
+ */
+export const highContrastSelection: CSSRules<DesignSystem> = highContrastSelected;
 
 // Used to set 'selected-background' color with an outline
 export const highContrastSelectedOutline: CSSRules<DesignSystem> = {
@@ -141,24 +138,24 @@ export const highContrastSelectedOutline: CSSRules<DesignSystem> = {
 // Used to set foreground and glyph to be 'button-text' color
 export const highContrastForeground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
-        color: ImportantColor(HighContrastColor.buttonText),
-        fill: ImportantColor(HighContrastColor.buttonText),
+        color: importantValue(HighContrastColor.buttonText),
+        fill: importantValue(HighContrastColor.buttonText),
     },
 };
 
 // Used to set foreground and glyph to be 'select-text' color
 export const highContrastSelectedForeground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
-        color: ImportantColor(HighContrastColor.selectedText),
-        fill: ImportantColor(HighContrastColor.selectedText),
+        color: importantValue(HighContrastColor.selectedText),
+        fill: importantValue(HighContrastColor.selectedText),
     },
 };
 
 // Used to set foreground and glyph to be 'highlight' color
 export const highContrastHighlightForeground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
-        color: ImportantColor(HighContrastColor.selectedBackground),
-        fill: ImportantColor(HighContrastColor.selectedBackground),
+        color: importantValue(HighContrastColor.selectedBackground),
+        fill: importantValue(HighContrastColor.selectedBackground),
     },
 };
 

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -20,20 +20,31 @@ export enum HighContrastColor {
 export const highContrastStealth: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         background: HighContrastColor.buttonBackground,
+        border: "none",
         color: HighContrastColor.buttonText,
         fill: HighContrastColor.buttonText,
-        border: "none",
         "-ms-high-contrast-adjust": "none",
     },
 };
 
-// Used to remove text backplate in 'button-text' colors
+// Used to remove text backplate in 'button-text' and 'button-background' colors
 export const highContrastOutline: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         background: HighContrastColor.buttonBackground,
         "border-color": HighContrastColor.buttonText,
         color: HighContrastColor.buttonText,
         fill: HighContrastColor.buttonText,
+        "-ms-high-contrast-adjust": "none",
+    },
+};
+
+// Used to remove text backplate in 'select-text' and 'selected-background' colors
+export const highContrastAccent: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        background: HighContrastColor.selectedBackground,
+        "border-color": HighContrastColor.selectedBackground,
+        color: HighContrastColor.selectedText,
+        fill: HighContrastColor.selectedText,
         "-ms-high-contrast-adjust": "none",
     },
 };
@@ -96,6 +107,15 @@ export const highContrastDoubleFocus: CSSRules<DesignSystem> = {
 export const highContrastSelection: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         background: HighContrastColor.selectedBackground,
+        color: HighContrastColor.selectedText,
+        fill: HighContrastColor.selectedText,
+    },
+};
+
+// Used to set 'selected-text' color with an outline
+export const highContrastSelectionOutline: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        background: HighContrastColor.selectedBackground,
         "border-color": HighContrastColor.buttonText,
         color: HighContrastColor.selectedText,
         fill: HighContrastColor.selectedText,
@@ -107,6 +127,14 @@ export const highContrastForeground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         color: "ButtonText !important",
         fill: "ButtonText !important",
+    },
+};
+
+// Used to set foreground and glyph to be 'select-text' color
+export const highContrastSelectionForeground: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        color: "HighlightText !important",
+        fill: "HighlightText !important",
     },
 };
 
@@ -132,5 +160,12 @@ export const highContrastBorderColor: CSSRules<DesignSystem> = {
 export const highContrastBackground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         background: HighContrastColor.buttonText,
+    },
+};
+
+// Used to set background to be 'selected-text' color
+export const highContrastSelectionBackground: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        background: HighContrastColor.selectedText,
     },
 };

--- a/packages/fast-components-styles-msft/src/utilities/important.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/important.spec.ts
@@ -1,8 +1,15 @@
 import { importantValue } from "./important";
+import defaultDesignSystem from "../design-system";
+import { height } from "./density";
 
 describe("important", (): void => {
     test("adds !important to a passed in css value", (): void => {
-        const result: string = importantValue("width: 10px");
-        expect(result).toEqual("width: 10px !important");
+        const result: string = importantValue("10px")(defaultDesignSystem);
+        expect(result).toEqual("10px !important");
+    });
+
+    test("adds !important to a design system function", (): void => {
+        const result: string = importantValue(height())(defaultDesignSystem);
+        expect(result).toEqual("32px !important");
     });
 });

--- a/packages/fast-components-styles-msft/src/utilities/important.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/important.spec.ts
@@ -1,0 +1,8 @@
+import { importantValue } from "./important";
+
+describe("important", (): void => {
+    test("adds !important to a passed in css value", (): void => {
+        const result: string = importantValue("width: 10px");
+        expect(result).toEqual("width: 10px !important");
+    });
+});

--- a/packages/fast-components-styles-msft/src/utilities/important.ts
+++ b/packages/fast-components-styles-msft/src/utilities/important.ts
@@ -1,6 +1,14 @@
+import {
+    checkDesignSystemResolver,
+    DesignSystem,
+    DesignSystemResolver
+} from "../design-system";
+
 /**
  * Sets a css value to be '!important'.
  */
-export function importantValue(value: string): string {
-    return `${value} !important`;
+export function importantValue(value: string | DesignSystemResolver<string>): DesignSystemResolver<string> {
+    return (designSystem: DesignSystem): string => {
+        return `${checkDesignSystemResolver(value, designSystem)} !important`;
+    }
 }

--- a/packages/fast-components-styles-msft/src/utilities/important.ts
+++ b/packages/fast-components-styles-msft/src/utilities/important.ts
@@ -1,0 +1,6 @@
+/**
+ * Sets a css value to be '!important'.
+ */
+export function importantValue(value: string): string {
+    return `${value} !important`;
+}

--- a/packages/fast-components-styles-msft/src/utilities/important.ts
+++ b/packages/fast-components-styles-msft/src/utilities/important.ts
@@ -1,14 +1,16 @@
 import {
     checkDesignSystemResolver,
     DesignSystem,
-    DesignSystemResolver
+    DesignSystemResolver,
 } from "../design-system";
 
 /**
  * Sets a css value to be '!important'.
  */
-export function importantValue(value: string | DesignSystemResolver<string>): DesignSystemResolver<string> {
+export function importantValue(
+    value: string | DesignSystemResolver<string>
+): DesignSystemResolver<string> {
     return (designSystem: DesignSystem): string => {
         return `${checkDesignSystemResolver(value, designSystem)} !important`;
-    }
+    };
 }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
While working on high contrast in Edge Web UI, I was noticing the icon components, from our icon packages, were not changing colors on hover. The fix was to set its fill property to the correct color on hover. We should not have to do this. The components should take care of setting the correct colors already.
After investigating, the `fill` property, in our button styles, was not set on hover. During the initial high contrast pass, we were testing to make sure text and icons were working properly, which they did, but did not test to see if icons from edge-icons or news-icons packages worked. If I had imported an edge-icon into a storybook example, I would have noticed that the fill property should have also been set on hover.
The fix is to set, as an example, `fill: "HighlightText"` (or whatever color it should be) to be included in the hover state. Now when any icon is being used in our Buttons, whether it is a beforeContent, afterContent, or an imported icon from one of our icon packages, the high contrast colors will be correct in all states.

There were also more common patterns that were be added to the `high-contrast` utility file.
Added:
- highContrastAccent
- highContrastSelectionOutline
- highContrastSelectionForeground
- highContrastSelectionBackground

The Button storybook example was also updated. The Stealth example was incorrect.



## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->