### PR TITLE
fix: remove circular dependency

### DIFF
--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -7,8 +7,16 @@ import {
 } from "@microsoft/fast-colors";
 import { Palette } from "../utilities/color/palette";
 import { withDefaults } from "@microsoft/fast-jss-utilities";
-import { defaultFontWeights, FontWeight } from "../utilities/fonts";
+import { FontWeight } from "../utilities/fonts";
 import designSystemSchema from "./design-system.schema";
+
+export const defaultFontWeights: FontWeight = {
+    light: 100,
+    semilight: 200,
+    normal: 400,
+    semibold: 600,
+    bold: 700,
+};
 
 export { designSystemSchema };
 

--- a/packages/fast-components-styles-msft/src/index.ts
+++ b/packages/fast-components-styles-msft/src/index.ts
@@ -67,7 +67,7 @@ export { DesignSystemDefaults };
 export const fontWeight: FontWeight = defaultFontWeights;
 // Delete when `fontWeight` export is removed
 import { defaultFontWeights } from "./design-system";
-import { FontWeight } from "./utilities/fonts"
+import { FontWeight } from "./utilities/fonts";
 
 /**
  * Export dialog styles

--- a/packages/fast-components-styles-msft/src/index.ts
+++ b/packages/fast-components-styles-msft/src/index.ts
@@ -57,9 +57,17 @@ export { ContextMenuItemStyles };
 /**
  * Export design system defaults and typings
  */
-import DesignSystemDefaults, { DesignSystem } from "./design-system";
+import DesignSystemDefaults from "./design-system";
 export * from "./design-system";
 export { DesignSystemDefaults };
+
+/**
+ * @deprecated - use applyFontWeight instead
+ */
+export const fontWeight: FontWeight = defaultFontWeights;
+// Delete when `fontWeight` export is removed
+import { defaultFontWeights } from "./design-system";
+import { FontWeight } from "./utilities/fonts"
 
 /**
  * Export dialog styles

--- a/packages/fast-components-styles-msft/src/utilities/fonts.ts
+++ b/packages/fast-components-styles-msft/src/utilities/fonts.ts
@@ -10,19 +10,6 @@ export interface FontWeight {
     bold: number;
 }
 
-export const defaultFontWeights: FontWeight = {
-    light: 100,
-    semilight: 200,
-    normal: 400,
-    semibold: 600,
-    bold: 700,
-};
-
-/**
- * @deprecated - use applyFontWeight instead
- */
-export const fontWeight: FontWeight = defaultFontWeights;
-
 /**
  * Retrieve the focusOutlineWidth from the design system
  */


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Removes circular dependency in styles package causing runtime errors on build packages.
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->