### PR TITLE
feat: add luminance to design system

### DIFF
--- a/packages/fast-color-explorer/app/app.tsx
+++ b/packages/fast-color-explorer/app/app.tsx
@@ -172,7 +172,9 @@ class App extends React.Component<AppProps, {}> {
               });
     }
 
-    private resolveRecipes = (luminance: number): Array<{ color: string; title: string }> => {
+    private resolveRecipes = (
+        luminance: number
+    ): Array<{ color: string; title: string }> => {
         const designSystem: DesignSystem = Object.assign({}, this.props.designSystem, {
             baseLayerLuminance: luminance,
         });

--- a/packages/fast-color-explorer/app/app.tsx
+++ b/packages/fast-color-explorer/app/app.tsx
@@ -2,6 +2,7 @@
 /* tslint:disable:no-empty */
 import { Canvas, Container, Row } from "@microsoft/fast-layouts-react";
 import {
+    DesignSystem,
     neutralLayerCard,
     neutralLayerCardContainer,
     neutralLayerFloating,
@@ -27,6 +28,7 @@ import {
     ColorRecipe,
     Swatch,
 } from "@microsoft/fast-components-styles-msft/dist/utilities/color/common";
+import { StandardLuminance } from "@microsoft/fast-components-styles-msft/dist/utilities/color/neutral-layer";
 
 interface AppProps {
     designSystem: ColorsDesignSystem;
@@ -170,13 +172,16 @@ class App extends React.Component<AppProps, {}> {
               });
     }
 
-    private resolveRecipes = (color: string): Array<{ color: string; title: string }> => {
+    private resolveRecipes = (luminance: number): Array<{ color: string; title: string }> => {
+        const designSystem: DesignSystem = Object.assign({}, this.props.designSystem, {
+            baseLayerLuminance: luminance,
+        });
         return this.backgroundRecipes
             .map((conf: [ColorRecipe<string>, string]): {
                 color: string;
                 title: string;
             } => ({
-                color: conf[0]((): string => color)(this.props.designSystem),
+                color: conf[0](designSystem),
                 title: conf[1],
             }))
             .reduce(
@@ -209,12 +214,11 @@ class App extends React.Component<AppProps, {}> {
     };
 
     private get lightModeLayers(): Array<{ color: string; title: string }> {
-        return this.resolveRecipes(this.props.designSystem.neutralPalette[0]);
+        return this.resolveRecipes(StandardLuminance.LightMode);
     }
 
     private get darkModeLayers(): Array<{ color: string; title: string }> {
-        const neutralPalette: string[] = this.props.designSystem.neutralPalette;
-        return this.resolveRecipes(neutralPalette[neutralPalette.length - 1]);
+        return this.resolveRecipes(StandardLuminance.DarkMode);
     }
 }
 

--- a/packages/fast-color-explorer/app/app.tsx
+++ b/packages/fast-color-explorer/app/app.tsx
@@ -28,7 +28,7 @@ import {
     ColorRecipe,
     Swatch,
 } from "@microsoft/fast-components-styles-msft/dist/utilities/color/common";
-import { StandardLuminance } from "@microsoft/fast-components-styles-msft/dist/utilities/color/neutral-layer";
+import { StandardLuminance } from "@microsoft/fast-components-styles-msft";
 
 interface AppProps {
     designSystem: ColorsDesignSystem;

--- a/packages/fast-color-explorer/app/design-system.ts
+++ b/packages/fast-color-explorer/app/design-system.ts
@@ -6,6 +6,7 @@ import {
 import { createColorPalette } from "@microsoft/fast-components-styles-msft";
 import { ColorRGBA64, parseColorHexRGB } from "@microsoft/fast-colors";
 import { defaultAccentColor, defaultNeutralColor } from "./colors";
+import { StandardLuminance } from "@microsoft/fast-components-styles-msft/dist/utilities/color/neutral-layer";
 
 const neutralPalette: Palette = createColorPalette(parseColorHexRGB(
     defaultNeutralColor
@@ -16,7 +17,7 @@ export const colorsDesignSystem: ColorsDesignSystem = Object.assign(
     {},
     DesignSystemDefaults,
     {
-        backgroundColor: neutralPalette[neutralPalette.length - 1],
+        baseLayerLuminance: StandardLuminance.DarkMode,
         neutralPalette,
         accentPalette: createColorPalette(parseColorHexRGB(
             defaultAccentColor

--- a/packages/fast-component-explorer/app/explorer-region.tsx
+++ b/packages/fast-component-explorer/app/explorer-region.tsx
@@ -7,6 +7,7 @@ import {
     DesignSystemDefaults,
 } from "@microsoft/fast-components-styles-msft";
 import Explorer from "./explorer";
+import { StandardLuminance } from "@microsoft/fast-components-styles-msft/dist/utilities/color/neutral-layer";
 
 const accent: string = "#FB356D";
 const accentPaletteSource: ColorRGBA64 | null = parseColor(accent);
@@ -18,10 +19,7 @@ if (accentPaletteSource !== null) {
         density: -2,
         accentBaseColor: accent,
         accentPalette: palette,
-        backgroundColor:
-            DesignSystemDefaults.neutralPalette[
-                DesignSystemDefaults.neutralPalette.length - 1
-            ],
+        baseLayerLuminance: StandardLuminance.DarkMode,
     });
 }
 

--- a/packages/fast-component-explorer/app/explorer.tsx
+++ b/packages/fast-component-explorer/app/explorer.tsx
@@ -84,6 +84,7 @@ import { Direction } from "@microsoft/fast-web-utilities";
 import { ColorRGBA64, parseColor } from "@microsoft/fast-colors";
 import { format, multiply, toPx } from "@microsoft/fast-jss-utilities";
 import { NavigationMenuClassNameContract } from "@microsoft/fast-tooling-react/dist/navigation-menu/navigation-menu.style";
+import { StandardLuminance } from "@microsoft/fast-components-styles-msft/dist/utilities/color/neutral-layer";
 
 interface ObjectOfComponentViewConfigs {
     [key: string]: ComponentViewConfig<any>;
@@ -112,9 +113,6 @@ function setViewConfigsWithCustomConfig(
 
     return componentViewConfigs;
 }
-
-const dark: string = `#333333`;
-const light: string = "#FFFFFF";
 
 class Explorer extends Foundation<ExplorerHandledProps, {}, ExplorerState> {
     public static displayName: string = "Explorer";
@@ -438,7 +436,7 @@ class Explorer extends Foundation<ExplorerHandledProps, {}, ExplorerState> {
                 viewerContentProps={this.state.scenario}
                 responsive={true}
                 jssStyleSheet={this.viewerStyleOverrides(
-                    get(this.state, "viewConfig.backgroundColor")
+                    neutralLayerL1(this.state.viewConfig)
                 )}
             />
         );
@@ -842,12 +840,14 @@ class Explorer extends Foundation<ExplorerHandledProps, {}, ExplorerState> {
     };
 
     private handleUpdateTheme = (): void => {
-        const isLightTheme: boolean = this.state.theme === ThemeName.light;
-        const updatedThemeColor: string = isLightTheme ? dark : light;
+        const isLightMode: boolean = this.state.theme === ThemeName.light;
+        const updatedLuminance: number = isLightMode
+            ? StandardLuminance.DarkMode
+            : StandardLuminance.LightMode;
         this.setState({
-            theme: isLightTheme ? ThemeName.dark : ThemeName.light,
+            theme: isLightMode ? ThemeName.dark : ThemeName.light,
             viewConfig: merge({}, this.state.viewConfig, {
-                backgroundColor: updatedThemeColor,
+                baseLayerLuminance: updatedLuminance,
             }),
         });
     };

--- a/packages/fast-component-explorer/app/preview.tsx
+++ b/packages/fast-component-explorer/app/preview.tsx
@@ -30,18 +30,17 @@ class Preview extends Foundation<{}, {}, PreviewState> {
 
     public render(): React.ReactNode {
         return (
-            <Background
-                className={get(this.props, "managedClasses.preview")}
-                value={this.state.backgroundColor}
-                dir={this.state.direction}
-            >
-                <DesignSystemProvider designSystem={this.state}>
+            <DesignSystemProvider designSystem={this.state}>
+                <Background
+                    className={get(this.props, "managedClasses.preview")}
+                    dir={this.state.direction}
+                >
                     <ViewerContent
                         components={childOptions}
                         plugins={initializedPlugins}
                     />
-                </DesignSystemProvider>
-            </Background>
+                </Background>
+            </DesignSystemProvider>
         );
     }
 

--- a/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
+++ b/packages/fast-components-styles-msft/src/design-system/design-system.schema.ts
@@ -236,6 +236,11 @@ export default {
             type: "number",
             default: 0,
         },
+        baseLayerLuminance: {
+            title: "Base layer luminance",
+            type: "number",
+            default: -1,
+        },
         neutralFillCardDelta: {
             title: "Neutral fill card delta",
             type: "number",

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -162,6 +162,14 @@ export interface DesignSystem {
     neutralFillToggleFocusDelta: number;
 
     /**
+     * The luminance value to base layer recipes on.
+     * Sets the luminance value for the L1 layer recipe in a manner that can adjust to variable contrast.
+     * 
+     * Currently defaults to -1 to turn the feature off and use backgroundColor for layer colors instead.
+     */
+    baseLayerLuminance: number; // 0...1
+
+    /**
      * Color swatch deltas for the neutral-fill-card recipe.
      */
     neutralFillCardDelta: number;
@@ -250,6 +258,7 @@ const designSystemDefaults: DesignSystem = {
     neutralFillToggleActiveDelta: -5,
     neutralFillToggleFocusDelta: 0,
 
+    baseLayerLuminance: -1,
     neutralFillCardDelta: 3,
 
     neutralForegroundDarkIndex: 93,

--- a/packages/fast-components-styles-msft/src/design-system/index.ts
+++ b/packages/fast-components-styles-msft/src/design-system/index.ts
@@ -164,7 +164,7 @@ export interface DesignSystem {
     /**
      * The luminance value to base layer recipes on.
      * Sets the luminance value for the L1 layer recipe in a manner that can adjust to variable contrast.
-     * 
+     *
      * Currently defaults to -1 to turn the feature off and use backgroundColor for layer colors instead.
      */
     baseLayerLuminance: number; // 0...1

--- a/packages/fast-components-styles-msft/src/utilities/color/index.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/index.ts
@@ -106,6 +106,7 @@ export {
     neutralLayerL4,
     NeutralPaletteLightModeLayers,
     NeutralPaletteDarkModeLayers,
+    StandardLuminance,
 } from "./neutral-layer";
 
 /**

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.spec.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.spec.ts
@@ -3,123 +3,116 @@ import {
     neutralLayerCardContainer,
     neutralLayerFloating,
     neutralLayerL1,
-    neutralLayerL1Alt,
     neutralLayerL2,
     neutralLayerL3,
     neutralLayerL4,
-    NeutralPaletteDarkModeLayers,
-    NeutralPaletteLightModeLayers,
+    StandardLuminance,
 } from "./neutral-layer";
 import designSystemDefaults, { DesignSystem } from "../../design-system";
 
-const darkThemeDesignSystem: DesignSystem = Object.assign({}, designSystemDefaults, {
-    backgroundColor: "#000000",
+const lightModeDesignSystem: DesignSystem = Object.assign({}, designSystemDefaults, {
+    baseLayerLuminance: StandardLuminance.LightMode,
 });
+
+const darkModeDesignSystem: DesignSystem = Object.assign({}, designSystemDefaults, {
+    baseLayerLuminance: StandardLuminance.DarkMode,
+});
+
+const enum NeutralPaletteLightModeOffsets {
+    L1 = 0,
+    L2 = 10,
+    L3 = 13,
+    L4 = 16,
+}
+
+const enum NeutralPaletteDarkModeOffsets {
+    L1 = 76,
+    L2 = 79,
+    L3 = 82,
+    L4 = 85,
+}
 
 describe("neutralLayer", (): void => {
     describe("L1", (): void => {
         test("should return values from L1 when in light mode", (): void => {
-            expect(neutralLayerL1(designSystemDefaults)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteLightModeLayers.L1]
+            expect(neutralLayerL1(lightModeDesignSystem)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteLightModeOffsets.L1]
             );
         });
         test("should return values from L1 when in dark mode", (): void => {
-            expect(neutralLayerL1(darkThemeDesignSystem)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L1]
+            expect(neutralLayerL1(darkModeDesignSystem)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeOffsets.L1]
             );
         });
         test("should operate on a provided background color", (): void => {
             expect(neutralLayerL1((): string => "#000000")(designSystemDefaults)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L1]
+                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeOffsets.L1]
             );
-            expect(neutralLayerL1((): string => "#FFFFFF")(darkThemeDesignSystem)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteLightModeLayers.L1]
-            );
-        });
-    });
-
-    describe("L1Alt", (): void => {
-        test("should return values from L1Alt when in light mode", (): void => {
-            expect(neutralLayerL1Alt(designSystemDefaults)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteLightModeLayers.L1Alt]
-            );
-        });
-        test("should return values from L1Alt when in dark mode", (): void => {
-            expect(neutralLayerL1Alt(darkThemeDesignSystem)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L1Alt]
-            );
-        });
-        test("should operate on a provided background color", (): void => {
-            expect(neutralLayerL1Alt((): string => "#000000")(designSystemDefaults)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L1Alt]
-            );
-            expect(
-                neutralLayerL1Alt((): string => "#FFFFFF")(darkThemeDesignSystem)
-            ).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteLightModeLayers.L1Alt]
+            expect(neutralLayerL1((): string => "#FFFFFF")(designSystemDefaults)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteLightModeOffsets.L1]
             );
         });
     });
 
     describe("L2", (): void => {
         test("should return values from L2 when in light mode", (): void => {
-            expect(neutralLayerL2(designSystemDefaults)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteLightModeLayers.L2]
+            expect(neutralLayerL2(lightModeDesignSystem)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteLightModeOffsets.L2]
             );
         });
         test("should return values from L2 when in dark mode", (): void => {
-            expect(neutralLayerL2(darkThemeDesignSystem)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L2]
+            expect(neutralLayerL2(darkModeDesignSystem)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeOffsets.L2]
             );
         });
         test("should operate on a provided background color", (): void => {
             expect(neutralLayerL2((): string => "#000000")(designSystemDefaults)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L2]
+                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeOffsets.L2]
             );
-            expect(neutralLayerL2((): string => "#FFFFFF")(darkThemeDesignSystem)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteLightModeLayers.L2]
+            expect(neutralLayerL2((): string => "#FFFFFF")(designSystemDefaults)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteLightModeOffsets.L2]
             );
         });
     });
 
     describe("L3", (): void => {
         test("should return values from L3 when in light mode", (): void => {
-            expect(neutralLayerL3(designSystemDefaults)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteLightModeLayers.L3]
+            expect(neutralLayerL3(lightModeDesignSystem)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteLightModeOffsets.L3]
             );
         });
         test("should return values from L3 when in dark mode", (): void => {
-            expect(neutralLayerL3(darkThemeDesignSystem)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L3]
+            expect(neutralLayerL3(darkModeDesignSystem)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeOffsets.L3]
             );
         });
         test("should operate on a provided background color", (): void => {
             expect(neutralLayerL3((): string => "#000000")(designSystemDefaults)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L3]
+                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeOffsets.L3]
             );
-            expect(neutralLayerL3((): string => "#FFFFFF")(darkThemeDesignSystem)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteLightModeLayers.L3]
+            expect(neutralLayerL3((): string => "#FFFFFF")(designSystemDefaults)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteLightModeOffsets.L3]
             );
         });
     });
 
     describe("L4", (): void => {
         test("should return values from L4 when in light mode", (): void => {
-            expect(neutralLayerL4(designSystemDefaults)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteLightModeLayers.L4]
+            expect(neutralLayerL4(lightModeDesignSystem)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteLightModeOffsets.L4]
             );
         });
         test("should return values from L4 when in dark mode", (): void => {
-            expect(neutralLayerL4(darkThemeDesignSystem)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L4]
+            expect(neutralLayerL4(darkModeDesignSystem)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeOffsets.L4]
             );
         });
         test("should operate on a provided background color", (): void => {
             expect(neutralLayerL4((): string => "#000000")(designSystemDefaults)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeLayers.L4]
+                designSystemDefaults.neutralPalette[NeutralPaletteDarkModeOffsets.L4]
             );
-            expect(neutralLayerL4((): string => "#FFFFFF")(darkThemeDesignSystem)).toBe(
-                designSystemDefaults.neutralPalette[NeutralPaletteLightModeLayers.L4]
+            expect(neutralLayerL4((): string => "#FFFFFF")(designSystemDefaults)).toBe(
+                designSystemDefaults.neutralPalette[NeutralPaletteLightModeOffsets.L4]
             );
         });
     });

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.ts
@@ -47,10 +47,15 @@ export enum StandardLuminance {
     DarkMode = 0.23,
 }
 
-function luminanceOrBackgroundColor(luminanceRecipe: DesignSystemResolver<string>, backgroundRecipe: DesignSystemResolver<string>): DesignSystemResolver<string> {
+function luminanceOrBackgroundColor(
+    luminanceRecipe: DesignSystemResolver<string>,
+    backgroundRecipe: DesignSystemResolver<string>
+): DesignSystemResolver<string> {
     return (designSystem: DesignSystem): string => {
-        return baseLayerLuminance(designSystem) === -1 ? backgroundRecipe(designSystem) : luminanceRecipe(designSystem);
-    }
+        return baseLayerLuminance(designSystem) === -1
+            ? backgroundRecipe(designSystem)
+            : luminanceRecipe(designSystem);
+    };
 }
 
 /**
@@ -166,7 +171,7 @@ export const neutralLayerCardContainer: ColorRecipe<Swatch> = colorRecipeFactory
  */
 export const neutralLayerL1: ColorRecipe<Swatch> = colorRecipeFactory(
     luminanceOrBackgroundColor(
-        getSwatch(baseLayerLuminanceIndex, neutralPalette, "L1"),
+        getSwatch(baseLayerLuminanceIndex, neutralPalette),
         swatchByMode(neutralPalette)(
             0,
             subtract(darkNeutralLayerL4, multiply(neutralFillCardDelta, 3))
@@ -212,7 +217,10 @@ export const neutralLayerL3: ColorRecipe<Swatch> = colorRecipeFactory(
  */
 export const neutralLayerL4: ColorRecipe<Swatch> = colorRecipeFactory(
     luminanceOrBackgroundColor(
-        getSwatch(add(neutralLayerL2Index, multiply(neutralFillCardDelta, 2)), neutralPalette),
+        getSwatch(
+            add(neutralLayerL2Index, multiply(neutralFillCardDelta, 2)),
+            neutralPalette
+        ),
         swatchByMode(neutralPalette)(
             add(lightNeutralLayerL2, multiply(neutralFillCardDelta, 2)),
             darkNeutralLayerL4

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.ts
@@ -81,14 +81,12 @@ const baseLayerLuminanceIndex: DesignSystemResolver<number> = findClosestSwatchI
  */
 const neutralLayerCardIndex: DesignSystemResolver<number> = (
     designSystem: DesignSystem
-): number => {
-    const palette: Palette = neutralPalette(designSystem);
-    return clamp(
+): number => 
+    clamp(
         subtract(baseLayerLuminanceIndex, neutralFillCardDelta)(designSystem),
         0,
-        palette.length - 1
+        neutralPalette(designSystem).length - 1
     );
-};
 
 /**
  * Light mode L2 is significant because it happens at the same point as the neutral fill flip. Use this as the minimum index for L2.

--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.ts
@@ -81,7 +81,7 @@ const baseLayerLuminanceIndex: DesignSystemResolver<number> = findClosestSwatchI
  */
 const neutralLayerCardIndex: DesignSystemResolver<number> = (
     designSystem: DesignSystem
-): number => 
+): number =>
     clamp(
         subtract(baseLayerLuminanceIndex, neutralFillCardDelta)(designSystem),
         0,

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -162,12 +162,12 @@ export function isLightMode(designSystem: DesignSystem): boolean {
  * Safely retrieves an index of a palette. The index is clamped to valid
  * array indexes so that a swatch is always returned
  */
-export function getSwatch(index: number, colorPalette: Palette, label?: string): Swatch;
+export function getSwatch(index: number, colorPalette: Palette): Swatch;
 export function getSwatch(
     index: DesignSystemResolver<number>,
-    colorPalette: DesignSystemResolver<Palette>, label?: string
+    colorPalette: DesignSystemResolver<Palette>
 ): DesignSystemResolver<Swatch>;
-export function getSwatch(index: any, colorPalette: any, label: string = ""): any {
+export function getSwatch(index: any, colorPalette: any): any {
     if (typeof index === "function") {
         return (designSystem: DesignSystem): Swatch => {
             return colorPalette(designSystem)[

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -85,14 +85,17 @@ export function findSwatchIndex(
  */
 export function findClosestSwatchIndex(
     paletteResolver: Palette | DesignSystemResolver<Palette>,
-    swatch: Swatch
+    swatch: Swatch | DesignSystemResolver<Swatch>
 ): DesignSystemResolver<number> {
     return (designSystem: DesignSystem): number => {
         const resolvedPalette: Palette = checkDesignSystemResolver(
             paletteResolver,
             designSystem
         );
-        const index: number = findSwatchIndex(resolvedPalette, swatch)(designSystem);
+        const resolvedSwatch: Swatch = checkDesignSystemResolver(swatch, designSystem);
+        const index: number = findSwatchIndex(resolvedPalette, resolvedSwatch)(
+            designSystem
+        );
         let swatchLuminance: number;
 
         if (index !== -1) {
@@ -159,8 +162,21 @@ export function isLightMode(designSystem: DesignSystem): boolean {
  * Safely retrieves an index of a palette. The index is clamped to valid
  * array indexes so that a swatch is always returned
  */
-export function getSwatch(index: number, colorPalette: Palette): Swatch {
-    return colorPalette[clamp(index, 0, colorPalette.length - 1)];
+export function getSwatch(index: number, colorPalette: Palette, label?: string): Swatch;
+export function getSwatch(
+    index: DesignSystemResolver<number>,
+    colorPalette: DesignSystemResolver<Palette>, label?: string
+): DesignSystemResolver<Swatch>;
+export function getSwatch(index: any, colorPalette: any, label: string = ""): any {
+    if (typeof index === "function") {
+        return (designSystem: DesignSystem): Swatch => {
+            return colorPalette(designSystem)[
+                clamp(index(designSystem), 0, colorPalette(designSystem).length - 1)
+            ];
+        };
+    } else {
+        return colorPalette[clamp(index, 0, colorPalette.length - 1)];
+    }
 }
 
 export function swatchByMode(

--- a/packages/fast-components-styles-msft/src/utilities/design-system.ts
+++ b/packages/fast-components-styles-msft/src/utilities/design-system.ts
@@ -201,6 +201,9 @@ export const neutralFillToggleFocusDelta: DesignSystemResolver<
     number
 > = getDesignSystemValue("neutralFillToggleFocusDelta");
 
+export const baseLayerLuminance: DesignSystemResolver<number> = getDesignSystemValue(
+    "baseLayerLuminance"
+);
 export const neutralFillCardDelta: DesignSystemResolver<number> = getDesignSystemValue(
     "neutralFillCardDelta"
 );


### PR DESCRIPTION
# Description

- Added luminance setting to design system
- Updated layer recipes to use luminance setting if configured
- Updated a couple apps to use luminance instead of fixed background

## Motivation & context

Dark and light mode has been based on the background color only, requiring us to force it by hard-coding either black or white, and doesn't allow for any other range except light or dark as we've defined it.

This allows any custom level of luminance, while staying within the layer system. Enums represent our standard light and dark mode base level.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->