### PR TITLE
fix: subpixel rendering issues in radio

### DIFF
--- a/packages/fast-components-styles-msft/src/radio/index.ts
+++ b/packages/fast-components-styles-msft/src/radio/index.ts
@@ -12,6 +12,8 @@ import {
     divide,
     format,
     toPx,
+    subtract,
+    multiply,
 } from "@microsoft/fast-jss-utilities";
 import {
     neutralFillInputActive,
@@ -40,7 +42,7 @@ const inputSize: DesignSystemResolver<string> = toPx(
 );
 
 const indicatorMargin: DesignSystemResolver<string> = toPx(
-    add(designUnit, densityCategorySwitch(0, 1, 2))
+    add(subtract(designUnit, multiply(outlineWidth, 2)), densityCategorySwitch(0, 1, 2))
 );
 
 const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
@@ -55,12 +57,10 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         position: "absolute",
         width: inputSize,
         height: inputSize,
-        appearance: "none",
         "-webkit-appearance": "none",
         "-moz-appearance": "none",
         "border-radius": "50%",
         margin: "0",
-        "z-index": "1",
         background: neutralFillInputRest,
         transition: "all 0.2s ease-in-out",
         border: format(
@@ -93,22 +93,14 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
     radio_stateIndicator: {
         position: "relative",
         "border-radius": "50%",
-        display: "inline-block",
         width: inputSize,
         height: inputSize,
-        "flex-shrink": "0",
-        "&::before": {
-            "pointer-events": "none",
-            position: "absolute",
-            "z-index": "1",
-            content: '""',
-            "border-radius": "50%",
-            top: indicatorMargin,
-            left: indicatorMargin,
-            bottom: indicatorMargin,
-            right: indicatorMargin,
-            background: "transparent",
-        },
+        border: format(
+            "{0} solid transparent",
+            toPx<DesignSystem>(outlineWidth)
+        ),
+        "box-sizing": "border-box",
+        "pointer-events": "none",
     },
     radio_label: {
         ...applyCursorPointer(),
@@ -122,13 +114,25 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
     },
     radio__checked: {
         "& $radio_stateIndicator": {
-            "&::before": {
-                background: neutralForegroundRest,
-                ...highContrastHighlightBackground,
-            },
+            background: neutralForegroundRest,
+            "box-shadow": format("inset 0 0 0 {0} {1}", indicatorMargin, neutralFillInputRest),
+            ...highContrastHighlightBackground,
+            border: format(
+                "{0} solid {1}",
+                toPx<DesignSystem>(outlineWidth),
+                neutralOutlineRest
+            ),
         },
-        "&:hover $radio_stateIndicator::before": {
+        "&:hover $radio_stateIndicator": {
             ...highContrastSelectedBackground,
+            "box-shadow": format("inset 0 0 0 {0} {1}", indicatorMargin, neutralFillInputHover),
+            
+        },
+        "&:hover:enabled $radio_stateIndicator": {
+            "box-shadow": format("inset 0 0 0 {0} {1}", indicatorMargin, neutralFillInputHover),
+        },
+        "&:active $radio_stateIndicator": {
+            "box-shadow": format("inset 0 0 0 {0} {1}", indicatorMargin, neutralFillInputActive),
         },
         "& $radio_input": {
             ...highContrastSelectedBackground,

--- a/packages/fast-components-styles-msft/src/radio/index.ts
+++ b/packages/fast-components-styles-msft/src/radio/index.ts
@@ -11,9 +11,9 @@ import {
     directionSwitch,
     divide,
     format,
-    toPx,
-    subtract,
     multiply,
+    subtract,
+    toPx,
 } from "@microsoft/fast-jss-utilities";
 import {
     neutralFillInputActive,
@@ -95,10 +95,7 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         "border-radius": "50%",
         width: inputSize,
         height: inputSize,
-        border: format(
-            "{0} solid transparent",
-            toPx<DesignSystem>(outlineWidth)
-        ),
+        border: format("{0} solid transparent", toPx<DesignSystem>(outlineWidth)),
         "box-sizing": "border-box",
         "pointer-events": "none",
     },
@@ -115,7 +112,11 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
     radio__checked: {
         "& $radio_stateIndicator": {
             background: neutralForegroundRest,
-            "box-shadow": format("inset 0 0 0 {0} {1}", indicatorMargin, neutralFillInputRest),
+            "box-shadow": format(
+                "inset 0 0 0 {0} {1}",
+                indicatorMargin,
+                neutralFillInputRest
+            ),
             ...highContrastHighlightBackground,
             border: format(
                 "{0} solid {1}",
@@ -125,14 +126,25 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         },
         "&:hover $radio_stateIndicator": {
             ...highContrastSelectedBackground,
-            "box-shadow": format("inset 0 0 0 {0} {1}", indicatorMargin, neutralFillInputHover),
-            
+            "box-shadow": format(
+                "inset 0 0 0 {0} {1}",
+                indicatorMargin,
+                neutralFillInputHover
+            ),
         },
         "&:hover:enabled $radio_stateIndicator": {
-            "box-shadow": format("inset 0 0 0 {0} {1}", indicatorMargin, neutralFillInputHover),
+            "box-shadow": format(
+                "inset 0 0 0 {0} {1}",
+                indicatorMargin,
+                neutralFillInputHover
+            ),
         },
         "&:active $radio_stateIndicator": {
-            "box-shadow": format("inset 0 0 0 {0} {1}", indicatorMargin, neutralFillInputActive),
+            "box-shadow": format(
+                "inset 0 0 0 {0} {1}",
+                indicatorMargin,
+                neutralFillInputActive
+            ),
         },
         "& $radio_input": {
             ...highContrastSelectedBackground,


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Closes: #2318 

The current layout of radio centers elements within each other this causes rendering issues at some zoom levels.

Example of 90% zoom in Chromium:
![image](https://user-images.githubusercontent.com/37851214/66662509-cff98400-ebfd-11e9-911c-3824ae2d598a.png)

Solution is to render the selected indicator with a single elements style.

67%
![image](https://user-images.githubusercontent.com/37851214/66662650-1222c580-ebfe-11e9-8845-d8fa651bbcae.png)

75%
![image](https://user-images.githubusercontent.com/37851214/66662699-2a92e000-ebfe-11e9-81b7-891094c28c2b.png)

80%
![image](https://user-images.githubusercontent.com/37851214/66662748-41393700-ebfe-11e9-963e-aaec6d284b5d.png)

90%
![image](https://user-images.githubusercontent.com/37851214/66662791-531ada00-ebfe-11e9-82a4-46bbfe0243ec.png)

110%
![image](https://user-images.githubusercontent.com/37851214/66662830-65951380-ebfe-11e9-8e36-ab919c37b3be.png)

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->