### PR TITLE
feat: allow properties to be categorized

### DIFF
--- a/packages/fast-tooling-react/README.md
+++ b/packages/fast-tooling-react/README.md
@@ -47,6 +47,7 @@ The tooling available in FAST Tooling React can be used together to create UI fo
         - [Examples & default](#examples-&-default)
         - [Badges](#badges)
         - [Dictionaries](#dictionaries)
+        - [Categories](#categories)
     - [JSON schema keywords](#json-schema-keywords)
         - [oneOf & anyOf](#oneof-&-anyof)
         - [Enums](#enums)
@@ -1305,6 +1306,45 @@ Example:
         "title": "A dictionary of strings",
         "propertyTitle": "A dictionary key",
         "type": "string"
+    }
+}
+```
+
+#### Categories
+
+To allow properties in an object to be categorized, the JSON schema can be amended with a `formConfig` property at the same level of the object. These categories can be expandable and will appear in the order they appear in the array.
+
+Example:
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "foo": {
+            "title": "String Property Foo",
+            "type": "string"
+        },
+        "bar": {
+            "title": "String Property Bar",
+            "type": "string"
+        }
+    },
+    "formConfig": {
+        "categories": [
+            {
+                "title": "Category A",
+                "expandable": true,
+                "items": [
+                    "foo"
+                ]
+            },
+            {
+                "title": "Category A",
+                "items": [
+                    "bar"
+                ]
+            }
+        ]
     }
 }
 ```

--- a/packages/fast-tooling-react/app/pages/form/index.ts
+++ b/packages/fast-tooling-react/app/pages/form/index.ts
@@ -138,3 +138,9 @@ import TooltipSchema from "../../../src/__tests__/schemas/tooltip.schema.json";
 export const tooltip: ExampleComponent = {
     schema: TooltipSchema,
 };
+
+import CategoriesSchema from "../../../src/__tests__/schemas/categories.schema.json";
+
+export const categories: ExampleComponent = {
+    schema: CategoriesSchema,
+};

--- a/packages/fast-tooling-react/src/__tests__/schemas/categories.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/categories.schema.json
@@ -4,6 +4,7 @@
     "description": "A test component's schema definition.",
     "type": "object",
     "id": "categories",
+    "propertyTitle": "Item key",
     "properties": {
         "uncategorizedString": {
             "title": "Uncategorized String",
@@ -99,6 +100,11 @@
                 ]
             }
         ]
+    },
+    "additionalProperties": {
+        "title": "Additional strings",
+        "type": "string",
+        "examples": ["bar"]
     },
     "required": [
         "toggle",

--- a/packages/fast-tooling-react/src/__tests__/schemas/categories.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/categories.schema.json
@@ -1,0 +1,107 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Component with categories",
+    "description": "A test component's schema definition.",
+    "type": "object",
+    "id": "categories",
+    "properties": {
+        "uncategorizedString": {
+            "title": "Uncategorized String",
+            "type": "string"
+        },
+        "uncategorizedBoolean": {
+            "title": "Uncategorized Boolean",
+            "type": "boolean"
+        },
+        "categorizedString": {
+            "title": "String",
+            "type": "string"
+        },
+        "toggle": {
+            "title": "Required Checkbox",
+            "type": "boolean"
+        },
+        "optionalToggle": {
+            "title": "Optional Checkbox",
+            "type": "boolean"
+        },
+        "defaultToggle": {
+            "title": "Default Checkbox",
+            "type": "boolean",
+            "default": true
+        },
+        "disabledToggle": {
+            "title": "Disabled Checkbox",
+            "type": "boolean",
+            "disabled": true
+        },
+        "optionalNull": {
+            "title": "optional null",
+            "type": "null"
+        },
+        "requiredNull": {
+            "title": "required null",
+            "type": "null"
+        }
+    },
+    "reactProperties": {
+        "children": {
+            "title": "Children",
+            "type": "children",
+            "defaults": [
+                "text"
+            ],
+            "examples": ["Foo"]
+        },
+        "restrictedWithChildren": {
+            "title": "Restricted children with react defaults",
+            "type": "children",
+            "ids": [
+                "objects",
+                "arrays"
+            ],
+            "defaults": [
+                "text"
+            ]
+        }
+    },
+    "formConfig": {
+        "categories": [
+            {
+                "title": "Textarea",
+                "expandable": true,
+                "items": [
+                    "categorizedString"
+                ]
+            },
+            {
+                "title": "Checkbox",
+                "expandable": true,
+                "items": [
+                    "toggle",
+                    "optionalToggle",
+                    "defaultToggle",
+                    "disabledToggle"
+                ]
+            },
+            {
+                "title": "Children",
+                "items": [
+                    "children",
+                    "restrictedWithChildren"
+                ]
+            },
+            {
+                "title": "Null",
+                "items": [
+                    "optionalNull",
+                    "requiredNull"
+                ]
+            }
+        ]
+    },
+    "required": [
+        "toggle",
+        "requiredNull"
+    ]
+}

--- a/packages/fast-tooling-react/src/__tests__/schemas/dictionary.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/dictionary.schema.json
@@ -4,6 +4,7 @@
     "description": "A test component's schema definition.",
     "type": "object",
     "id": "dictionary",
+    "propertyTitle": "Item key",
     "properties": {
         "additionalObjects": {
             "title": "A dictionary of objects",
@@ -27,7 +28,6 @@
     },
     "additionalProperties": {
         "title": "String item",
-        "propertyTitle": "Item key",
         "type": "string"
     }
 }

--- a/packages/fast-tooling-react/src/form/form-category.props.ts
+++ b/packages/fast-tooling-react/src/form/form-category.props.ts
@@ -13,18 +13,14 @@ export interface FormCategoryClassNameContract {
 export interface FormCategoryProps {
     /**
      * Passes the category title
+     * If the title is null, this should not render in a category
      */
-    title: string;
+    title: string | null;
 
     /**
      * Is the category expandable
      */
     expandable?: boolean;
-
-    /**
-     * Passes the id
-     */
-    id?: string;
 }
 
 export interface FormCategoryState {

--- a/packages/fast-tooling-react/src/form/form-category.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form-category.spec.tsx
@@ -10,8 +10,7 @@ import { FormCategoryProps } from "./form-category.props";
 configure({ adapter: new Adapter() });
 
 const formCategoryProps: FormCategoryProps = {
-    title: "",
-    id: "Foo",
+    title: "Category",
 };
 
 describe("FormCategory", () => {

--- a/packages/fast-tooling-react/src/form/form-category.tsx
+++ b/packages/fast-tooling-react/src/form/form-category.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { uniqueId } from "lodash-es";
 import styles from "./form-category.style";
 import {
     FormCategoryClassNameContract,
@@ -18,6 +19,8 @@ class FormCategory extends React.Component<
     FormCategoryState
 > {
     public static displayName: string = "FormCategory";
+
+    private id: string = uniqueId("category");
 
     constructor(
         props: FormCategoryProps & ManagedClasses<FormCategoryClassNameContract>
@@ -49,7 +52,7 @@ class FormCategory extends React.Component<
 
     private generateContainerAttributes(): React.HtmlHTMLAttributes<HTMLDivElement> {
         const attributes: Partial<React.HtmlHTMLAttributes<HTMLDivElement>> = {
-            id: this.props.id,
+            id: this.id,
         };
 
         if (this.props.expandable) {
@@ -76,7 +79,7 @@ class FormCategory extends React.Component<
             <button
                 onClick={this.handleCategoryCollapse}
                 aria-expanded={this.state.expanded}
-                aria-controls={this.props.id}
+                aria-controls={this.id}
                 className={this.props.managedClasses.formCategory_button}
             >
                 {this.props.title}

--- a/packages/fast-tooling-react/src/form/form-section.props.ts
+++ b/packages/fast-tooling-react/src/form/form-section.props.ts
@@ -157,11 +157,6 @@ export interface FormSectionProps {
     untitled: string;
 
     /**
-     * The configuration for ordering properties by their names
-     */
-    orderByPropertyNames?: FormOrderByPropertyNamesProps;
-
-    /**
      * The validation errors
      */
     validationErrors: ErrorObject[] | void;
@@ -177,36 +172,19 @@ export interface FormSectionProps {
     displayValidationBrowserDefault?: boolean;
 }
 
-export interface FormCategoryItems {
+export interface FormCategoryConfig {
     /**
-     * The items weight
+     * The display name, used as a category label
      */
-    weight: number;
+    title: string | null;
 
     /**
-     * The parameters to pass to generate the form item
+     * Category property keys
      */
-    params: FormControlParameters;
-}
-
-export interface FormCategoryProps {
-    /**
-     * The category weight
-     */
-    weight: number;
+    items: string[];
 
     /**
-     * The category form items
-     */
-    items: FormCategoryItems[];
-
-    /**
-     * The category title
-     */
-    title: string;
-
-    /**
-     * Allows category to be expandable
+     * Expandable
      */
     expandable?: boolean;
 }
@@ -272,16 +250,23 @@ export interface AssignedCategoryParams {
     expandable?: boolean;
 }
 
-export interface FormControlsWithConfigOptions {
+export interface FormControlItem {
     /**
-     * Parameters such as weight, attribute assignment etc
+     * The property name
      */
-    parameters: FormControlParameters[];
+    propertyName: string;
 
+    /**
+     * The rendered control
+     */
+    render: React.ReactNode;
+}
+
+export interface FormControlsWithConfigOptions {
     /**
      * Form items which conform to a section
      */
-    items: React.ReactNode[];
+    items: FormControlItem[];
 }
 
 export interface OptionalToggleConfig {

--- a/packages/fast-tooling-react/src/form/form-section.tsx
+++ b/packages/fast-tooling-react/src/form/form-section.tsx
@@ -1,15 +1,7 @@
-import React from "react";
-import { get, omit } from "lodash-es";
-import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
-import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
-import FormCategory from "./form-category";
-import styles from "./form-section.style";
 import {
-    checkCategoryConfigPropertyCount,
     checkIsDifferentSchema,
     checkIsObject,
     generateExampleData,
-    getCategoryParams,
     getData,
     getErrorFromDataLocation,
     getInitialOneOfAnyOfState,
@@ -17,11 +9,17 @@ import {
     getIsRequired,
     getLabel,
     getOneOfAnyOfSelectOptions,
+    PropertyKeyword,
 } from "./utilities";
+import React from "react";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
+import FormCategory from "./form-category";
+import styles from "./form-section.style";
+import { get, omit } from "lodash-es";
 import {
-    FormCategoryItems,
-    FormCategoryProps,
-    FormControlParameters,
+    FormCategoryConfig,
+    FormControlItem,
     FormControlsWithConfigOptions,
     FormSectionClassNameContract,
     FormSectionProps,
@@ -110,22 +108,18 @@ class FormSection extends React.Component<
     /**
      * Renders the form
      */
-    private renderForm(dataLocation: string, schema: any): React.ReactNode {
-        // check to see if this is a root level object
-        // if so, use it to generate the form and do not generate a link
-        if (dataLocation === "") {
-            return this.generateFormObject(
-                schema,
-                schema.required || undefined,
-                schema.not ? schema.not.required : undefined
-            );
-        }
+    private renderRootObject(dataLocation: string, schema: any): React.ReactNode {
+        return this.generateFormObject(
+            schema,
+            schema.required || undefined,
+            schema.not ? schema.not.required : undefined
+        );
     }
 
     /**
      * Generates form elements based on field type
      */
-    private renderFormControl(
+    private renderFormControl = (
         schema: any,
         propertyName: string,
         schemaLocation: string,
@@ -133,9 +127,10 @@ class FormSection extends React.Component<
         required: boolean,
         label: string,
         invalidMessage: string | null
-    ): React.ReactNode {
+    ): React.ReactNode => {
+        // if this is a root level object use it to generate the form and do not generate a link
         if (schema.type === "object" && propertyName === "") {
-            return this.renderForm(propertyName, schema);
+            return this.renderRootObject(propertyName, schema);
         }
 
         return (
@@ -162,50 +157,76 @@ class FormSection extends React.Component<
                 displayValidationInline={this.props.displayValidationInline}
             />
         );
-    }
+    };
 
     /**
      * Renders form items into categories
      */
     private renderCategories(
-        formControlParameters: FormControlParameters[]
+        categories: FormCategoryConfig[] = [],
+        controls: FormControlsWithConfigOptions
     ): React.ReactNode {
-        const categoryParams: FormCategoryProps[] = getCategoryParams(
-            formControlParameters,
-            this.props.orderByPropertyNames
-        );
+        return this.getAllCategories(categories).map(
+            (category: FormCategoryConfig, index: number): React.ReactNode => {
+                if (category.title === null) {
+                    return controls.items.map(
+                        (controlItem: FormControlItem): React.ReactNode => {
+                            if (category.items.indexOf(controlItem.propertyName) > -1) {
+                                return controlItem.render;
+                            }
+                        }
+                    );
+                }
 
-        return categoryParams.map((categoryParam: FormCategoryProps, index: number) => {
-            return (
-                <FormCategory
-                    key={index}
-                    expandable={categoryParam.expandable}
-                    title={categoryParam.title}
-                >
-                    {this.renderCategoryItems(categoryParam.items)}
-                </FormCategory>
-            );
-        });
+                return (
+                    <FormCategory
+                        key={index}
+                        expandable={category.expandable}
+                        title={category.title}
+                    >
+                        {this.getCategoryItems(controls, category)}
+                    </FormCategory>
+                );
+            }
+        );
     }
 
-    /**
-     * Renders category items
-     */
-    private renderCategoryItems(items: FormCategoryItems[]): React.ReactNode {
-        return items.map((item: FormCategoryItems) => {
-            return this.renderFormControl(
-                item.params.schema,
-                item.params.propertyName,
-                item.params.schemaLocation,
-                item.params.dataLocation,
-                item.params.isRequired,
-                item.params.title,
-                getErrorFromDataLocation(
-                    item.params.dataLocation,
-                    this.props.validationErrors
-                )
-            );
-        });
+    private getCategoryItems(
+        controls: FormControlsWithConfigOptions,
+        category: FormCategoryConfig
+    ): React.ReactNode {
+        return controls.items.map(
+            (controlItem: FormControlItem): React.ReactNode => {
+                if (category.items.indexOf(controlItem.propertyName) > -1) {
+                    return controlItem.render;
+                }
+            }
+        );
+    }
+
+    private getAllCategories(categories: FormCategoryConfig[]): FormCategoryConfig[] {
+        // All categorized properties
+        const categorized: string[] = categories.reduce<string[]>(
+            (accumulator: string[], category: FormCategoryConfig): string[] => {
+                return accumulator.concat(category.items);
+            },
+            []
+        );
+        // All uncategorized properties
+        const uncategorized: string[] = Object.keys(
+            get(this.props.schema, PropertyKeyword.reactProperties, {})
+        )
+            .concat(Object.keys(get(this.props.schema, PropertyKeyword.properties, {})))
+            .filter((category: string) => {
+                return categorized.indexOf(category) < 0;
+            });
+        // All categorized and uncategorized properties
+        return [
+            {
+                title: null,
+                items: uncategorized,
+            },
+        ].concat(categories);
     }
 
     private getFormControlsAndConfigurationOptions(
@@ -215,7 +236,6 @@ class FormSection extends React.Component<
     ): FormControlsWithConfigOptions {
         const formControls: FormControlsWithConfigOptions = {
             items: [],
-            parameters: [],
         };
 
         const propertyKeys: string[] = [];
@@ -271,8 +291,9 @@ class FormSection extends React.Component<
                                 ),
                             };
 
-                            formControls.items.push(
-                                this.renderFormControl(
+                            formControls.items.push({
+                                propertyName: params.propertyName,
+                                render: this.renderFormControl(
                                     params.property,
                                     params.propertyName,
                                     params.schemaLocation,
@@ -280,15 +301,8 @@ class FormSection extends React.Component<
                                     params.isRequired,
                                     params.title,
                                     params.invalidMessage
-                                )
-                            );
-
-                            if (
-                                params.property.type !== "object" &&
-                                typeof params.property[propertyKey] === "undefined"
-                            ) {
-                                formControls.parameters.push(params);
-                            }
+                                ),
+                            });
                         }
                     }
                 );
@@ -296,25 +310,6 @@ class FormSection extends React.Component<
         );
 
         return formControls;
-    }
-
-    private getFormObjectItemsOrConfigCategories(
-        formControls: FormControlsWithConfigOptions
-    ): React.ReactNode {
-        if (this.props.orderByPropertyNames) {
-            if (
-                checkCategoryConfigPropertyCount(
-                    formControls,
-                    this.props.orderByPropertyNames
-                )
-            ) {
-                return formControls.items;
-            }
-
-            return this.renderCategories(formControls.parameters);
-        }
-
-        return formControls.items;
     }
 
     /**
@@ -335,7 +330,10 @@ class FormSection extends React.Component<
                 not
             );
 
-            return this.getFormObjectItemsOrConfigCategories(formControls);
+            return this.renderCategories(
+                get(this.props.schema, "formConfig.categories"),
+                formControls
+            );
         }
     }
 

--- a/packages/fast-tooling-react/src/form/utilities/form.tsx
+++ b/packages/fast-tooling-react/src/form/utilities/form.tsx
@@ -6,17 +6,8 @@ import {
     squareBracketsRegex,
 } from "../../data-utilities/location";
 import ajv, { ErrorObject, ValidationError } from "ajv";
+import { AttributeSettingsMappingToPropertyNames } from "../form.props";
 import {
-    AttributeSettingsMappingToPropertyNames,
-    FormOrderByPropertyNamesCategories,
-    FormOrderByPropertyNamesProps,
-} from "../form.props";
-import {
-    AssignedCategoryParams,
-    AssignedParamsByCategoryConfig,
-    FormCategoryProps,
-    FormControlParameters,
-    FormControlsWithConfigOptions,
     FormSectionProps,
     InitialOneOfAnyOfState,
     OneOfAnyOf,
@@ -415,157 +406,8 @@ export function isConst(property: any): boolean {
     return typeof property.const !== "undefined";
 }
 
-/**
- * Organizes the categories and items by weight
- */
-export function getWeightedCategoriesAndItems(
-    categoryParams: FormCategoryProps[]
-): FormCategoryProps[] {
-    categoryParams.sort(function(a: any, b: any): number {
-        return b.weight - a.weight;
-    });
-
-    for (const categoryParam of categoryParams) {
-        categoryParam.items.sort(function(a: any, b: any): number {
-            return b.weight - a.weight;
-        });
-    }
-
-    return categoryParams;
-}
-
 export function checkIsObject(property: any, schema: any): boolean {
     return (property.properties || property.type === "object") && property === schema;
-}
-
-export function findAssignedParamsByCategoryProperties(
-    config: AssignedParamsByCategoryConfig
-): AssignedCategoryParams {
-    for (const propertyName of config.categoryProperties) {
-        if (propertyName === config.formControlParameter.propertyName) {
-            return {
-                category: config.category.title,
-                expandable: config.category.expandable,
-                categoryWeight: config.category.weight,
-                itemWeight: config.categoryProperty.weight || config.assignedItemWeight,
-            };
-        }
-    }
-}
-
-export function getCategoryIndex(
-    assignedCategoryParams: AssignedCategoryParams,
-    categoryParams: FormCategoryProps[]
-): number {
-    for (
-        let i: number = 0, categoryParamsLength: number = categoryParams.length;
-        i < categoryParamsLength;
-        i++
-    ) {
-        if (assignedCategoryParams.category === categoryParams[i].title) {
-            return i;
-        }
-    }
-}
-
-export function checkCategoryConfigPropertyCount(
-    formControls: FormControlsWithConfigOptions,
-    orderByPropertyNames: FormOrderByPropertyNamesProps
-): boolean {
-    return (
-        typeof orderByPropertyNames.showCategoriesAtPropertyCount === "number" &&
-        orderByPropertyNames.showCategoriesAtPropertyCount >= formControls.items.length
-    );
-}
-
-export function findOrderedByPropertyNames(
-    category: FormOrderByPropertyNamesCategories,
-    formControlParameter: FormControlParameters,
-    assignedItemWeight: number
-): AssignedCategoryParams {
-    for (const categoryProperty of category.properties) {
-        const categoryProperties: string[] = Array.isArray(categoryProperty.propertyName)
-            ? categoryProperty.propertyName
-            : [categoryProperty.propertyName];
-
-        const assignedParamsByCategoryProperties: AssignedCategoryParams = findAssignedParamsByCategoryProperties(
-            {
-                categoryProperties,
-                formControlParameter,
-                category,
-                categoryProperty,
-                assignedItemWeight,
-            }
-        );
-
-        if (Boolean(assignedParamsByCategoryProperties)) {
-            return assignedParamsByCategoryProperties;
-        }
-    }
-}
-
-function getAssignedCategoryParams(
-    formControlParameter: FormControlParameters,
-    assignedItemWeight: number,
-    orderByPropertyNames: FormOrderByPropertyNamesProps
-): AssignedCategoryParams {
-    for (const category of orderByPropertyNames.categories) {
-        const formControlOrderedByPropertyNames: AssignedCategoryParams = findOrderedByPropertyNames(
-            category,
-            formControlParameter,
-            assignedItemWeight
-        );
-
-        if (Boolean(formControlOrderedByPropertyNames)) {
-            return formControlOrderedByPropertyNames;
-        }
-    }
-
-    return {
-        category: "Default",
-        categoryWeight: orderByPropertyNames.defaultCategoryWeight || 0,
-        itemWeight: 0,
-    };
-}
-
-export function getCategoryParams(
-    formControlParameters: FormControlParameters[],
-    orderByPropertyNames: FormOrderByPropertyNamesProps
-): FormCategoryProps[] {
-    const categoryParams: FormCategoryProps[] = [];
-
-    for (const formControlParameter of formControlParameters) {
-        const assignedCategoryParams: AssignedCategoryParams = getAssignedCategoryParams(
-            formControlParameter,
-            0,
-            orderByPropertyNames
-        );
-        const categoryIndex: number = getCategoryIndex(
-            assignedCategoryParams,
-            categoryParams
-        );
-
-        if (typeof categoryIndex === "number") {
-            categoryParams[categoryIndex].items.push({
-                weight: assignedCategoryParams.itemWeight,
-                params: formControlParameter,
-            });
-        } else {
-            categoryParams.push({
-                title: assignedCategoryParams.category,
-                weight: assignedCategoryParams.categoryWeight,
-                expandable: assignedCategoryParams.expandable,
-                items: [
-                    {
-                        weight: assignedCategoryParams.itemWeight,
-                        params: formControlParameter,
-                    },
-                ],
-            });
-        }
-    }
-
-    return getWeightedCategoriesAndItems(categoryParams);
 }
 
 export function handleToggleClick(value: any, id: string, updateRequested: any): any {

--- a/packages/fast-tooling-react/webpack.config.js
+++ b/packages/fast-tooling-react/webpack.config.js
@@ -10,17 +10,20 @@ module.exports = {
         historyApiFallback: true,
         open: true,
         overlay: true,
-        port: 7002
+        port: 7002,
     },
     devtool: process.env.NODE_ENV === "production" ? "none" : "inline-source-map",
     entry: {
         app: path.resolve(appDir, "index.tsx"),
-        focusVisible: path.resolve(__dirname, "node_modules/focus-visible/dist/focus-visible.min.js")
+        focusVisible: path.resolve(
+            __dirname,
+            "../../node_modules/focus-visible/dist/focus-visible.min.js"
+        ),
     },
     output: {
         path: outDir,
         publicPath: "/",
-        filename: "[name].js"
+        filename: "[name].js",
     },
     mode: process.env.NODE_ENV || "development",
     module: {
@@ -33,19 +36,19 @@ module.exports = {
                         options: {
                             compilerOptions: {
                                 declaration: false,
-                            }
-                        }
-                    }
-                ]
-            }
-        ]
+                            },
+                        },
+                    },
+                ],
+            },
+        ],
     },
     plugins: [
         new HtmlWebpackPlugin({
             contentBase: outDir,
-        })
+        }),
     ],
     resolve: {
         extensions: [".js", ".tsx", ".ts", ".json"],
-    }
-}
+    },
+};


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Allows the use of categories to be set for properties in the JSON schema.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Closes #1655 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->