### PR TITLE
fix: Validation errors not displayed on component creation in fast-tooling-react form

### DIFF
--- a/packages/fast-tooling-react/src/form/form.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form.spec.tsx
@@ -7,6 +7,7 @@ import { FormProps } from "./form.props";
 import objectSchema from "../__tests__/schemas/objects.schema.json";
 import arraySchema from "../__tests__/schemas/arrays.schema.json";
 import childrenSchema from "../__tests__/schemas/children.schema.json";
+import invalidDataSchema from "../__tests__/schemas/invalid-data.schema.json";
 import pluginSchema from "../__tests__/schemas/plugin.schema.json";
 
 import { StringUpdateSchemaPlugin } from "../../app/pages/form/plugin/plugin";
@@ -426,5 +427,38 @@ describe("Form", () => {
         rendered.update();
 
         expect(rendered.find("SelectFormControl")).toHaveLength(1);
+    });
+    test("should set validation errors to the form state.", () => {
+        const data: any = {
+            validBooleanRequired: true,
+            invalidBooleanWrongType: "foo",
+            invalidNullWrongType: "bar",
+            invalidStringWrongType: false,
+            invalidNumberWrongType: "bar",
+            invalidEnumWrongType: "hello",
+            invalidObjectWrongType: true,
+            invalidArrayWrongType: "world",
+            objectExample: {
+                invalidBooleanWrongType: "bat",
+            },
+            arrayExample: [true],
+        };
+
+        const rendered: any = mount(
+            <Form
+                schema={invalidDataSchema}
+                data={data}
+                onChange={jest.fn()}
+                displayValidationInline={true}
+            />
+        );
+
+        expect(rendered.find("ArrayFormControl")).toHaveLength(2);
+        expect(rendered.find("ArrayFormControl").get(0).props.invalidMessage).toEqual(
+            "should be array"
+        );
+        expect(rendered.find("ArrayFormControl").get(1).props.invalidMessage).toEqual(
+            "Contains invalid data"
+        );
     });
 });

--- a/packages/fast-tooling-react/src/form/form.tsx
+++ b/packages/fast-tooling-react/src/form/form.tsx
@@ -99,7 +99,7 @@ class Form extends React.Component<
                     ? props.location
                     : "",
             navigation: this.navigation.get(),
-            validationErrors: void 0,
+            validationErrors: this.getValidationErrors(props),
         };
     }
 


### PR DESCRIPTION
# Description

Trigger validation change in form constructor to bubble up configuration errors.

## Motivation & context

Closes #2285

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [X] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [X] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.