### PR TITLE
fix: add the prefix forced-colors to fix high contrast in Edge chromium

### DIFF
--- a/packages/fast-components-react-msft/src/accent-button/accent-button.stories.tsx
+++ b/packages/fast-components-react-msft/src/accent-button/accent-button.stories.tsx
@@ -5,7 +5,14 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Accent button", module)
     .add("Default", () => <AccentButton>Accent button</AccentButton>)
-    .add("Anchor", () => <AccentButton href="#">Anchor button</AccentButton>)
+    .add("Anchor", () => 
+    <AccentButton 
+        href="#"
+        beforeContent={glyphFactory(SVGGlyph.download)}
+        afterContent={glyphFactory(SVGGlyph.user)}
+    >
+        Anchor button
+    </AccentButton>)
     .add("Before content", () => (
         <AccentButton beforeContent={glyphFactory(SVGGlyph.download)}>
             With before content

--- a/packages/fast-components-react-msft/src/accent-button/accent-button.stories.tsx
+++ b/packages/fast-components-react-msft/src/accent-button/accent-button.stories.tsx
@@ -5,14 +5,15 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Accent button", module)
     .add("Default", () => <AccentButton>Accent button</AccentButton>)
-    .add("Anchor", () => 
-    <AccentButton 
-        href="#"
-        beforeContent={glyphFactory(SVGGlyph.download)}
-        afterContent={glyphFactory(SVGGlyph.user)}
-    >
-        Anchor button
-    </AccentButton>)
+    .add("Anchor", () => (
+        <AccentButton
+            href="#"
+            beforeContent={glyphFactory(SVGGlyph.download)}
+            afterContent={glyphFactory(SVGGlyph.user)}
+        >
+            Anchor button
+        </AccentButton>
+    ))
     .add("Before content", () => (
         <AccentButton beforeContent={glyphFactory(SVGGlyph.download)}>
             With before content

--- a/packages/fast-components-react-msft/src/button/button.stories.tsx
+++ b/packages/fast-components-react-msft/src/button/button.stories.tsx
@@ -5,14 +5,15 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Button", module)
     .add("Default", () => <Button>Button</Button>)
-    .add("Anchor", () => 
-        <Button 
+    .add("Anchor", () => (
+        <Button
             href="#"
             beforeContent={glyphFactory(SVGGlyph.user)}
             afterContent={glyphFactory(SVGGlyph.download)}
         >
             Anchor button
-        </Button>)
+        </Button>
+    ))
     .add("Anchor - disabled", () => (
         <Button href="#" disabled={true}>
             Anchor button
@@ -22,7 +23,9 @@ storiesOf("Button", module)
         <Button appearance={ButtonAppearance.primary}>Primary Button</Button>
     ))
     .add("Primary Anchor", () => (
-        <Button appearance={ButtonAppearance.primary} href={"#"}>Primary Anchor</Button>
+        <Button appearance={ButtonAppearance.primary} href={"#"}>
+            Primary Anchor
+        </Button>
     ))
     .add("Primary - disabled", () => (
         <Button appearance={ButtonAppearance.primary} disabled={true}>

--- a/packages/fast-components-react-msft/src/button/button.stories.tsx
+++ b/packages/fast-components-react-msft/src/button/button.stories.tsx
@@ -5,7 +5,14 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Button", module)
     .add("Default", () => <Button>Button</Button>)
-    .add("Anchor", () => <Button href="#">Anchor button</Button>)
+    .add("Anchor", () => 
+        <Button 
+            href="#"
+            beforeContent={glyphFactory(SVGGlyph.user)}
+            afterContent={glyphFactory(SVGGlyph.download)}
+        >
+            Anchor button
+        </Button>)
     .add("Anchor - disabled", () => (
         <Button href="#" disabled={true}>
             Anchor button

--- a/packages/fast-components-react-msft/src/button/button.stories.tsx
+++ b/packages/fast-components-react-msft/src/button/button.stories.tsx
@@ -14,6 +14,9 @@ storiesOf("Button", module)
     .add("Primary", () => (
         <Button appearance={ButtonAppearance.primary}>Primary Button</Button>
     ))
+    .add("Primary Anchor", () => (
+        <Button appearance={ButtonAppearance.primary} href={"#"}>Primary Anchor</Button>
+    ))
     .add("Primary - disabled", () => (
         <Button appearance={ButtonAppearance.primary} disabled={true}>
             Primary Button

--- a/packages/fast-components-react-msft/src/call-to-action/call-to-action.stories.tsx
+++ b/packages/fast-components-react-msft/src/call-to-action/call-to-action.stories.tsx
@@ -8,7 +8,9 @@ storiesOf("Call to action", module)
         <CallToAction appearance={CallToActionAppearance.primary}>Buy now</CallToAction>
     ))
     .add(" Primary Anchor", () => (
-        <CallToAction appearance={CallToActionAppearance.primary} href="#">Buy now</CallToAction>
+        <CallToAction appearance={CallToActionAppearance.primary} href="#">
+            Buy now
+        </CallToAction>
     ))
     .add("Justified", () => (
         <CallToAction appearance={CallToActionAppearance.justified}>Buy now</CallToAction>

--- a/packages/fast-components-react-msft/src/call-to-action/call-to-action.stories.tsx
+++ b/packages/fast-components-react-msft/src/call-to-action/call-to-action.stories.tsx
@@ -7,6 +7,9 @@ storiesOf("Call to action", module)
     .add("Primary", () => (
         <CallToAction appearance={CallToActionAppearance.primary}>Buy now</CallToAction>
     ))
+    .add(" Primary Anchor", () => (
+        <CallToAction appearance={CallToActionAppearance.primary} href="#">Buy now</CallToAction>
+    ))
     .add("Justified", () => (
         <CallToAction appearance={CallToActionAppearance.justified}>Buy now</CallToAction>
     ))

--- a/packages/fast-components-react-msft/src/checkbox/checkbox.stories.tsx
+++ b/packages/fast-components-react-msft/src/checkbox/checkbox.stories.tsx
@@ -72,5 +72,12 @@ storiesOf("Checkbox", module)
                 Hello render prop
             </Label>
         );
-        return <Checkbox inputId={id} onChange={action("onChnage")} label={label} disabled={true}/>;
-    });;
+        return (
+            <Checkbox
+                inputId={id}
+                onChange={action("onChnage")}
+                label={label}
+                disabled={true}
+            />
+        );
+    });

--- a/packages/fast-components-react-msft/src/checkbox/checkbox.stories.tsx
+++ b/packages/fast-components-react-msft/src/checkbox/checkbox.stories.tsx
@@ -62,4 +62,15 @@ storiesOf("Checkbox", module)
             </Label>
         );
         return <Checkbox inputId={id} onChange={action("onChnage")} label={label} />;
-    });
+    })
+    .add("Disabled with label", () => {
+        const id: string = uniqueId();
+        const label: (className: string) => React.ReactNode = (
+            className: string
+        ): React.ReactNode => (
+            <Label className={className} htmlFor={id}>
+                Hello render prop
+            </Label>
+        );
+        return <Checkbox inputId={id} onChange={action("onChnage")} label={label} disabled={true}/>;
+    });;

--- a/packages/fast-components-react-msft/src/lightweight-button/lightweight-button.stories.tsx
+++ b/packages/fast-components-react-msft/src/lightweight-button/lightweight-button.stories.tsx
@@ -5,14 +5,15 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Lightweight button", module)
     .add("Default", () => <LightweightButton>Lightweight button</LightweightButton>)
-    .add("Anchor", () => 
+    .add("Anchor", () => (
         <LightweightButton
             href="#"
             beforeContent={glyphFactory(SVGGlyph.download)}
             afterContent={glyphFactory(SVGGlyph.user)}
         >
             Anchor button
-        </LightweightButton>)
+        </LightweightButton>
+    ))
     .add("Before content", () => (
         <LightweightButton beforeContent={glyphFactory(SVGGlyph.download)}>
             With before content

--- a/packages/fast-components-react-msft/src/lightweight-button/lightweight-button.stories.tsx
+++ b/packages/fast-components-react-msft/src/lightweight-button/lightweight-button.stories.tsx
@@ -5,7 +5,14 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Lightweight button", module)
     .add("Default", () => <LightweightButton>Lightweight button</LightweightButton>)
-    .add("Anchor", () => <LightweightButton href="#">Anchor button</LightweightButton>)
+    .add("Anchor", () => 
+        <LightweightButton
+            href="#"
+            beforeContent={glyphFactory(SVGGlyph.download)}
+            afterContent={glyphFactory(SVGGlyph.user)}
+        >
+            Anchor button
+        </LightweightButton>)
     .add("Before content", () => (
         <LightweightButton beforeContent={glyphFactory(SVGGlyph.download)}>
             With before content

--- a/packages/fast-components-react-msft/src/neutral-button/neutral-button.stories.tsx
+++ b/packages/fast-components-react-msft/src/neutral-button/neutral-button.stories.tsx
@@ -5,7 +5,14 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Neutral button", module)
     .add("Default", () => <NeutralButton>Neutral button</NeutralButton>)
-    .add("Anchor", () => <NeutralButton href="#">Anchor button</NeutralButton>)
+    .add("Anchor", () => 
+        <NeutralButton 
+            href="#"
+            beforeContent={glyphFactory(SVGGlyph.download)}
+            afterContent={glyphFactory(SVGGlyph.user)}
+        >
+            Anchor button
+        </NeutralButton>)
     .add("Before content", () => (
         <NeutralButton beforeContent={glyphFactory(SVGGlyph.download)}>
             With before content

--- a/packages/fast-components-react-msft/src/neutral-button/neutral-button.stories.tsx
+++ b/packages/fast-components-react-msft/src/neutral-button/neutral-button.stories.tsx
@@ -5,14 +5,15 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Neutral button", module)
     .add("Default", () => <NeutralButton>Neutral button</NeutralButton>)
-    .add("Anchor", () => 
-        <NeutralButton 
+    .add("Anchor", () => (
+        <NeutralButton
             href="#"
             beforeContent={glyphFactory(SVGGlyph.download)}
             afterContent={glyphFactory(SVGGlyph.user)}
         >
             Anchor button
-        </NeutralButton>)
+        </NeutralButton>
+    ))
     .add("Before content", () => (
         <NeutralButton beforeContent={glyphFactory(SVGGlyph.download)}>
             With before content

--- a/packages/fast-components-react-msft/src/outline-button/outline-button.stories.tsx
+++ b/packages/fast-components-react-msft/src/outline-button/outline-button.stories.tsx
@@ -5,7 +5,14 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Outline button", module)
     .add("Default", () => <OutlineButton>Outline button</OutlineButton>)
-    .add("Anchor", () => <OutlineButton href="#">Anchor button</OutlineButton>)
+    .add("Anchor", () => 
+        <OutlineButton 
+            href="#"
+            beforeContent={glyphFactory(SVGGlyph.download)}
+            afterContent={glyphFactory(SVGGlyph.user)}
+        >
+            Anchor button
+        </OutlineButton>)
     .add("Before content", () => (
         <OutlineButton beforeContent={glyphFactory(SVGGlyph.download)}>
             With before content

--- a/packages/fast-components-react-msft/src/outline-button/outline-button.stories.tsx
+++ b/packages/fast-components-react-msft/src/outline-button/outline-button.stories.tsx
@@ -5,14 +5,15 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Outline button", module)
     .add("Default", () => <OutlineButton>Outline button</OutlineButton>)
-    .add("Anchor", () => 
-        <OutlineButton 
+    .add("Anchor", () => (
+        <OutlineButton
             href="#"
             beforeContent={glyphFactory(SVGGlyph.download)}
             afterContent={glyphFactory(SVGGlyph.user)}
         >
             Anchor button
-        </OutlineButton>)
+        </OutlineButton>
+    ))
     .add("Before content", () => (
         <OutlineButton beforeContent={glyphFactory(SVGGlyph.download)}>
             With before content

--- a/packages/fast-components-react-msft/src/radio/radio.stories.tsx
+++ b/packages/fast-components-react-msft/src/radio/radio.stories.tsx
@@ -28,4 +28,14 @@ storiesOf("Radio", module)
         );
 
         return <Radio inputId={id} label={label} onChange={action("onChange")} />;
+    })
+    .add("Disabled with slot label", () => {
+        const id: string = uniqueId();
+        return (
+            <Radio inputId={id} onChange={action("onChange")} disabled={true}>
+                <Label slot="label" htmlFor={id}>
+                    Hello slot
+                </Label>
+            </Radio>
+        );
     });

--- a/packages/fast-components-react-msft/src/stealth-button/stealth-button.stories.tsx
+++ b/packages/fast-components-react-msft/src/stealth-button/stealth-button.stories.tsx
@@ -5,14 +5,15 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Stealth button", module)
     .add("Default", () => <StealthButton>Stealth button</StealthButton>)
-    .add("Anchor", () => 
-        <StealthButton 
+    .add("Anchor", () => (
+        <StealthButton
             href="#"
             beforeContent={glyphFactory(SVGGlyph.download)}
             afterContent={glyphFactory(SVGGlyph.user)}
         >
             Anchor button
-        </StealthButton>)
+        </StealthButton>
+    ))
     .add("Before content", () => (
         <StealthButton beforeContent={glyphFactory(SVGGlyph.download)}>
             With before content

--- a/packages/fast-components-react-msft/src/stealth-button/stealth-button.stories.tsx
+++ b/packages/fast-components-react-msft/src/stealth-button/stealth-button.stories.tsx
@@ -5,7 +5,14 @@ import { glyphFactory, SVGGlyph } from "../../assets/svg-element";
 
 storiesOf("Stealth button", module)
     .add("Default", () => <StealthButton>Stealth button</StealthButton>)
-    .add("Anchor", () => <StealthButton href="#">Anchor button</StealthButton>)
+    .add("Anchor", () => 
+        <StealthButton 
+            href="#"
+            beforeContent={glyphFactory(SVGGlyph.download)}
+            afterContent={glyphFactory(SVGGlyph.user)}
+        >
+            Anchor button
+        </StealthButton>)
     .add("Before content", () => (
         <StealthButton beforeContent={glyphFactory(SVGGlyph.download)}>
             With before content

--- a/packages/fast-components-react-msft/src/toggle/toggle.stories.tsx
+++ b/packages/fast-components-react-msft/src/toggle/toggle.stories.tsx
@@ -48,5 +48,7 @@ storiesOf("Toggle", module)
         }
         return <ToggleStateHandler>{render}</ToggleStateHandler>;
     })
-    .add("Disabled", () => <Toggle {...toggleProps} disabled={true} />)
-    .add("No Label", () => <Toggle inputId={uniqueId()} />);
+    .add("No Label", () => <Toggle inputId={uniqueId()} />)
+    .add("Disabled unhandled", () => <Toggle {...toggleProps} disabled={true} />)
+    .add("Disabled handled", () => <Toggle {...toggleProps} selected={true} disabled={true}/>);
+    

--- a/packages/fast-components-react-msft/src/toggle/toggle.stories.tsx
+++ b/packages/fast-components-react-msft/src/toggle/toggle.stories.tsx
@@ -50,5 +50,6 @@ storiesOf("Toggle", module)
     })
     .add("No Label", () => <Toggle inputId={uniqueId()} />)
     .add("Disabled unhandled", () => <Toggle {...toggleProps} disabled={true} />)
-    .add("Disabled handled", () => <Toggle {...toggleProps} selected={true} disabled={true}/>);
-    
+    .add("Disabled handled", () => (
+        <Toggle {...toggleProps} selected={true} disabled={true} />
+    ));

--- a/packages/fast-components-styles-msft/src/accent-button/index.ts
+++ b/packages/fast-components-styles-msft/src/accent-button/index.ts
@@ -13,11 +13,12 @@ import {
 } from "../utilities/color";
 import {
     highContrastAccent,
-    HighContrastColor,
     highContrastDisabledBorder,
     highContrastDisabledForeground,
     highContrastDoubleFocus,
-    highContrastSelector,
+    highContrastHighlightForeground,
+    highContrastSelectedForeground,
+    highContrastSelectedOutline,
 } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
@@ -29,16 +30,9 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
         background: accentFillRest,
         "&:hover:enabled": {
             background: accentFillHover,
-            [highContrastSelector]: {
-                background: HighContrastColor.selectedText,
-                "border-color": HighContrastColor.selectedBackground,
-                color: HighContrastColor.selectedBackground,
-                fill: HighContrastColor.selectedBackground,
-            },
+            ...highContrastSelectedOutline,
             "& $button_beforeContent, & $button_afterContent": {
-                [highContrastSelector]: {
-                    fill: "Highlight",
-                },
+                ...highContrastHighlightForeground,
             },
         },
         "&:active:enabled": {
@@ -60,12 +54,16 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
         },
         "& $button_beforeContent, & $button_afterContent": {
             fill: accentForegroundCut,
-            [highContrastSelector]: {
-                fill: "HighlightText",
-            },
+            ...highContrastSelectedForeground,
         },
         ...highContrastAccent,
         "a&": {
+            "&:hover:enabled": {
+                ...highContrastSelectedOutline,
+                "& $button_beforeContent, & $button_afterContent": {
+                    ...highContrastHighlightForeground,
+                },
+            },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
                 "& $button_beforeContent, & $button_afterContent": {

--- a/packages/fast-components-styles-msft/src/accent-button/index.ts
+++ b/packages/fast-components-styles-msft/src/accent-button/index.ts
@@ -66,10 +66,10 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
             "& $button_beforeContent, & $button_afterContent": {
                 ...highContrastLinkForeground,
             },
-            "&:hover:enabled": {
+            "&:hover": {
                 ...highContrastLinkBorder,
                 "& $button_beforeContent, & $button_afterContent": {
-                    ...highContrastHighlightForeground,
+                    ...highContrastLinkForeground,
                 },
             },
             "&$button__disabled": {
@@ -79,8 +79,11 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
                 },
                 "&:hover": {
                     [highContrastSelector]: {
-                        "box-shadow": "none"
-                    }
+                        "box-shadow": "none !important"
+                    },
+                    "& $button_beforeContent, & $button_afterContent": {
+                        ...highContrastDisabledForeground,
+                    },
                 }
             },
         },

--- a/packages/fast-components-styles-msft/src/accent-button/index.ts
+++ b/packages/fast-components-styles-msft/src/accent-button/index.ts
@@ -79,12 +79,12 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
                 },
                 "&:hover": {
                     [highContrastSelector]: {
-                        "box-shadow": "none !important"
+                        "box-shadow": "none !important",
                     },
                     "& $button_beforeContent, & $button_afterContent": {
                         ...highContrastDisabledForeground,
                     },
-                }
+                },
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/accent-button/index.ts
+++ b/packages/fast-components-styles-msft/src/accent-button/index.ts
@@ -13,12 +13,13 @@ import {
 } from "../utilities/color";
 import {
     highContrastAccent,
-    HighContrastColor,
     highContrastDisabledBorder,
     highContrastDisabledForeground,
     highContrastDoubleFocus,
     highContrastHighlightForeground,
-    highContrastOptOutProperty,
+    highContrastLinkBorder,
+    highContrastLinkForeground,
+    highContrastLinkOutline,
     highContrastSelectedForeground,
     highContrastSelectedOutline,
     highContrastSelector,
@@ -61,14 +62,12 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
         },
         ...highContrastAccent,
         "a&": {
-            [highContrastSelector]: {
-                background: "none",
-                "border-color": HighContrastColor.hyperLinks,
-                color: HighContrastColor.hyperLinks,
-                fill: HighContrastColor.hyperLinks,
+            ...highContrastLinkOutline,
+            "& $button_beforeContent, & $button_afterContent": {
+                ...highContrastLinkForeground,
             },
             "&:hover:enabled": {
-                ...highContrastSelectedOutline,
+                ...highContrastLinkBorder,
                 "& $button_beforeContent, & $button_afterContent": {
                     ...highContrastHighlightForeground,
                 },
@@ -78,6 +77,11 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
                 "& $button_beforeContent, & $button_afterContent": {
                     ...highContrastDisabledForeground,
                 },
+                "&:hover": {
+                    [highContrastSelector]: {
+                        "box-shadow": "none"
+                    }
+                }
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/accent-button/index.ts
+++ b/packages/fast-components-styles-msft/src/accent-button/index.ts
@@ -13,12 +13,15 @@ import {
 } from "../utilities/color";
 import {
     highContrastAccent,
+    HighContrastColor,
     highContrastDisabledBorder,
     highContrastDisabledForeground,
     highContrastDoubleFocus,
     highContrastHighlightForeground,
+    highContrastOptOutProperty,
     highContrastSelectedForeground,
     highContrastSelectedOutline,
+    highContrastSelector,
 } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
@@ -58,6 +61,12 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
         },
         ...highContrastAccent,
         "a&": {
+            [highContrastSelector]: {
+                background: "none",
+                "border-color": HighContrastColor.hyperLinks,
+                color: HighContrastColor.hyperLinks,
+                fill: HighContrastColor.hyperLinks,
+            },
             "&:hover:enabled": {
                 ...highContrastSelectedOutline,
                 "& $button_beforeContent, & $button_afterContent": {

--- a/packages/fast-components-styles-msft/src/action-toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/action-toggle/index.ts
@@ -14,11 +14,13 @@ import {
 } from "../utilities/color";
 import { glyphSize, horizontalSpacing } from "../utilities/density";
 import {
+    HighContrastColor,
     highContrastDisabledForeground,
     highContrastForeground,
     highContrastSelectedForeground,
     highContrastSelector,
 } from "../utilities/high-contrast";
+import { importantValue } from "../utilities/important";
 
 // Since MSFT button is already styled, we need to override in this way to alter button classes
 export const actionToggleButtonOverrides: ComponentStyles<
@@ -50,7 +52,7 @@ const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = {
             "&:hover:enabled": {
                 "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {
                     [highContrastSelector]: {
-                        fill: "Highlight !important",
+                        fill: importantValue(HighContrastColor.selectedBackground),
                     },
                 },
             },
@@ -77,7 +79,7 @@ const styles: ComponentStyles<ActionToggleClassNameContract, DesignSystem> = {
         "&:hover:enabled": {
             "& $actionToggle_selectedGlyph, & $actionToggle_unselectedGlyph": {
                 [highContrastSelector]: {
-                    fill: "Highlight !important",
+                    fill: importantValue(HighContrastColor.selectedBackground),
                 },
             },
         },

--- a/packages/fast-components-styles-msft/src/action-trigger/index.ts
+++ b/packages/fast-components-styles-msft/src/action-trigger/index.ts
@@ -14,11 +14,13 @@ import {
 } from "../utilities/color";
 import { glyphSize, horizontalSpacing } from "../utilities/density";
 import {
+    HighContrastColor,
     highContrastDisabledForeground,
     highContrastForeground,
     highContrastSelectedForeground,
     highContrastSelector,
 } from "../utilities/high-contrast";
+import { importantValue } from "../utilities/important";
 
 // Since MSFT button is already styled, we need to override in this way to alter button classes
 export const actionTriggerButtonOverrides: ComponentStyles<
@@ -52,7 +54,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = {
             "&:hover:enabled": {
                 "& $actionTrigger_glyph": {
                     [highContrastSelector]: {
-                        fill: "Highlight !important",
+                        fill: importantValue(HighContrastColor.selectedBackground),
                     },
                 },
             },
@@ -75,7 +77,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = {
         "&:hover:enabled": {
             "& $actionTrigger_glyph": {
                 [highContrastSelector]: {
-                    fill: "Highlight !important",
+                    fill: importantValue(HighContrastColor.selectedBackground),
                 },
             },
         },

--- a/packages/fast-components-styles-msft/src/auto-suggest/index.ts
+++ b/packages/fast-components-styles-msft/src/auto-suggest/index.ts
@@ -7,7 +7,7 @@ import { neutralFillStealthRest } from "../utilities/color";
 import { heightNumber } from "../utilities/density";
 import { applyElevation, ElevationMultiplier } from "../utilities/elevation";
 import { designUnit, outlineWidth } from "../utilities/design-system";
-import { highContrastSelector } from "../utilities/high-contrast";
+import { HighContrastColor, highContrastSelector } from "../utilities/high-contrast";
 
 const visibleChildCount: number = 10;
 const styles: ComponentStyles<AutoSuggestClassNameContract, DesignSystem> = {
@@ -30,8 +30,12 @@ const styles: ComponentStyles<AutoSuggestClassNameContract, DesignSystem> = {
         overflow: "auto",
         ...applyElevatedCornerRadius(),
         [highContrastSelector]: {
-            background: "ButtonFace",
-            border: format<DesignSystem>("{0} solid ButtonText", toPx(outlineWidth)),
+            background: HighContrastColor.background,
+            border: format<DesignSystem>(
+                "{0} solid {1}",
+                toPx(outlineWidth),
+                () => HighContrastColor.buttonText
+            ),
         },
     },
     autoSuggest__menuOpen: {},

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -1,5 +1,5 @@
+import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import { applyCursorPointer } from "../utilities/cursor";
-import { ButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import {
     applyFocusVisible,
     directionSwitch,
@@ -30,7 +30,7 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
-import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
+import { ButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import {
     focusOutlineWidth,
@@ -41,12 +41,13 @@ import { applyDisabledState } from "../utilities/disabled";
 import {
     highContrastAccent,
     highContrastBackground,
-    HighContrastColor,
     highContrastDisabledBorder,
     highContrastDisabledForeground,
     highContrastDoubleFocus,
     highContrastHighlightBackground,
     highContrastHighlightForeground,
+    highContrastLinkBorder,
+    highContrastLinkOutline,
     highContrastOutline,
     highContrastOutlineFocus,
     highContrastSelected,
@@ -153,16 +154,16 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         },
         ...highContrastOutline,
         "a&": {
-            [highContrastSelector]: {
-                background: HighContrastColor.buttonBackground,
-                "border-color": HighContrastColor.hyperLinks,
-                color: HighContrastColor.hyperLinks,
-                fill: HighContrastColor.hyperLinks,
+            ...highContrastLinkOutline,
+            "&:hover": {
+                ...highContrastLinkBorder
             },
             "&$button__disabled": {
                 "&:hover": {
-                    ...highContrastDisabledBorder,
-                },
+                    [highContrastSelector]: {
+                        "box-shadow": "none"
+                    }
+                }
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -156,14 +156,14 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         "a&": {
             ...highContrastLinkOutline,
             "&:hover": {
-                ...highContrastLinkBorder
+                ...highContrastLinkBorder,
             },
             "&$button__disabled": {
                 "&:hover": {
                     [highContrastSelector]: {
-                        "box-shadow": "none !important"
-                    }
-                }
+                        "box-shadow": "none !important",
+                    },
+                },
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -161,7 +161,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             "&$button__disabled": {
                 "&:hover": {
                     [highContrastSelector]: {
-                        "box-shadow": "none"
+                        "box-shadow": "none !important"
                     }
                 }
             },

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -1,5 +1,5 @@
+import { applyCursorPointer } from "../utilities/cursor";
 import { ButtonClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import {
     applyFocusVisible,
     directionSwitch,
@@ -30,7 +30,7 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
-import { applyCursorPointer } from "../utilities/cursor";
+import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import {
     focusOutlineWidth,
@@ -41,6 +41,7 @@ import { applyDisabledState } from "../utilities/disabled";
 import {
     highContrastAccent,
     highContrastBackground,
+    HighContrastColor,
     highContrastDisabledBorder,
     highContrastDisabledForeground,
     highContrastDoubleFocus,
@@ -51,6 +52,7 @@ import {
     highContrastSelected,
     highContrastSelectedForeground,
     highContrastSelectedOutline,
+    highContrastSelector,
     highContrastStealth,
 } from "../utilities/high-contrast";
 import { applyScaledTypeRamp } from "../utilities/typography";
@@ -151,6 +153,12 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         },
         ...highContrastOutline,
         "a&": {
+            [highContrastSelector]: {
+                background: HighContrastColor.buttonBackground,
+                "border-color": HighContrastColor.hyperLinks,
+                color: HighContrastColor.hyperLinks,
+                fill: HighContrastColor.hyperLinks,
+            },
             "&$button__disabled": {
                 "&:hover": {
                     ...highContrastDisabledBorder,

--- a/packages/fast-components-styles-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-styles-msft/src/call-to-action/index.ts
@@ -100,7 +100,7 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
             ...applyGlyphTransform(),
         }),
         [highContrastSelector]: {
-            ...highContrastOptOutProperty
+            ...highContrastOptOutProperty,
         },
     },
     callToAction_glyph: {
@@ -126,8 +126,8 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
                 "border-color": HighContrastColor.selectedBackground,
             },
             "a&, & $button_contentRegion, & $callToAction_glyph": {
-                ...highContrastHighlightForeground
-            }
+                ...highContrastHighlightForeground,
+            },
         },
     },
     callToAction__lightweight: {

--- a/packages/fast-components-styles-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-styles-msft/src/call-to-action/index.ts
@@ -21,9 +21,11 @@ import {
 import { glyphSize } from "../utilities/density";
 import { designUnit } from "../utilities/design-system";
 import {
+    HighContrastColor,
     highContrastDisabledForeground,
     highContrastForeground,
     highContrastHighlightForeground,
+    highContrastOptOutProperty,
     highContrastSelectedForeground,
     highContrastSelector,
 } from "../utilities/high-contrast";
@@ -97,6 +99,9 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
         ...applyFocusVisible("& $callToAction_glyph", {
             ...applyGlyphTransform(),
         }),
+        [highContrastSelector]: {
+            ...highContrastOptOutProperty
+        },
     },
     callToAction_glyph: {
         fill: neutralForegroundRest,
@@ -115,8 +120,14 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
             fill: accentForegroundCut,
             ...highContrastSelectedForeground,
         },
-        "&:hover $callToAction_glyph": {
-            ...highContrastHighlightForeground,
+        "&:hover": {
+            [highContrastSelector]: {
+                background: HighContrastColor.selectedText,
+                "border-color": HighContrastColor.selectedBackground,
+            },
+            "a&, & $button_contentRegion, & $callToAction_glyph": {
+                ...highContrastHighlightForeground
+            }
         },
     },
     callToAction__lightweight: {

--- a/packages/fast-components-styles-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-styles-msft/src/call-to-action/index.ts
@@ -123,7 +123,7 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
         },
         "&:hover": {
             "& $callToAction_glyph": {
-                ...highContrastHighlightForeground
+                ...highContrastHighlightForeground,
             },
         },
         "a&": {
@@ -132,13 +132,12 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
             },
             "&:hover": {
                 [highContrastSelector]: {
-                    "box-shadow": "none !important"
+                    "box-shadow": "none !important",
                 },
                 "a& & $button_contentRegion, & $callToAction_glyph": {
-                    ...highContrastLinkForeground
+                    ...highContrastLinkForeground,
                 },
-            }
-            
+            },
         },
     },
     callToAction__lightweight: {

--- a/packages/fast-components-styles-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-styles-msft/src/call-to-action/index.ts
@@ -25,6 +25,7 @@ import {
     highContrastDisabledForeground,
     highContrastForeground,
     highContrastHighlightForeground,
+    highContrastLinkForeground,
     highContrastOptOutProperty,
     highContrastSelectedForeground,
     highContrastSelector,
@@ -116,18 +117,20 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
         ...highContrastForeground,
     },
     callToAction__primary: {
-        "& $callToAction_glyph": {
+        "& $button_contentRegion, $callToAction_glyph": {
             fill: accentForegroundCut,
             ...highContrastSelectedForeground,
         },
         "&:hover": {
             [highContrastSelector]: {
-                background: HighContrastColor.selectedText,
                 "border-color": HighContrastColor.selectedBackground,
             },
             "a&, & $button_contentRegion, & $callToAction_glyph": {
-                ...highContrastHighlightForeground,
+                ...highContrastHighlightForeground
             },
+        },
+        "a&, & $button_contentRegion, & $callToAction_glyph": {
+            ...highContrastLinkForeground
         },
     },
     callToAction__lightweight: {

--- a/packages/fast-components-styles-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-styles-msft/src/call-to-action/index.ts
@@ -132,7 +132,7 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
             },
             "&:hover": {
                 [highContrastSelector]: {
-                    "box-shadow": "none"
+                    "box-shadow": "none !important"
                 },
                 "a& & $button_contentRegion, & $callToAction_glyph": {
                     ...highContrastLinkForeground

--- a/packages/fast-components-styles-msft/src/call-to-action/index.ts
+++ b/packages/fast-components-styles-msft/src/call-to-action/index.ts
@@ -122,15 +122,23 @@ const styles: ComponentStyles<CallToActionClassNameContract, DesignSystem> = {
             ...highContrastSelectedForeground,
         },
         "&:hover": {
-            [highContrastSelector]: {
-                "border-color": HighContrastColor.selectedBackground,
-            },
-            "a&, & $button_contentRegion, & $callToAction_glyph": {
+            "& $callToAction_glyph": {
                 ...highContrastHighlightForeground
             },
         },
-        "a&, & $button_contentRegion, & $callToAction_glyph": {
-            ...highContrastLinkForeground
+        "a&": {
+            "& $button_contentRegion, & $callToAction_glyph": {
+                ...highContrastLinkForeground,
+            },
+            "&:hover": {
+                [highContrastSelector]: {
+                    "box-shadow": "none"
+                },
+                "a& & $button_contentRegion, & $callToAction_glyph": {
+                    ...highContrastLinkForeground
+                },
+            }
+            
         },
     },
     callToAction__lightweight: {

--- a/packages/fast-components-styles-msft/src/carousel/index.ts
+++ b/packages/fast-components-styles-msft/src/carousel/index.ts
@@ -10,7 +10,9 @@ import {
 import { CarouselClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { designUnit, outlineWidth } from "../utilities/design-system";
 import {
+    HighContrastColor,
     highContrastHighlightBackground,
+    highContrastOptOutProperty,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -55,6 +57,9 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                 opacity: "1",
             },
         },
+        [highContrastSelector]: {
+            ...highContrastOptOutProperty,
+        }
     },
     carousel_slides: {},
     carousel_sequenceIndicators: {
@@ -140,6 +145,9 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                     toPx<DesignSystem>(outlineWidth),
                     darkModeNeutralOutlineRest
                 ),
+                [highContrastSelector]: {
+                    background: "none"
+                }
             },
             "& span::before": {
                 "border-color": darkModeNeutralForegroundRest,
@@ -162,9 +170,12 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
             "& > svg": {
                 fill: darkModeNeutralForegroundRest,
                 [highContrastSelector]: {
-                    fill: "ButtonText",
+                    fill: HighContrastColor.buttonBackground,
                 },
             },
+            [highContrastSelector]: {
+                background: "none"
+            }
         },
         "& $carousel_sequenceIndicator": {
             "&::before": {
@@ -190,6 +201,9 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                     toPx<DesignSystem>(outlineWidth),
                     lightModeNeutralOutlineRest
                 ),
+                [highContrastSelector]: {
+                    background: "none"
+                }
             },
             "& span::before": {
                 "border-color": lightModeNeutralForegroundRest,
@@ -212,9 +226,12 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
             "& > svg": {
                 fill: lightModeNeutralForegroundRest,
                 [highContrastSelector]: {
-                    fill: "ButtonText",
+                    fill: HighContrastColor.buttonText,
                 },
             },
+            [highContrastSelector]: {
+                background: "none"
+            }
         },
         "& $carousel_sequenceIndicator": {
             "&::before": {

--- a/packages/fast-components-styles-msft/src/carousel/index.ts
+++ b/packages/fast-components-styles-msft/src/carousel/index.ts
@@ -59,7 +59,7 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
         },
         [highContrastSelector]: {
             ...highContrastOptOutProperty,
-        }
+        },
     },
     carousel_slides: {},
     carousel_sequenceIndicators: {
@@ -146,8 +146,8 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                     darkModeNeutralOutlineRest
                 ),
                 [highContrastSelector]: {
-                    background: "none"
-                }
+                    background: "none",
+                },
             },
             "& span::before": {
                 "border-color": darkModeNeutralForegroundRest,
@@ -174,8 +174,8 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                 },
             },
             [highContrastSelector]: {
-                background: "none"
-            }
+                background: "none",
+            },
         },
         "& $carousel_sequenceIndicator": {
             "&::before": {
@@ -202,8 +202,8 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                     lightModeNeutralOutlineRest
                 ),
                 [highContrastSelector]: {
-                    background: "none"
-                }
+                    background: "none",
+                },
             },
             "& span::before": {
                 "border-color": lightModeNeutralForegroundRest,
@@ -230,8 +230,8 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                 },
             },
             [highContrastSelector]: {
-                background: "none"
-            }
+                background: "none",
+            },
         },
         "& $carousel_sequenceIndicator": {
             "&::before": {

--- a/packages/fast-components-styles-msft/src/carousel/index.ts
+++ b/packages/fast-components-styles-msft/src/carousel/index.ts
@@ -11,7 +11,6 @@ import { CarouselClassNameContract } from "@microsoft/fast-components-class-name
 import { designUnit, outlineWidth } from "../utilities/design-system";
 import {
     HighContrastColor,
-    highContrastHighlightBackground,
     highContrastOptOutProperty,
     highContrastSelector,
 } from "../utilities/high-contrast";
@@ -89,11 +88,6 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
             height: toPx<DesignSystem>(designUnit),
             width: "32px",
             transition: "all 0.05s ease-in-out",
-            [highContrastSelector]: {
-                opacity: "1",
-                background: "ButtonFace",
-                "border-color": "ButtonText",
-            },
         },
         "&:not($carousel_sequenceIndicator__active)": {
             "&:hover": {
@@ -101,8 +95,8 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                     opacity: "0.9",
                     [highContrastSelector]: {
                         opacity: "1",
-                        background: "Highlight",
-                        "border-color": "HighlightText",
+                        background: HighContrastColor.selectedBackground,
+                        "border-color": HighContrastColor.selectedText,
                     },
                 },
             },
@@ -111,9 +105,6 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
     carousel_sequenceIndicator__active: {
         "&::before": {
             opacity: "1",
-            [highContrastSelector]: {
-                "border-color": "HighlightText",
-            },
         },
     },
     carousel_tabPanel: {
@@ -156,10 +147,11 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                 "&::before": {
                     background: neutralFillStealthHover((): string => black),
                     [highContrastSelector]: {
-                        background: "Highlight",
+                        background: HighContrastColor.selectedBackground,
                         border: format(
-                            "{0} solid HighlightText",
-                            toPx<DesignSystem>(outlineWidth)
+                            "{0} solid {1}",
+                            toPx<DesignSystem>(outlineWidth),
+                            () => HighContrastColor.selectedText
                         ),
                     },
                 },
@@ -181,11 +173,20 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
             "&::before": {
                 background: darkModeNeutralFillStealthRest,
                 "border-color": darkModeNeutralOutlineRest,
+                [highContrastSelector]: {
+                    opacity: "1",
+                    background: HighContrastColor.buttonBackground,
+                    "border-color": HighContrastColor.buttonText,
+                },
             },
             "&$carousel_sequenceIndicator__active": {
                 "&::before": {
                     background: darkModeNeutralFillStealthRest,
-                    ...highContrastHighlightBackground,
+                    [highContrastSelector]: {
+                        opacity: "1",
+                        background: HighContrastColor.selectedBackground,
+                        "border-color": HighContrastColor.selectedText,
+                    },
                 },
             },
         },
@@ -214,8 +215,9 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                     [highContrastSelector]: {
                         background: "Highlight",
                         border: format(
-                            "{0} solid HighlightText",
-                            toPx<DesignSystem>(outlineWidth)
+                            "{0} solid {1}",
+                            toPx<DesignSystem>(outlineWidth),
+                            () => HighContrastColor.selectedText
                         ),
                     },
                 },
@@ -237,11 +239,20 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
             "&::before": {
                 background: lightModeNeutralFillStealthRest,
                 "border-color": lightModeNeutralOutlineRest,
+                [highContrastSelector]: {
+                    opacity: "1",
+                    background: HighContrastColor.buttonBackground,
+                    "border-color": HighContrastColor.buttonText,
+                },
             },
             "&$carousel_sequenceIndicator__active": {
                 "&::before": {
                     background: lightModeNeutralFillStealthRest,
-                    ...highContrastHighlightBackground,
+                    [highContrastSelector]: {
+                        opacity: "1",
+                        background: HighContrastColor.selectedBackground,
+                        "border-color": HighContrastColor.selectedText,
+                    },
                 },
             },
         },

--- a/packages/fast-components-styles-msft/src/checkbox/index.ts
+++ b/packages/fast-components-styles-msft/src/checkbox/index.ts
@@ -71,7 +71,7 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
             "padding-right": directionSwitch("", horizontalSpacing(2)),
         },
         [highContrastSelector]: {
-            ...highContrastOptOutProperty
+            ...highContrastOptOutProperty,
         },
     },
     checkbox_input: {
@@ -111,11 +111,14 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
             "box-shadow": format<DesignSystem>("0 0 0 1px {0} inset", neutralFocus),
             "border-color": neutralFocus,
             [highContrastSelector]: {
-                "box-shadow": format<DesignSystem>("0 0 0 1px {0}", () => HighContrastColor.buttonText),
+                "box-shadow": format<DesignSystem>(
+                    "0 0 0 1px {0}",
+                    () => HighContrastColor.buttonText
+                ),
             },
         }),
         [highContrastSelector]: {
-            background: "none"
+            background: "none",
         },
     },
     checkbox_stateIndicator: {
@@ -140,7 +143,7 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
         ...applyCursorPointer(),
         color: neutralForegroundRest,
         ...applyScaledTypeRamp("t7"),
-        ...highContrastTextForeground
+        ...highContrastTextForeground,
     },
     checkbox__checked: {
         "& $checkbox_stateIndicator": {

--- a/packages/fast-components-styles-msft/src/checkbox/index.ts
+++ b/packages/fast-components-styles-msft/src/checkbox/index.ts
@@ -1,5 +1,9 @@
-import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
+import {
+    densityCategorySwitch,
+    heightNumber,
+    horizontalSpacing,
+} from "../utilities/density";
 import { CheckboxClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import {
     add,
@@ -20,11 +24,7 @@ import {
     neutralOutlineRest,
 } from "../utilities/color";
 import { applyCornerRadius } from "../utilities/border";
-import {
-    densityCategorySwitch,
-    heightNumber,
-    horizontalSpacing,
-} from "../utilities/density";
+import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { designUnit, outlineWidth } from "../utilities/design-system";
@@ -32,10 +32,13 @@ import { applyCursorDisabled, applyCursorPointer } from "../utilities/cursor";
 import { ColorRecipe } from "src/utilities/color/common";
 import {
     highContrastBorderColor,
+    HighContrastColor,
     highContrastDisabledBorder,
     highContrastHighlightBackground,
+    highContrastOptOutProperty,
     highContrastSelectedBackground,
     highContrastSelector,
+    highContrastTextForeground,
 } from "../utilities/high-contrast";
 
 const inputSize: DesignSystemResolver<string> = toPx(
@@ -67,6 +70,9 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
             "padding-left": directionSwitch(horizontalSpacing(2), ""),
             "padding-right": directionSwitch("", horizontalSpacing(2)),
         },
+        [highContrastSelector]: {
+            ...highContrastOptOutProperty
+        },
     },
     checkbox_input: {
         position: "absolute",
@@ -92,6 +98,10 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
         "&:hover:enabled": {
             background: neutralFillInputHover,
             "border-color": neutralOutlineHover,
+            [highContrastSelector]: {
+                background: "none",
+                "border-color": HighContrastColor.selectedBackground,
+            },
         },
         "&:active:enabled": {
             background: neutralFillInputActive,
@@ -101,10 +111,12 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
             "box-shadow": format<DesignSystem>("0 0 0 1px {0} inset", neutralFocus),
             "border-color": neutralFocus,
             [highContrastSelector]: {
-                "box-shadow": format<DesignSystem>("0 0 0 1px ButtonText"),
+                "box-shadow": format<DesignSystem>("0 0 0 1px {0}", () => HighContrastColor.buttonText),
             },
         }),
-        ...highContrastBorderColor,
+        [highContrastSelector]: {
+            background: "none"
+        },
     },
     checkbox_stateIndicator: {
         position: "relative",
@@ -128,9 +140,7 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
         ...applyCursorPointer(),
         color: neutralForegroundRest,
         ...applyScaledTypeRamp("t7"),
-        [highContrastSelector]: {
-            color: "ButtonText",
-        },
+        ...highContrastTextForeground
     },
     checkbox__checked: {
         "& $checkbox_stateIndicator": {
@@ -142,7 +152,7 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
                 [highContrastSelector]: {
                     background: format(
                         "url('data:image/svg+xml;utf8,{0}')",
-                        indicatorSvg("HighlightText")
+                        indicatorSvg(HighContrastColor.selectedText)
                     ),
                 },
             },
@@ -153,7 +163,7 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
                     [highContrastSelector]: {
                         background: format(
                             "url('data:image/svg+xml;utf8,{0}')",
-                            indicatorSvg("Highlight")
+                            indicatorSvg(HighContrastColor.selectedBackground)
                         ),
                     },
                 },
@@ -179,7 +189,10 @@ const styles: ComponentStyles<CheckboxClassNameContract, DesignSystem> = {
                 height: "auto",
                 background: neutralForegroundRest,
                 [highContrastSelector]: {
-                    backgroundColor: "ButtonHighlight",
+                    background: format(
+                        "url('data:image/svg+xml;utf8,{0}')",
+                        indicatorSvg(HighContrastColor.selectedBackground)
+                    ),
                 },
             },
         },

--- a/packages/fast-components-styles-msft/src/context-menu-item/index.ts
+++ b/packages/fast-components-styles-msft/src/context-menu-item/index.ts
@@ -11,15 +11,20 @@ import {
 } from "../utilities/color";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { height, horizontalSpacingNumber } from "../utilities/density";
-import { designUnit } from "../utilities/design-system";
+import { designUnit, focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import {
+    HighContrastColor,
     highContrastDisabled,
+    highContrastDoubleFocus,
+    highContrastOptOutProperty,
     highContrastOutlineFocus,
     highContrastSelected,
+    highContrastSelector,
     highContrastStealth,
 } from "../utilities/high-contrast";
+import { importantValue } from "../utilities/important";
 
 const glyphWidth: number = 16;
 const styles: ComponentStyles<ContextMenuItemClassNameContract, DesignSystem> = {
@@ -47,7 +52,21 @@ const styles: ComponentStyles<ContextMenuItemClassNameContract, DesignSystem> = 
         ...applyFocusPlaceholderBorder(),
         ...applyFocusVisible<DesignSystem>({
             "border-color": neutralFocus,
-            ...highContrastOutlineFocus,
+            [highContrastSelector]: {
+                color: HighContrastColor.selectedText,
+                fill: HighContrastColor.selectedText,
+                background: HighContrastColor.selectedBackground,
+                border: format(
+                    "{0} solid {1}",
+                    toPx<DesignSystem>(outlineWidth),
+                    () => HighContrastColor.buttonText
+                ),
+                "box-shadow": format(
+                    "0 0 0 {0} inset {1}",
+                    toPx(focusOutlineWidth),
+                    () => HighContrastColor.selectedText
+                ),
+            },
         }),
         "&:hover": {
             background: neutralFillStealthHover,
@@ -55,6 +74,7 @@ const styles: ComponentStyles<ContextMenuItemClassNameContract, DesignSystem> = 
         },
         "&:active": {
             background: neutralFillStealthActive,
+            ...highContrastSelected,
         },
         ...highContrastStealth,
     },

--- a/packages/fast-components-styles-msft/src/flipper/index.ts
+++ b/packages/fast-components-styles-msft/src/flipper/index.ts
@@ -72,10 +72,10 @@ const styles: ComponentStyles<FlipperClassNameContract, DesignSystem> = {
             "&::before": {
                 background: neutralFillStealthHover,
                 "border-color": neutralOutlineHover,
-                ...highContrastHighlightBackground
+                ...highContrastHighlightBackground,
             },
             "& $flipper_glyph": {
-                ...highContrastSelectedForeground
+                ...highContrastSelectedForeground,
             },
         },
         ...applyFocusVisible({
@@ -87,7 +87,7 @@ const styles: ComponentStyles<FlipperClassNameContract, DesignSystem> = {
         "&::-moz-focus-inner": {
             border: "0",
         },
-        ...highContrastOutline
+        ...highContrastOutline,
     },
     flipper_glyph: {
         position: "relative",

--- a/packages/fast-components-styles-msft/src/flipper/index.ts
+++ b/packages/fast-components-styles-msft/src/flipper/index.ts
@@ -22,6 +22,8 @@ import { outlineWidth } from "../utilities/design-system";
 import { applyCursorPointer } from "../utilities/cursor";
 import {
     highContrastHighlightBackground,
+    highContrastOutline,
+    highContrastSelectedForeground,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -57,7 +59,7 @@ const styles: ComponentStyles<FlipperClassNameContract, DesignSystem> = {
             bottom: "0",
             left: "0",
             [highContrastSelector]: {
-                background: "ButtonFace",
+                background: "none",
             },
         },
         "&:active": {
@@ -70,12 +72,10 @@ const styles: ComponentStyles<FlipperClassNameContract, DesignSystem> = {
             "&::before": {
                 background: neutralFillStealthHover,
                 "border-color": neutralOutlineHover,
-                ...highContrastHighlightBackground,
+                ...highContrastHighlightBackground
             },
             "& $flipper_glyph": {
-                [highContrastSelector]: {
-                    fill: "HighlightText",
-                },
+                ...highContrastSelectedForeground
             },
         },
         ...applyFocusVisible({
@@ -87,9 +87,7 @@ const styles: ComponentStyles<FlipperClassNameContract, DesignSystem> = {
         "&::-moz-focus-inner": {
             border: "0",
         },
-        [highContrastSelector]: {
-            fill: "ButtonText",
-        },
+        ...highContrastOutline
     },
     flipper_glyph: {
         position: "relative",

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -12,10 +12,12 @@ import { applyFocusVisible, toPx } from "@microsoft/fast-jss-utilities";
 import { focusOutlineWidth } from "../utilities/design-system";
 import {
     highContrastBackground,
+    HighContrastColor,
     highContrastDisabledForeground,
-    highContrastForeground,
     highContrastHighlightBackground,
     highContrastHighlightForeground,
+    highContrastSelector,
+    highContrastStealth,
 } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> = {
@@ -64,8 +66,15 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             fill: accentForegroundActive,
             "background-color": "transparent",
         },
-        ...highContrastForeground,
+        ...highContrastStealth,
         "a&": {
+            [highContrastSelector]: {
+                color: HighContrastColor.hyperLinks,
+            },
+            // Underline
+            "&:hover $button_contentRegion::before": {
+                background: HighContrastColor.hyperLinks,
+            },
             "&:hover$button__disabled": {
                 ...highContrastDisabledForeground,
             },

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -70,6 +70,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
         "a&": {
             [highContrastSelector]: {
                 color: HighContrastColor.hyperLinks,
+                fill: HighContrastColor.hyperLinks,
             },
             // Underline
             "&:hover $button_contentRegion::before": {

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -12,10 +12,10 @@ import { applyFocusVisible, toPx } from "@microsoft/fast-jss-utilities";
 import { focusOutlineWidth } from "../utilities/design-system";
 import {
     highContrastBackground,
-    HighContrastColor,
     highContrastDisabledForeground,
     highContrastHighlightBackground,
     highContrastHighlightForeground,
+    highContrastLinkValue,
     highContrastSelector,
     highContrastStealth,
 } from "../utilities/high-contrast";
@@ -69,12 +69,12 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
         ...highContrastStealth,
         "a&": {
             [highContrastSelector]: {
-                color: HighContrastColor.hyperLinks,
-                fill: HighContrastColor.hyperLinks,
+                color: highContrastLinkValue,
+                fill: highContrastLinkValue,
             },
             // Underline
             "&:hover $button_contentRegion::before": {
-                background: HighContrastColor.hyperLinks,
+                background: highContrastLinkValue,
             },
             "&:hover$button__disabled": {
                 ...highContrastDisabledForeground,

--- a/packages/fast-components-styles-msft/src/neutral-button/index.ts
+++ b/packages/fast-components-styles-msft/src/neutral-button/index.ts
@@ -11,8 +11,9 @@ import {
     neutralForegroundRest,
 } from "../utilities/color";
 import {
-    HighContrastColor,
     highContrastDisabledBorder,
+    highContrastLinkBorder,
+    highContrastLinkOutline,
     highContrastOutline,
     highContrastOutlineFocus,
     highContrastSelected,
@@ -45,13 +46,17 @@ const styles: ComponentStyles<NeutralButtonClassNameContract, DesignSystem> = {
         },
         ...highContrastOutline,
         "a&": {
-            [highContrastSelector]: {
-                "border-color": HighContrastColor.hyperLinks,
-                color: HighContrastColor.hyperLinks,
-                fill: HighContrastColor.hyperLinks,
+            ...highContrastLinkOutline,
+            "&:hover": {
+                ...highContrastLinkBorder
             },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
+                "&:hover": {
+                    [highContrastSelector]: {
+                        "box-shadow": "none"
+                    }
+                }
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/neutral-button/index.ts
+++ b/packages/fast-components-styles-msft/src/neutral-button/index.ts
@@ -11,10 +11,12 @@ import {
     neutralForegroundRest,
 } from "../utilities/color";
 import {
+    HighContrastColor,
     highContrastDisabledBorder,
     highContrastOutline,
     highContrastOutlineFocus,
     highContrastSelected,
+    highContrastSelector,
 } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<NeutralButtonClassNameContract, DesignSystem> = {
@@ -43,6 +45,11 @@ const styles: ComponentStyles<NeutralButtonClassNameContract, DesignSystem> = {
         },
         ...highContrastOutline,
         "a&": {
+            [highContrastSelector]: {
+                "border-color": HighContrastColor.hyperLinks,
+                color: HighContrastColor.hyperLinks,
+                fill: HighContrastColor.hyperLinks,
+            },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
             },

--- a/packages/fast-components-styles-msft/src/neutral-button/index.ts
+++ b/packages/fast-components-styles-msft/src/neutral-button/index.ts
@@ -54,7 +54,7 @@ const styles: ComponentStyles<NeutralButtonClassNameContract, DesignSystem> = {
                 ...highContrastDisabledBorder,
                 "&:hover": {
                     [highContrastSelector]: {
-                        "box-shadow": "none"
+                        "box-shadow": "none !important"
                     }
                 }
             },

--- a/packages/fast-components-styles-msft/src/neutral-button/index.ts
+++ b/packages/fast-components-styles-msft/src/neutral-button/index.ts
@@ -48,15 +48,15 @@ const styles: ComponentStyles<NeutralButtonClassNameContract, DesignSystem> = {
         "a&": {
             ...highContrastLinkOutline,
             "&:hover": {
-                ...highContrastLinkBorder
+                ...highContrastLinkBorder,
             },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
                 "&:hover": {
                     [highContrastSelector]: {
-                        "box-shadow": "none !important"
-                    }
-                }
+                        "box-shadow": "none !important",
+                    },
+                },
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -74,7 +74,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
                 ...highContrastDisabledBorder,
                 "&:hover": {
                     [highContrastSelector]: {
-                        "box-shadow": "none"
+                        "box-shadow": "none !important"
                     }
                 }
             },

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -13,10 +13,12 @@ import {
 import { horizontalSpacing } from "../utilities/density";
 import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 import {
+    HighContrastColor,
     highContrastDisabledBorder,
     highContrastOutline,
     highContrastOutlineFocus,
     highContrastSelected,
+    highContrastSelector,
 } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> = {
@@ -63,6 +65,15 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
         },
         ...highContrastOutline,
         "a&": {
+            background: "red",
+            [highContrastSelector]: {
+                "border-color": HighContrastColor.hyperLinks,
+                color: HighContrastColor.hyperLinks,
+                fill: HighContrastColor.hyperLinks,
+            },
+            "&:hover:enabled": {
+                background: "yellow"
+            },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
             },

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -13,8 +13,9 @@ import {
 import { horizontalSpacing } from "../utilities/density";
 import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 import {
-    HighContrastColor,
     highContrastDisabledBorder,
+    highContrastLinkBorder,
+    highContrastLinkOutline,
     highContrastOutline,
     highContrastOutlineFocus,
     highContrastSelected,
@@ -65,17 +66,17 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
         },
         ...highContrastOutline,
         "a&": {
-            background: "red",
-            [highContrastSelector]: {
-                "border-color": HighContrastColor.hyperLinks,
-                color: HighContrastColor.hyperLinks,
-                fill: HighContrastColor.hyperLinks,
-            },
-            "&:hover:enabled": {
-                background: "yellow"
+            ...highContrastLinkOutline,
+            "&:hover": {
+                ...highContrastLinkBorder
             },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
+                "&:hover": {
+                    [highContrastSelector]: {
+                        "box-shadow": "none"
+                    }
+                }
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -68,15 +68,15 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
         "a&": {
             ...highContrastLinkOutline,
             "&:hover": {
-                ...highContrastLinkBorder
+                ...highContrastLinkBorder,
             },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
                 "&:hover": {
                     [highContrastSelector]: {
-                        "box-shadow": "none !important"
-                    }
-                }
+                        "box-shadow": "none !important",
+                    },
+                },
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/patterns/input-field.ts
+++ b/packages/fast-components-styles-msft/src/patterns/input-field.ts
@@ -21,6 +21,7 @@ import { applyScaledTypeRamp } from "../utilities/typography";
 import { applyFontWeightNormal } from "../utilities/fonts";
 import { outlineWidth } from "../utilities/design-system";
 import {
+    HighContrastColor,
     highContrastDisabledBorder,
     highContrastOutlineFocus,
     highContrastSelector,
@@ -52,8 +53,12 @@ export function inputFieldStyles(
             background: neutralFillInputHover,
             "border-color": neutralOutlineHover,
             [highContrastSelector]: {
-                background: "Background",
-                border: format("{0} solid Highlight", toPx<DesignSystem>(outlineWidth)),
+                background: "none",
+                border: format(
+                    "{0} solid {1}",
+                    toPx<DesignSystem>(outlineWidth),
+                    () => HighContrastColor.selectedBackground
+                ),
             },
         },
         "&:active:enabled": {
@@ -72,6 +77,9 @@ export function inputFieldStyles(
         },
         "&::placeholder": {
             color: neutralForegroundHint(neutralFillInputRest),
+            [highContrastSelector]: {
+                color: HighContrastColor.disabledText,
+            }
         },
     };
 }
@@ -84,6 +92,14 @@ export function filledInputFieldStyles(): CSSRules<{}> {
         "&:hover:enabled": {
             background: neutralFillHover,
             "border-color": "transparent",
+            [highContrastSelector]: {
+                background: "none",
+                border: format(
+                    "{0} solid {1}",
+                    toPx<DesignSystem>(outlineWidth),
+                    () => HighContrastColor.selectedBackground
+                ),
+            },
         },
         "&:active:enabled": {
             "border-color": "transparent",
@@ -93,6 +109,9 @@ export function filledInputFieldStyles(): CSSRules<{}> {
         },
         "&::placeholder": {
             color: neutralForegroundHint(neutralFillRest),
+            [highContrastSelector]: {
+                color: HighContrastColor.disabledText,
+            }
         },
     };
 }

--- a/packages/fast-components-styles-msft/src/patterns/input-field.ts
+++ b/packages/fast-components-styles-msft/src/patterns/input-field.ts
@@ -79,7 +79,7 @@ export function inputFieldStyles(
             color: neutralForegroundHint(neutralFillInputRest),
             [highContrastSelector]: {
                 color: HighContrastColor.disabledText,
-            }
+            },
         },
     };
 }
@@ -111,7 +111,7 @@ export function filledInputFieldStyles(): CSSRules<{}> {
             color: neutralForegroundHint(neutralFillRest),
             [highContrastSelector]: {
                 color: HighContrastColor.disabledText,
-            }
+            },
         },
     };
 }

--- a/packages/fast-components-styles-msft/src/pivot/index.ts
+++ b/packages/fast-components-styles-msft/src/pivot/index.ts
@@ -65,6 +65,7 @@ const styles: ComponentStyles<PivotClassNameContract, DesignSystem> = {
         [highContrastSelector]: {
             color: "ButtonText",
             "-ms-high-contrast-adjust": "none",
+            "forced-color-adjust": "none"
         },
     },
     pivot_tab__active: {

--- a/packages/fast-components-styles-msft/src/pivot/index.ts
+++ b/packages/fast-components-styles-msft/src/pivot/index.ts
@@ -22,8 +22,10 @@ import { focusOutlineWidth } from "../utilities/design-system";
 import { applyCursorPointer } from "../utilities/cursor";
 import {
     highContrastBorderColor,
+    HighContrastColor,
     highContrastForeground,
     highContrastHighlightBackground,
+    highContrastOptOutProperty,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -34,6 +36,9 @@ const styles: ComponentStyles<PivotClassNameContract, DesignSystem> = {
         overflow: "hidden",
         color: neutralForegroundRest,
         transition: "all 0.2s ease-in-out",
+        [highContrastSelector]: {
+            ...highContrastOptOutProperty,
+        },
     },
     pivot_tabList: {
         display: "flex",
@@ -63,9 +68,7 @@ const styles: ComponentStyles<PivotClassNameContract, DesignSystem> = {
             ...highContrastBorderColor,
         }),
         [highContrastSelector]: {
-            color: "ButtonText",
-            "-ms-high-contrast-adjust": "none",
-            "forced-color-adjust": "none"
+            color: HighContrastColor.buttonText,
         },
     },
     pivot_tab__active: {

--- a/packages/fast-components-styles-msft/src/pivot/index.ts
+++ b/packages/fast-components-styles-msft/src/pivot/index.ts
@@ -109,8 +109,8 @@ const styles: ComponentStyles<PivotClassNameContract, DesignSystem> = {
     },
     pivot_tabPanelContent: {
         [highContrastSelector]: {
-            color: HighContrastColor.text
-        }
+            color: HighContrastColor.text,
+        },
     },
     "@keyframes fromRight": {
         "0%": {

--- a/packages/fast-components-styles-msft/src/pivot/index.ts
+++ b/packages/fast-components-styles-msft/src/pivot/index.ts
@@ -27,6 +27,7 @@ import {
     highContrastHighlightBackground,
     highContrastOptOutProperty,
     highContrastSelector,
+    highContrastTextForeground,
 } from "../utilities/high-contrast";
 
 const activeIndicatorHeight: number = 3;
@@ -106,7 +107,11 @@ const styles: ComponentStyles<PivotClassNameContract, DesignSystem> = {
     pivot_tabPanels__animateNext: {
         animation: format("{0} 0.2s", directionSwitch("fromRight", "fromLeft")),
     },
-    pivot_tabPanelContent: {},
+    pivot_tabPanelContent: {
+        [highContrastSelector]: {
+            color: HighContrastColor.text
+        }
+    },
     "@keyframes fromRight": {
         "0%": {
             opacity: "0",

--- a/packages/fast-components-styles-msft/src/progress/index.ts
+++ b/packages/fast-components-styles-msft/src/progress/index.ts
@@ -6,10 +6,15 @@ import {
     neutralFillRest,
     neutralForegroundHint,
 } from "../utilities/color";
-import { multiply, toPx } from "@microsoft/fast-jss-utilities";
-import { designUnit } from "../utilities/design-system";
+import { format, multiply, toPx } from "@microsoft/fast-jss-utilities";
+import { designUnit, outlineWidth } from "../utilities/design-system";
 import { glyphSize, height, heightNumber } from "../utilities/density";
-import { highContrastBackground, highContrastSelector } from "../utilities/high-contrast";
+import {
+    highContrastBackground,
+    HighContrastColor,
+    highContrastOptOutProperty,
+    highContrastSelector
+} from "../utilities/high-contrast";
 
 const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = {
     progress: {
@@ -18,6 +23,9 @@ const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = {
         "align-items": "center",
         height: toPx<DesignSystem>(designUnit),
         "text-align": "left",
+        [highContrastSelector]: {
+            ...highContrastOptOutProperty
+        },
     },
     progress__circular: {
         height: "unset",
@@ -32,7 +40,7 @@ const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = {
         "& $progress_valueIndicator": {
             stroke: accentFillRest,
             [highContrastSelector]: {
-                stroke: "ButtonText",
+                stroke: HighContrastColor.buttonText,
             },
         },
         "& $progress_valueIndicator__indeterminate": {
@@ -41,7 +49,7 @@ const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = {
         "& $progress_indicator": {
             stroke: neutralFillRest,
             [highContrastSelector]: {
-                stroke: "ButtonFace",
+                stroke: HighContrastColor.buttonBackground,
             },
         },
     },
@@ -97,16 +105,24 @@ const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = {
         "-webkit-mask-image": "-webkit-radial-gradient(white, black)",
         "mask-image": "-webkit-radial-gradient(white, black)",
         [highContrastSelector]: {
-            background: "ButtonFace",
-            border: "1px solid ButtonText",
+            background: HighContrastColor.buttonBackground,
+            border: format<DesignSystem>(
+                "{0} solid {1}",
+                toPx(outlineWidth),
+                () => HighContrastColor.buttonText
+            ),
         },
     },
     progress_indicator__determinate: {
         height: toPx<DesignSystem>(designUnit),
         "border-radius": "2px",
         [highContrastSelector]: {
-            background: "ButtonFace",
-            border: "1px solid ButtonText",
+            background: HighContrastColor.buttonBackground,
+            border: format<DesignSystem>(
+                "{0} solid {1}",
+                toPx(outlineWidth),
+                () => HighContrastColor.buttonText
+            ),
         },
     },
     progress_dot: {
@@ -117,7 +133,7 @@ const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = {
         "border-radius": "100px",
         "animation-timing-function": "cubic-bezier(0.4, 0.0, 0.6, 1.0)",
         [highContrastSelector]: {
-            background: "ButtonText",
+            background: HighContrastColor.buttonText,
             opacity: "1 !important",
         },
     },

--- a/packages/fast-components-styles-msft/src/progress/index.ts
+++ b/packages/fast-components-styles-msft/src/progress/index.ts
@@ -13,7 +13,7 @@ import {
     highContrastBackground,
     HighContrastColor,
     highContrastOptOutProperty,
-    highContrastSelector
+    highContrastSelector,
 } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = {
@@ -24,7 +24,7 @@ const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = {
         height: toPx<DesignSystem>(designUnit),
         "text-align": "left",
         [highContrastSelector]: {
-            ...highContrastOptOutProperty
+            ...highContrastOptOutProperty,
         },
     },
     progress__circular: {

--- a/packages/fast-components-styles-msft/src/radio/index.ts
+++ b/packages/fast-components-styles-msft/src/radio/index.ts
@@ -53,7 +53,7 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         "align-items": "center",
         transition: "all 0.2s ease-in-out",
         [highContrastSelector]: {
-            ...highContrastOptOutProperty
+            ...highContrastOptOutProperty,
         },
     },
     radio_input: {
@@ -81,7 +81,11 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
             "border-color": neutralOutlineHover,
             [highContrastSelector]: {
                 background: "none",
-                border: format("{0} solid {1}", toPx<DesignSystem>(outlineWidth), () => HighContrastColor.selectedBackground),
+                border: format(
+                    "{0} solid {1}",
+                    toPx<DesignSystem>(outlineWidth),
+                    () => HighContrastColor.selectedBackground
+                ),
             },
         },
         "&:active": {
@@ -92,12 +96,19 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
             "box-shadow": format<DesignSystem>("0 0 0 1px {0} inset", neutralFocus),
             "border-color": neutralFocus,
             [highContrastSelector]: {
-                "box-shadow": format<DesignSystem>("0 0 0 1px {0}", () => HighContrastColor.buttonText),
+                "box-shadow": format<DesignSystem>(
+                    "0 0 0 1px {0}",
+                    () => HighContrastColor.buttonText
+                ),
             },
         }),
         [highContrastSelector]: {
             background: "none",
-            border: format("{0} solid {1}", toPx<DesignSystem>(outlineWidth), () => HighContrastColor.buttonText),
+            border: format(
+                "{0} solid {1}",
+                toPx<DesignSystem>(outlineWidth),
+                () => HighContrastColor.buttonText
+            ),
         },
     },
     radio_stateIndicator: {

--- a/packages/fast-components-styles-msft/src/radio/index.ts
+++ b/packages/fast-components-styles-msft/src/radio/index.ts
@@ -1,9 +1,9 @@
-import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import {
     densityCategorySwitch,
     heightNumber,
     horizontalSpacing,
 } from "../utilities/density";
+import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { RadioClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import {
     add,
@@ -23,14 +23,16 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
-import { DesignSystem, DesignSystemResolver } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { designUnit, outlineWidth } from "../utilities/design-system";
 import { applyCursorDisabled, applyCursorPointer } from "../utilities/cursor";
 import {
+    HighContrastColor,
     highContrastDisabledBorder,
     highContrastHighlightBackground,
+    highContrastOptOutProperty,
     highContrastSelectedBackground,
     highContrastSelector,
 } from "../utilities/high-contrast";
@@ -50,6 +52,9 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         "flex-direction": "row",
         "align-items": "center",
         transition: "all 0.2s ease-in-out",
+        [highContrastSelector]: {
+            ...highContrastOptOutProperty
+        },
     },
     radio_input: {
         position: "absolute",
@@ -74,6 +79,10 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         "&:hover:enabled": {
             background: neutralFillInputHover,
             "border-color": neutralOutlineHover,
+            [highContrastSelector]: {
+                background: "none",
+                border: format("{0} solid {1}", toPx<DesignSystem>(outlineWidth), () => HighContrastColor.selectedBackground),
+            },
         },
         "&:active": {
             background: neutralFillInputActive,
@@ -83,11 +92,12 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
             "box-shadow": format<DesignSystem>("0 0 0 1px {0} inset", neutralFocus),
             "border-color": neutralFocus,
             [highContrastSelector]: {
-                "box-shadow": "0 0 0 1px ButtonText inset",
+                "box-shadow": format<DesignSystem>("0 0 0 1px {0}", () => HighContrastColor.buttonText),
             },
         }),
         [highContrastSelector]: {
-            border: format("{0} solid ButtonText", toPx<DesignSystem>(outlineWidth)),
+            background: "none",
+            border: format("{0} solid {1}", toPx<DesignSystem>(outlineWidth), () => HighContrastColor.buttonText),
         },
     },
     radio_stateIndicator: {
@@ -117,14 +127,17 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         "margin-left": directionSwitch(horizontalSpacing(2), ""),
         "margin-right": directionSwitch("", horizontalSpacing(2)),
         [highContrastSelector]: {
-            color: "ButtonText",
+            background: "none",
+            color: HighContrastColor.text,
         },
     },
     radio__checked: {
         "& $radio_stateIndicator": {
             "&::before": {
                 background: neutralForegroundRest,
-                ...highContrastHighlightBackground,
+                [highContrastSelector]: {
+                    background: HighContrastColor.selectedBackground,
+                },
             },
         },
         "&:hover $radio_stateIndicator::before": {

--- a/packages/fast-components-styles-msft/src/select-option/index.ts
+++ b/packages/fast-components-styles-msft/src/select-option/index.ts
@@ -1,5 +1,5 @@
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { applyCursorDefault, applyCursorPointer } from "../utilities/cursor";
-import { SelectOptionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import {
     applyFocusVisible,
     directionSwitch,
@@ -16,17 +16,19 @@ import {
     neutralFocus,
     neutralForegroundRest,
 } from "../utilities/color";
-import { ComponentStyles } from "@microsoft/fast-jss-manager";
+import { SelectOptionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import { designUnit, focusOutlineWidth } from "../utilities/design-system";
 import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import {
+    HighContrastColor,
     highContrastDisabledBorder,
     highContrastSelected,
     highContrastSelector,
     highContrastStealth,
 } from "../utilities/high-contrast";
+import { importantValue } from "../utilities/important";
 
 const styles: ComponentStyles<SelectOptionClassNameContract, DesignSystem> = {
     selectOption: {
@@ -80,10 +82,10 @@ const styles: ComponentStyles<SelectOptionClassNameContract, DesignSystem> = {
     },
     selectOption__selected: {
         [highContrastSelector]: {
-            background: "Highlight !important",
-            "border-color": "ButtonText !important",
-            color: "HighlightText !important",
-            fill: "HighlightText !important",
+            background: importantValue(HighContrastColor.selectedBackground),
+            "border-color": importantValue(HighContrastColor.buttonText),
+            color: importantValue(HighContrastColor.selectedText),
+            fill: importantValue(HighContrastColor.selectedText),
         },
         background: neutralFillStealthSelected,
         "&:hover": {

--- a/packages/fast-components-styles-msft/src/select-option/index.ts
+++ b/packages/fast-components-styles-msft/src/select-option/index.ts
@@ -52,7 +52,7 @@ const styles: ComponentStyles<SelectOptionClassNameContract, DesignSystem> = {
         ...applyFocusPlaceholderBorder(),
         ...applyFocusVisible<DesignSystem>({
             "border-color": neutralFocus,
-            ...highContrastOutlineFocus
+            ...highContrastOutlineFocus,
         }),
         "&:hover": {
             background: neutralFillStealthHover,

--- a/packages/fast-components-styles-msft/src/select-option/index.ts
+++ b/packages/fast-components-styles-msft/src/select-option/index.ts
@@ -1,5 +1,5 @@
+import { SelectOptionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
-import { applyCursorDefault, applyCursorPointer } from "../utilities/cursor";
 import {
     applyFocusVisible,
     directionSwitch,
@@ -16,7 +16,7 @@ import {
     neutralFocus,
     neutralForegroundRest,
 } from "../utilities/color";
-import { SelectOptionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import { applyCursorDefault, applyCursorPointer } from "../utilities/cursor";
 import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import { designUnit, focusOutlineWidth } from "../utilities/design-system";
 import { applyDisabledState } from "../utilities/disabled";
@@ -24,6 +24,7 @@ import { applyScaledTypeRamp } from "../utilities/typography";
 import {
     HighContrastColor,
     highContrastDisabledBorder,
+    highContrastOutlineFocus,
     highContrastSelected,
     highContrastSelector,
     highContrastStealth,
@@ -51,6 +52,7 @@ const styles: ComponentStyles<SelectOptionClassNameContract, DesignSystem> = {
         ...applyFocusPlaceholderBorder(),
         ...applyFocusVisible<DesignSystem>({
             "border-color": neutralFocus,
+            ...highContrastOutlineFocus
         }),
         "&:hover": {
             background: neutralFillStealthHover,

--- a/packages/fast-components-styles-msft/src/slider-label/index.ts
+++ b/packages/fast-components-styles-msft/src/slider-label/index.ts
@@ -1,13 +1,18 @@
+import { applyCursorDefault } from "../utilities/cursor";
 import { SliderLabelClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import { DesignSystem } from "../design-system";
 import { neutralForegroundRest, neutralOutlineRest } from "../utilities/color";
-import { applyCursorDefault } from "../utilities/cursor";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { heightNumber } from "../utilities/density";
 import { designUnit } from "../utilities/design-system";
 import { applyScaledTypeRamp } from "../utilities/typography";
-import { highContrastBackground } from "../utilities/high-contrast";
+import {
+    highContrastBackground,
+    highContrastOptOutProperty,
+    highContrastSelector,
+    highContrastTextForeground
+} from "../utilities/high-contrast";
 
 function minMaxLabelMargin(config: DesignSystem): string {
     return toPx(((heightNumber()(config) / 2 + designUnit(config)) / 2) * -1);
@@ -17,6 +22,9 @@ const styles: ComponentStyles<SliderLabelClassNameContract, DesignSystem> = {
     sliderLabel: {
         display: "grid",
         ...applyCursorDefault(),
+        [highContrastSelector]: {
+            ...highContrastOptOutProperty,
+        },
     },
 
     sliderLabel_positioningRegion: {
@@ -27,6 +35,7 @@ const styles: ComponentStyles<SliderLabelClassNameContract, DesignSystem> = {
         ...applyScaledTypeRamp("t9"),
         "white-space": "nowrap",
         color: neutralForegroundRest,
+        ...highContrastTextForeground,
     },
 
     sliderLabel_tickMark: {

--- a/packages/fast-components-styles-msft/src/slider-label/index.ts
+++ b/packages/fast-components-styles-msft/src/slider-label/index.ts
@@ -11,7 +11,7 @@ import {
     highContrastBackground,
     highContrastOptOutProperty,
     highContrastSelector,
-    highContrastTextForeground
+    highContrastTextForeground,
 } from "../utilities/high-contrast";
 
 function minMaxLabelMargin(config: DesignSystem): string {

--- a/packages/fast-components-styles-msft/src/slider/index.ts
+++ b/packages/fast-components-styles-msft/src/slider/index.ts
@@ -1,5 +1,5 @@
-import { SliderClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
+import { applyCursorPointer } from "../utilities/cursor";
 import {
     add,
     applyFocusVisible,
@@ -19,7 +19,7 @@ import {
     neutralForegroundRest,
     neutralOutlineRest,
 } from "../utilities/color";
-import { applyCursorPointer } from "../utilities/cursor";
+import { SliderClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { densityCategorySwitch, heightNumber } from "../utilities/density";
 import {
     backgroundColor,
@@ -30,10 +30,13 @@ import { applyDisabledState } from "../utilities/disabled";
 import { applyElevation, ElevationMultiplier } from "../utilities/elevation";
 import {
     highContrastBackground,
+    HighContrastColor,
     highContrastDisabledBackground,
     highContrastHighlightBackground,
+    highContrastOptOutProperty,
     highContrastSelector,
 } from "../utilities/high-contrast";
+import { importantValue } from "../utilities/important";
 
 const thumbSizeValue: DesignSystemResolver<number> = divide(heightNumber(), 2);
 const thumbSize: DesignSystemResolver<string> = toPx(thumbSizeValue);
@@ -56,6 +59,9 @@ const styles: ComponentStyles<SliderClassNameContract, DesignSystem> = {
     slider: {
         display: "inline-grid",
         ...applyCursorPointer(),
+        [highContrastSelector]: {
+            ...highContrastOptOutProperty,
+        },
     },
     slider_layoutRegion: {
         display: "grid",
@@ -77,8 +83,9 @@ const styles: ComponentStyles<SliderClassNameContract, DesignSystem> = {
             ),
             [highContrastSelector]: {
                 "box-shadow": format(
-                    `0 0 0 2px Background, 0 0 0 {0} ButtonText`,
-                    toPx(add(focusOutlineWidth, 2))
+                    `0 0 0 2px Background, 0 0 0 {0} {1}`,
+                    toPx(add(focusOutlineWidth, 2)),
+                    () => HighContrastColor.buttonText
                 ),
             },
         }),
@@ -89,9 +96,9 @@ const styles: ComponentStyles<SliderClassNameContract, DesignSystem> = {
             background: neutralForegroundActive,
         },
         [highContrastSelector]: {
-            background: "ButtonText",
+            background: HighContrastColor.buttonText,
             "&:hover, &:active": {
-                background: "Highlight",
+                background: HighContrastColor.selectedBackground,
             },
         },
     },
@@ -118,6 +125,14 @@ const styles: ComponentStyles<SliderClassNameContract, DesignSystem> = {
             },
             "&:active": {
                 background: neutralForegroundRest,
+            },
+        },
+        "& $slider_layoutRegion": {
+            "& div > span": {
+                color: importantValue(HighContrastColor.disabledText),
+            },
+            "& div > div": {
+                background: importantValue(HighContrastColor.disabledText),
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/stealth-button/index.ts
+++ b/packages/fast-components-styles-msft/src/stealth-button/index.ts
@@ -51,7 +51,7 @@ const styles: ComponentStyles<StealthButtonClassNameContract, DesignSystem> = {
                 ...highContrastDisabledBorder,
                 "&:hover": {
                     [highContrastSelector]: {
-                        "box-shadow": "none"
+                        "box-shadow": "none !important"
                     }
                 }
             },

--- a/packages/fast-components-styles-msft/src/stealth-button/index.ts
+++ b/packages/fast-components-styles-msft/src/stealth-button/index.ts
@@ -45,15 +45,15 @@ const styles: ComponentStyles<StealthButtonClassNameContract, DesignSystem> = {
         "a&": {
             ...highContrastLinkOutline,
             "&:hover": {
-                ...highContrastLinkBorder
+                ...highContrastLinkBorder,
             },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
                 "&:hover": {
                     [highContrastSelector]: {
-                        "box-shadow": "none !important"
-                    }
-                }
+                        "box-shadow": "none !important",
+                    },
+                },
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/stealth-button/index.ts
+++ b/packages/fast-components-styles-msft/src/stealth-button/index.ts
@@ -11,8 +11,9 @@ import {
 } from "../utilities/color";
 import { baseButton, buttonStyles } from "../patterns/button";
 import {
-    HighContrastColor,
     highContrastDisabledBorder,
+    highContrastLinkBorder,
+    highContrastLinkOutline,
     highContrastOutlineFocus,
     highContrastSelected,
     highContrastSelector,
@@ -42,12 +43,17 @@ const styles: ComponentStyles<StealthButtonClassNameContract, DesignSystem> = {
         },
         ...highContrastStealth,
         "a&": {
-            [highContrastSelector]: {
-                color: HighContrastColor.hyperLinks,
-                fill: HighContrastColor.hyperLinks,
+            ...highContrastLinkOutline,
+            "&:hover": {
+                ...highContrastLinkBorder
             },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
+                "&:hover": {
+                    [highContrastSelector]: {
+                        "box-shadow": "none"
+                    }
+                }
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/stealth-button/index.ts
+++ b/packages/fast-components-styles-msft/src/stealth-button/index.ts
@@ -11,9 +11,11 @@ import {
 } from "../utilities/color";
 import { baseButton, buttonStyles } from "../patterns/button";
 import {
+    HighContrastColor,
     highContrastDisabledBorder,
     highContrastOutlineFocus,
     highContrastSelected,
+    highContrastSelector,
     highContrastStealth,
 } from "../utilities/high-contrast";
 
@@ -40,6 +42,10 @@ const styles: ComponentStyles<StealthButtonClassNameContract, DesignSystem> = {
         },
         ...highContrastStealth,
         "a&": {
+            [highContrastSelector]: {
+                color: HighContrastColor.hyperLinks,
+                fill: HighContrastColor.hyperLinks,
+            },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
             },

--- a/packages/fast-components-styles-msft/src/text-action/index.ts
+++ b/packages/fast-components-styles-msft/src/text-action/index.ts
@@ -1,7 +1,13 @@
 import { applyCornerRadius } from "../utilities/border";
 import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
-import { applyFocusVisible, directionSwitch, format, subtract, toPx } from "@microsoft/fast-jss-utilities";
+import {
+    applyFocusVisible,
+    directionSwitch,
+    format,
+    subtract,
+    toPx,
+} from "@microsoft/fast-jss-utilities";
 import { DesignSystem } from "../design-system";
 import { TextActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import {
@@ -81,14 +87,14 @@ const styles: ComponentStyles<TextActionClassNameContract, DesignSystem> = {
             "border-color": neutralOutlineHover,
             [highContrastSelector]: {
                 background: "none",
-                "border-color": HighContrastColor.selectedBackground
-            }
+                "border-color": HighContrastColor.selectedBackground,
+            },
         },
         "&:active": {
             background: neutralFillInputActive,
             "border-color": neutralOutlineActive,
         },
-        ...highContrastOutline
+        ...highContrastOutline,
     },
     textAction__filled: {
         background: neutralFillRest,
@@ -98,7 +104,7 @@ const styles: ComponentStyles<TextActionClassNameContract, DesignSystem> = {
             "border-color": "transparent",
             [highContrastSelector]: {
                 background: "none",
-                "border-color": HighContrastColor.selectedBackground
+                "border-color": HighContrastColor.selectedBackground,
             },
         },
         "&:active": {
@@ -138,7 +144,7 @@ const styles: ComponentStyles<TextActionClassNameContract, DesignSystem> = {
                 border: format(
                     "{0} solid {1}",
                     toPx<DesignSystem>(outlineWidth),
-                    () => HighContrastColor.buttonText    
+                    () => HighContrastColor.buttonText
                 ),
             },
         },

--- a/packages/fast-components-styles-msft/src/text-action/index.ts
+++ b/packages/fast-components-styles-msft/src/text-action/index.ts
@@ -1,9 +1,9 @@
-import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { TextActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
-import { directionSwitch, format, subtract, toPx } from "@microsoft/fast-jss-utilities";
-import { DesignSystem } from "../design-system";
 import { applyCornerRadius } from "../utilities/border";
+import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
+import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
+import { applyFocusVisible, directionSwitch, format, subtract, toPx } from "@microsoft/fast-jss-utilities";
+import { DesignSystem } from "../design-system";
+import { TextActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import {
     neutralFillActive,
     neutralFillHover,
@@ -21,11 +21,14 @@ import { glyphSize, height, horizontalSpacing } from "../utilities/density";
 import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 import { applyDisabledState } from "../utilities/disabled";
 import {
+    HighContrastColor,
     highContrastDisabledBorder,
     highContrastDisabledForeground,
     highContrastForeground,
+    highContrastOutline,
     highContrastSelector,
 } from "../utilities/high-contrast";
+import { importantValue } from "../utilities/important";
 
 // Since MSFT text field is already styled, we need to override in this way to alter text field classes
 export const textFieldOverrides: ComponentStyles<
@@ -43,12 +46,8 @@ export const textFieldOverrides: ComponentStyles<
             background: "none",
             border: "none",
             "box-shadow": "none",
-            [highContrastSelector]: {
-                background: "none",
-                border: "none",
-                "box-shadow": "none",
-            },
         },
+        ...highContrastForeground,
     },
 };
 
@@ -80,11 +79,16 @@ const styles: ComponentStyles<TextActionClassNameContract, DesignSystem> = {
         "&:hover": {
             background: neutralFillInputHover,
             "border-color": neutralOutlineHover,
+            [highContrastSelector]: {
+                background: "none",
+                "border-color": HighContrastColor.selectedBackground
+            }
         },
         "&:active": {
             background: neutralFillInputActive,
             "border-color": neutralOutlineActive,
         },
+        ...highContrastOutline
     },
     textAction__filled: {
         background: neutralFillRest,
@@ -92,10 +96,22 @@ const styles: ComponentStyles<TextActionClassNameContract, DesignSystem> = {
         "&:hover": {
             background: neutralFillHover,
             "border-color": "transparent",
+            [highContrastSelector]: {
+                background: "none",
+                "border-color": HighContrastColor.selectedBackground
+            },
         },
         "&:active": {
             background: neutralFillActive,
             "border-color": "transparent",
+        },
+        [highContrastSelector]: {
+            background: "none",
+            border: format(
+                "{0} solid {1}",
+                toPx<DesignSystem>(outlineWidth),
+                () => HighContrastColor.buttonText
+            ),
         },
     },
     textAction__outline: {},
@@ -115,10 +131,15 @@ const styles: ComponentStyles<TextActionClassNameContract, DesignSystem> = {
         [highContrastSelector]: {
             "&, &:hover": {
                 "box-shadow": format(
-                    "0 0 0 {0} ButtonText inset",
-                    toPx<DesignSystem>(subtract(focusOutlineWidth, outlineWidth))
+                    "0 0 0 {0} {1} inset",
+                    toPx<DesignSystem>(subtract(focusOutlineWidth, outlineWidth)),
+                    () => HighContrastColor.buttonText
                 ),
-                border: format("{0} solid ButtonText", toPx<DesignSystem>(outlineWidth)),
+                border: format(
+                    "{0} solid {1}",
+                    toPx<DesignSystem>(outlineWidth),
+                    () => HighContrastColor.buttonText    
+                ),
             },
         },
     },
@@ -152,16 +173,33 @@ const styles: ComponentStyles<TextActionClassNameContract, DesignSystem> = {
         flex: "0 0 auto",
         cursor: "pointer",
         [highContrastSelector]: {
-            background: "ButtonFace",
-            fill: "ButtonText",
+            fill: HighContrastColor.buttonText,
         },
         "&:hover": {
             [highContrastSelector]: {
-                background: "Highlight",
-                fill: "HighlightText",
+                background: HighContrastColor.selectedBackground,
+                fill: HighContrastColor.selectedText,
+            },
+        },
+        "&:active": {
+            [highContrastSelector]: {
+                background: HighContrastColor.selectedBackground,
+                fill: HighContrastColor.selectedText,
             },
         },
         "&:disabled": {},
+        ...applyFocusVisible<DesignSystem>({
+            [highContrastSelector]: {
+                background: HighContrastColor.selectedBackground,
+                fill: HighContrastColor.selectedText,
+                "border-color": importantValue(HighContrastColor.buttonText),
+                "box-shadow": format(
+                    "0 0 0 {0} inset {1}",
+                    toPx(focusOutlineWidth),
+                    () => HighContrastColor.buttonBackground
+                ),
+            },
+        }),
     },
     textAction_beforeGlyph: {
         ...glyphStyles,

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -173,7 +173,7 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
                             background: importantValue(HighContrastColor.disabledText),
                         },
                     },
-                }
+                },
             },
             "&:hover": {
                 [highContrastSelector]: {
@@ -182,7 +182,7 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
                     "& + span": {
                         background: HighContrastColor.selectedBackground,
                     },
-                }
+                },
             },
             "&:active": {
                 [highContrastSelector]: {
@@ -232,7 +232,7 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         "user-select": "none",
         "margin-top": "0",
         "padding-bottom": "0",
-        ...highContrastTextForeground
+        ...highContrastTextForeground,
     },
 };
 

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -1,3 +1,4 @@
+import { DesignSystem, DesignSystemResolver } from "../design-system";
 import {
     accentFillRest,
     accentForegroundCut,
@@ -12,7 +13,6 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
-import { applyDisabledState } from "../utilities/disabled";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import {
     add,
@@ -25,17 +25,14 @@ import {
     toPx,
 } from "@microsoft/fast-jss-utilities";
 import { ToggleClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { DesignSystem, DesignSystemResolver } from "../design-system";
+import { applyDisabledState } from "../utilities/disabled";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { densityCategorySwitch, heightNumber } from "../utilities/density";
 import { designUnit, focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 import { applyCursorDisabled, applyCursorPointer } from "../utilities/cursor";
 import {
-    highContrastBackground,
-    highContrastBorderColor,
+    HighContrastColor,
     highContrastDoubleFocus,
-    highContrastHighlightBackground,
-    highContrastSelectedBackground,
     highContrastSelector,
 } from "../utilities/high-contrast";
 
@@ -68,12 +65,19 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         display: "block",
         "padding-bottom": "7px",
         clear: "both",
+        [highContrastSelector]: {
+            color: HighContrastColor.text,
+        },
     },
     toggle_toggleButton: {
         ...applyCursorPointer(),
         position: "relative",
         "margin-top": "0",
         float: directionSwitch("left", "right"),
+        [highContrastSelector]: {
+            "-ms-high-contrast-adjust": "none",
+            "forced-color-adjust": "none",
+        }
     },
     toggle_stateIndicator: {
         position: "absolute",
@@ -86,7 +90,6 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         width: toPx(indicatorSize),
         height: toPx(indicatorSize),
         background: neutralForegroundRest,
-        ...highContrastBackground,
     },
     toggle_input: {
         ...applyCursorPointer(),
@@ -110,6 +113,7 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             "border-color": neutralOutlineActive,
             [highContrastSelector]: {
                 background: "Highlight",
+                "border-color": "Highlight",
                 "& + span": {
                     background: "HighlightText",
                 },
@@ -119,6 +123,7 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             background: neutralFillInputHover,
             "border-color": neutralOutlineHover,
             [highContrastSelector]: {
+                background: "HighlightText",
                 "border-color": "Highlight",
                 "& + span": {
                     background: "Highlight",
@@ -135,7 +140,13 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
                 ),
             },
         }),
-        ...highContrastBorderColor,
+        [highContrastSelector]: {
+            background: HighContrastColor.buttonBackground,
+            "border-color": HighContrastColor.buttonText,
+            "& + span": {
+                background: HighContrastColor.buttonText,
+            },
+        },
     },
     toggle__checked: {
         "& $toggle_input": {
@@ -161,20 +172,29 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
                     },
                 },
             },
+            "&:hover": {
+                [highContrastSelector]: {
+                    background: "HighlightText",
+                    "border-color": "Highlight",
+                    "& + span": {
+                        background: "Highlight",
+                    },
+                }
+            },
+            "&:active": {
+                [highContrastSelector]: {
+                    background: "Highlight !important",
+                    "border-color": "Highlight !important",
+                    "& + span": {
+                        background: "HighlightText !important",
+                    },
+                },
+            },
             [highContrastSelector]: {
                 background: "Highlight",
                 "border-color": "Highlight",
-                "&:hover": {
+                "& + span": {
                     background: "HighlightText",
-                    "border-color": "Highlight",
-                },
-                "&:active": {
-                    [highContrastSelector]: {
-                        background: "Highlight",
-                        "& + span": {
-                            background: "HighlightText",
-                        },
-                    },
                 },
             },
         },
@@ -182,10 +202,6 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             left: directionSwitch(toPx(indicatorCheckedOffset), "unset"),
             right: directionSwitch("unset", toPx(indicatorCheckedOffset)),
             background: accentForegroundCut,
-            ...highContrastSelectedBackground,
-            "&:hover": {
-                ...highContrastHighlightBackground,
-            },
         },
     },
     toggle__disabled: {

--- a/packages/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/fast-components-styles-msft/src/toggle/index.ts
@@ -1,4 +1,18 @@
+import { applyScaledTypeRamp } from "../utilities/typography";
 import { DesignSystem, DesignSystemResolver } from "../design-system";
+import { ComponentStyles } from "@microsoft/fast-jss-manager";
+import {
+    add,
+    applyFocusVisible,
+    directionSwitch,
+    divide,
+    format,
+    multiply,
+    subtract,
+    toPx,
+} from "@microsoft/fast-jss-utilities";
+import { ToggleClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
+import { applyDisabledState } from "../utilities/disabled";
 import {
     accentFillRest,
     accentForegroundCut,
@@ -13,28 +27,17 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
-import { ComponentStyles } from "@microsoft/fast-jss-manager";
-import {
-    add,
-    applyFocusVisible,
-    directionSwitch,
-    divide,
-    format,
-    multiply,
-    subtract,
-    toPx,
-} from "@microsoft/fast-jss-utilities";
-import { ToggleClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { applyDisabledState } from "../utilities/disabled";
-import { applyScaledTypeRamp } from "../utilities/typography";
 import { densityCategorySwitch, heightNumber } from "../utilities/density";
 import { designUnit, focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 import { applyCursorDisabled, applyCursorPointer } from "../utilities/cursor";
 import {
     HighContrastColor,
     highContrastDoubleFocus,
+    highContrastOptOutProperty,
     highContrastSelector,
+    highContrastTextForeground,
 } from "../utilities/high-contrast";
+import { importantValue } from "../utilities/important";
 
 const height: DesignSystemResolver<number> = add(divide(heightNumber(), 2), designUnit);
 const width: DesignSystemResolver<number> = multiply(height, 2);
@@ -58,6 +61,9 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         display: "inline-block",
         color: neutralForegroundRest,
         transition: "all 0.2s ease-in-out",
+        [highContrastSelector]: {
+            ...highContrastOptOutProperty,
+        },
     },
     toggle_label: {
         ...applyCursorPointer(),
@@ -65,19 +71,12 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         display: "block",
         "padding-bottom": "7px",
         clear: "both",
-        [highContrastSelector]: {
-            color: HighContrastColor.text,
-        },
     },
     toggle_toggleButton: {
         ...applyCursorPointer(),
         position: "relative",
         "margin-top": "0",
         float: directionSwitch("left", "right"),
-        [highContrastSelector]: {
-            "-ms-high-contrast-adjust": "none",
-            "forced-color-adjust": "none",
-        }
     },
     toggle_stateIndicator: {
         position: "absolute",
@@ -112,10 +111,10 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             background: neutralFillInputActive,
             "border-color": neutralOutlineActive,
             [highContrastSelector]: {
-                background: "Highlight",
-                "border-color": "Highlight",
+                background: HighContrastColor.selectedBackground,
+                "border-color": HighContrastColor.selectedText,
                 "& + span": {
-                    background: "HighlightText",
+                    background: HighContrastColor.selectedText,
                 },
             },
         },
@@ -123,10 +122,10 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             background: neutralFillInputHover,
             "border-color": neutralOutlineHover,
             [highContrastSelector]: {
-                background: "HighlightText",
-                "border-color": "Highlight",
+                background: HighContrastColor.selectedText,
+                "border-color": HighContrastColor.selectedBackground,
                 "& + span": {
-                    background: "Highlight",
+                    background: HighContrastColor.selectedBackground,
                 },
             },
         },
@@ -135,8 +134,9 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             "border-color": neutralFocus,
             [highContrastSelector]: {
                 "box-shadow": format<DesignSystem>(
-                    "0 0 0 {0} ButtonText inset",
-                    toPx<DesignSystem>(outlineWidth)
+                    "0 0 0 {0} {1} inset",
+                    toPx<DesignSystem>(outlineWidth),
+                    () => HighContrastColor.buttonText
                 ),
             },
         }),
@@ -164,37 +164,40 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
                 ...highContrastDoubleFocus,
             }),
             "&:disabled": {
-                [highContrastSelector]: {
-                    background: "GrayText !important",
-                    "border-color": "GrayText !important",
-                    "& + span": {
-                        background: "Background !important",
+                "& $toggle_input, & $toggle_label, & $toggle_statusMessage": {
+                    [highContrastSelector]: {
+                        background: "none",
+                        "border-color": importantValue(HighContrastColor.disabledText),
+                        color: importantValue(HighContrastColor.disabledText),
+                        "& + span": {
+                            background: importantValue(HighContrastColor.disabledText),
+                        },
                     },
-                },
+                }
             },
             "&:hover": {
                 [highContrastSelector]: {
-                    background: "HighlightText",
-                    "border-color": "Highlight",
+                    background: HighContrastColor.selectedText,
+                    "border-color": HighContrastColor.selectedBackground,
                     "& + span": {
-                        background: "Highlight",
+                        background: HighContrastColor.selectedBackground,
                     },
                 }
             },
             "&:active": {
                 [highContrastSelector]: {
-                    background: "Highlight !important",
-                    "border-color": "Highlight !important",
+                    background: importantValue(HighContrastColor.selectedBackground),
+                    "border-color": importantValue(HighContrastColor.selectedBackground),
                     "& + span": {
-                        background: "HighlightText !important",
+                        background: importantValue(HighContrastColor.selectedText),
                     },
                 },
             },
             [highContrastSelector]: {
-                background: "Highlight",
-                "border-color": "Highlight",
+                background: HighContrastColor.selectedBackground,
+                "border-color": HighContrastColor.selectedBackground,
                 "& + span": {
-                    background: "HighlightText",
+                    background: HighContrastColor.selectedText,
                 },
             },
         },
@@ -211,10 +214,11 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
             background: neutralFillSelected,
             "border-color": neutralFillSelected,
             [highContrastSelector]: {
-                background: "Background !important",
-                "border-color": "GrayText !important",
+                background: "none",
+                "border-color": importantValue(HighContrastColor.disabledText),
+                color: importantValue(HighContrastColor.disabledText),
                 "& + span": {
-                    background: "GrayText !important",
+                    background: importantValue(HighContrastColor.disabledText),
                 },
             },
         },
@@ -228,6 +232,7 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
         "user-select": "none",
         "margin-top": "0",
         "padding-bottom": "0",
+        ...highContrastTextForeground
     },
 };
 

--- a/packages/fast-components-styles-msft/src/utilities/disabled.ts
+++ b/packages/fast-components-styles-msft/src/utilities/disabled.ts
@@ -3,7 +3,7 @@ import { DesignSystem } from "../design-system";
 import { applyCursorDisabled } from "./cursor";
 import { disabledOpacity } from "../utilities/design-system";
 import { toString } from "@microsoft/fast-jss-utilities";
-import { highContrastSelector } from "./high-contrast";
+import { HighContrastColor, highContrastSelector } from "./high-contrast";
 
 export function applyDisabledState(
     config?: DesignSystem /* @deprecated - this function doesn't need an argument */
@@ -13,7 +13,7 @@ export function applyDisabledState(
         ...applyCursorDisabled(),
         [highContrastSelector]: {
             opacity: "1",
-            color: "GrayText",
+            color: HighContrastColor.disabledText,
         },
     };
 }

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -18,9 +18,9 @@ export enum HighContrastColor {
 // Function used to to set high contrast media query
 export function applyHighContrastSelector(): string {
     return window.matchMedia("(forced-colors: none)").matches ||
-           window.matchMedia("(forced-colors: active)").matches 
-           ? "@media (forced-colors: active)" 
-           : "@media (-ms-high-contrast: active)";
+        window.matchMedia("(forced-colors: active)").matches
+        ? "@media (forced-colors: active)"
+        : "@media (-ms-high-contrast: active)";
 }
 
 // Used to to set high contrast media query
@@ -30,7 +30,7 @@ export const highContrastSelector: string = applyHighContrastSelector();
 export function applyhighContrastOptOutProperty(): CSSRules<{}> {
     return {
         "-ms-high-contrast-adjust": "none",
-        "forced-color-adjust": "none"
+        "forced-color-adjust": "none",
     };
 }
 

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -4,17 +4,24 @@ import { format, toPx } from "@microsoft/fast-jss-utilities";
 import { focusOutlineWidth, outlineWidth } from "./design-system";
 import { importantValue } from "./important";
 
-export const highContrastSelector: string = "@media (-ms-high-contrast:active)";
+export function applyHighContrastSelector(): string {
+    return window.matchMedia("(forced-colors: none)").matches ||
+           window.matchMedia("(forced-colors: active)").matches 
+           ? "@media (forced-colors: active)" 
+           : "@media (-ms-high-contrast: active)";
+}
+
+export const highContrastSelector: string = applyHighContrastSelector();
 
 export enum HighContrastColor {
-    text = "WindowText",
+    text = "Text",
     hyperLinks = "LinkText",
     disabledText = "GrayText",
     selectedText = "HighlightText",
     selectedBackground = "Highlight",
     buttonText = "ButtonText",
     buttonBackground = "ButtonFace",
-    background = "Background",
+    background = "Canvas",
 }
 
 // Used to remove text backplate and borders in 'button-text' colors
@@ -25,6 +32,7 @@ export const highContrastStealth: CSSRules<DesignSystem> = {
         color: HighContrastColor.buttonText,
         fill: HighContrastColor.buttonText,
         "-ms-high-contrast-adjust": "none",
+        "forced-color-adjust": "none"
     },
 };
 
@@ -36,6 +44,7 @@ export const highContrastOutline: CSSRules<DesignSystem> = {
         color: HighContrastColor.buttonText,
         fill: HighContrastColor.buttonText,
         "-ms-high-contrast-adjust": "none",
+        "forced-color-adjust": "none"
     },
 };
 
@@ -47,6 +56,7 @@ export const highContrastAccent: CSSRules<DesignSystem> = {
         color: HighContrastColor.selectedText,
         fill: HighContrastColor.selectedText,
         "-ms-high-contrast-adjust": "none",
+        "forced-color-adjust": "none"
     },
 };
 

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -4,17 +4,8 @@ import { format, toPx } from "@microsoft/fast-jss-utilities";
 import { focusOutlineWidth, outlineWidth } from "./design-system";
 import { importantValue } from "./important";
 
-export function applyHighContrastSelector(): string {
-    return window.matchMedia("(forced-colors: none)").matches ||
-           window.matchMedia("(forced-colors: active)").matches 
-           ? "@media (forced-colors: active)" 
-           : "@media (-ms-high-contrast: active)";
-}
-
-export const highContrastSelector: string = applyHighContrastSelector();
-
 export enum HighContrastColor {
-    text = "Text",
+    text = "WindowText",
     hyperLinks = "LinkText",
     disabledText = "GrayText",
     selectedText = "HighlightText",
@@ -24,6 +15,28 @@ export enum HighContrastColor {
     background = "Canvas",
 }
 
+// Function used to to set high contrast media query
+export function applyHighContrastSelector(): string {
+    return window.matchMedia("(forced-colors: none)").matches ||
+           window.matchMedia("(forced-colors: active)").matches 
+           ? "@media (forced-colors: active)" 
+           : "@media (-ms-high-contrast: active)";
+}
+
+// Used to to set high contrast media query
+export const highContrastSelector: string = applyHighContrastSelector();
+
+// Function used to to opt-out of high contrast color scheme for 'forced-colors' and '-ms' prefixes
+export function applyhighContrastOptOutProperty(): CSSRules<{}> {
+    return {
+        "-ms-high-contrast-adjust": "none",
+        "forced-color-adjust": "none"
+    };
+}
+
+// Used to to opt-out of high contrast color scheme
+export const highContrastOptOutProperty: CSSRules<{}> = applyhighContrastOptOutProperty();
+
 // Used to remove text backplate and borders in 'button-text' colors
 export const highContrastStealth: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
@@ -31,8 +44,7 @@ export const highContrastStealth: CSSRules<DesignSystem> = {
         border: "none",
         color: HighContrastColor.buttonText,
         fill: HighContrastColor.buttonText,
-        "-ms-high-contrast-adjust": "none",
-        "forced-color-adjust": "none"
+        ...highContrastOptOutProperty,
     },
 };
 
@@ -43,8 +55,7 @@ export const highContrastOutline: CSSRules<DesignSystem> = {
         "border-color": HighContrastColor.buttonText,
         color: HighContrastColor.buttonText,
         fill: HighContrastColor.buttonText,
-        "-ms-high-contrast-adjust": "none",
-        "forced-color-adjust": "none"
+        ...highContrastOptOutProperty,
     },
 };
 
@@ -55,8 +66,7 @@ export const highContrastAccent: CSSRules<DesignSystem> = {
         "border-color": HighContrastColor.selectedBackground,
         color: HighContrastColor.selectedText,
         fill: HighContrastColor.selectedText,
-        "-ms-high-contrast-adjust": "none",
-        "forced-color-adjust": "none"
+        ...highContrastOptOutProperty,
     },
 };
 
@@ -98,7 +108,7 @@ export const highContrastDisabledBackground: CSSRules<DesignSystem> = {
     },
 };
 
-// Used to set focus with keyboard focus
+// Used to set focus for keyboard focus
 export const highContrastOutlineFocus: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         "border-color": HighContrastColor.buttonText,
@@ -110,7 +120,7 @@ export const highContrastOutlineFocus: CSSRules<DesignSystem> = {
     },
 };
 
-// Used to set double focus with keyboard focus
+// Used to set double focus for keyboard focus
 export const highContrastDoubleFocus: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         "border-color": importantValue(HighContrastColor.buttonText),
@@ -122,7 +132,7 @@ export const highContrastDoubleFocus: CSSRules<DesignSystem> = {
     },
 };
 
-// Used to set 'selected-text' color
+// Used to set 'selected-text' on foreground and 'selected-background' on background
 export const highContrastSelected: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         background: HighContrastColor.selectedBackground,
@@ -135,7 +145,7 @@ export const highContrastSelected: CSSRules<DesignSystem> = {
  */
 export const highContrastSelection: CSSRules<DesignSystem> = highContrastSelected;
 
-// Used to set 'selected-background' color with an outline
+// Used to set 'selected-background' on foreground and 'selected-text' on background with an outline
 export const highContrastSelectedOutline: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         background: HighContrastColor.selectedText,
@@ -166,6 +176,14 @@ export const highContrastHighlightForeground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         color: importantValue(HighContrastColor.selectedBackground),
         fill: importantValue(HighContrastColor.selectedBackground),
+    },
+};
+
+// Used to set foreground and glyph to be 'text' color
+export const highContrastTextForeground: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        color: importantValue(HighContrastColor.text),
+        fill: importantValue(HighContrastColor.text),
     },
 };
 

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -246,7 +246,7 @@ export const highContrastLinkOutline: CSSRules<DesignSystem> = {
         color: highContrastLinkValue,
         fill: highContrastLinkValue,
     },
-}
+};
 
 // Used to set border color to be 'link' color
 export const highContrastLinkBorder: CSSRules<DesignSystem> = {

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -5,7 +5,7 @@ import { focusOutlineWidth, outlineWidth } from "./design-system";
 import { importantValue } from "./important";
 
 export enum HighContrastColor {
-    text = "WindowText",
+    text = "Text",
     hyperLinks = "LinkText",
     disabledText = "GrayText",
     selectedText = "HighlightText",
@@ -184,6 +184,14 @@ export const highContrastTextForeground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         color: importantValue(HighContrastColor.text),
         fill: importantValue(HighContrastColor.text),
+    },
+};
+
+// Used to set foreground and glyph to be 'link' color
+export const highContrastLinkForeground: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        color: importantValue(HighContrastColor.hyperLinks),
+        fill: importantValue(HighContrastColor.hyperLinks),
     },
 };
 

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -6,7 +6,8 @@ import { importantValue } from "./important";
 
 export enum HighContrastColor {
     text = "WindowText",
-    hyperLinks = "LinkText",
+    forcedLink = "LinkText",
+    msLink = "-ms-hotlight",
     disabledText = "GrayText",
     selectedText = "HighlightText",
     selectedBackground = "Highlight",
@@ -15,7 +16,18 @@ export enum HighContrastColor {
     background = "Canvas",
 }
 
-// Function used to to set high contrast media query
+// Function used to to set link color base on 'forced-color' query
+export function applyHighContrastlinkValue(): string {
+    return window.matchMedia("(forced-colors: none)").matches ||
+        window.matchMedia("(forced-colors: active)").matches
+        ? "LinkText !important"
+        : "-ms-hotlight !important";
+}
+
+// Used to to set high contrast base on 'forced-color' query
+export const highContrastLinkValue: string = applyHighContrastlinkValue();
+
+// Function used to to set high contrast base on 'forced-color' query
 export function applyHighContrastSelector(): string {
     return window.matchMedia("(forced-colors: none)").matches ||
         window.matchMedia("(forced-colors: active)").matches
@@ -23,7 +35,7 @@ export function applyHighContrastSelector(): string {
         : "@media (-ms-high-contrast: active)";
 }
 
-// Used to to set high contrast media query
+// Used to to set high contrast base on 'forced-color' query
 export const highContrastSelector: string = applyHighContrastSelector();
 
 // Function used to to opt-out of high contrast color scheme for 'forced-colors' and '-ms' prefixes
@@ -229,10 +241,10 @@ export const highContrastHighlightBackground: CSSRules<DesignSystem> = {
 // Used to set button to 'link' color
 export const highContrastLinkOutline: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
-        background: HighContrastColor.background,
-        "border-color": HighContrastColor.hyperLinks,
-        color: HighContrastColor.hyperLinks,
-        fill: HighContrastColor.hyperLinks,
+        background: HighContrastColor.buttonBackground,
+        "border-color": highContrastLinkValue,
+        color: highContrastLinkValue,
+        fill: highContrastLinkValue,
     },
 }
 
@@ -241,8 +253,8 @@ export const highContrastLinkBorder: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         "box-shadow": format(
             "0 0 0 {0} inset {1}",
-            toPx(focusOutlineWidth),
-            () => HighContrastColor.hyperLinks
+            toPx(outlineWidth),
+            () => highContrastLinkValue
         ),
     },
 };
@@ -250,7 +262,7 @@ export const highContrastLinkBorder: CSSRules<DesignSystem> = {
 // Used to set foreground and glyph to be 'link' color
 export const highContrastLinkForeground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
-        color: importantValue(HighContrastColor.hyperLinks),
-        fill: importantValue(HighContrastColor.hyperLinks),
+        color: highContrastLinkValue,
+        fill: highContrastLinkValue,
     },
 };

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -5,7 +5,7 @@ import { focusOutlineWidth, outlineWidth } from "./design-system";
 import { importantValue } from "./important";
 
 export enum HighContrastColor {
-    text = "Text",
+    text = "WindowText",
     hyperLinks = "LinkText",
     disabledText = "GrayText",
     selectedText = "HighlightText",
@@ -41,7 +41,7 @@ export const highContrastOptOutProperty: CSSRules<{}> = applyhighContrastOptOutP
 export const highContrastStealth: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         background: HighContrastColor.buttonBackground,
-        border: "none",
+        border: "transparent",
         color: HighContrastColor.buttonText,
         fill: HighContrastColor.buttonText,
         ...highContrastOptOutProperty,
@@ -187,14 +187,6 @@ export const highContrastTextForeground: CSSRules<DesignSystem> = {
     },
 };
 
-// Used to set foreground and glyph to be 'link' color
-export const highContrastLinkForeground: CSSRules<DesignSystem> = {
-    [highContrastSelector]: {
-        color: importantValue(HighContrastColor.hyperLinks),
-        fill: importantValue(HighContrastColor.hyperLinks),
-    },
-};
-
 // Used to set borders to be 'text' color
 export const highContrastBorder: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
@@ -231,5 +223,34 @@ export const highContrastSelectedBackground: CSSRules<DesignSystem> = {
 export const highContrastHighlightBackground: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
         background: HighContrastColor.selectedBackground,
+    },
+};
+
+// Used to set button to 'link' color
+export const highContrastLinkOutline: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        background: HighContrastColor.background,
+        "border-color": HighContrastColor.hyperLinks,
+        color: HighContrastColor.hyperLinks,
+        fill: HighContrastColor.hyperLinks,
+    },
+}
+
+// Used to set border color to be 'link' color
+export const highContrastLinkBorder: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        "box-shadow": format(
+            "0 0 0 {0} inset {1}",
+            toPx(focusOutlineWidth),
+            () => HighContrastColor.hyperLinks
+        ),
+    },
+};
+
+// Used to set foreground and glyph to be 'link' color
+export const highContrastLinkForeground: CSSRules<DesignSystem> = {
+    [highContrastSelector]: {
+        color: importantValue(HighContrastColor.hyperLinks),
+        fill: importantValue(HighContrastColor.hyperLinks),
     },
 };


### PR DESCRIPTION
Edge chromium canary uses the new standard prefix, which is 'forced-color' adjust property. We currently are only using `-ms-high-contrast` adjust property. We still want to keep the `-ms-high-contrast` standard to support Edge and IE. 
The color values have also been updated, for example, for background, `forced-colors` uses "Canvas". For an anchor in `-ms-high-contrast` it uses "-ms-hotlight", where `forced-colors` use "LinkText".

# Description
This change is to make sure, when in high contrast, our components will work in Edge chromium, using `forced-colors` and that `-ms-high-contrast` will also work when the browser does not have the `forced-colors` flag.
- I created a function,`applyHighContrastSelector `,  it will check if `forced-colors` flag is enabled on the browser, if so, then prefix with `forced-colors` query, if not that `-ms-high-contrast` query will be used.
- For the scenario where we have two anchor color value. I created a similar function as the media query, called, `applyHighContrastlinkValue`. This detects that, in `forced-colors` we use "LinkText", and in `-ms-high-contrast` we use "-ms-hotlight".
- Now that "LinkText" is available, I created extra const objects to use on our anchor buttons.
`highContrastLinkOutline `, `highContrastLinkBorder ` and `highContrastLinkForeground `.
- Components like `Radio`, `Checkbox`, `Toggle`, `Pivot`, `Progress`, `Carousel`, `Slider label`, `Slider` had to be re-addressed, when using `forced-colors`.  The fix is to use the opt out property, `forced-colors-adjust` and `-ms-high-contrast-adjust`. These property allowed me to opt particular elements out of `forced-colors` and `-ms-high-contrast` mode. Then I added the correct color values to elements. I created a function, `applyhighContrastOptOutProperty`, that uses both property.
- Making sure there no hardcode color values. Instead we are using the enum or the color pattern objects.
- Create extra stories that shows Anchor and Disabled on some of our button components.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->