### PR TITLE
feat: CSS positionable flyout

### DIFF
--- a/packages/fast-components-class-name-contracts-msft/src/flyout/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/flyout/index.ts
@@ -5,7 +5,12 @@ export interface FlyoutClassNameContract {
     /**
      * The root of the flyout component
      */
-    flyout?: string;
+    flyout_positioner?: string;
+
+    /**
+     * The root of the flyout component
+     */
+    flyout_visual?: string;
 
     /**
      * left flyout horizontal state

--- a/packages/fast-components-class-name-contracts-msft/src/flyout/index.ts
+++ b/packages/fast-components-class-name-contracts-msft/src/flyout/index.ts
@@ -5,10 +5,10 @@ export interface FlyoutClassNameContract {
     /**
      * The root of the flyout component
      */
-    flyout_positioner?: string;
+    flyout_wrapper?: string;
 
     /**
-     * The root of the flyout component
+     * The flyout visual
      */
     flyout_visual?: string;
 

--- a/packages/fast-components-react-msft/src/flyout/flyout.spec.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.spec.tsx
@@ -20,7 +20,8 @@ configure({ adapter: new Adapter() });
 
 describe("flyout", (): void => {
     const managedClasses: FlyoutClassNameContract = {
-        flyout: "flyout",
+        flyout_positioner: "flyout_positioner",
+        flyout_visual: "flyout_visual",
         flyout__left: "flyout__left",
         flyout__right: "flyout__right",
         flyout__top: "flyout__top",
@@ -67,7 +68,7 @@ describe("flyout", (): void => {
             />
         );
 
-        expect(rendered.find(`.${managedClasses.flyout}`).prop("aria-disabled")).toEqual(
+        expect(rendered.find(`.${managedClasses.flyout_positioner}`).prop("aria-disabled")).toEqual(
             false
         );
     });
@@ -78,7 +79,7 @@ describe("flyout", (): void => {
             <MSFTFlyout managedClasses={managedClasses} visible={true} label={label} />
         );
 
-        expect(rendered.find(`.${managedClasses.flyout}`).prop("aria-label")).toEqual(
+        expect(rendered.find(`.${managedClasses.flyout_positioner}`).prop("aria-label")).toEqual(
             label
         );
     });
@@ -94,7 +95,7 @@ describe("flyout", (): void => {
         );
 
         expect(
-            rendered.find(`.${managedClasses.flyout}`).prop("aria-labelledby")
+            rendered.find(`.${managedClasses.flyout_positioner}`).prop("aria-labelledby")
         ).toEqual(labelledby);
     });
 
@@ -109,7 +110,7 @@ describe("flyout", (): void => {
         );
 
         expect(
-            rendered.find(`.${managedClasses.flyout}`).prop("aria-describedby")
+            rendered.find(`.${managedClasses.flyout_positioner}`).prop("aria-describedby")
         ).toEqual(describedby);
     });
 

--- a/packages/fast-components-react-msft/src/flyout/flyout.spec.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.spec.tsx
@@ -68,9 +68,9 @@ describe("flyout", (): void => {
             />
         );
 
-        expect(rendered.find(`.${managedClasses.flyout_positioner}`).prop("aria-disabled")).toEqual(
-            false
-        );
+        expect(
+            rendered.find(`.${managedClasses.flyout_positioner}`).prop("aria-disabled")
+        ).toEqual(false);
     });
 
     test("should add an `aria-label` attribute to the `flyout` element when the `label` prop is provided", () => {
@@ -79,9 +79,9 @@ describe("flyout", (): void => {
             <MSFTFlyout managedClasses={managedClasses} visible={true} label={label} />
         );
 
-        expect(rendered.find(`.${managedClasses.flyout_positioner}`).prop("aria-label")).toEqual(
-            label
-        );
+        expect(
+            rendered.find(`.${managedClasses.flyout_positioner}`).prop("aria-label")
+        ).toEqual(label);
     });
 
     test("should add an `aria-labelledby` attribute to the `flyout` element when the `labelledby` prop is provided", () => {

--- a/packages/fast-components-react-msft/src/flyout/flyout.stories.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.stories.tsx
@@ -180,7 +180,6 @@ storiesOf("Flyout", module)
     .add("with top/right inset", () => (
         <FlyoutTest
             horizontalPositioningMode={FlyoutAxisPositioningMode.inset}
-            defaultHorizontalPosition={FlyoutHorizontalPosition.right}
-            defaultVerticalPosition={FlyoutVerticalPosition.top}
+            verticalPositioningMode={FlyoutAxisPositioningMode.inset}
         />
     ));

--- a/packages/fast-components-react-msft/src/flyout/flyout.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.tsx
@@ -75,10 +75,7 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
      * Renders the component
      */
     public render(): React.ReactElement<HTMLDivElement> {
-
-        const {
-            flyout_visual
-        }: FlyoutClassNameContract = this.props.managedClasses;
+        const { flyout_visual }: FlyoutClassNameContract = this.props.managedClasses;
 
         return (
             <ViewportPositioner
@@ -122,10 +119,11 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
                 }}
             >
                 <div
-                 className={classNames(flyout_visual)}
-                {...this.unhandledProps()}
-                role="dialog">
-                {this.props.children}
+                    className={classNames(flyout_visual)}
+                    {...this.unhandledProps()}
+                    role="dialog"
+                >
+                    {this.props.children}
                 </div>
             </ViewportPositioner>
         );

--- a/packages/fast-components-react-msft/src/flyout/flyout.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.tsx
@@ -7,7 +7,7 @@ import {
     ViewportPositionerHorizontalPosition,
     ViewportPositionerVerticalPosition,
 } from "@microsoft/fast-components-react-base";
-import { keyCodeEscape } from "@microsoft/fast-web-utilities";
+import { classNames, keyCodeEscape } from "@microsoft/fast-web-utilities";
 import { canUseDOM } from "exenv-es6";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -75,11 +75,14 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
      * Renders the component
      */
     public render(): React.ReactElement<HTMLDivElement> {
+
+        const {
+            flyout_visual
+        }: FlyoutClassNameContract = this.props.managedClasses;
+
         return (
             <ViewportPositioner
-                {...this.unhandledProps()}
                 ref={this.rootEl}
-                role="dialog"
                 aria-label={this.props.label}
                 aria-labelledby={this.props.labelledBy}
                 aria-describedby={this.props.describedBy}
@@ -118,7 +121,12 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
                     width: this.props.width,
                 }}
             >
+                <div
+                 className={classNames(flyout_visual)}
+                {...this.unhandledProps()}
+                role="dialog">
                 {this.props.children}
+                </div>
             </ViewportPositioner>
         );
     }
@@ -160,7 +168,6 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
 
     private generateManagedClassNames(): ViewportPositionerClassNameContract {
         const {
-            flyout,
             flyout__left,
             flyout__right,
             flyout__top,
@@ -170,7 +177,6 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
         }: FlyoutClassNameContract = this.props.managedClasses;
 
         return {
-            viewportPositioner: flyout,
             viewportPositioner__left: flyout__left,
             viewportPositioner__right: flyout__right,
             viewportPositioner__top: flyout__top,

--- a/packages/fast-components-styles-msft/src/flyout/index.ts
+++ b/packages/fast-components-styles-msft/src/flyout/index.ts
@@ -7,15 +7,18 @@ import { applyElevation, ElevationMultiplier } from "../utilities/elevation";
 import { highContrastBorder } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<FlyoutClassNameContract, DesignSystem> = {
-    flyout: {
+    flyout_positioner: {
         display: "none",
-        background: backgroundColor,
-        ...applyFloatingCornerRadius(),
-        ...applyElevation(ElevationMultiplier.e14),
-        "z-index": "1",
         '&[aria-hidden="false"]': {
             display: "block",
         },
+    },
+    flyout_visual: {
+        height: "100%",
+        width: "100%",
+        background: backgroundColor,
+        ...applyFloatingCornerRadius(),
+        ...applyElevation(ElevationMultiplier.e14),
         ...highContrastBorder,
     },
     flyout__top: {},


### PR DESCRIPTION
Description
Currently it is challenging to use css to modify the position of a flyout, typically to use margins to add spacing between the flyout and the anchor.  This change wraps the flyout visual within the viewport positioner rather than use the positioner itself.  This arrangement prevents the positioner's code from attempting to override the CSS.

## Motivation & context
Makes the component easier to style and use.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [x] This change causes current functionality to break.
This changes the internals so it's possible (but fairly unlikely) that it may interfere with previous implementations' efforts to tweak layout.  Seemed like a good idea to do this on a major version change.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
