### PR TITLE
fix: enable home and end keys on slider

### DIFF
--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -14,8 +14,8 @@ import {
     keyCodeEnd,
     keyCodeHome,
     keyCodePageDown,
-    keyCodePageUp
-    } from "@microsoft/fast-web-utilities";
+    keyCodePageUp,
+} from "@microsoft/fast-web-utilities";
 import { DisplayNamePrefix } from "../utilities";
 import { SliderMode, SliderOrientation } from "./slider.props";
 
@@ -733,13 +733,16 @@ describe("Slider", (): void => {
         const container: HTMLDivElement = document.createElement("div");
         document.body.appendChild(container);
 
-        const rendered: any = mount(<Slider managedClasses={managedClasses} initialValue={50} />, {
-            attachTo: container,
-        });
+        const rendered: any = mount(
+            <Slider managedClasses={managedClasses} initialValue={50} />,
+            {
+                attachTo: container,
+            }
+        );
 
         const thumb: any = rendered.find(`.${managedClasses.slider_thumb__upperValue}`);
         expect(rendered.state("upperValue")).toBe(50);
-        thumb.simulate("keydown", { keyCode: keyCodeHome, defaultPrevented: false});
+        thumb.simulate("keydown", { keyCode: keyCodeHome, defaultPrevented: false });
         expect(rendered.state("upperValue")).toBe(0);
         thumb.simulate("keydown", { keyCode: keyCodeEnd });
         expect(rendered.state("upperValue")).toBe(100);

--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -729,7 +729,7 @@ describe("Slider", (): void => {
         expect(rendered.instance()["constrainToStep"](16, 10)).toBe(20);
     });
 
-    test("home and end keys set values to either end of range", (): void => {
+    test("home key sets value to start of range", (): void => {
         const container: HTMLDivElement = document.createElement("div");
         document.body.appendChild(container);
 
@@ -744,6 +744,23 @@ describe("Slider", (): void => {
         expect(rendered.state("upperValue")).toBe(50);
         thumb.simulate("keydown", { keyCode: keyCodeHome, defaultPrevented: false });
         expect(rendered.state("upperValue")).toBe(0);
+
+        document.body.removeChild(container);
+    });
+
+    test("end key sets value to end of range", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const rendered: any = mount(
+            <Slider managedClasses={managedClasses} initialValue={50} />,
+            {
+                attachTo: container,
+            }
+        );
+
+        const thumb: any = rendered.find(`.${managedClasses.slider_thumb__upperValue}`);
+        expect(rendered.state("upperValue")).toBe(50);
         thumb.simulate("keydown", { keyCode: keyCodeEnd });
         expect(rendered.state("upperValue")).toBe(100);
 

--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -11,9 +11,11 @@ import {
     keyCodeArrowLeft,
     keyCodeArrowRight,
     keyCodeArrowUp,
+    keyCodeEnd,
+    keyCodeHome,
     keyCodePageDown,
-    keyCodePageUp,
-} from "@microsoft/fast-web-utilities";
+    keyCodePageUp
+    } from "@microsoft/fast-web-utilities";
 import { DisplayNamePrefix } from "../utilities";
 import { SliderMode, SliderOrientation } from "./slider.props";
 
@@ -725,6 +727,24 @@ describe("Slider", (): void => {
         // where value is the number to be constrained and step the step increment
         expect(rendered.instance()["constrainToStep"](14, 10)).toBe(10);
         expect(rendered.instance()["constrainToStep"](16, 10)).toBe(20);
+    });
+
+    test("home and end keys set values to either end of range", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const rendered: any = mount(<Slider managedClasses={managedClasses} initialValue={50} />, {
+            attachTo: container,
+        });
+
+        const thumb: any = rendered.find(`.${managedClasses.slider_thumb__upperValue}`);
+        expect(rendered.state("upperValue")).toBe(50);
+        thumb.simulate("keydown", { keyCode: keyCodeHome, defaultPrevented: false});
+        expect(rendered.state("upperValue")).toBe(0);
+        thumb.simulate("keydown", { keyCode: keyCodeEnd });
+        expect(rendered.state("upperValue")).toBe(100);
+
+        document.body.removeChild(container);
     });
 
     // tslint:disable-next-line:no-shadowed-variable

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -14,6 +14,8 @@ import {
     keyCodeArrowLeft,
     keyCodeArrowRight,
     keyCodeArrowUp,
+    keyCodeEnd,
+    keyCodeHome,
     keyCodePageDown,
     keyCodePageUp,
 } from "@microsoft/fast-web-utilities";
@@ -851,6 +853,39 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
                     this.startIncrementing(1, true, thumb, event);
                 }
                 break;
+            case keyCodeHome:
+                this.setMinValue(thumb);
+                break;
+
+            case keyCodeEnd:
+                this.setMaxValue(thumb);
+                break;
+        }
+    };
+
+    /**
+     * sets the active thumb to it's minimum value
+     */
+    private setMinValue = (thumb: SliderThumb): void => {
+        const thumbRange: SliderRange = this.getConstrainedRange(true);
+
+        if (thumb === SliderThumb.upperThumb) {
+            this.updateValues(null, thumbRange.minValue);
+        } else {
+            this.updateValues(thumbRange.minValue, null);
+        }
+    };
+
+    /**
+     * sets the active thumb to it's maximum value
+     */
+    private setMaxValue = (thumb: SliderThumb): void => {
+        const thumbRange: SliderRange = this.getConstrainedRange(true);
+
+        if (thumb === SliderThumb.upperThumb) {
+            this.updateValues(null, thumbRange.maxValue);
+        } else {
+            this.updateValues(thumbRange.maxValue, null);
         }
     };
 

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -864,7 +864,7 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
     };
 
     /**
-     * sets the active thumb to it's minimum value
+     * sets the active thumb to its minimum value
      */
     private setMinValue = (thumb: SliderThumb): void => {
         const thumbRange: SliderRange = this.getConstrainedRange(true);

--- a/packages/fast-components-react-msft/src/slider/slider.stories.tsx
+++ b/packages/fast-components-react-msft/src/slider/slider.stories.tsx
@@ -103,6 +103,20 @@ storiesOf("Slider", module)
             <SliderLabel valuePositionBinding={100} label="High" />
         </Slider>
     ))
+    .add("Multiple", () => (
+        <Slider
+            range={{ minValue: 0, maxValue: 100 }}
+            mode={SliderMode.adjustBoth}
+            jssStyleSheet={vertcialSliderStyles}
+            onValueChange={action("onValueChange")}
+        >
+            <SliderLabel valuePositionBinding={0} label="Low" />
+            <SliderLabel valuePositionBinding={25} label="25" />
+            <SliderLabel valuePositionBinding={50} label="50" />
+            <SliderLabel valuePositionBinding={75} label="75" />
+            <SliderLabel valuePositionBinding={100} label="High" />
+        </Slider>
+    ))
     .add("Disabled", () => (
         <Slider
             range={{ minValue: 0, maxValue: 100 }}


### PR DESCRIPTION
# Description
Home and end keys moves slider thumbs to beginning or end of the range.

## Motivation & context
https://github.com/microsoft/fast-dna/issues/1914

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.