### PR TITLE
feat: deprecated and updated references to LightModeBackgrounds and DarkModeBackgrounds

### DIFF
--- a/packages/fast-color-explorer/app/app.tsx
+++ b/packages/fast-color-explorer/app/app.tsx
@@ -2,12 +2,10 @@
 /* tslint:disable:no-empty */
 import { Canvas, Container, Row } from "@microsoft/fast-layouts-react";
 import {
-    DesignSystem,
     neutralLayerCard,
     neutralLayerCardContainer,
     neutralLayerFloating,
     neutralLayerL1,
-    neutralLayerL1Alt,
     neutralLayerL2,
     neutralLayerL3,
     neutralLayerL4,
@@ -24,8 +22,6 @@ import { AppState } from "./state";
 import { connect } from "react-redux";
 import {
     Background,
-    DarkModeBackgrounds,
-    LightModeBackgrounds,
 } from "@microsoft/fast-components-react-msft";
 import { FixedSizeList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
@@ -59,7 +55,7 @@ class App extends React.Component<AppProps, {}> {
         [neutralLayerCardContainer, "neutralLayerCardContainer"],
         [neutralLayerL1, "neutralLayerL1"],
         [neutralLayerL2, "neutralLayerL2"],
-        [neutralLayerL3, "neutralLlayerL3"],
+        [neutralLayerL3, "neutralLayerL3"],
         [neutralLayerL4, "neutralLayerL4"],
     ];
 
@@ -100,7 +96,7 @@ class App extends React.Component<AppProps, {}> {
                                 </Row>
                             </Container>
                         </Canvas>
-                        <Background value={DarkModeBackgrounds.L4}>
+                        <Background value={neutralLayerL4}>
                             <ControlPane />
                         </Background>
                     </Row>

--- a/packages/fast-color-explorer/app/app.tsx
+++ b/packages/fast-color-explorer/app/app.tsx
@@ -20,9 +20,7 @@ import { ControlPane } from "./control-pane";
 import React from "react";
 import { AppState } from "./state";
 import { connect } from "react-redux";
-import {
-    Background,
-} from "@microsoft/fast-components-react-msft";
+import { Background } from "@microsoft/fast-components-react-msft";
 import { FixedSizeList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
 import {

--- a/packages/fast-color-explorer/app/design-system.ts
+++ b/packages/fast-color-explorer/app/design-system.ts
@@ -1,20 +1,23 @@
 import {
     DesignSystem,
     DesignSystemDefaults,
+    Palette,
 } from "@microsoft/fast-components-styles-msft";
 import { createColorPalette } from "@microsoft/fast-components-styles-msft";
 import { ColorRGBA64, parseColorHexRGB } from "@microsoft/fast-colors";
 import { defaultAccentColor, defaultNeutralColor } from "./colors";
+
+const neutralPalette: Palette = createColorPalette(parseColorHexRGB(
+    defaultNeutralColor
+) as ColorRGBA64);
 
 export type ColorsDesignSystem = DesignSystem;
 export const colorsDesignSystem: ColorsDesignSystem = Object.assign(
     {},
     DesignSystemDefaults,
     {
-        backgroundColor: "#000000",
-        neutralPalette: createColorPalette(parseColorHexRGB(
-            defaultNeutralColor
-        ) as ColorRGBA64),
+        backgroundColor: neutralPalette[neutralPalette.length - 1],
+        neutralPalette,
         accentPalette: createColorPalette(parseColorHexRGB(
             defaultAccentColor
         ) as ColorRGBA64),

--- a/packages/fast-color-explorer/app/design-system.ts
+++ b/packages/fast-color-explorer/app/design-system.ts
@@ -11,6 +11,7 @@ export const colorsDesignSystem: ColorsDesignSystem = Object.assign(
     {},
     DesignSystemDefaults,
     {
+        backgroundColor: "#000000",
         neutralPalette: createColorPalette(parseColorHexRGB(
             defaultNeutralColor
         ) as ColorRGBA64),

--- a/packages/fast-components-react-msft/src/background/README.md
+++ b/packages/fast-components-react-msft/src/background/README.md
@@ -18,18 +18,19 @@ import { DesignSystemDefaults } from "@microsoft/fast-components-styles-msft";
 
 ## value
 
-The *background* expects a `value` property that can be either a color string or a number. When the value is a color string, the color will be used directly and applied to CSS and the DesignSystem. When the value is a number, that number will be treated as an index and used to obtain a color from the `DesignSystem.neutralPalette`.
+The *background* expects a `value` property that can be a color recipe, color string, or a number. When the value is a color recipe it will be evaluated within the context of the design system. A color string will be used directly and applied to CSS and the DesignSystem. Using a number is not recommended because it doesn't scale with variable length palettes, however, a number will be treated as an index and used to obtain a color from the `DesignSystem.neutralPalette`.
 
-For convince, we've also exported both light-mode and dark-mode enums with common background colors, `LightModeBackgrounds` and `DarkModeBackgrounds` respectively. Each of these objects has the following properties:
+The recommended usage is to provide one of the layer recipes:
 
-- `L1`
-- `L1Alt`
-- `L2`
-- `L3`
-- `L4`
+- `neutralLayerFloating`
+- `neutralLayerCardContainer`
+- `neutralLayerL1`
+- `neutralLayerL2`
+- `neutralLayerL3`
+- `neutralLayerL4`
 
 ```jsx
-<Background value={DarkModeBackgrounds.L1}>
+<Background value={neutralLayerL1}>
     <Heading>Hello world</Heading>
 </Background>
 ```

--- a/packages/fast-components-react-msft/src/background/background.props.ts
+++ b/packages/fast-components-react-msft/src/background/background.props.ts
@@ -11,7 +11,7 @@ import { DesignSystemMergingFunction } from "@microsoft/fast-jss-manager-react";
  * Friendly names for the indexes of light mode backgrounds
  * on the neutral ramp. These values are designed to work with
  * the default neutral ramp provided by the DesignSystem
- * 
+ *
  * @deprecated Use the recipes because they can be more dynamic for different ramps
  */
 export enum LightModeBackgrounds {
@@ -26,7 +26,7 @@ export enum LightModeBackgrounds {
  * Friendly names for the indexes of dark mode backgrounds
  * on the neutral ramp. These values are designed to work with
  * the default neutral ramp provided by the DesignSystem
- * 
+ *
  * @deprecated Use the recipes because they can be more dynamic for different ramps
  */
 export enum DarkModeBackgrounds {

--- a/packages/fast-components-react-msft/src/background/background.props.ts
+++ b/packages/fast-components-react-msft/src/background/background.props.ts
@@ -11,6 +11,8 @@ import { DesignSystemMergingFunction } from "@microsoft/fast-jss-manager-react";
  * Friendly names for the indexes of light mode backgrounds
  * on the neutral ramp. These values are designed to work with
  * the default neutral ramp provided by the DesignSystem
+ * 
+ * @deprecated Use the recipes because they can be more dynamic for different ramps
  */
 export enum LightModeBackgrounds {
     L1 = NeutralPaletteLightModeLayers.L1,
@@ -24,6 +26,8 @@ export enum LightModeBackgrounds {
  * Friendly names for the indexes of dark mode backgrounds
  * on the neutral ramp. These values are designed to work with
  * the default neutral ramp provided by the DesignSystem
+ * 
+ * @deprecated Use the recipes because they can be more dynamic for different ramps
  */
 export enum DarkModeBackgrounds {
     L1 = NeutralPaletteDarkModeLayers.L1,

--- a/packages/fast-components-react-msft/src/background/background.spec.tsx
+++ b/packages/fast-components-react-msft/src/background/background.spec.tsx
@@ -51,7 +51,7 @@ describe("Background", (): void => {
             mount(<Background />)
                 .find("div")
                 .prop("style").backgroundColor
-        ).toBe(DesignSystemDefaults.neutralPalette[Background.defaultProps.value]);
+        ).toBe(Background.defaultProps.value(DesignSystemDefaults));
     });
     test("should assign a background color directly when it is a string", (): void => {
         expect(
@@ -125,9 +125,9 @@ describe("Background", (): void => {
             mount(<Background value={-1} />)
                 .find("div")
                 .prop("style").backgroundColor
-        ).toBe(DesignSystemDefaults.neutralPalette[Background.defaultProps.value]);
+        ).toBe(Background.defaultProps.value(DesignSystemDefaults));
     });
-    test("should use a custom desgin system merging function if provided", (): void => {
+    test("should use a custom design system merging function if provided", (): void => {
         const spy: jest.SpyInstance = jest.fn();
         const designSystem: any = { a: true };
 

--- a/packages/fast-components-react-msft/src/background/background.tsx
+++ b/packages/fast-components-react-msft/src/background/background.tsx
@@ -3,6 +3,7 @@ import {
     DesignSystem,
     DesignSystemDefaults,
     DesignSystemResolver,
+    neutralLayerL1,
 } from "@microsoft/fast-components-styles-msft";
 import {
     DesignSystemConsumer,
@@ -14,7 +15,6 @@ import { Omit } from "utility-types";
 import {
     BackgroundHandledProps,
     BackgroundUnhandledProps,
-    LightModeBackgrounds,
 } from "./background.props";
 
 export default class Background extends Foundation<
@@ -23,10 +23,10 @@ export default class Background extends Foundation<
     {}
 > {
     public static defaultProps: Partial<
-        Omit<BackgroundHandledProps, "value"> & { value: LightModeBackgrounds }
+        Omit<BackgroundHandledProps, "value"> & { value: DesignSystemResolver<string> }
     > = {
         tag: "div",
-        value: LightModeBackgrounds.L1,
+        value: neutralLayerL1,
         drawBackground: true,
     };
     protected handledProps: HandledProps<Required<BackgroundHandledProps>> = {
@@ -57,9 +57,7 @@ export default class Background extends Foundation<
                     : has(designSystem.neutralPalette, background)
                         ? get(designSystem.neutralPalette, background)
                         : DesignSystemDefaults.neutralPalette[background] ||
-                          DesignSystemDefaults.neutralPalette[
-                              Background.defaultProps.value
-                          ];
+                          Background.defaultProps.value(DesignSystemDefaults);
 
         const style: React.CSSProperties = Object.assign(
             {},

--- a/packages/fast-components-react-msft/src/background/background.tsx
+++ b/packages/fast-components-react-msft/src/background/background.tsx
@@ -12,10 +12,7 @@ import {
 import { get, has, memoize } from "lodash-es";
 import React from "react";
 import { Omit } from "utility-types";
-import {
-    BackgroundHandledProps,
-    BackgroundUnhandledProps,
-} from "./background.props";
+import { BackgroundHandledProps, BackgroundUnhandledProps } from "./background.props";
 
 export default class Background extends Foundation<
     BackgroundHandledProps,


### PR DESCRIPTION
# Description

Deprecated and updated references to LightModeBackgrounds and DarkModeBackgrounds.

## Motivation & context

These enums replicate another background layer enum that has previously been deprecated. Using indexes for background offsets is fragile because it doesn't account for variable sized palettes. Updating to use layer recipes instead.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->