### PR TITLE
feat: add a BareForm secondary export without drag and drop context

### DIFF
--- a/packages/fast-tooling-react/README.md
+++ b/packages/fast-tooling-react/README.md
@@ -33,6 +33,7 @@ The tooling available in FAST Tooling React can be used together to create UI fo
     - [Width](#width)
     - [Height](#height)
 - [Form](#form)
+    - [Drag and drop](#drag-and-drop)
     - [Using form plugins](#using-form-plugins)
     - [React children as options](#react-children-as-options)
     - [Controlling the visible section](#controlling-the-visible-section)
@@ -912,6 +913,10 @@ handleChange = (data) => {
     });
 }
 ```
+
+### Drag and drop
+
+Drag and drop is provided to the `Form` using the `react-dnd` package as well as the `HTML5Backend`. If you are using `react-dnd` somewhere else and need to implement the backend once, use the secondary export `BareForm`.
 
 ### Using form plugins
 

--- a/packages/fast-tooling-react/app/pages/form-and-navigation.tsx
+++ b/packages/fast-tooling-react/app/pages/form-and-navigation.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { DesignSystemProvider } from "@microsoft/fast-jss-manager-react";
 import { getDataFromSchema } from "../../src/data-utilities";
-import { Form, FormPlugin, FormPluginProps, Navigation } from "../../src";
+import { BareForm, FormPlugin, FormPluginProps, Navigation } from "../../src";
 import {
     FormAttributeSettingsMappingToPropertyNames,
     FormChildOptionItem,
@@ -163,7 +163,7 @@ class FormAndNavigationTestPage extends React.Component<{}, FormTestPageState> {
                                 "Segoe UI, SegoeUI, Helvetica Neue, Helvetica, Arial, sans-serif",
                         }}
                     >
-                        <Form {...this.coerceFormProps()} />
+                        <BareForm {...this.coerceFormProps()} />
                     </div>
                 </div>
             </DesignSystemProvider>
@@ -179,6 +179,7 @@ class FormAndNavigationTestPage extends React.Component<{}, FormTestPageState> {
                 onLocationUpdate={this.handleLocationOnChange}
                 dataLocation={this.state.dataLocation}
                 onChange={this.handleDataOnChange}
+                dragAndDropReordering={true}
             />
         );
     }

--- a/packages/fast-tooling-react/src/form/controls/control.array.spec.tsx
+++ b/packages/fast-tooling-react/src/form/controls/control.array.spec.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
-import ArrayFormControlStyled, {
-    TestArrayFormControl as ArrayFormControl,
-} from "./control.array";
+import ArrayFormControlStyled, { ArrayFormControl } from "./control.array";
+import HTML5Backend from "react-dnd-html5-backend";
+import { ContextComponent, DragDropContext } from "react-dnd";
 import {
     ArrayFormControlClassNameContract,
     ArrayFormControlProps,
 } from "./control.array.props";
+
+const TestArrayFormControl: typeof ArrayFormControl &
+    ContextComponent<any> = DragDropContext(HTML5Backend)(ArrayFormControl);
 
 /*
  * Configure Enzyme
@@ -70,7 +73,7 @@ describe("ArrayFormControl", () => {
     });
     test("should generate a button to add an array item if the maximum number of items has not been reached", () => {
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 schema={{ maxItems: 2 }}
                 data={["foo"]}
@@ -84,7 +87,7 @@ describe("ArrayFormControl", () => {
     });
     test("should generate a button to add an array item if no maximum number of items has been specified", () => {
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 data={["foo"]}
                 managedClasses={managedClasses}
@@ -97,7 +100,7 @@ describe("ArrayFormControl", () => {
     });
     test("should not generate a button to add an array item if the maximum number of items has been reached", () => {
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 schema={{ maxItems: 2 }}
                 data={["foo", "bar"]}
@@ -112,7 +115,7 @@ describe("ArrayFormControl", () => {
     test("should add an item to the array if the add button has been clicked", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 schema={schema}
                 data={["foo"]}
@@ -134,7 +137,7 @@ describe("ArrayFormControl", () => {
     test("should show a remove button on an existing array item if the minimum number of items has not been reached", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 schema={schema}
                 data={["foo", "bar", "bat"]}
@@ -151,7 +154,7 @@ describe("ArrayFormControl", () => {
     test("should show a remove button on an existing array item if the minimum number of items has not been specified", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 data={["foo", "bar"]}
                 managedClasses={managedClasses}
@@ -167,7 +170,7 @@ describe("ArrayFormControl", () => {
     test("should not show a remove button on existing array items if the minimum number of items has been reached", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 schema={schema}
                 data={["foo", "bar"]}
@@ -184,7 +187,7 @@ describe("ArrayFormControl", () => {
     test("should remove an array item if the remove button has been clicked", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 schema={schema}
                 data={["foo", "bar", "bat"]}
@@ -206,7 +209,7 @@ describe("ArrayFormControl", () => {
     test("should remove the data if the soft remove is triggered", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 schema={schema}
                 data={["foo", "bar", "bat"]}
@@ -227,7 +230,7 @@ describe("ArrayFormControl", () => {
         const callback: any = jest.fn();
         const data: string[] = ["foo", "bar", "bat"];
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 schema={schema}
                 data={data}
@@ -254,7 +257,7 @@ describe("ArrayFormControl", () => {
     test("should not show an invalid message inline if `invalidMessage` is passed and `displayValidationInline` is undefined", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 managedClasses={managedClasses}
                 invalidMessage={invalidMessage}
@@ -266,7 +269,7 @@ describe("ArrayFormControl", () => {
     test("should show an invalid message inline if `invalidMessage` is passed and `displayValidationInline` is true", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 managedClasses={managedClasses}
                 invalidMessage={invalidMessage}
@@ -280,7 +283,7 @@ describe("ArrayFormControl", () => {
         const invalidMessage1: string = "Foo";
         const invalidMessage2: string = "Bar";
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 managedClasses={managedClasses}
                 invalidMessage={invalidMessage1}
@@ -297,7 +300,7 @@ describe("ArrayFormControl", () => {
     test("should add an invalid data class if there is an invalid message", () => {
         const invalidMessage: string = "Foo";
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 managedClasses={managedClasses}
                 invalidMessage={invalidMessage}
@@ -311,7 +314,7 @@ describe("ArrayFormControl", () => {
     test("should not add an invalid data class if an invalid message has not been passed", () => {
         const invalidMessage: string = "";
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 managedClasses={managedClasses}
                 invalidMessage={invalidMessage}
@@ -324,7 +327,7 @@ describe("ArrayFormControl", () => {
     });
     test("should show a default indicator if default values exist and no data is available", () => {
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 data={undefined}
                 default={[]}
@@ -338,7 +341,7 @@ describe("ArrayFormControl", () => {
     });
     test("should not show a default indicator if data exists", () => {
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 data={[]}
                 default={[]}
@@ -354,7 +357,7 @@ describe("ArrayFormControl", () => {
         const defaultValue: string[] = [];
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 onChange={callback}
                 data={undefined}
@@ -379,7 +382,7 @@ describe("ArrayFormControl", () => {
         const defaultArrayItem1: string = "foo";
         const defaultArrayItem2: string = "bar";
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 data={undefined}
                 default={[defaultArrayItem1, defaultArrayItem2]}
@@ -396,7 +399,7 @@ describe("ArrayFormControl", () => {
         const defaultArrayItem1: string = "hello";
         const defaultArrayItem2: string = "world";
         const rendered: any = mount(
-            <ArrayFormControl
+            <TestArrayFormControl
                 {...arrayProps}
                 data={[arrayItem1, arrayItem2]}
                 default={[defaultArrayItem1, defaultArrayItem2]}

--- a/packages/fast-tooling-react/src/form/controls/control.array.tsx
+++ b/packages/fast-tooling-react/src/form/controls/control.array.tsx
@@ -1,7 +1,5 @@
 import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import React from "react";
-import HTML5Backend from "react-dnd-html5-backend";
-import { ContextComponent, DragDropContext } from "react-dnd";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { get, uniqueId } from "lodash-es";
 import { generateExampleData, getArrayLinks, isRootLocation } from "../utilities";
@@ -377,8 +375,5 @@ class ArrayFormControl extends BaseFormControl<
     };
 }
 
-const TestArrayFormControl: typeof ArrayFormControl &
-    ContextComponent<any> = DragDropContext(HTML5Backend)(ArrayFormControl);
-
-export { TestArrayFormControl };
-export default DragDropContext(HTML5Backend)(manageJss(styles)(ArrayFormControl));
+export { ArrayFormControl };
+export default manageJss(styles)(ArrayFormControl);

--- a/packages/fast-tooling-react/src/form/controls/control.children.spec.tsx
+++ b/packages/fast-tooling-react/src/form/controls/control.children.spec.tsx
@@ -1,16 +1,21 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, ReactWrapper } from "enzyme";
+import HTML5Backend from "react-dnd-html5-backend";
+import { ContextComponent, DragDropContext } from "react-dnd";
 import {
     keyCodeArrowDown,
     keyCodeArrowUp,
     keyCodeEnter,
 } from "@microsoft/fast-web-utilities";
-import { TestChildrenFormControl as ChildrenFormControl } from "./control.children";
+import { ChildrenFormControl } from "./control.children";
 import {
     ChildrenFormControlClassNameContract,
     ChildrenFormControlProps,
 } from "./control.children.props";
+
+const ChildrenFormControlWithDragAndDrop: typeof ChildrenFormControl &
+    ContextComponent<any> = DragDropContext(HTML5Backend)(ChildrenFormControl);
 
 /*
  * Configure Enzyme
@@ -96,20 +101,29 @@ describe("ChildrenFormControl", () => {
     test("should not throw", () => {
         expect(() => {
             mount(
-                <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+                <ChildrenFormControlWithDragAndDrop
+                    {...childrenProps}
+                    managedClasses={managedClasses}
+                />
             );
         }).not.toThrow();
     });
     test("should generate a text input", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.find("input")).toHaveLength(1);
     });
     test("should add an `aria-autocomplete` with `list` value on a text input", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
         const input: any = rendered.find("input");
 
@@ -117,21 +131,30 @@ describe("ChildrenFormControl", () => {
     });
     test("should generate a button", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.find("button")).toHaveLength(1);
     });
     test("should generate a label", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.find("label")).toHaveLength(1);
     });
     test("should generate a listbox", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
         const listbox: any = rendered.find("ul");
 
@@ -140,7 +163,10 @@ describe("ChildrenFormControl", () => {
     });
     test("should add an `aria-controls` on a text input with the same value as the id of the `listbox`", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
         const inputAriaControls: string = rendered.find("input").props()["aria-controls"];
         const listboxId: string = rendered.find("ul").props()["id"];
@@ -149,7 +175,10 @@ describe("ChildrenFormControl", () => {
     });
     test("should add an `aria-labelledby` on a text input with the same value as the id of the `label`", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
         const inputAriaLabelledby: string = rendered.find("input").props()[
             "aria-labelledby"
@@ -160,7 +189,10 @@ describe("ChildrenFormControl", () => {
     });
     test("should have a listbox with an `aria-hidden` attribute set to `true`", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
         const listbox: any = rendered.find("ul");
 
@@ -168,7 +200,10 @@ describe("ChildrenFormControl", () => {
     });
     test("should have a listbox with an `aria-hidden` attribute set to `false` when the button is clicked", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
         const button: any = rendered.find("button");
 
@@ -180,7 +215,10 @@ describe("ChildrenFormControl", () => {
     });
     test("should generate options based on the `childOptions` provided", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
         const listboxItems: any = rendered.find("ul li");
 
@@ -188,7 +226,10 @@ describe("ChildrenFormControl", () => {
     });
     test("should generate options based on the `childOptions` provided and filtered by a search term", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
         const input: any = rendered.find("input");
 
@@ -200,7 +241,10 @@ describe("ChildrenFormControl", () => {
     });
     test("should have a listbox that can be navigated by the `down` key", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
         const button: any = rendered.find("button");
         const input: any = rendered.find("input");
@@ -261,7 +305,10 @@ describe("ChildrenFormControl", () => {
     });
     test("should have a listbox that can be navigated by the `up` key", () => {
         const rendered: any = mount(
-            <ChildrenFormControl {...childrenProps} managedClasses={managedClasses} />
+            <ChildrenFormControlWithDragAndDrop
+                {...childrenProps}
+                managedClasses={managedClasses}
+            />
         );
         const button: any = rendered.find("button");
         const input: any = rendered.find("input");
@@ -322,7 +369,7 @@ describe("ChildrenFormControl", () => {
     });
     test("should show if children are present in the data as an item with a button", () => {
         const renderedWithOneChild: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 data={{ id: "alpha", props: {} }}
                 managedClasses={managedClasses}
@@ -337,7 +384,7 @@ describe("ChildrenFormControl", () => {
         ).toHaveLength(1);
 
         const renderedWithOneChildString: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 data={"hello world"}
                 managedClasses={managedClasses}
@@ -352,7 +399,7 @@ describe("ChildrenFormControl", () => {
         ).toHaveLength(1);
 
         const renderedWithThreeChildren: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 managedClasses={managedClasses}
                 data={[
@@ -379,7 +426,7 @@ describe("ChildrenFormControl", () => {
     test("should fire a callback to update the data when an `option` in the `listbox` is clicked", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 onChange={callback}
                 managedClasses={managedClasses}
@@ -400,7 +447,7 @@ describe("ChildrenFormControl", () => {
     test("should fire a callback to update the data when a default text `option` in the `listbox` is clicked", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 managedClasses={managedClasses}
                 defaultChildOptions={["text"]}
@@ -424,7 +471,7 @@ describe("ChildrenFormControl", () => {
         const childItem: any = Symbol();
         const callback: any = jest.fn();
         const rendered: ReactWrapper = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 onUpdateActiveSection={callback}
                 managedClasses={managedClasses}
@@ -451,7 +498,7 @@ describe("ChildrenFormControl", () => {
     test("should update active section to item clicked when ctrl key is pressed and a new item is provided to an existing set of items", () => {
         const callback: any = jest.fn();
         const rendered: ReactWrapper = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 data={[Symbol(), Symbol()]}
                 onUpdateActiveSection={callback}
@@ -479,7 +526,7 @@ describe("ChildrenFormControl", () => {
     test("should not add a child option to the data when a value has been added to the `input` that is an empty string", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 onChange={callback}
                 managedClasses={managedClasses}
@@ -494,7 +541,7 @@ describe("ChildrenFormControl", () => {
     test("should not add a child option to the data when a value has been added to the `input` that does not partially match any of the options", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 onChange={callback}
                 managedClasses={managedClasses}
@@ -509,7 +556,7 @@ describe("ChildrenFormControl", () => {
     test("should add a child option to the data when a value has been added to the `input` that at least partially matches one of the options", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 onChange={callback}
                 managedClasses={managedClasses}
@@ -525,7 +572,7 @@ describe("ChildrenFormControl", () => {
     test("should remove a child option from the data when the remove button has been clicked", () => {
         const callback: any = jest.fn();
         const renderedWithTwoChildren: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 managedClasses={managedClasses}
                 data={[
@@ -556,7 +603,7 @@ describe("ChildrenFormControl", () => {
     });
     test("should show a default indicator if default values exist and no data is available", () => {
         const rendered: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 managedClasses={managedClasses}
                 data={undefined}
@@ -570,7 +617,7 @@ describe("ChildrenFormControl", () => {
     });
     test("should not show a default indicator if data exists", () => {
         const rendered: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 managedClasses={managedClasses}
                 data={"foo"}
@@ -586,7 +633,7 @@ describe("ChildrenFormControl", () => {
         const defaultValue: string = "foo";
         const callback: any = jest.fn();
         const rendered: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 managedClasses={managedClasses}
                 data={undefined}
@@ -608,7 +655,7 @@ describe("ChildrenFormControl", () => {
     test("should show default values if they exist and no data is available", () => {
         const children: string = "foo";
         const rendered: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 managedClasses={managedClasses}
                 data={undefined}
@@ -622,7 +669,7 @@ describe("ChildrenFormControl", () => {
         const children: string = "foo";
         const defaultChildren: string = "bar";
         const rendered: any = mount(
-            <ChildrenFormControl
+            <ChildrenFormControlWithDragAndDrop
                 {...childrenProps}
                 managedClasses={managedClasses}
                 data={children}

--- a/packages/fast-tooling-react/src/form/controls/control.children.tsx
+++ b/packages/fast-tooling-react/src/form/controls/control.children.tsx
@@ -1,8 +1,6 @@
 import { generateExampleData } from "../utilities";
 import React from "react";
-import { cloneDeep, get, uniqueId } from "lodash-es";
-import HTML5Backend from "react-dnd-html5-backend";
-import { ContextComponent, DragDropContext } from "react-dnd";
+import { get, uniqueId } from "lodash-es";
 import {
     keyCodeArrowDown,
     keyCodeArrowUp,
@@ -864,8 +862,5 @@ class ChildrenFormControl extends BaseFormControl<
     }
 }
 
-const TestChildrenFormControl: typeof ChildrenFormControl &
-    ContextComponent<any> = DragDropContext(HTML5Backend)(ChildrenFormControl);
-
-export { TestChildrenFormControl };
-export default DragDropContext(HTML5Backend)(manageJss(styles)(ChildrenFormControl));
+export { ChildrenFormControl };
+export default manageJss(styles)(ChildrenFormControl);

--- a/packages/fast-tooling-react/src/form/form-control-switch.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form-control-switch.spec.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, render, shallow } from "enzyme";
 import FormControlSwitch, { FormControlSwitchProps } from "./form-control-switch";
+import { ContextComponent, DragDropContext } from "react-dnd";
+import HTML5Backend from "react-dnd-html5-backend";
 
 import numberFieldSchema from "../__tests__/schemas/number-field.schema.json";
 import textareaSchema from "../__tests__/schemas/textarea.schema.json";
@@ -10,6 +12,9 @@ import objectSchema from "../__tests__/schemas/objects.schema.json";
 import arraySchema from "../__tests__/schemas/arrays.schema.json";
 import childrenSchema from "../__tests__/schemas/children.schema.json";
 import oneOfSchema from "../__tests__/schemas/one-of.schema.json";
+
+const TestFormControlSwitch: typeof FormControlSwitch &
+    ContextComponent<any> = DragDropContext(HTML5Backend)(FormControlSwitch);
 
 /*
  * Configure Enzyme
@@ -35,12 +40,12 @@ const formControlProps: FormControlSwitchProps = {
 describe("FormControl", () => {
     test("should not throw", () => {
         expect(() => {
-            mount(<FormControlSwitch {...formControlProps} />);
+            mount(<TestFormControlSwitch {...formControlProps} />);
         }).not.toThrow();
     });
     test("should render a number field when a number type is available", () => {
         const rendered: any = mount(
-            <FormControlSwitch
+            <TestFormControlSwitch
                 {...formControlProps}
                 schema={numberFieldSchema.properties.quantity}
                 schemaLocation={"properties.quantity"}
@@ -54,7 +59,7 @@ describe("FormControl", () => {
     });
     test("should render a textarea when a string type is available", () => {
         const rendered: any = mount(
-            <FormControlSwitch
+            <TestFormControlSwitch
                 {...formControlProps}
                 schema={textareaSchema.properties.textWithDefault}
                 schemaLocation={"properties.text"}
@@ -68,7 +73,7 @@ describe("FormControl", () => {
     });
     test("should render a checkbox when a boolean type is available", () => {
         const rendered: any = mount(
-            <FormControlSwitch
+            <TestFormControlSwitch
                 {...formControlProps}
                 schema={checkboxSchema.properties.toggle}
                 schemaLocation={"properties.toggle"}
@@ -82,7 +87,7 @@ describe("FormControl", () => {
     });
     test("should render a link when an object type is available", () => {
         const rendered: any = mount(
-            <FormControlSwitch
+            <TestFormControlSwitch
                 {...formControlProps}
                 schema={objectSchema.properties.objectNoRequired}
                 schemaLocation={"properties.objectNoRequired"}
@@ -96,7 +101,7 @@ describe("FormControl", () => {
     });
     test("should render the array UI when an array type is available", () => {
         const rendered: any = mount(
-            <FormControlSwitch
+            <TestFormControlSwitch
                 {...formControlProps}
                 schema={arraySchema.properties.strings}
                 schemaLocation={"properties.strings"}
@@ -110,7 +115,7 @@ describe("FormControl", () => {
     });
     test("should render the children UI when a children type is available", () => {
         const rendered: any = mount(
-            <FormControlSwitch
+            <TestFormControlSwitch
                 {...formControlProps}
                 schema={childrenSchema.reactProperties.children}
                 schemaLocation={"reactProperties.children"}
@@ -124,7 +129,7 @@ describe("FormControl", () => {
     });
     test("should render a select when enums are available", () => {
         const rendered: any = mount(
-            <FormControlSwitch
+            <TestFormControlSwitch
                 {...formControlProps}
                 schema={textareaSchema.properties.tag}
                 schemaLocation={"properties.tag"}
@@ -138,7 +143,7 @@ describe("FormControl", () => {
     });
     test("should restrict the child options if ids have been passed", () => {
         const renderedWithDefault: any = mount(
-            <FormControlSwitch
+            <TestFormControlSwitch
                 {...formControlProps}
                 childOptions={[
                     {
@@ -163,7 +168,7 @@ describe("FormControl", () => {
         );
 
         const renderedWithoutDefaultAndIds: any = mount(
-            <FormControlSwitch
+            <TestFormControlSwitch
                 {...formControlProps}
                 childOptions={[
                     {
@@ -190,7 +195,7 @@ describe("FormControl", () => {
         );
 
         const renderedWithDefaultAndIds: any = mount(
-            <FormControlSwitch
+            <TestFormControlSwitch
                 {...formControlProps}
                 childOptions={[
                     {

--- a/packages/fast-tooling-react/src/form/form-section.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form-section.spec.tsx
@@ -3,6 +3,12 @@ import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
 import FormSection from "./form-section";
 import { FormSectionProps } from "./form-section.props";
+import { ContextComponent, DragDropContext } from "react-dnd";
+import HTML5Backend from "react-dnd-html5-backend";
+
+const TestFormSection: typeof FormSection & ContextComponent<any> = DragDropContext(
+    HTML5Backend
+)(FormSection);
 
 /*
  * Configure Enzyme
@@ -25,7 +31,7 @@ const formSectionProps: FormSectionProps = {
 describe("FormSection", () => {
     test("should not throw", () => {
         expect(() => {
-            mount(<FormSection {...formSectionProps} />);
+            mount(<TestFormSection {...formSectionProps} />);
         }).not.toThrow();
     });
 });

--- a/packages/fast-tooling-react/src/form/form-section.tsx
+++ b/packages/fast-tooling-react/src/form/form-section.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { get, omit, uniqueId } from "lodash-es";
+import { get, omit } from "lodash-es";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import FormCategory from "./form-category";

--- a/packages/fast-tooling-react/src/form/form.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount } from "enzyme";
-import Form from "./form";
+import { Form } from "./";
 import { FormProps } from "./form.props";
 
 import objectSchema from "../__tests__/schemas/objects.schema.json";

--- a/packages/fast-tooling-react/src/form/index.ts
+++ b/packages/fast-tooling-react/src/form/index.ts
@@ -1,4 +1,10 @@
-import Form from "./form";
+import BareForm from "./form";
 import { FormPlugin, FormPluginProps } from "./plugin";
+import { ContextComponent, DragDropContext } from "react-dnd";
+import HTML5Backend from "react-dnd-html5-backend";
 
-export { Form, FormPlugin, FormPluginProps };
+const Form: typeof BareForm & ContextComponent<any> = DragDropContext(HTML5Backend)(
+    BareForm
+);
+
+export { Form, BareForm, FormPlugin, FormPluginProps };


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
This change adds a BareForm that does not provide the drag and drop context. This is for use when the Form is used in conjunction with the Navigation.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
After the consolidation of drag and drop libraries it was noticed that using the Navigation and Form together caused an error due to multiple globals being introduced from the HTML5Backend. To combat this a secondary export is added in this PR for those who need to use both.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->