### PR TITLE
fix: building some fast packages failed because of missing dependency ref

### DIFF
--- a/packages/fast-storybook-design-system-addon/package.json
+++ b/packages/fast-storybook-design-system-addon/package.json
@@ -84,7 +84,8 @@
     "ts-jest": "^24.0.2",
     "tslint": "^5.9.1",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.5.1"
+    "typescript": "^3.5.1",
+    "lodash-es": "^4.0.0"
   },
   "peerDependencies": {
     "@microsoft/fast-jss-manager-react": "^4.3.5",


### PR DESCRIPTION
# Description
Was trying to build fast-components-react-msft and it failed on this (oddly bootstrapping worked ok though).

## Motivation & context
fix build break.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
