### PR TITLE
fix: viewport positioner adds incorrect classnames

### DIFF
--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -166,7 +166,7 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().state.disabled).toBe(true);
     });
 
-    test("positioning values applied correctly for specified default position - pt1", (): void => {
+    test("positioning values applied correctly for specified default position - adjacent + top + left", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
@@ -197,6 +197,12 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__left
         );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__right
+        );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__horizontalInset
+        );
 
         expect(positioner.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.top
@@ -207,9 +213,15 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__top
         );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__bottom
+        );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__verticalInset
+        );
     });
 
-    test("positioning values applied correctly for specified default position - pt2", (): void => {
+    test("positioning values applied correctly for specified default position - adjacent + bottom + right", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
@@ -240,6 +252,12 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__right
         );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__left
+        );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__horizontalInset
+        );
 
         expect(positioner.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.bottom
@@ -250,9 +268,15 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__bottom
         );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__top
+        );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__verticalInset
+        );
     });
 
-    test("positioning values applied correctly for specified default position - pt3", (): void => {
+    test("positioning values applied correctly for specified default position - inset + top + left", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
@@ -283,6 +307,9 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__left
         );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__right
+        );
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__horizontalInset
         );
@@ -296,12 +323,15 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__top
         );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__bottom
+        );
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__verticalInset
         );
     });
 
-    test("positioning values applied correctly for specified default position - pt4", (): void => {
+    test("positioning values applied correctly for specified default position - inset + bottom + right", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();
@@ -332,6 +362,9 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__right
         );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__left
+        );
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__horizontalInset
         );
@@ -344,6 +377,9 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().state.yTransformOrigin).toBe("top");
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__bottom
+        );
+        expect(positioner.instance().rootElement.current.className).not.toContain(
+            managedClasses.viewportPositioner__top
         );
         expect(positioner.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__verticalInset

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -255,35 +255,37 @@ class ViewportPositioner extends Foundation<
             horizontalPosition === ViewportPositionerHorizontalPositionLabel.insetLeft ||
             horizontalPosition === ViewportPositionerHorizontalPositionLabel.insetRight;
 
-            return super.generateClassNames(
-                classNames(
-                    viewportPositioner,
-                    [
-                        viewportPositioner__left,
+        return super.generateClassNames(
+            classNames(
+                viewportPositioner,
+                [
+                    viewportPositioner__left,
+                    horizontalPosition ===
+                        ViewportPositionerHorizontalPositionLabel.left ||
                         horizontalPosition ===
-                            ViewportPositionerHorizontalPositionLabel.left ||
+                            ViewportPositionerHorizontalPositionLabel.insetLeft,
+                ],
+                [
+                    viewportPositioner__right,
+                    horizontalPosition ===
+                        ViewportPositionerHorizontalPositionLabel.right ||
                         horizontalPosition ===
-                            ViewportPositionerHorizontalPositionLabel.insetLeft
-                    ],
-                    [
-                        viewportPositioner__right,
-                        horizontalPosition ===
-                            ViewportPositionerHorizontalPositionLabel.right ||
-                        horizontalPosition ===
-                            ViewportPositionerHorizontalPositionLabel.insetRight
-                    ],
-                    [viewportPositioner__horizontalInset, isHorizontalInset],
-                    [
-                        viewportPositioner__top,
-                        verticalPosition === ViewportPositionerVerticalPositionLabel.top ||
-                        verticalPosition === ViewportPositionerVerticalPositionLabel.insetTop
-                    ],
-                    [
-                        viewportPositioner__bottom,
-                        verticalPosition === ViewportPositionerVerticalPositionLabel.bottom ||
-                        verticalPosition === ViewportPositionerVerticalPositionLabel.insetBottom
-                    ],
-                    [viewportPositioner__verticalInset, isVerticalInset]
+                            ViewportPositionerHorizontalPositionLabel.insetRight,
+                ],
+                [viewportPositioner__horizontalInset, isHorizontalInset],
+                [
+                    viewportPositioner__top,
+                    verticalPosition === ViewportPositionerVerticalPositionLabel.top ||
+                        verticalPosition ===
+                            ViewportPositionerVerticalPositionLabel.insetTop,
+                ],
+                [
+                    viewportPositioner__bottom,
+                    verticalPosition === ViewportPositionerVerticalPositionLabel.bottom ||
+                        verticalPosition ===
+                            ViewportPositionerVerticalPositionLabel.insetBottom,
+                ],
+                [viewportPositioner__verticalInset, isVerticalInset]
             )
         );
     }

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -255,33 +255,35 @@ class ViewportPositioner extends Foundation<
             horizontalPosition === ViewportPositionerHorizontalPositionLabel.insetLeft ||
             horizontalPosition === ViewportPositionerHorizontalPositionLabel.insetRight;
 
-        return super.generateClassNames(
-            classNames(
-                viewportPositioner,
-                [
-                    viewportPositioner__left,
-                    horizontalPosition ===
-                        ViewportPositionerHorizontalPositionLabel.left ||
-                        isHorizontalInset,
-                ],
-                [
-                    viewportPositioner__right,
-                    horizontalPosition ===
-                        ViewportPositionerHorizontalPositionLabel.right ||
-                        isHorizontalInset,
-                ],
-                [viewportPositioner__horizontalInset, isHorizontalInset],
-                [
-                    viewportPositioner__top,
-                    verticalPosition === ViewportPositionerVerticalPositionLabel.top ||
-                        isVerticalInset,
-                ],
-                [
-                    viewportPositioner__bottom,
-                    verticalPosition === ViewportPositionerVerticalPositionLabel.bottom ||
-                        isVerticalInset,
-                ],
-                [viewportPositioner__verticalInset, isVerticalInset]
+            return super.generateClassNames(
+                classNames(
+                    viewportPositioner,
+                    [
+                        viewportPositioner__left,
+                        horizontalPosition ===
+                            ViewportPositionerHorizontalPositionLabel.left ||
+                        horizontalPosition ===
+                            ViewportPositionerHorizontalPositionLabel.insetLeft
+                    ],
+                    [
+                        viewportPositioner__right,
+                        horizontalPosition ===
+                            ViewportPositionerHorizontalPositionLabel.right ||
+                        horizontalPosition ===
+                            ViewportPositionerHorizontalPositionLabel.insetRight
+                    ],
+                    [viewportPositioner__horizontalInset, isHorizontalInset],
+                    [
+                        viewportPositioner__top,
+                        verticalPosition === ViewportPositionerVerticalPositionLabel.top ||
+                        verticalPosition === ViewportPositionerVerticalPositionLabel.insetTop
+                    ],
+                    [
+                        viewportPositioner__bottom,
+                        verticalPosition === ViewportPositionerVerticalPositionLabel.bottom ||
+                        verticalPosition === ViewportPositionerVerticalPositionLabel.insetBottom
+                    ],
+                    [viewportPositioner__verticalInset, isVerticalInset]
             )
         );
     }


### PR DESCRIPTION
# Description
Noticed that viewport positioner was incorrectly adding additional classnames in addition to the correct ones.  Fixed that and tightened the tests to check for this.

## Motivation & context
Made using positioning classes useless to control layout.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.