### PR TITLE
fix: use only context and jss styles to apply select menu background

### DIFF
--- a/packages/fast-components-react-msft/src/select/select.tsx
+++ b/packages/fast-components-react-msft/src/select/select.tsx
@@ -93,7 +93,11 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, {}> {
         state: SelectState,
         defaultMenu: React.ReactNode
     ): React.ReactNode => {
-        return <Background value={neutralLayerFloating}>{defaultMenu}</Background>;
+        return (
+            <Background value={neutralLayerFloating} tag={null}>
+                {defaultMenu}
+            </Background>
+        );
     };
 
     /**

--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -67,7 +67,9 @@ const styles: ComponentStyles<SelectClassNameContract, DesignSystem> = {
         ...highContrastForeground,
     },
     select_menu: {
-        background: neutralFillStealthRest,
+        background: (designSystem: DesignSystem): string => {
+            return designSystem.backgroundColor;
+        },
         ...applyElevatedCornerRadius(),
         ...applyElevation(ElevationMultiplier.e11),
         position: "relative",

--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -3,6 +3,7 @@ import {
     neutralFillStealthRest,
     neutralForegroundRest,
     neutralOutlineRest,
+    neutralLayerFloating,
 } from "../utilities/color";
 import {
     directionSwitch,
@@ -67,9 +68,7 @@ const styles: ComponentStyles<SelectClassNameContract, DesignSystem> = {
         ...highContrastForeground,
     },
     select_menu: {
-        background: (designSystem: DesignSystem): string => {
-            return designSystem.backgroundColor;
-        },
+        background: neutralLayerFloating,
         ...applyElevatedCornerRadius(),
         ...applyElevation(ElevationMultiplier.e11),
         position: "relative",

--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -1,9 +1,8 @@
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import {
-    neutralFillStealthRest,
     neutralForegroundRest,
-    neutralOutlineRest,
     neutralLayerFloating,
+    neutralOutlineRest,
 } from "../utilities/color";
 import {
     directionSwitch,


### PR DESCRIPTION
# Description
The approach of using actual wrapping dom elements was interfering with advanced layout options for select menu.  A slight change of approach allows passing of color to base component using only context and not actually wrapping the menu in a dom element. 

## Motivation & context
Removing wrapping dom element and using only context + css makes layout easier (and removes an element from the dom)

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->