### PR TITLE
fix: text-action compatibility with ie11

### DIFF
--- a/packages/fast-components-styles-msft/src/text-action/index.ts
+++ b/packages/fast-components-styles-msft/src/text-action/index.ts
@@ -1,9 +1,13 @@
-import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { TextActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
+import { CSSRules, ComponentStyles } from "@microsoft/fast-jss-manager";
 import { directionSwitch, format, subtract, toPx } from "@microsoft/fast-jss-utilities";
-import { DesignSystem } from "../design-system";
-import { applyCornerRadius } from "../utilities/border";
+import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
+import { glyphSize, height, horizontalSpacing } from "../utilities/density";
+import {
+    highContrastDisabledBorder,
+    highContrastDisabledForeground,
+    highContrastForeground,
+    highContrastSelector,
+} from "../utilities/high-contrast";
 import {
     neutralFillActive,
     neutralFillHover,
@@ -17,15 +21,12 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
-import { glyphSize, height, horizontalSpacing } from "../utilities/density";
-import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
+
+import { DesignSystem } from "../design-system";
+import { TextActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
+import { applyCornerRadius } from "../utilities/border";
 import { applyDisabledState } from "../utilities/disabled";
-import {
-    highContrastDisabledBorder,
-    highContrastDisabledForeground,
-    highContrastForeground,
-    highContrastSelector,
-} from "../utilities/high-contrast";
 
 // Since MSFT text field is already styled, we need to override in this way to alter text field classes
 export const textFieldOverrides: ComponentStyles<
@@ -36,7 +37,7 @@ export const textFieldOverrides: ComponentStyles<
         height: "calc(100% - 4px)",
         margin: "2px 1px",
         border: "none",
-        flex: "1 0 0",
+        flex: "1 0 0px", // IE 11 does not accept "0" for flex-basis. Using "0px" for compatibility.
         background: "transparent",
         "min-width": "inherit",
         "&:hover, &:hover:enabled, &:disabled, &:active, &:active:enabled, &:focus, &:focus:enabled": {

--- a/packages/fast-components-styles-msft/src/text-action/index.ts
+++ b/packages/fast-components-styles-msft/src/text-action/index.ts
@@ -1,13 +1,9 @@
-import { CSSRules, ComponentStyles } from "@microsoft/fast-jss-manager";
+import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
+import { TextActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
+import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import { directionSwitch, format, subtract, toPx } from "@microsoft/fast-jss-utilities";
-import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
-import { glyphSize, height, horizontalSpacing } from "../utilities/density";
-import {
-    highContrastDisabledBorder,
-    highContrastDisabledForeground,
-    highContrastForeground,
-    highContrastSelector,
-} from "../utilities/high-contrast";
+import { DesignSystem } from "../design-system";
+import { applyCornerRadius } from "../utilities/border";
 import {
     neutralFillActive,
     neutralFillHover,
@@ -21,12 +17,15 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "../utilities/color";
-
-import { DesignSystem } from "../design-system";
-import { TextActionClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { TextFieldClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { applyCornerRadius } from "../utilities/border";
+import { glyphSize, height, horizontalSpacing } from "../utilities/density";
+import { focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 import { applyDisabledState } from "../utilities/disabled";
+import {
+    highContrastDisabledBorder,
+    highContrastDisabledForeground,
+    highContrastForeground,
+    highContrastSelector,
+} from "../utilities/high-contrast";
 
 // Since MSFT text field is already styled, we need to override in this way to alter text field classes
 export const textFieldOverrides: ComponentStyles<


### PR DESCRIPTION
# Description

Updated the flex-basis parameter of textField. This makes it compatible with IE11. It does not recognize the third parameter "0" as valid.

## Motivation & context

Makes the control compatible with IE11.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.