### PR TITLE
fix: beforeContent and afterContent in Buttons changing to white when hovered

### DIFF
--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -133,7 +133,6 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             background: neutralFillHover,
             ...highContrastSelected,
             "& $button_beforeContent, & $button_afterContent": {
-                fill: accentForegroundCut,
                 ...highContrastSelectedForeground,
             },
         },


### PR DESCRIPTION
We noticed the glyphs was changing color #FFF in color explorer.

# Description

`fill: accentForegroundCut,` was effecting this and it is not needed here.

![image](https://user-images.githubusercontent.com/37851220/64570781-79efa300-d316-11e9-9b8b-1849db1a2074.png)

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->