### PR TITLE
feat: add viewport context

### DIFF
--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-context.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-context.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export interface ViewportContextType {
+    viewport: React.RefObject<any> | HTMLElement;
+}
+
+export const ViewportContext: React.Context<ViewportContextType> = React.createContext({
+    viewport: null,
+});

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -16,6 +16,7 @@ import {
     ViewportPositionerHorizontalPosition,
     ViewportPositionerVerticalPosition,
 } from "./viewport-positioner.props";
+import Button from "../button";
 
 /*
  * Configure Enzyme

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -1,6 +1,7 @@
 import { storiesOf } from "@storybook/react";
 import React from "react";
-import ViewportPositioner, { AxisPositioningMode, ViewportPositionerProps } from "./";
+import { AxisPositioningMode } from "./viewport-positioner.props";
+import ViewportPositioner, { AxisPositioningMode, ViewportContext, ViewportPositionerProps } from "./";
 import Foundation from "@microsoft/fast-components-foundation-react";
 import { ViewportPositionerVerticalPosition } from "./viewport-positioner.props";
 import { isNil } from "lodash-es";

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -1,6 +1,10 @@
 import { storiesOf } from "@storybook/react";
 import React from "react";
-import ViewportPositioner, { AxisPositioningMode, ViewportContext, ViewportPositionerProps } from "./";
+import ViewportPositioner, {
+    AxisPositioningMode,
+    ViewportContext,
+    ViewportPositionerProps,
+} from "./";
 import Foundation from "@microsoft/fast-components-foundation-react";
 import { ViewportPositionerVerticalPosition } from "./viewport-positioner.props";
 
@@ -44,9 +48,7 @@ class TestViewport extends React.Component<TestViewportProps, {}> {
                             width: "0",
                         }}
                     >
-                        <ViewportPositioner
-                            {...this.props.positionerProps}
-                        >
+                        <ViewportPositioner {...this.props.positionerProps}>
                             <div
                                 style={{
                                     height: "100%",
@@ -55,7 +57,7 @@ class TestViewport extends React.Component<TestViewportProps, {}> {
                                 }}
                             >
                                 Positioner
-                        </div>
+                            </div>
                         </ViewportPositioner>
                     </div>
                 </div>

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -1,10 +1,8 @@
 import { storiesOf } from "@storybook/react";
 import React from "react";
-import { AxisPositioningMode } from "./viewport-positioner.props";
 import ViewportPositioner, { AxisPositioningMode, ViewportContext, ViewportPositionerProps } from "./";
 import Foundation from "@microsoft/fast-components-foundation-react";
 import { ViewportPositionerVerticalPosition } from "./viewport-positioner.props";
-import { isNil } from "lodash-es";
 
 const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
 
@@ -25,38 +23,43 @@ class TestViewport extends React.Component<TestViewportProps, {}> {
 
     public render(): JSX.Element {
         return (
-            <div
-                ref={this.rootElement}
-                style={{
-                    height: "400px",
-                    width: "400px",
-                    margin: "50px",
-                    overflow: "scroll",
+            <ViewportContext.Provider
+                value={{
+                    viewport: this.rootElement,
                 }}
             >
-                {this.props.children}
                 <div
+                    ref={this.rootElement}
                     style={{
-                        height: "0",
-                        width: "0",
+                        height: "400px",
+                        width: "400px",
+                        margin: "50px",
+                        overflow: "scroll",
                     }}
                 >
-                    <ViewportPositioner
-                        {...this.props.positionerProps}
-                        viewport={this.rootElement}
+                    {this.props.children}
+                    <div
+                        style={{
+                            height: "0",
+                            width: "0",
+                        }}
                     >
-                        <div
-                            style={{
-                                height: "100%",
-                                width: "100%",
-                                background: "yellow",
-                            }}
+                        <ViewportPositioner
+                            {...this.props.positionerProps}
                         >
-                            Positioner
+                            <div
+                                style={{
+                                    height: "100%",
+                                    width: "100%",
+                                    background: "yellow",
+                                }}
+                            >
+                                Positioner
                         </div>
-                    </ViewportPositioner>
+                        </ViewportPositioner>
+                    </div>
                 </div>
-            </div>
+            </ViewportContext.Provider>
         );
     }
 }

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -18,6 +18,7 @@ import {
     ViewportPositionerUnhandledProps,
     ViewportPositionerVerticalPosition,
 } from "./viewport-positioner.props";
+import { ThemeProvider } from "emotion-theming";
 
 export interface Dimension {
     height: number;

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -20,7 +20,7 @@ import {
     ViewportPositionerVerticalPosition,
 } from "./viewport-positioner.props";
 import { ThemeProvider } from "emotion-theming";
-import { ViewportContext, ViewportContextType} from "./viewport-context";
+import { ViewportContext, ViewportContextType } from "./viewport-context";
 
 export interface Dimension {
     height: number;
@@ -431,7 +431,7 @@ class ViewportPositioner extends Foundation<
         const viewportElement: HTMLElement = this.getViewportElement();
         const anchorElement: HTMLElement = this.getAnchorElement();
 
-        if (isNil(viewportElement) || isNil(anchorElement)){
+        if (isNil(viewportElement) || isNil(anchorElement)) {
             return;
         }
 
@@ -1181,14 +1181,17 @@ class ViewportPositioner extends Foundation<
     /**
      *
      */
-    private extractElementFromRef = (sourceRef: React.RefObject<any>): HTMLElement | null => {
-
+    private extractElementFromRef = (
+        sourceRef: React.RefObject<any>
+    ): HTMLElement | null => {
         if (!isNil(sourceRef.current)) {
             if (sourceRef.current instanceof HTMLElement) {
                 return sourceRef.current;
             }
 
-            const foundNode: Element | Text | null = ReactDOM.findDOMNode(sourceRef.current);
+            const foundNode: Element | Text | null = ReactDOM.findDOMNode(
+                sourceRef.current
+            );
 
             if (foundNode instanceof HTMLElement) {
                 return foundNode;
@@ -1196,7 +1199,7 @@ class ViewportPositioner extends Foundation<
         }
 
         return null;
-    }
+    };
 
     /**
      * Converts simple horizontal position to a position label based on AxisPositioningMode
@@ -1253,4 +1256,4 @@ class ViewportPositioner extends Foundation<
 ViewportPositioner.contextType = ViewportContext;
 export default ViewportPositioner;
 export * from "./viewport-positioner.props";
-export { ViewportPositionerClassNameContract, ViewportContext, ViewportContextType  };
+export { ViewportPositionerClassNameContract, ViewportContext, ViewportContextType };

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -1179,7 +1179,7 @@ class ViewportPositioner extends Foundation<
     };
 
     /**
-     *
+     * returns an html element from a ref
      */
     private extractElementFromRef = (
         sourceRef: React.RefObject<any>

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -19,7 +19,6 @@ import {
     ViewportPositionerUnhandledProps,
     ViewportPositionerVerticalPosition,
 } from "./viewport-positioner.props";
-import { ThemeProvider } from "emotion-theming";
 import { ViewportContext, ViewportContextType } from "./viewport-context";
 
 export interface Dimension {

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -4,6 +4,7 @@ import { classNames } from "@microsoft/fast-web-utilities";
 import { canUseDOM } from "exenv-es6";
 import { get, isNil } from "lodash-es";
 import React from "react";
+import ReactDOM from "react-dom";
 import {
     DisplayNamePrefix,
     IntersectionObserverEntry,
@@ -19,6 +20,7 @@ import {
     ViewportPositionerVerticalPosition,
 } from "./viewport-positioner.props";
 import { ThemeProvider } from "emotion-theming";
+import { ViewportContext, ViewportContextType} from "./viewport-context";
 
 export interface Dimension {
     height: number;
@@ -117,6 +119,8 @@ class ViewportPositioner extends Foundation<
     ViewportPositionerState
 > {
     public static displayName: string = `${DisplayNamePrefix}ViewportPositioner`;
+
+    public static contextType: React.Context<ViewportContextType> = ViewportContext;
 
     public static defaultProps: Partial<ViewportPositionerProps> = {
         horizontalPositioningMode: AxisPositioningMode.uncontrolled,
@@ -424,11 +428,15 @@ class ViewportPositioner extends Foundation<
      *  once to get correct initial placement
      */
     private setNoObserverMode = (): void => {
-        const viewPortElement: HTMLElement = this.getViewportElement();
+        const viewportElement: HTMLElement = this.getViewportElement();
         const anchorElement: HTMLElement = this.getAnchorElement();
 
+        if (isNil(viewportElement) || isNil(anchorElement)){
+            return;
+        }
+
         this.positionerRect = this.rootElement.current.getBoundingClientRect();
-        this.viewportRect = viewPortElement.getBoundingClientRect();
+        this.viewportRect = viewportElement.getBoundingClientRect();
         const anchorRect: ClientRect | DOMRect = anchorElement.getBoundingClientRect();
 
         this.anchorTop = anchorRect.top;
@@ -1140,27 +1148,55 @@ class ViewportPositioner extends Foundation<
         if (this.props.anchor instanceof HTMLElement) {
             return this.props.anchor;
         } else {
-            return this.props.anchor.current;
+            return this.extractElementFromRef(this.props.anchor);
         }
     };
 
     /**
-     * get the viewport element
+     * get the viewport element, prefer one provided in props, then context, then document root
      */
     private getViewportElement = (): HTMLElement | null => {
-        if (isNil(this.props.viewport)) {
-            if (document.scrollingElement instanceof HTMLElement) {
-                return document.scrollingElement as HTMLElement;
+        if (!isNil(this.props.viewport)) {
+            if (this.props.viewport instanceof HTMLElement) {
+                return this.props.viewport;
+            } else {
+                return this.extractElementFromRef(this.props.viewport);
             }
-            return null;
         }
 
-        if (this.props.viewport instanceof HTMLElement) {
-            return this.props.viewport;
-        } else {
-            return this.props.viewport.current;
+        if (!isNil(this.context.viewport)) {
+            if (this.context.viewport instanceof HTMLElement) {
+                return this.context.viewport;
+            } else {
+                return this.extractElementFromRef(this.context.viewport);
+            }
         }
+
+        if (document.scrollingElement instanceof HTMLElement) {
+            return document.scrollingElement as HTMLElement;
+        }
+        return null;
     };
+
+    /**
+     *
+     */
+    private extractElementFromRef = (sourceRef: React.RefObject<any>): HTMLElement | null => {
+
+        if (!isNil(sourceRef.current)) {
+            if (sourceRef.current instanceof HTMLElement) {
+                return sourceRef.current;
+            }
+
+            const foundNode: Element | Text | null = ReactDOM.findDOMNode(sourceRef.current);
+
+            if (foundNode instanceof HTMLElement) {
+                return foundNode;
+            }
+        }
+
+        return null;
+    }
 
     /**
      * Converts simple horizontal position to a position label based on AxisPositioningMode
@@ -1214,7 +1250,7 @@ class ViewportPositioner extends Foundation<
         }
     };
 }
-
+ViewportPositioner.contextType = ViewportContext;
 export default ViewportPositioner;
 export * from "./viewport-positioner.props";
-export { ViewportPositionerClassNameContract };
+export { ViewportPositionerClassNameContract, ViewportContext, ViewportContextType  };

--- a/packages/fast-components-react-msft/src/flyout/flyout.stories.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.stories.tsx
@@ -8,6 +8,7 @@ import {
     FlyoutProps,
     FlyoutVerticalPosition,
 } from "./";
+import {ViewportContext} from "@microsoft/fast-components-react-base";
 import { FlyoutAxisPositioningMode } from "./flyout.props";
 import { Heading, HeadingSize } from "../heading";
 import { Paragraph, ParagraphSize } from "../paragraph";
@@ -24,27 +25,61 @@ interface FlyoutTestState {
 class FlyoutTest extends React.Component<Omit<FlyoutProps, "anchor">, FlyoutTestState> {
     private anchor: React.RefObject<any>;
 
+    private rootElement: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
+
     constructor(props: FlyoutProps) {
         super(props);
 
         this.anchor = React.createRef();
+
         this.state = {
             visible: false,
         };
     }
 
+    public componentDidMount(): void {
+        this.rootElement.current.scrollTop = 100;
+        this.rootElement.current.scrollLeft = 100;
+    }
+
     public render(): JSX.Element {
         return (
-            <React.Fragment>
-                <AccentButton
-                    ref={this.anchor}
-                    onClick={this.updateFlyoutState}
-                    style={{ margin: "0 auto" }}
+            <ViewportContext.Provider
+                value={{
+                    viewport: this.rootElement
+                }}
+            >
+                <div
+                    ref={this.rootElement}
+                    style={{
+                        margin: "20px 0",
+                        position: "relative",
+                        height: "400px",
+                        width: "600px",
+                        overflow: "scroll",
+                        whiteSpace: "nowrap"
+                    }}
                 >
-                    Flyout anchor
-                </AccentButton>
-                {this.renderFlyout()}
-            </React.Fragment>
+                    <div
+                        style={{
+                            height: "500px",
+                            width: "800px",
+                            background: "blue",
+                        }}
+                    >
+                        <AccentButton
+                            style={{
+                                margin: "230px 0 0 380px",
+                            }}
+                            ref={this.anchor}
+                            onClick={this.updateFlyoutState}
+                        >
+                            Flyout anchor
+                        </AccentButton>
+                        {this.renderFlyout()}
+                    </div>
+                </div>
+            </ViewportContext.Provider>
         );
     }
 
@@ -54,10 +89,9 @@ class FlyoutTest extends React.Component<Omit<FlyoutProps, "anchor">, FlyoutTest
         }
 
         const { children, visible, ...props }: Partial<FlyoutProps> = this.props;
-        const anchor: HTMLElement = ReactDOM.findDOMNode(this.anchor.current);
 
         return (
-            <Flyout anchor={anchor} visible={this.state.visible} {...props}>
+            <Flyout anchor={this.anchor} visible={this.state.visible} {...props}>
                 {children}
             </Flyout>
         );
@@ -71,25 +105,45 @@ class FlyoutTest extends React.Component<Omit<FlyoutProps, "anchor">, FlyoutTest
 }
 
 storiesOf("Flyout", module)
-    .add("Default", () => <FlyoutTest />)
-    .add("with Children", () => (
-        <FlyoutTest>
-            <Heading size={HeadingSize._5}>Flyout</Heading>
-            <Paragraph size={ParagraphSize._3}>This is a flyout component.</Paragraph>
-            <AccentButton>Accept</AccentButton>
-        </FlyoutTest>
-    ))
-    .add("with soft dismiss", () => (
-        /* tslint:disable-next-line:jsx-no-lambda */
-        <FlyoutTest onDismiss={(): void => alert("soft dismiss")} />
-    ))
-    .add("with Height", () => <FlyoutTest height={"100px"} />)
-    .add("with Width", () => <FlyoutTest width={"200px"} />)
-    .add("with Height and Width", () => <FlyoutTest height={"100px"} width={"200px"} />)
-    .add("with horizontal always in view", () => (
-        <FlyoutTest horizontalAlwaysInView={true} />
-    ))
-    .add("with vertical always in view", () => <FlyoutTest verticalAlwaysInView={true} />)
+    .add("Default", () => (
+        <div>
+            <Heading
+                size={HeadingSize._4}
+            >
+                By default the flyout's only sets the vertical axis positioning mode to "adjacent" which places above or below the anchor based on available space (default placement is below the anchor).
+            </Heading>
+            <FlyoutTest>
+                <Heading size={HeadingSize._5}>Flyout</Heading>
+            </FlyoutTest>
+        </div>))
+    .add("Flyout aligned vertically", () => (
+        <div>
+        <Heading
+            size={HeadingSize._4}
+        >
+            Setting the horizonal axis positioning mode to "inset" aligns the flyout with the anchor horizontally as well as vertically
+        </Heading>
+        <FlyoutTest
+                horizontalPositioningMode={FlyoutAxisPositioningMode.inset}
+                verticalPositioningMode={FlyoutAxisPositioningMode.adjacent}
+            >
+                <Heading size={HeadingSize._5}>Flyout</Heading>
+            </FlyoutTest>
+    </div>))
+    .add("Flyout aligned horizontally", () => (
+            <div>
+            <Heading
+                size={HeadingSize._4}
+            >
+                Setting the verical axis positioning mode to "inset" and the horizontal mode to "adjacent" places the flyout beside the anchor
+            </Heading>
+            <FlyoutTest
+                    horizontalPositioningMode={FlyoutAxisPositioningMode.adjacent}
+                    verticalPositioningMode={FlyoutAxisPositioningMode.inset}
+                >
+                    <Heading size={HeadingSize._5}>Flyout</Heading>
+                </FlyoutTest>
+        </div>))
     .add("with bottom/left adjacent", () => (
         <FlyoutTest
             horizontalPositioningMode={FlyoutAxisPositioningMode.adjacent}
@@ -183,4 +237,15 @@ storiesOf("Flyout", module)
             defaultHorizontalPosition={FlyoutHorizontalPosition.right}
             defaultVerticalPosition={FlyoutVerticalPosition.top}
         />
+    ))
+    .add("with Height", () => <FlyoutTest height={"100px"} />)
+    .add("with Width", () => <FlyoutTest width={"200px"} />)
+    .add("with Height and Width", () => <FlyoutTest height={"100px"} width={"200px"} />)
+    .add("with horizontal always in view", () => (
+        <FlyoutTest horizontalAlwaysInView={true} />
+    ))
+    .add("with vertical always in view", () => <FlyoutTest verticalAlwaysInView={true} />)
+    .add("with soft dismiss", () => (
+        /* tslint:disable-next-line:jsx-no-lambda */
+        <FlyoutTest onDismiss={(): void => alert("soft dismiss")} />
     ));

--- a/packages/fast-components-react-msft/src/flyout/flyout.stories.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.stories.tsx
@@ -8,7 +8,7 @@ import {
     FlyoutProps,
     FlyoutVerticalPosition,
 } from "./";
-import {ViewportContext} from "@microsoft/fast-components-react-base";
+import { ViewportContext } from "@microsoft/fast-components-react-base";
 import { FlyoutAxisPositioningMode } from "./flyout.props";
 import { Heading, HeadingSize } from "../heading";
 import { Paragraph, ParagraphSize } from "../paragraph";
@@ -25,7 +25,9 @@ interface FlyoutTestState {
 class FlyoutTest extends React.Component<Omit<FlyoutProps, "anchor">, FlyoutTestState> {
     private anchor: React.RefObject<any>;
 
-    private rootElement: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
+    private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
+        HTMLDivElement
+    >();
 
     constructor(props: FlyoutProps) {
         super(props);
@@ -46,7 +48,7 @@ class FlyoutTest extends React.Component<Omit<FlyoutProps, "anchor">, FlyoutTest
         return (
             <ViewportContext.Provider
                 value={{
-                    viewport: this.rootElement
+                    viewport: this.rootElement,
                 }}
             >
                 <div
@@ -57,7 +59,7 @@ class FlyoutTest extends React.Component<Omit<FlyoutProps, "anchor">, FlyoutTest
                         height: "400px",
                         width: "600px",
                         overflow: "scroll",
-                        whiteSpace: "nowrap"
+                        whiteSpace: "nowrap",
                     }}
                 >
                     <div
@@ -107,43 +109,44 @@ class FlyoutTest extends React.Component<Omit<FlyoutProps, "anchor">, FlyoutTest
 storiesOf("Flyout", module)
     .add("Default", () => (
         <div>
-            <Heading
-                size={HeadingSize._4}
-            >
-                By default the flyout's only sets the vertical axis positioning mode to "adjacent" which places above or below the anchor based on available space (default placement is below the anchor).
+            <Heading size={HeadingSize._4}>
+                By default the flyout's only sets the vertical axis positioning mode to
+                "adjacent" which places above or below the anchor based on available space
+                (default placement is below the anchor).
             </Heading>
             <FlyoutTest>
                 <Heading size={HeadingSize._5}>Flyout</Heading>
             </FlyoutTest>
-        </div>))
+        </div>
+    ))
     .add("Flyout aligned vertically", () => (
         <div>
-        <Heading
-            size={HeadingSize._4}
-        >
-            Setting the horizonal axis positioning mode to "inset" aligns the flyout with the anchor horizontally as well as vertically
-        </Heading>
-        <FlyoutTest
+            <Heading size={HeadingSize._4}>
+                Setting the horizonal axis positioning mode to "inset" aligns the flyout
+                with the anchor horizontally as well as vertically
+            </Heading>
+            <FlyoutTest
                 horizontalPositioningMode={FlyoutAxisPositioningMode.inset}
                 verticalPositioningMode={FlyoutAxisPositioningMode.adjacent}
             >
                 <Heading size={HeadingSize._5}>Flyout</Heading>
             </FlyoutTest>
-    </div>))
+        </div>
+    ))
     .add("Flyout aligned horizontally", () => (
-            <div>
-            <Heading
-                size={HeadingSize._4}
-            >
-                Setting the verical axis positioning mode to "inset" and the horizontal mode to "adjacent" places the flyout beside the anchor
+        <div>
+            <Heading size={HeadingSize._4}>
+                Setting the verical axis positioning mode to "inset" and the horizontal
+                mode to "adjacent" places the flyout beside the anchor
             </Heading>
             <FlyoutTest
-                    horizontalPositioningMode={FlyoutAxisPositioningMode.adjacent}
-                    verticalPositioningMode={FlyoutAxisPositioningMode.inset}
-                >
-                    <Heading size={HeadingSize._5}>Flyout</Heading>
-                </FlyoutTest>
-        </div>))
+                horizontalPositioningMode={FlyoutAxisPositioningMode.adjacent}
+                verticalPositioningMode={FlyoutAxisPositioningMode.inset}
+            >
+                <Heading size={HeadingSize._5}>Flyout</Heading>
+            </FlyoutTest>
+        </div>
+    ))
     .add("with bottom/left adjacent", () => (
         <FlyoutTest
             horizontalPositioningMode={FlyoutAxisPositioningMode.adjacent}


### PR DESCRIPTION
# Description
Viewport context is intended to provide developers with an easy way to set the viewport for a region of the dom tree without having to pass down the reference through multiple component layers.  Any viewport positioners that are children of the context will use that as the viewport if none are specified in it's props.

## Motivation & context
Make developers life easier

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

