### PR TITLE
chore: default placeholder for input is wrong in Edge

### DIFF
--- a/packages/fast-tooling-react/src/style/utilities.ts
+++ b/packages/fast-tooling-react/src/style/utilities.ts
@@ -224,6 +224,9 @@ export function applyInputStyle(): CSSRules<{}> {
         "&:invalid": {
             border: `1px solid ${error}`,
         },
+        "&::placeholder": {
+            color: "#767676",
+        },
     };
 }
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Edge appears to be setting default placeholder to black. Added a selector to add consistancy across browsers.

Before:
![image](https://user-images.githubusercontent.com/37851214/65464594-08801c00-de0f-11e9-8ccc-cbc7d9ed3e17.png)


After:
![image](https://user-images.githubusercontent.com/37851214/65464577-fb632d00-de0e-11e9-8e8c-98a7ac918f2f.png)

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->