### PR TITLE
fix: use defaultChecked instead of checked to ensure checkbox input updates based on props

### DIFF
--- a/packages/fast-components-react-base/src/checkbox/checkbox.spec.tsx
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.spec.tsx
@@ -87,12 +87,27 @@ describe("checkbox", (): void => {
         expect(rendered.find(".input-class").prop("name")).toBe(checkboxName);
     });
 
-    test("should initialize as unchecked if the `checked` prop is not provided", () => {
+    test("should add `checked` attribute to the input element when the checked prop is passed", () => {
+        const rendered: any = shallow(
+            <Checkbox managedClasses={managedClasses} checked={true} inputId={"id"} />
+        );
+
+        expect(rendered.find(".input-class").prop("defaultChecked")).toBe(true);
         expect(
-            shallow(<Checkbox managedClasses={managedClasses} inputId="id" />).state(
-                "checked"
-            )
-        ).toBe(false);
+            rendered
+                .find(".input-class")
+                .html()
+                .includes("checked")
+        ).toBe(true);
+    });
+
+    test("should initialize as unchecked if the `checked` prop is not provided", () => {
+        const rendered: any = shallow(
+            <Checkbox managedClasses={managedClasses} inputId="id" />
+        );
+
+        expect(rendered.state("checked")).toBe(false);
+        expect(rendered.find(".input-class").prop("defaultChecked")).toBe(false);
     });
 
     test("should allow a change event to update the checked state when no `checked` prop is provided", () => {
@@ -101,10 +116,24 @@ describe("checkbox", (): void => {
         );
 
         expect(rendered.state("checked")).toBe(false);
+        expect(rendered.find(".input-class").prop("defaultChecked")).toBe(false);
+        expect(
+            rendered
+                .find(".input-class")
+                .html()
+                .includes("checked")
+        ).toBe(false);
 
         rendered.find(inputSelector).simulate("change");
 
         expect(rendered.state("checked")).toBe(true);
+        expect(rendered.find(".input-class").prop("defaultChecked")).toBe(true);
+        expect(
+            rendered
+                .find(".input-class")
+                .html()
+                .includes("checked")
+        ).toBe(true);
     });
 
     test("should call a registerd callback after a change event", () => {

--- a/packages/fast-components-react-base/src/checkbox/checkbox.stories.tsx
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.stories.tsx
@@ -28,17 +28,18 @@ function CheckboxStateHandler(props: {
 }
 
 storiesOf("Checkbox", module)
-    .add("Unhandled", () => (
-        <Checkbox inputId={uniqueId()} onChange={action("onChange")} />
-    ))
+    .add("Unhandled", () => {
+        const id: string = uniqueId();
+
+        return <Checkbox inputId={id} onChange={action("onChange")} />;
+    })
     .add("Handled", () => {
+        const id: string = uniqueId();
         function render(
             checked: boolean,
             onChange: React.ChangeEventHandler<HTMLInputElement>
         ): JSX.Element {
-            return (
-                <Checkbox inputId={uniqueId()} checked={checked} onChange={onChange} />
-            );
+            return <Checkbox inputId={id} checked={checked} onChange={onChange} />;
         }
         return <CheckboxStateHandler>{render}</CheckboxStateHandler>;
     })

--- a/packages/fast-components-react-base/src/checkbox/checkbox.tsx
+++ b/packages/fast-components-react-base/src/checkbox/checkbox.tsx
@@ -114,8 +114,9 @@ class Checkbox extends Foundation<
                     ref={this.inputRef}
                     onChange={this.handleCheckboxChange}
                     disabled={this.props.disabled || null}
-                    checked={this.state.checked}
+                    defaultChecked={this.state.checked}
                     value={this.props.value}
+                    key={this.props.inputId}
                 />
                 <span className={classNames(checkbox_stateIndicator)} />
                 {this.renderLabelBySlot()}


### PR DESCRIPTION
The underlying input of checkboxes was not updating when the "checked" property was changing. Updating the input to receive a value of defaultChecked rectify's the issue.

<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->