### PR TITLE
chore: cleanup unused imports, typos, and warnings in styles package

### DIFF
--- a/packages/fast-components-styles-msft/src/action-toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/action-toggle/index.ts
@@ -1,14 +1,10 @@
-import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import {
     ActionToggleClassNameContract,
     ButtonClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-msft";
-import {
-    applyLocalizedProperty,
-    Direction,
-    directionSwitch,
-} from "@microsoft/fast-jss-utilities";
-import { DesignSystem, withDesignSystemDefaults } from "../design-system/index";
+import { directionSwitch } from "@microsoft/fast-jss-utilities";
+import { DesignSystem } from "../design-system/index";
 import {
     accentForegroundActive,
     accentForegroundCut,

--- a/packages/fast-components-styles-msft/src/auto-suggest-option/index.ts
+++ b/packages/fast-components-styles-msft/src/auto-suggest-option/index.ts
@@ -3,7 +3,7 @@ import {
     directionSwitch,
     format,
 } from "@microsoft/fast-jss-utilities";
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
+import { DesignSystem } from "../design-system";
 import { AutoSuggestOptionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { height, horizontalSpacing } from "../utilities/density";
 import {
@@ -13,9 +13,9 @@ import {
     neutralFocus,
     neutralForegroundRest,
 } from "../utilities/color";
-import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { applyScaledTypeRamp } from "../utilities/typography";
-import { Direction, ellipsis, toPx } from "@microsoft/fast-jss-utilities";
+import { ellipsis, toPx } from "@microsoft/fast-jss-utilities";
 import { applyCornerRadius, applyFocusPlaceholderBorder } from "../utilities/border";
 import { applyCursorDefault } from "../utilities/cursor";
 import { applyDisabledState } from "../utilities/disabled";

--- a/packages/fast-components-styles-msft/src/auto-suggest/index.ts
+++ b/packages/fast-components-styles-msft/src/auto-suggest/index.ts
@@ -1,5 +1,5 @@
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
-import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
+import { DesignSystem } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { AutoSuggestClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { add, format, multiply, toPx } from "@microsoft/fast-jss-utilities";
 import { applyElevatedCornerRadius } from "../utilities/border";

--- a/packages/fast-components-styles-msft/src/badge/index.ts
+++ b/packages/fast-components-styles-msft/src/badge/index.ts
@@ -1,9 +1,5 @@
 import { BadgeClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import {
-    ComponentStyles,
-    ComponentStyleSheet,
-    CSSRules,
-} from "@microsoft/fast-jss-manager";
+import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
 import { ellipsis, format, toPx } from "@microsoft/fast-jss-utilities";
 import { DesignSystem, withDesignSystemDefaults } from "../design-system/index";
 import { applyCornerRadius } from "../utilities/border";

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -231,7 +231,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             ...highContrastOutlineFocus,
             "box-shadow": format(
                 "0 0 0 {0} {1} inset",
-                toPx(subtract(focusOutlineWidth, outlineWidth)),
+                toPx<DesignSystem>(subtract(focusOutlineWidth, outlineWidth)),
                 neutralFocus
             ),
             "border-color": neutralFocus,

--- a/packages/fast-components-styles-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-styles-msft/src/call-to-action/index.ts
@@ -1,15 +1,10 @@
-import {
-    ComponentStyles,
-    ComponentStyleSheet,
-    CSSRules,
-} from "@microsoft/fast-jss-manager";
+import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import {
     ButtonClassNameContract,
     CallToActionClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-msft";
 import {
     applyFocusVisible,
-    Direction,
     directionSwitch,
     format,
     multiply,

--- a/packages/fast-components-styles-msft/src/caption/index.ts
+++ b/packages/fast-components-styles-msft/src/caption/index.ts
@@ -1,5 +1,5 @@
 import { DesignSystem } from "../design-system";
-import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { CaptionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 
 const styles: ComponentStyles<CaptionClassNameContract, DesignSystem> = {

--- a/packages/fast-components-styles-msft/src/context-menu-item/index.ts
+++ b/packages/fast-components-styles-msft/src/context-menu-item/index.ts
@@ -11,7 +11,7 @@ import {
 } from "../utilities/color";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { height, horizontalSpacingNumber } from "../utilities/density";
-import { designUnit, focusOutlineWidth } from "../utilities/design-system";
+import { designUnit } from "../utilities/design-system";
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import {

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -272,7 +272,7 @@ export function checkDesignSystemResolver<T>(
 
 /**
  * Returns a function that calls the callback with designSystemDefaults ensured.
- * @deprecated - use design system property accesseor functions instead
+ * @deprecated - use design system property accessor functions instead
  */
 export function ensureDesignSystemDefaults<T>(
     callback: (designSystem: DesignSystem) => T

--- a/packages/fast-components-styles-msft/src/heading/index.ts
+++ b/packages/fast-components-styles-msft/src/heading/index.ts
@@ -1,5 +1,5 @@
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
-import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
+import { DesignSystem } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { HeadingClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { applyFontWeightSemiBold } from "../utilities/fonts";
 

--- a/packages/fast-components-styles-msft/src/label/index.ts
+++ b/packages/fast-components-styles-msft/src/label/index.ts
@@ -1,5 +1,5 @@
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
-import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
+import { DesignSystem } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { LabelClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { applyScreenReader } from "@microsoft/fast-jss-utilities";
 import { neutralForegroundRest } from "../utilities/color";

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -1,5 +1,5 @@
 import { ButtonBaseClassNameContract as LightweightButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { DesignSystem } from "../design-system";
 import { baseButton, buttonStyles } from "../patterns/button";
 import {

--- a/packages/fast-components-styles-msft/src/metatext/index.ts
+++ b/packages/fast-components-styles-msft/src/metatext/index.ts
@@ -1,5 +1,5 @@
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
-import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
+import { DesignSystem } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { MetatextClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { neutralForegroundHint } from "../utilities/color";
 import { applyScaledTypeRamp } from "../utilities/typography";

--- a/packages/fast-components-styles-msft/src/neutral-button/index.ts
+++ b/packages/fast-components-styles-msft/src/neutral-button/index.ts
@@ -2,7 +2,7 @@ import { ButtonBaseClassNameContract as NeutralButtonClassNameContract } from "@
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { DesignSystem } from "../design-system";
 import { baseButton, buttonStyles } from "../patterns/button";
-import { applyFocusVisible, format, toPx } from "@microsoft/fast-jss-utilities";
+import { applyFocusVisible } from "@microsoft/fast-jss-utilities";
 import {
     neutralFillActive,
     neutralFillHover,

--- a/packages/fast-components-styles-msft/src/number-field/index.ts
+++ b/packages/fast-components-styles-msft/src/number-field/index.ts
@@ -1,5 +1,5 @@
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
-import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
+import { DesignSystem } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { NumberFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { directionSwitch, format } from "@microsoft/fast-jss-utilities";
 import { height, horizontalSpacing } from "../utilities/density";

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -52,7 +52,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
         ...applyFocusVisible<DesignSystem>({
             "box-shadow": format(
                 "0 0 0 {0} {1} inset",
-                toPx(subtract(focusOutlineWidth, outlineWidth)),
+                toPx<DesignSystem>(subtract(focusOutlineWidth, outlineWidth)),
                 neutralFocus
             ),
             "border-color": neutralFocus,

--- a/packages/fast-components-styles-msft/src/paragraph/index.ts
+++ b/packages/fast-components-styles-msft/src/paragraph/index.ts
@@ -1,4 +1,4 @@
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
+import { DesignSystem } from "../design-system";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { ParagraphClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { applyFontWeightNormal } from "../utilities/fonts";

--- a/packages/fast-components-styles-msft/src/progress/index.ts
+++ b/packages/fast-components-styles-msft/src/progress/index.ts
@@ -1,8 +1,5 @@
-import designSystemDefaults, {
-    DesignSystem,
-    withDesignSystemDefaults,
-} from "../design-system";
-import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
+import { DesignSystem } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { ProgressClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import {
     accentFillRest,

--- a/packages/fast-components-styles-msft/src/stealth-button/index.ts
+++ b/packages/fast-components-styles-msft/src/stealth-button/index.ts
@@ -1,6 +1,6 @@
 import { ButtonBaseClassNameContract as StealthButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
-import { applyFocusVisible, format, toPx } from "@microsoft/fast-jss-utilities";
+import { applyFocusVisible } from "@microsoft/fast-jss-utilities";
 import { DesignSystem } from "../design-system";
 import {
     neutralFillStealthActive,

--- a/packages/fast-components-styles-msft/src/subheading/index.ts
+++ b/packages/fast-components-styles-msft/src/subheading/index.ts
@@ -1,5 +1,5 @@
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
-import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
+import { DesignSystem } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { SubheadingClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { applyFontWeightNormal } from "../utilities/fonts";
 

--- a/packages/fast-components-styles-msft/src/text-area/index.ts
+++ b/packages/fast-components-styles-msft/src/text-area/index.ts
@@ -1,6 +1,6 @@
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
+import { DesignSystem } from "../design-system";
 import { TextAreaClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { ComponentStyles, ComponentStyleSheet } from "@microsoft/fast-jss-manager";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { height } from "../utilities/density";
 import { inputFieldStyles } from "../patterns/input-field";
 import { multiply, toPx } from "@microsoft/fast-jss-utilities";

--- a/packages/fast-components-styles-msft/src/utilities/acrylic.ts
+++ b/packages/fast-components-styles-msft/src/utilities/acrylic.ts
@@ -1,6 +1,6 @@
 import { AcrylicConfig, applyAcrylic, toPx } from "@microsoft/fast-jss-utilities";
 import { CSSRules } from "@microsoft/fast-jss-manager";
-import designSystemDefaults, { DesignSystem } from "../design-system";
+import { DesignSystem } from "../design-system";
 import { parseColorString } from "../utilities/color/common";
 import { ColorRGBA64 } from "@microsoft/fast-colors";
 

--- a/packages/fast-components-styles-msft/src/utilities/color/accent-fill.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/accent-fill.ts
@@ -3,7 +3,6 @@ import {
     accentBaseColor,
     accentFillActiveDelta,
     accentFillHoverDelta,
-    accentFillRestDelta,
     accentFillSelectedDelta,
     accentPalette,
     neutralFillActiveDelta,

--- a/packages/fast-components-styles-msft/src/utilities/color/common.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/common.spec.ts
@@ -48,7 +48,7 @@ describe("parseColorHexRGB", (): void => {
     test("should parse #RRGGBB color strings", (): void => {
         expect(parseColorString("#001122") instanceof ColorRGBA64).toBe(true);
     });
-    test("should throw if the color is a malformed shothand hex", (): void => {
+    test("should throw if the color is a malformed shorthand hex", (): void => {
         expect(
             (): void => {
                 parseColorString("#GGG");

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-card.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-card.spec.ts
@@ -1,5 +1,3 @@
-import { Palette } from "./palette";
-import { neutralPalette } from "../design-system";
 import { neutralFillCard } from "./neutral-fill-card";
 import defaultDesignSystem, { DesignSystem } from "../../design-system";
 

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-stealth.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-fill-stealth.ts
@@ -29,7 +29,7 @@ const neutralFillStealthSwapThreshold: DesignSystemResolver<
     neutralFillStealthActiveDelta
 );
 
-function neutralFillStealthAlogrithm(
+function neutralFillStealthAlgorithm(
     deltaResolver: DesignSystemResolver<number>
 ): DesignSystemResolver<Swatch> {
     return (designSystem: DesignSystem): Swatch => {
@@ -57,14 +57,14 @@ export const neutralFillStealth: ColorRecipe<FillSwatchFamily> = colorRecipeFact
 );
 
 export const neutralFillStealthRest: ColorRecipe<Swatch> = colorRecipeFactory(
-    neutralFillStealthAlogrithm(neutralFillStealthRestDelta)
+    neutralFillStealthAlgorithm(neutralFillStealthRestDelta)
 );
 export const neutralFillStealthHover: ColorRecipe<Swatch> = colorRecipeFactory(
-    neutralFillStealthAlogrithm(neutralFillStealthHoverDelta)
+    neutralFillStealthAlgorithm(neutralFillStealthHoverDelta)
 );
 export const neutralFillStealthActive: ColorRecipe<Swatch> = colorRecipeFactory(
-    neutralFillStealthAlogrithm(neutralFillStealthActiveDelta)
+    neutralFillStealthAlgorithm(neutralFillStealthActiveDelta)
 );
 export const neutralFillStealthSelected: ColorRecipe<Swatch> = colorRecipeFactory(
-    neutralFillStealthAlogrithm(neutralFillStealthSelectedDelta)
+    neutralFillStealthAlgorithm(neutralFillStealthSelectedDelta)
 );

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground-hint.ts
@@ -4,7 +4,7 @@ import { colorRecipeFactory, SwatchRecipe } from "./common";
 import { backgroundColor, neutralPalette } from "../design-system";
 
 /**
- * Resolves the index that the contrast serach algorithm should start at
+ * Resolves the index that the contrast search algorithm should start at
  */
 function neutralForegroundHintInitialIndexResolver(
     referenceColor: string,
@@ -17,7 +17,7 @@ function neutralForegroundHintInitialIndexResolver(
 /**
  * resolves the direction to look for accessible swatches
  */
-function neturalForegroundHintDirectionResolver(
+function neutralForegroundHintDirectionResolver(
     referenceIndex: number,
     sourcePalette: Palette,
     designSystem: DesignSystem
@@ -29,7 +29,7 @@ const neutralForegroundHintAlgorithm: ReturnType<
     ReturnType<ReturnType<ReturnType<typeof swatchByContrast>>>
 > = swatchByContrast(backgroundColor)(neutralPalette)(
     neutralForegroundHintInitialIndexResolver
-)(neturalForegroundHintDirectionResolver);
+)(neutralForegroundHintDirectionResolver);
 
 function contrastTargetFactory(
     targetContrast: number

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-foreground.ts
@@ -24,7 +24,7 @@ import {
 } from "./palette";
 
 /**
- * Resolves the index that the contrast serach algorithm should start at
+ * Resolves the index that the contrast search algorithm should start at
  */
 function neutralForegroundInitialIndexResolver(
     referenceColor: string,

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.spec.ts
@@ -28,7 +28,7 @@ describe("neutralLayer", (): void => {
                 designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L1]
             );
         });
-        test("should opperate on a provided background color", (): void => {
+        test("should operate on a provided background color", (): void => {
             expect(neutralLayerL1((): string => "#000000")(designSystemDefaults)).toBe(
                 designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L1]
             );
@@ -49,7 +49,7 @@ describe("neutralLayer", (): void => {
                 designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L1Alt]
             );
         });
-        test("should opperate on a provided background color", (): void => {
+        test("should operate on a provided background color", (): void => {
             expect(neutralLayerL1Alt((): string => "#000000")(designSystemDefaults)).toBe(
                 designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L1Alt]
             );
@@ -72,7 +72,7 @@ describe("neutralLayer", (): void => {
                 designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L2]
             );
         });
-        test("should opperate on a provided background color", (): void => {
+        test("should operate on a provided background color", (): void => {
             expect(neutralLayerL2((): string => "#000000")(designSystemDefaults)).toBe(
                 designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L2]
             );
@@ -93,7 +93,7 @@ describe("neutralLayer", (): void => {
                 designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L3]
             );
         });
-        test("should opperate on a provided background color", (): void => {
+        test("should operate on a provided background color", (): void => {
             expect(neutralLayerL3((): string => "#000000")(designSystemDefaults)).toBe(
                 designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L3]
             );
@@ -114,7 +114,7 @@ describe("neutralLayer", (): void => {
                 designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L4]
             );
         });
-        test("should opperate on a provided background color", (): void => {
+        test("should operate on a provided background color", (): void => {
             expect(neutralLayerL4((): string => "#000000")(designSystemDefaults)).toBe(
                 designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L4]
             );
@@ -133,7 +133,7 @@ describe("neutralLayer", (): void => {
             ).toBeTruthy();
         });
 
-        test("should opperate on a provided background color", (): void => {
+        test("should operate on a provided background color", (): void => {
             const color: string = neutralLayerFloating((): string => "#000000")(
                 designSystemDefaults
             );
@@ -150,7 +150,7 @@ describe("neutralLayer", (): void => {
                 )
             ).toBeTruthy();
         });
-        test("should opperate on a provided background color", (): void => {
+        test("should operate on a provided background color", (): void => {
             const color: string = neutralLayerCardContainer((): string => "#000000")(
                 designSystemDefaults
             );
@@ -167,7 +167,7 @@ describe("neutralLayer", (): void => {
                 )
             ).toBeTruthy();
         });
-        test("should opperate on a provided background color", (): void => {
+        test("should operate on a provided background color", (): void => {
             const color: string = neutralLayerCard((): string => "#000000")(
                 designSystemDefaults
             );

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.spec.ts
@@ -59,7 +59,7 @@ describe("palette", (): void => {
 describe("findSwatchIndex", (): void => {
     const accent: string = accentBaseColor(designSystemDefaults);
 
-    test("should impelment design-system defaults", (): void => {
+    test("should implement design-system defaults", (): void => {
         expect(findSwatchIndex(neutralPalette, "#FFF")({} as DesignSystem)).toBe(0);
         expect(
             findSwatchIndex(accentPalette, accentBaseColor({} as DesignSystem))(
@@ -223,7 +223,7 @@ describe("swatchByContrast", (): void => {
             expect(directionResolver).toHaveBeenCalledTimes(1);
             expect(directionResolver.mock.calls[0][0]).toBe(index);
         });
-        test("should recieve the palette length - 1 if the resolved index is greater than the palette length", (): void => {
+        test("should receive the palette length - 1 if the resolved index is greater than the palette length", (): void => {
             const index: number = 105;
             const indexResolver: jest.SpyInstance = jest.fn(() => index);
             const directionResolver: jest.SpyInstance = jest.fn(() => 1);
@@ -237,7 +237,7 @@ describe("swatchByContrast", (): void => {
                 neutralPalette({} as DesignSystem).length - 1
             );
         });
-        test("should recieve recieve 0 if the resolved index is less than 0", (): void => {
+        test("should receive 0 if the resolved index is less than 0", (): void => {
             const index: number = -20;
             const indexResolver: jest.SpyInstance = jest.fn(() => index);
             const directionResolver: jest.SpyInstance = jest.fn(() => 1);
@@ -275,7 +275,7 @@ describe("swatchByContrast", (): void => {
         });
     });
 
-    test("should return the color at the inital index if it satisfies the predicate", (): void => {
+    test("should return the color at the initial index if it satisfies the predicate", (): void => {
         const indexResolver: () => number = (): number => 0;
         const directionResolver: () => 1 | -1 = (): 1 | -1 => 1;
         const contrastCondition: () => boolean = (): boolean => true;

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -1,8 +1,5 @@
 import { clamp, inRange } from "lodash-es";
-import defaultDesignSystem, {
-    DesignSystem,
-    DesignSystemResolver,
-} from "../../design-system";
+import { DesignSystem, DesignSystemResolver } from "../../design-system";
 import { backgroundColor } from "../../utilities/design-system";
 import { accentPalette, neutralPalette } from "../design-system";
 import {

--- a/packages/fast-components-styles-msft/src/utilities/cursor.ts
+++ b/packages/fast-components-styles-msft/src/utilities/cursor.ts
@@ -1,5 +1,5 @@
 import { CSSRules } from "@microsoft/fast-jss-manager";
-import { DesignSystem, withDesignSystemDefaults } from "../design-system";
+import { DesignSystem } from "../design-system";
 
 export function applyCursorDefault(): CSSRules<DesignSystem> {
     return {

--- a/packages/fast-components-styles-msft/src/utilities/fonts.ts
+++ b/packages/fast-components-styles-msft/src/utilities/fonts.ts
@@ -1,8 +1,5 @@
 import { CSSRules } from "@microsoft/fast-jss-manager";
-import designSystemDefaults, {
-    DesignSystem,
-    DesignSystemResolver,
-} from "../design-system";
+import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { getFontWeight } from "./design-system";
 
 export interface FontWeight {


### PR DESCRIPTION
# Description

Cleaned up unused imports, typos, and warnings in styles package.

## Motivation & context

Keeping things neat and orderly.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->