### PR TITLE
feat: add dynamic scaling capability to viewport positioner

### DIFF
--- a/packages/fast-components-react-base/src/select/select.schema.ts
+++ b/packages/fast-components-react-base/src/select/select.schema.ts
@@ -103,6 +103,10 @@ export default {
                     title: "Fixed after initial placement",
                     type: "boolean",
                 },
+                scaleToFit:{
+                    title: "Scale to fit",
+                    type: "boolean",
+                }
             },
         },
     },

--- a/packages/fast-components-react-base/src/select/select.schema.ts
+++ b/packages/fast-components-react-base/src/select/select.schema.ts
@@ -103,10 +103,11 @@ export default {
                     title: "Fixed after initial placement",
                     type: "boolean",
                 },
-                scaleToFit:{
+                scaleToFit: {
                     title: "Scale to fit",
                     type: "boolean",
-                }
+                    default: "false",
+                },
             },
         },
     },

--- a/packages/fast-components-react-base/src/select/select.schema.ts
+++ b/packages/fast-components-react-base/src/select/select.schema.ts
@@ -106,7 +106,7 @@ export default {
                 scaleToFit: {
                     title: "Scale to fit",
                     type: "boolean",
-                    default: "false",
+                    default: false,
                 },
             },
         },

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
@@ -99,6 +99,12 @@ export interface ViewportPositionerHandledProps extends ViewportPositionerManage
     fixedAfterInitialPlacement?: boolean;
 
     /**
+     * Whether the positioner should scale to fill all the available space relative to the anchor.
+     * Otherwise the positioner is sized to match content.  Default is false.
+     */
+    scaleToAvailableSpace?: boolean;
+
+    /**
      * The children of the viewport positioner
      */
     children?: React.ReactNode;

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
@@ -102,7 +102,7 @@ export interface ViewportPositionerHandledProps extends ViewportPositionerManage
      * Whether the positioner should scale to fill all the available space relative to the anchor.
      * Otherwise the positioner is sized to match content.  Default is false.
      */
-    scaleToAvailableSpace?: boolean;
+    scaleToFit?: boolean;
 
     /**
      * The children of the viewport positioner

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.schema.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.schema.ts
@@ -56,6 +56,7 @@ export default {
         scaleToFit: {
             title: "Scale to fit",
             type: "boolean",
+            default: "false",
         },
     },
     reactProperties: {

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.schema.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.schema.ts
@@ -53,6 +53,10 @@ export default {
             title: "Fixed after initial placement",
             type: "boolean",
         },
+        scaleToFit: {
+            title: "Scale to fit",
+            type: "boolean",
+        },
     },
     reactProperties: {
         children: {

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.schema.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.schema.ts
@@ -56,7 +56,7 @@ export default {
         scaleToFit: {
             title: "Scale to fit",
             type: "boolean",
-            default: "false",
+            default: false,
         },
     },
     reactProperties: {

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -1345,4 +1345,191 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().baseHorizontalOffset).toBe(-10);
         expect(positioner.instance().baseVerticalOffset).toBe(-10);
     });
+
+    test("Positioner scaled sizes calculated correctly", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div
+                style={{
+                    height: "100px",
+                    width: "100px",
+                }}
+            >
+                <div
+                    style={{
+                        height: "10px",
+                        width: "10px",
+                    }}
+                    ref={anchorElement}
+                />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.inset}
+                    verticalPositioningMode={AxisPositioningMode.inset}
+                    anchor={anchorElement}
+                    viewport={document.firstElementChild as HTMLElement}
+                    managedClasses={managedClasses}
+                    scaleToAvailableSpace={true}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        positioner.instance().viewportRect = viewportRect;
+        positioner.instance().anchorTop = 100;
+        positioner.instance().anchorRight = 160;
+        positioner.instance().anchorBottom = 110;
+        positioner.instance().anchorLeft = 150;
+        positioner.instance().anchorWidth = 10;
+        positioner.instance().anchorHeight = 10;
+
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerWidth"](
+                    ViewportPositionerHorizontalPositionLabel.insetRight
+                )
+        ).toBe(100);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerWidth"](ViewportPositionerHorizontalPosition.right)
+        ).toBe(90);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerHeight"](
+                    ViewportPositionerVerticalPositionLabel.insetBottom
+                )
+        ).toBe(100);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerHeight"](ViewportPositionerVerticalPosition.bottom)
+        ).toBe(90);
+
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerWidth"](
+                    ViewportPositionerHorizontalPositionLabel.insetLeft
+                )
+        ).toBe(10);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerWidth"](ViewportPositionerHorizontalPosition.left)
+        ).toBe(0);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerHeight"](
+                    ViewportPositionerVerticalPositionLabel.insetTop
+                )
+        ).toBe(10);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerHeight"](ViewportPositionerVerticalPosition.top)
+        ).toBe(0);
+    });
+
+    test("Positioner scaled sizes limited to viewport width", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div
+                style={{
+                    height: "100px",
+                    width: "100px",
+                }}
+            >
+                <div
+                    style={{
+                        height: "10px",
+                        width: "10px",
+                    }}
+                    ref={anchorElement}
+                />
+                <ViewportPositioner
+                    horizontalPositioningMode={AxisPositioningMode.inset}
+                    verticalPositioningMode={AxisPositioningMode.inset}
+                    anchor={anchorElement}
+                    viewport={document.firstElementChild as HTMLElement}
+                    managedClasses={managedClasses}
+                    scaleToAvailableSpace={true}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+
+        positioner.instance().viewportRect = viewportRect;
+        positioner.instance().anchorTop = 0;
+        positioner.instance().anchorRight = 60;
+        positioner.instance().anchorBottom = 10;
+        positioner.instance().anchorLeft = 50;
+        positioner.instance().anchorWidth = 10;
+        positioner.instance().anchorHeight = 10;
+
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerWidth"](
+                    ViewportPositionerHorizontalPositionLabel.insetRight
+                )
+        ).toBe(100);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerWidth"](ViewportPositionerHorizontalPosition.right)
+        ).toBe(100);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerHeight"](
+                    ViewportPositionerVerticalPositionLabel.insetBottom
+                )
+        ).toBe(100);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerHeight"](ViewportPositionerVerticalPosition.bottom)
+        ).toBe(100);
+
+        positioner.instance().anchorTop = 300;
+        positioner.instance().anchorRight = 360;
+        positioner.instance().anchorBottom = 310;
+        positioner.instance().anchorLeft = 3350;
+
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerWidth"](
+                    ViewportPositionerHorizontalPositionLabel.insetLeft
+                )
+        ).toBe(100);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerWidth"](ViewportPositionerHorizontalPosition.left)
+        ).toBe(100);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerHeight"](
+                    ViewportPositionerVerticalPositionLabel.insetTop
+                )
+        ).toBe(100);
+        expect(
+            positioner
+                .instance()
+                ["getNextPositionerHeight"](ViewportPositionerVerticalPosition.top)
+        ).toBe(100);
+    });
 });

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -1346,7 +1346,7 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().baseVerticalOffset).toBe(-10);
     });
 
-    test("Positioner scaled sizes calculated correctly", (): void => {
+    test("Should scale positioner dimenstions to match the viewports height when scaleTofit is set to true", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
@@ -1371,7 +1371,7 @@ describe("viewport positioner", (): void => {
                     anchor={anchorElement}
                     viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
-                    scaleToAvailableSpace={true}
+                    scaleToFit={true}
                 />
             </div>
         );
@@ -1462,7 +1462,7 @@ describe("viewport positioner", (): void => {
                     anchor={anchorElement}
                     viewport={document.firstElementChild as HTMLElement}
                     managedClasses={managedClasses}
-                    scaleToAvailableSpace={true}
+                    scaleToFit={true}
                 />
             </div>
         );

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import ViewportPositioner, {
+    Dimension,
     ViewportPositionerClassNameContract,
     ViewportPositionerHandledProps,
     ViewportPositionerHorizontalPositionLabel,
@@ -1165,11 +1166,17 @@ describe("viewport positioner", (): void => {
         positioner.instance().baseHorizontalOffset = 10;
         positioner.instance().baseVerticalOffset = 10;
 
+        const positionerDimension: Dimension = {
+            width: 10,
+            height: 10,
+        };
+
         expect(
             positioner
                 .instance()
                 ["getHorizontalPositioningState"](
-                    ViewportPositionerHorizontalPositionLabel.right
+                    ViewportPositionerHorizontalPositionLabel.right,
+                    positionerDimension
                 )["left"]
         ).toBe(20);
 
@@ -1177,7 +1184,8 @@ describe("viewport positioner", (): void => {
             positioner
                 .instance()
                 ["getHorizontalPositioningState"](
-                    ViewportPositionerHorizontalPositionLabel.left
+                    ViewportPositionerHorizontalPositionLabel.left,
+                    positionerDimension
                 )["right"]
         ).toBe(0);
 
@@ -1185,7 +1193,8 @@ describe("viewport positioner", (): void => {
             positioner
                 .instance()
                 ["getHorizontalPositioningState"](
-                    ViewportPositionerHorizontalPositionLabel.insetRight
+                    ViewportPositionerHorizontalPositionLabel.insetRight,
+                    positionerDimension
                 )["left"]
         ).toBe(10);
 
@@ -1193,7 +1202,8 @@ describe("viewport positioner", (): void => {
             positioner
                 .instance()
                 ["getHorizontalPositioningState"](
-                    ViewportPositionerHorizontalPositionLabel.insetLeft
+                    ViewportPositionerHorizontalPositionLabel.insetLeft,
+                    positionerDimension
                 )["right"]
         ).toBe(-10);
 
@@ -1201,7 +1211,8 @@ describe("viewport positioner", (): void => {
             positioner
                 .instance()
                 ["getVerticalPositioningState"](
-                    ViewportPositionerVerticalPositionLabel.top
+                    ViewportPositionerVerticalPositionLabel.top,
+                    positionerDimension
                 )["bottom"]
         ).toBe(10);
 
@@ -1209,7 +1220,8 @@ describe("viewport positioner", (): void => {
             positioner
                 .instance()
                 ["getVerticalPositioningState"](
-                    ViewportPositionerVerticalPositionLabel.bottom
+                    ViewportPositionerVerticalPositionLabel.bottom,
+                    positionerDimension
                 )["top"]
         ).toBe(10);
 
@@ -1217,7 +1229,8 @@ describe("viewport positioner", (): void => {
             positioner
                 .instance()
                 ["getVerticalPositioningState"](
-                    ViewportPositionerVerticalPositionLabel.insetTop
+                    ViewportPositionerVerticalPositionLabel.insetTop,
+                    positionerDimension
                 )["bottom"]
         ).toBe(0);
 
@@ -1225,7 +1238,8 @@ describe("viewport positioner", (): void => {
             positioner
                 .instance()
                 ["getVerticalPositioningState"](
-                    ViewportPositionerVerticalPositionLabel.insetBottom
+                    ViewportPositionerVerticalPositionLabel.insetBottom,
+                    positionerDimension
                 )["top"]
         ).toBe(0);
     });
@@ -1386,55 +1400,43 @@ describe("viewport positioner", (): void => {
         positioner.instance().anchorWidth = 10;
         positioner.instance().anchorHeight = 10;
 
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerWidth"](
-                    ViewportPositionerHorizontalPositionLabel.insetRight
-                )
-        ).toBe(100);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerWidth"](ViewportPositionerHorizontalPosition.right)
-        ).toBe(90);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerHeight"](
-                    ViewportPositionerVerticalPositionLabel.insetBottom
-                )
-        ).toBe(100);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerHeight"](ViewportPositionerVerticalPosition.bottom)
-        ).toBe(90);
+        let positionerDimension: Dimension;
 
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerWidth"](
-                    ViewportPositionerHorizontalPositionLabel.insetLeft
-                )
-        ).toBe(10);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerWidth"](ViewportPositionerHorizontalPosition.left)
-        ).toBe(0);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerHeight"](
-                    ViewportPositionerVerticalPositionLabel.insetTop
-                )
-        ).toBe(10);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerHeight"](ViewportPositionerVerticalPosition.top)
-        ).toBe(0);
+        positionerDimension = positioner
+            .instance()
+            ["getNextPositionerDimension"](
+                ViewportPositionerHorizontalPositionLabel.insetRight,
+                ViewportPositionerVerticalPositionLabel.insetBottom
+            );
+        expect(positionerDimension.width).toBe(100);
+        expect(positionerDimension.height).toBe(100);
+
+        positionerDimension = positioner
+            .instance()
+            ["getNextPositionerDimension"](
+                ViewportPositionerHorizontalPositionLabel.right,
+                ViewportPositionerVerticalPositionLabel.bottom
+            );
+        expect(positionerDimension.width).toBe(90);
+        expect(positionerDimension.height).toBe(90);
+
+        positionerDimension = positioner
+            .instance()
+            ["getNextPositionerDimension"](
+                ViewportPositionerHorizontalPositionLabel.insetLeft,
+                ViewportPositionerVerticalPositionLabel.insetTop
+            );
+        expect(positionerDimension.width).toBe(10);
+        expect(positionerDimension.height).toBe(10);
+
+        positionerDimension = positioner
+            .instance()
+            ["getNextPositionerDimension"](
+                ViewportPositionerHorizontalPositionLabel.left,
+                ViewportPositionerVerticalPositionLabel.top
+            );
+        expect(positionerDimension.width).toBe(0);
+        expect(positionerDimension.height).toBe(0);
     });
 
     test("Positioner scaled sizes limited to viewport width", (): void => {
@@ -1467,6 +1469,7 @@ describe("viewport positioner", (): void => {
             </div>
         );
 
+        let positionerDimension: Dimension;
         const positioner: any = rendered.find("BaseViewportPositioner");
 
         positioner.instance().viewportRect = viewportRect;
@@ -1477,59 +1480,45 @@ describe("viewport positioner", (): void => {
         positioner.instance().anchorWidth = 10;
         positioner.instance().anchorHeight = 10;
 
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerWidth"](
-                    ViewportPositionerHorizontalPositionLabel.insetRight
-                )
-        ).toBe(100);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerWidth"](ViewportPositionerHorizontalPosition.right)
-        ).toBe(100);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerHeight"](
-                    ViewportPositionerVerticalPositionLabel.insetBottom
-                )
-        ).toBe(100);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerHeight"](ViewportPositionerVerticalPosition.bottom)
-        ).toBe(100);
+        positionerDimension = positioner
+            .instance()
+            ["getNextPositionerDimension"](
+                ViewportPositionerHorizontalPositionLabel.insetRight,
+                ViewportPositionerVerticalPositionLabel.insetBottom
+            );
+        expect(positionerDimension.width).toBe(100);
+        expect(positionerDimension.height).toBe(100);
+
+        positionerDimension = positioner
+            .instance()
+            ["getNextPositionerDimension"](
+                ViewportPositionerHorizontalPositionLabel.right,
+                ViewportPositionerVerticalPositionLabel.bottom
+            );
+        expect(positionerDimension.width).toBe(100);
+        expect(positionerDimension.height).toBe(100);
 
         positioner.instance().anchorTop = 300;
         positioner.instance().anchorRight = 360;
         positioner.instance().anchorBottom = 310;
         positioner.instance().anchorLeft = 3350;
 
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerWidth"](
-                    ViewportPositionerHorizontalPositionLabel.insetLeft
-                )
-        ).toBe(100);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerWidth"](ViewportPositionerHorizontalPosition.left)
-        ).toBe(100);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerHeight"](
-                    ViewportPositionerVerticalPositionLabel.insetTop
-                )
-        ).toBe(100);
-        expect(
-            positioner
-                .instance()
-                ["getNextPositionerHeight"](ViewportPositionerVerticalPosition.top)
-        ).toBe(100);
+        positionerDimension = positioner
+            .instance()
+            ["getNextPositionerDimension"](
+                ViewportPositionerHorizontalPositionLabel.insetLeft,
+                ViewportPositionerVerticalPositionLabel.insetTop
+            );
+        expect(positionerDimension.width).toBe(100);
+        expect(positionerDimension.height).toBe(100);
+
+        positionerDimension = positioner
+            .instance()
+            ["getNextPositionerDimension"](
+                ViewportPositionerHorizontalPositionLabel.left,
+                ViewportPositionerVerticalPositionLabel.top
+            );
+        expect(positionerDimension.width).toBe(100);
+        expect(positionerDimension.height).toBe(100);
     });
 });

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -21,11 +21,13 @@ import {
  */
 configure({ adapter: new Adapter() });
 
+// viewport rect is deliberately offset so we are testing that
+// calculations are correct when the viewport is not positioned at origin (i.e. x and y = 0)
 const viewportRect: ClientRect = {
-    top: 0,
-    right: 100,
-    bottom: 100,
-    left: 0,
+    top: 100,
+    right: 250,
+    bottom: 200,
+    left: 150,
     height: 100,
     width: 100,
 };
@@ -419,10 +421,10 @@ describe("viewport positioner", (): void => {
 
         positioner.instance().viewportRect = viewportRect;
         positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 80;
-        positioner.instance().anchorRight = 90;
-        positioner.instance().anchorBottom = 90;
-        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorTop = 180;
+        positioner.instance().anchorRight = 240;
+        positioner.instance().anchorBottom = 190;
+        positioner.instance().anchorLeft = 230;
         positioner.instance().anchorWidth = 10;
         positioner.instance().anchorHeight = 10;
         positioner.instance().scrollTop = 0;
@@ -431,30 +433,22 @@ describe("viewport positioner", (): void => {
         expect(
             positioner
                 .instance()
-                ["getHorizontalPositionAvailableWidth"](
-                    ViewportPositionerHorizontalPosition.left
-                )
+                ["getAvailableWidth"](ViewportPositionerHorizontalPosition.left)
         ).toBe(80);
         expect(
             positioner
                 .instance()
-                ["getHorizontalPositionAvailableWidth"](
-                    ViewportPositionerHorizontalPosition.right
-                )
+                ["getAvailableWidth"](ViewportPositionerHorizontalPosition.right)
         ).toBe(10);
         expect(
             positioner
                 .instance()
-                ["getVerticalPositionAvailableHeight"](
-                    ViewportPositionerVerticalPosition.top
-                )
+                ["getAvailableHeight"](ViewportPositionerVerticalPosition.top)
         ).toBe(80);
         expect(
             positioner
                 .instance()
-                ["getVerticalPositionAvailableHeight"](
-                    ViewportPositionerVerticalPosition.bottom
-                )
+                ["getAvailableHeight"](ViewportPositionerVerticalPosition.bottom)
         ).toBe(10);
     });
 
@@ -491,10 +485,10 @@ describe("viewport positioner", (): void => {
 
         positioner.instance().viewportRect = viewportRect;
         positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 80;
-        positioner.instance().anchorRight = 90;
-        positioner.instance().anchorBottom = 90;
-        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorTop = 180;
+        positioner.instance().anchorRight = 240;
+        positioner.instance().anchorBottom = 190;
+        positioner.instance().anchorLeft = 230;
         positioner.instance().anchorWidth = 10;
         positioner.instance().anchorHeight = 10;
         positioner.instance().scrollTop = 0;
@@ -503,28 +497,24 @@ describe("viewport positioner", (): void => {
         expect(
             positioner
                 .instance()
-                ["getHorizontalPositionAvailableWidth"](
-                    ViewportPositionerHorizontalPositionLabel.insetLeft
-                )
+                ["getAvailableWidth"](ViewportPositionerHorizontalPositionLabel.insetLeft)
         ).toBe(90);
         expect(
             positioner
                 .instance()
-                ["getHorizontalPositionAvailableWidth"](
+                ["getAvailableWidth"](
                     ViewportPositionerHorizontalPositionLabel.insetRight
                 )
         ).toBe(20);
         expect(
             positioner
                 .instance()
-                ["getVerticalPositionAvailableHeight"](
-                    ViewportPositionerVerticalPositionLabel.insetTop
-                )
+                ["getAvailableHeight"](ViewportPositionerVerticalPositionLabel.insetTop)
         ).toBe(90);
         expect(
             positioner
                 .instance()
-                ["getVerticalPositionAvailableHeight"](
+                ["getAvailableHeight"](
                     ViewportPositionerVerticalPositionLabel.insetBottom
                 )
         ).toBe(20);
@@ -639,10 +629,10 @@ describe("viewport positioner", (): void => {
 
         positioner.instance().viewportRect = viewportRect;
         positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 80;
-        positioner.instance().anchorRight = 90;
-        positioner.instance().anchorBottom = 90;
-        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorTop = 180;
+        positioner.instance().anchorRight = 240;
+        positioner.instance().anchorBottom = 190;
+        positioner.instance().anchorLeft = 230;
         positioner.instance().anchorWidth = 10;
         positioner.instance().anchorHeight = 10;
         positioner.instance().scrollTop = 0;
@@ -691,10 +681,10 @@ describe("viewport positioner", (): void => {
 
         positioner.instance().viewportRect = viewportRect;
         positioner.instance().positionerRect = positionerRectX20Y20;
-        positioner.instance().anchorTop = 10;
-        positioner.instance().anchorRight = 20;
-        positioner.instance().anchorBottom = 20;
-        positioner.instance().anchorLeft = 10;
+        positioner.instance().anchorTop = 110;
+        positioner.instance().anchorRight = 170;
+        positioner.instance().anchorBottom = 120;
+        positioner.instance().anchorLeft = 160;
         positioner.instance().anchorWidth = 10;
         positioner.instance().anchorHeight = 10;
         positioner.instance().scrollTop = 0;
@@ -744,10 +734,10 @@ describe("viewport positioner", (): void => {
         const positioner: any = rendered.find("BaseViewportPositioner");
 
         positioner.instance().viewportRect = viewportRect;
-        positioner.instance().anchorTop = 200;
-        positioner.instance().anchorRight = 210;
-        positioner.instance().anchorBottom = 210;
-        positioner.instance().anchorLeft = 200;
+        positioner.instance().anchorTop = 210;
+        positioner.instance().anchorRight = 270;
+        positioner.instance().anchorBottom = 220;
+        positioner.instance().anchorLeft = 260;
         positioner.instance().setState({ noObserverMode: false });
         expect(positioner.instance().state.noObserverMode).toBe(false);
 
@@ -757,22 +747,47 @@ describe("viewport positioner", (): void => {
                 ["getHorizontalTranslate"](
                     ViewportPositionerHorizontalPositionLabel.insetLeft
                 )
-        ).toBe(-111);
+        ).toBe(-21);
         expect(
             positioner
                 .instance()
                 ["getHorizontalTranslate"](ViewportPositionerHorizontalPosition.left)
-        ).toBe(-101);
+        ).toBe(-11);
         expect(
             positioner
                 .instance()
                 ["getVerticalTranslate"](ViewportPositionerVerticalPositionLabel.insetTop)
-        ).toBe(-111);
+        ).toBe(-21);
         expect(
             positioner
                 .instance()
                 ["getVerticalTranslate"](ViewportPositionerVerticalPosition.top)
-        ).toBe(-101);
+        ).toBe(-11);
+
+        expect(
+            positioner
+                .instance()
+                ["getHorizontalTranslate"](
+                    ViewportPositionerHorizontalPositionLabel.insetRight
+                )
+        ).toBe(0);
+        expect(
+            positioner
+                .instance()
+                ["getHorizontalTranslate"](ViewportPositionerHorizontalPosition.right)
+        ).toBe(0);
+        expect(
+            positioner
+                .instance()
+                ["getVerticalTranslate"](
+                    ViewportPositionerVerticalPositionLabel.insetBottom
+                )
+        ).toBe(0);
+        expect(
+            positioner
+                .instance()
+                ["getVerticalTranslate"](ViewportPositionerVerticalPosition.bottom)
+        ).toBe(0);
     });
 
     test("Translate transforms calculated correctly - bottom/right", (): void => {
@@ -809,10 +824,10 @@ describe("viewport positioner", (): void => {
         const positioner: any = rendered.find("BaseViewportPositioner");
 
         positioner.instance().viewportRect = viewportRect;
-        positioner.instance().anchorTop = -210;
-        positioner.instance().anchorRight = -200;
-        positioner.instance().anchorBottom = -200;
-        positioner.instance().anchorLeft = -210;
+        positioner.instance().anchorTop = 80;
+        positioner.instance().anchorRight = 140;
+        positioner.instance().anchorBottom = 90;
+        positioner.instance().anchorLeft = 130;
 
         expect(
             positioner
@@ -820,24 +835,47 @@ describe("viewport positioner", (): void => {
                 ["getHorizontalTranslate"](
                     ViewportPositionerHorizontalPositionLabel.insetRight
                 )
-        ).toBe(211);
+        ).toBe(21);
         expect(
             positioner
                 .instance()
                 ["getHorizontalTranslate"](ViewportPositionerHorizontalPosition.right)
-        ).toBe(201);
+        ).toBe(11);
         expect(
             positioner
                 .instance()
                 ["getVerticalTranslate"](
                     ViewportPositionerVerticalPositionLabel.insetBottom
                 )
-        ).toBe(211);
+        ).toBe(21);
         expect(
             positioner
                 .instance()
                 ["getVerticalTranslate"](ViewportPositionerVerticalPosition.bottom)
-        ).toBe(201);
+        ).toBe(11);
+
+        expect(
+            positioner
+                .instance()
+                ["getHorizontalTranslate"](
+                    ViewportPositionerHorizontalPositionLabel.insetLeft
+                )
+        ).toBe(0);
+        expect(
+            positioner
+                .instance()
+                ["getHorizontalTranslate"](ViewportPositionerHorizontalPosition.left)
+        ).toBe(0);
+        expect(
+            positioner
+                .instance()
+                ["getVerticalTranslate"](ViewportPositionerVerticalPositionLabel.insetTop)
+        ).toBe(0);
+        expect(
+            positioner
+                .instance()
+                ["getVerticalTranslate"](ViewportPositionerVerticalPosition.top)
+        ).toBe(0);
     });
 
     test("Positioner moves to biggest area on updateLayout() when spacing changes", (): void => {
@@ -879,10 +917,10 @@ describe("viewport positioner", (): void => {
 
         positioner.instance().viewportRect = viewportRect;
         positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 80;
-        positioner.instance().anchorRight = 90;
-        positioner.instance().anchorBottom = 90;
-        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorTop = 180;
+        positioner.instance().anchorRight = 240;
+        positioner.instance().anchorBottom = 190;
+        positioner.instance().anchorLeft = 230;
         positioner.instance().anchorWidth = 10;
         positioner.instance().anchorHeight = 10;
         positioner.instance().scrollTop = 0;
@@ -898,10 +936,10 @@ describe("viewport positioner", (): void => {
             ViewportPositionerVerticalPosition.top
         );
 
-        positioner.instance().anchorTop = 10;
-        positioner.instance().anchorRight = 20;
-        positioner.instance().anchorBottom = 20;
-        positioner.instance().anchorLeft = 10;
+        positioner.instance().anchorTop = 110;
+        positioner.instance().anchorRight = 170;
+        positioner.instance().anchorBottom = 120;
+        positioner.instance().anchorLeft = 160;
 
         positioner.instance()["updateLayout"]();
 
@@ -949,10 +987,10 @@ describe("viewport positioner", (): void => {
 
         positioner.instance().viewportRect = viewportRect;
         positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 80;
-        positioner.instance().anchorRight = 90;
-        positioner.instance().anchorBottom = 90;
-        positioner.instance().anchorLeft = 80;
+        positioner.instance().anchorTop = 180;
+        positioner.instance().anchorRight = 240;
+        positioner.instance().anchorBottom = 190;
+        positioner.instance().anchorLeft = 230;
         positioner.instance().anchorWidth = 10;
         positioner.instance().anchorHeight = 10;
         positioner.instance().scrollTop = 0;
@@ -968,10 +1006,10 @@ describe("viewport positioner", (): void => {
             ViewportPositionerVerticalPosition.top
         );
 
-        positioner.instance().anchorTop = 20;
-        positioner.instance().anchorRight = 30;
-        positioner.instance().anchorBottom = 30;
-        positioner.instance().anchorLeft = 20;
+        positioner.instance().anchorTop = 120;
+        positioner.instance().anchorRight = 180;
+        positioner.instance().anchorBottom = 130;
+        positioner.instance().anchorLeft = 170;
 
         positioner.instance()["updateLayout"]();
 
@@ -982,10 +1020,10 @@ describe("viewport positioner", (): void => {
             ViewportPositionerVerticalPosition.top
         );
 
-        positioner.instance().anchorTop = 10;
-        positioner.instance().anchorRight = 20;
-        positioner.instance().anchorBottom = 20;
-        positioner.instance().anchorLeft = 10;
+        positioner.instance().anchorTop = 110;
+        positioner.instance().anchorRight = 170;
+        positioner.instance().anchorBottom = 120;
+        positioner.instance().anchorLeft = 160;
 
         positioner.instance()["updateLayout"]();
 

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -1,53 +1,194 @@
 import { storiesOf } from "@storybook/react";
 import React from "react";
-import ViewportPositioner from "./";
-import { AxisPositioningMode } from "./viewport-positioner.props";
+import ViewportPositioner, { AxisPositioningMode, ViewportPositionerProps } from "./";
 import Foundation from "@microsoft/fast-components-foundation-react";
+import { ViewportPositionerVerticalPosition } from "./viewport-positioner.props";
+import { isNil } from "lodash-es";
 
 const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
 
-const rootElement: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
+interface TestViewportProps {
+    positionerProps: ViewportPositionerProps;
+}
 
-storiesOf("Viewport Positioner", module).add("Default", () => (
-    <div
-        ref={rootElement}
-        style={{
-            height: "400px",
-            width: "400px",
-            overflow: "scroll",
-        }}
-    >
-        <div
-            style={{
-                height: "600px",
-                width: "600px",
-                padding: "250px",
-                background: "blue",
+class TestViewport extends React.Component<TestViewportProps, {}> {
+    private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
+        HTMLDivElement
+    >();
+
+    constructor(props: TestViewportProps) {
+        super(props);
+
+        this.state = {};
+    }
+
+    public render(): JSX.Element {
+        return (
+            <div
+                ref={this.rootElement}
+                style={{
+                    height: "400px",
+                    width: "400px",
+                    margin: "50px",
+                    overflow: "scroll",
+                }}
+            >
+                {this.props.children}
+                <div
+                    style={{
+                        height: "0",
+                        width: "0",
+                    }}
+                >
+                    <ViewportPositioner
+                        {...this.props.positionerProps}
+                        viewport={this.rootElement}
+                    >
+                        <div
+                            style={{
+                                height: "100%",
+                                width: "100%",
+                                background: "yellow",
+                            }}
+                        >
+                            Positioner
+                        </div>
+                    </ViewportPositioner>
+                </div>
+            </div>
+        );
+    }
+}
+
+storiesOf("Viewport Positioner", module)
+    .add("Default", () => (
+        <TestViewport
+            positionerProps={{
+                verticalPositioningMode: AxisPositioningMode.adjacent,
+                horizontalPositioningMode: AxisPositioningMode.adjacent,
+                anchor: anchorElement,
+                style: {
+                    height: "100px",
+                    width: "100px",
+                },
             }}
         >
             <div
-                ref={anchorElement}
                 style={{
-                    height: "100px",
-                    width: "100px",
-                    background: "green",
+                    height: "1200px",
+                    width: "1200px",
+                    padding: "500px",
+                    background: "blue",
                 }}
             >
-                Anchor
+                <div
+                    ref={anchorElement}
+                    style={{
+                        height: "100px",
+                        width: "100px",
+                        background: "green",
+                    }}
+                >
+                    Anchor
+                </div>
             </div>
-        </div>
-        <ViewportPositioner
-            verticalPositioningMode={AxisPositioningMode.adjacent}
-            horizontalPositioningMode={AxisPositioningMode.adjacent}
-            anchor={anchorElement}
-            viewport={rootElement}
-            style={{
-                height: "100px",
-                width: "100px",
-                background: "yellow",
+        </TestViewport>
+    ))
+    .add("Squishy region", () => (
+        <TestViewport
+            positionerProps={{
+                verticalPositioningMode: AxisPositioningMode.adjacent,
+                horizontalPositioningMode: AxisPositioningMode.adjacent,
+                defaultVerticalPosition: ViewportPositionerVerticalPosition.uncontrolled,
+                verticalThreshold: 0,
+                horizontalThreshold: 0,
+                anchor: anchorElement,
             }}
         >
-            Positioner
-        </ViewportPositioner>
-    </div>
-));
+            <div
+                style={{
+                    height: "1200px",
+                    width: "1200px",
+                    padding: "550px",
+                    background: "blue",
+                }}
+            >
+                <div
+                    ref={anchorElement}
+                    style={{
+                        height: "100px",
+                        width: "100px",
+                        background: "green",
+                    }}
+                >
+                    Anchor
+                </div>
+            </div>
+        </TestViewport>
+    ))
+    .add("Always in view - adjacent", () => (
+        <TestViewport
+            positionerProps={{
+                verticalPositioningMode: AxisPositioningMode.adjacent,
+                horizontalPositioningMode: AxisPositioningMode.adjacent,
+                verticalAlwaysInView: true,
+                horizontalAlwaysInView: true,
+                anchor: anchorElement,
+                style: {
+                    height: "100px",
+                    width: "100px",
+                },
+            }}
+        >
+            <div
+                style={{
+                    height: "1200px",
+                    width: "1200px",
+                    padding: "550px",
+                    background: "blue",
+                }}
+            >
+                <div
+                    ref={anchorElement}
+                    style={{
+                        height: "100px",
+                        width: "100px",
+                        background: "green",
+                    }}
+                >
+                    Anchor
+                </div>
+            </div>
+        </TestViewport>
+    ))
+    .add("Always in view - inset", () => (
+        <TestViewport
+            positionerProps={{
+                verticalPositioningMode: AxisPositioningMode.inset,
+                horizontalPositioningMode: AxisPositioningMode.inset,
+                verticalAlwaysInView: true,
+                horizontalAlwaysInView: true,
+                anchor: anchorElement,
+            }}
+        >
+            <div
+                style={{
+                    height: "1200px",
+                    width: "1200px",
+                    padding: "550px",
+                    background: "blue",
+                }}
+            >
+                <div
+                    ref={anchorElement}
+                    style={{
+                        height: "100px",
+                        width: "100px",
+                        background: "green",
+                    }}
+                >
+                    Anchor
+                </div>
+            </div>
+        </TestViewport>
+    ));

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -101,8 +101,6 @@ storiesOf("Viewport Positioner", module)
                 horizontalPositioningMode: AxisPositioningMode.adjacent,
                 defaultVerticalPosition: ViewportPositionerVerticalPosition.uncontrolled,
                 scaleToAvailableSpace: true,
-                verticalThreshold: 0,
-                horizontalThreshold: 0,
                 anchor: anchorElement,
             }}
         >

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -100,6 +100,7 @@ storiesOf("Viewport Positioner", module)
                 verticalPositioningMode: AxisPositioningMode.adjacent,
                 horizontalPositioningMode: AxisPositioningMode.adjacent,
                 defaultVerticalPosition: ViewportPositionerVerticalPosition.uncontrolled,
+                scaleToAvailableSpace: true,
                 verticalThreshold: 0,
                 horizontalThreshold: 0,
                 anchor: anchorElement,

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -100,7 +100,7 @@ storiesOf("Viewport Positioner", module)
                 verticalPositioningMode: AxisPositioningMode.adjacent,
                 horizontalPositioningMode: AxisPositioningMode.adjacent,
                 defaultVerticalPosition: ViewportPositionerVerticalPosition.uncontrolled,
-                scaleToAvailableSpace: true,
+                scaleToFit: true,
                 anchor: anchorElement,
             }}
         >

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -12,9 +12,7 @@ interface TestViewportProps {
 }
 
 class TestViewport extends React.Component<TestViewportProps, {}> {
-    private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
-        HTMLDivElement
-    >();
+    private rootElement: React.RefObject<HTMLDivElement>;
 
     constructor(props: TestViewportProps) {
         super(props);

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -12,7 +12,9 @@ interface TestViewportProps {
 }
 
 class TestViewport extends React.Component<TestViewportProps, {}> {
-    private rootElement: React.RefObject<HTMLDivElement>;
+    private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
+        HTMLDivElement
+    >();
 
     constructor(props: TestViewportProps) {
         super(props);

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -936,27 +936,17 @@ class ViewportPositioner extends Foundation<
         };
 
         if (this.props.scaleToFit) {
-            newPositionerDimension.height = this.getConstrainedAxisDimension(
+            newPositionerDimension.height = Math.min(
                 this.getAvailableHeight(desiredVerticalPosition),
                 this.viewportRect.height
             );
-            newPositionerDimension.width = this.getConstrainedAxisDimension(
+            newPositionerDimension.width = Math.min(
                 this.getAvailableWidth(desiredHorizontalPosition),
                 this.viewportRect.width
             );
         }
 
         return newPositionerDimension;
-    };
-
-    /**
-     * Constrains axis dimension to max value
-     */
-    private getConstrainedAxisDimension = (
-        availableSpace: number,
-        maxValue: number
-    ): number => {
-        return availableSpace > maxValue ? maxValue : availableSpace;
     };
 
     /**

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -123,7 +123,7 @@ class ViewportPositioner extends Foundation<
         verticalLockToDefault: false,
         horizontalLockToDefault: false,
         fixedAfterInitialPlacement: false,
-        scaleToAvailableSpace: false,
+        scaleToFit: false,
         managedClasses: {},
     };
 
@@ -142,7 +142,7 @@ class ViewportPositioner extends Foundation<
         verticalAlwaysInView: void 0,
         verticalLockToDefault: void 0,
         fixedAfterInitialPlacement: void 0,
-        scaleToAvailableSpace: void 0,
+        scaleToFit: void 0,
         disabled: void 0,
     };
 
@@ -322,10 +322,10 @@ class ViewportPositioner extends Foundation<
             (isNil(this.positionerRect) && !this.state.noObserverMode);
 
         return {
-            height: this.props.scaleToAvailableSpace
+            height: this.props.scaleToFit
                 ? `${this.state.verticalSelectedPositionHeight}px`
                 : null,
-            width: this.props.scaleToAvailableSpace
+            width: this.props.scaleToFit
                 ? `${this.state.horizontalSelectedPositionWidth}px`
                 : null,
             opacity: shouldHide ? 0 : undefined,
@@ -914,7 +914,7 @@ class ViewportPositioner extends Foundation<
         desiredHorizontalPosition: ViewportPositionerHorizontalPositionLabel
     ): number => {
         let newPositionerRectWidth: number = this.positionerRect.width;
-        if (this.props.scaleToAvailableSpace) {
+        if (this.props.scaleToFit) {
             const availableWidth: number = this.getAvailableWidth(
                 desiredHorizontalPosition
             );
@@ -933,7 +933,7 @@ class ViewportPositioner extends Foundation<
         desiredVerticalPosition: ViewportPositionerVerticalPositionLabel
     ): number => {
         let newPositionerRectHeight: number = this.positionerRect.height;
-        if (this.props.scaleToAvailableSpace) {
+        if (this.props.scaleToFit) {
             const availableHeight: number = this.getAvailableHeight(
                 desiredVerticalPosition
             );

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -123,6 +123,7 @@ class ViewportPositioner extends Foundation<
         verticalLockToDefault: false,
         horizontalLockToDefault: false,
         fixedAfterInitialPlacement: false,
+        scaleToAvailableSpace: false,
         managedClasses: {},
     };
 
@@ -141,6 +142,7 @@ class ViewportPositioner extends Foundation<
         verticalAlwaysInView: void 0,
         verticalLockToDefault: void 0,
         fixedAfterInitialPlacement: void 0,
+        scaleToAvailableSpace: void 0,
         disabled: void 0,
     };
 
@@ -320,12 +322,12 @@ class ViewportPositioner extends Foundation<
             (isNil(this.positionerRect) && !this.state.noObserverMode);
 
         return {
-            height: isNil(this.props.verticalThreshold)
-                ? null
-                : `${this.state.verticalSelectedPositionHeight}px`,
-            width: isNil(this.props.horizontalThreshold)
-                ? null
-                : `${this.state.horizontalSelectedPositionWidth}px`,
+            height: this.props.scaleToAvailableSpace
+                ? `${this.state.verticalSelectedPositionHeight}px`
+                : null,
+            width: this.props.scaleToAvailableSpace
+                ? `${this.state.horizontalSelectedPositionWidth}px`
+                : null,
             opacity: shouldHide ? 0 : undefined,
             position: "relative",
             transformOrigin: `${this.state.xTransformOrigin} ${
@@ -912,7 +914,7 @@ class ViewportPositioner extends Foundation<
         desiredHorizontalPosition: ViewportPositionerHorizontalPositionLabel
     ): number => {
         let newPositionerRectWidth: number = this.positionerRect.width;
-        if (!isNil(this.props.horizontalThreshold)) {
+        if (this.props.scaleToAvailableSpace) {
             const availableWidth: number = this.getAvailableWidth(
                 desiredHorizontalPosition
             );
@@ -931,7 +933,7 @@ class ViewportPositioner extends Foundation<
         desiredVerticalPosition: ViewportPositionerVerticalPositionLabel
     ): number => {
         let newPositionerRectHeight: number = this.positionerRect.height;
-        if (!isNil(this.props.verticalThreshold)) {
+        if (this.props.scaleToAvailableSpace) {
             const availableHeight: number = this.getAvailableHeight(
                 desiredVerticalPosition
             );

--- a/packages/fast-components-react-msft/src/flyout/flyout.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.tsx
@@ -61,6 +61,7 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
         verticalThreshold: void 0,
         viewport: void 0,
         width: void 0,
+        scaleToFit: void 0,
     };
 
     private rootEl: React.RefObject<ViewportPositioner>;

--- a/packages/fast-components-react-msft/src/select/select.schema.ts
+++ b/packages/fast-components-react-msft/src/select/select.schema.ts
@@ -103,6 +103,10 @@ export default {
                     title: "Fixed after initial placement",
                     type: "boolean",
                 },
+                scaleToFit: {
+                    title: "Scale to fit",
+                    type: "boolean",
+                },
             },
         },
     },

--- a/packages/fast-components-react-msft/src/select/select.schema.ts
+++ b/packages/fast-components-react-msft/src/select/select.schema.ts
@@ -106,6 +106,7 @@ export default {
                 scaleToFit: {
                     title: "Scale to fit",
                     type: "boolean",
+                    default: "false",
                 },
             },
         },

--- a/packages/fast-components-react-msft/src/select/select.schema.ts
+++ b/packages/fast-components-react-msft/src/select/select.schema.ts
@@ -106,7 +106,7 @@ export default {
                 scaleToFit: {
                     title: "Scale to fit",
                     type: "boolean",
-                    default: "false",
+                    default: false,
                 },
             },
         },


### PR DESCRIPTION
# Description
This change adds a new "scaleToAvailableSpace" prop to viewport positioner.  Default is false which is the current behavior of a fixed size positioner. When it is set to true the positioner will dynamically scale to fill all the available space in the assigned region.  This is useful for scaling menus and the such.

## Motivation & context
Provide a means of scaling positioned content to available space.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
