### PR TITLE
feat: select class and style support for scaling menus

### DIFF
--- a/packages/fast-components-class-name-contracts-base/src/select/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/select/index.ts
@@ -28,6 +28,11 @@ export interface SelectClassNameContract {
     select__multiSelectable?: string;
 
     /**
+     * select menu positioning wrapper
+     */
+    select__menuPositioningWrapper?: string;
+
+    /**
      * left positioner horizontal state
      */
     select__menuPositionLeft?: string;

--- a/packages/fast-components-class-name-contracts-base/src/select/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/select/index.ts
@@ -30,7 +30,7 @@ export interface SelectClassNameContract {
     /**
      * select menu positioning wrapper
      */
-    select__menuPositioningWrapper?: string;
+    select__menuPositioningRegion?: string;
 
     /**
      * left positioner horizontal state

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -321,6 +321,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
      */
     private generateViewportPositionerClassNames(): ViewportPositionerClassNameContract {
         const {
+            select__menuPositioningWrapper,
             select__menuPositionLeft,
             select__menuPositionRight,
             select__menuPositionTop,
@@ -330,6 +331,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         }: SelectClassNameContract = this.props.managedClasses;
 
         return {
+            viewportPositioner: select__menuPositioningWrapper,
             viewportPositioner__left: select__menuPositionLeft,
             viewportPositioner__right: select__menuPositionRight,
             viewportPositioner__top: select__menuPositionTop,

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -321,7 +321,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
      */
     private generateViewportPositionerClassNames(): ViewportPositionerClassNameContract {
         const {
-            select__menuPositioningWrapper,
+            select__menuPositioningRegion,
             select__menuPositionLeft,
             select__menuPositionRight,
             select__menuPositionTop,
@@ -331,7 +331,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         }: SelectClassNameContract = this.props.managedClasses;
 
         return {
-            viewportPositioner: select__menuPositioningWrapper,
+            viewportPositioner: select__menuPositioningRegion,
             viewportPositioner__left: select__menuPositionLeft,
             viewportPositioner__right: select__menuPositionRight,
             viewportPositioner__top: select__menuPositionTop,

--- a/packages/fast-components-react-msft/src/select/select.stories.tsx
+++ b/packages/fast-components-react-msft/src/select/select.stories.tsx
@@ -6,6 +6,7 @@ import { Select } from "./";
 import { uniqueId } from "lodash-es";
 import { action } from "@storybook/addon-actions";
 import { AxisPositioningMode } from "@microsoft/fast-components-react-base";
+import { Dialog } from "../dialog";
 
 const rootElement: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
 
@@ -184,102 +185,100 @@ storiesOf("Select", module)
             />
         </Select>
     ))
-    .add("Scaling", () => (
-        <div
-            ref={rootElement}
-            style={{
-                height: "400px",
-                width: "400px",
-                margin: "50px",
-                overflow: "scroll",
-            }}
-        >
+    .add("Scaling in dialog", () => (
+        <Dialog modal={true} visible={true}>
             <div
+                ref={rootElement}
                 style={{
-                    height: "1200px",
-                    width: "1200px",
-                    padding: "500px",
-                    background: "blue",
+                    height: "100%",
+                    width: "100%",
+                    overflowY: "scroll",
+                    overflowX: "hidden",
                 }}
             >
-                <Select
+                <div
                     style={{
-                        width: "180px",
-                    }}
-                    placeholder="Select an option"
-                    onValueChange={action("onValueChange")}
-                    menuFlyoutConfig={{
-                        viewport: rootElement,
-                        horizontalPositioningMode: AxisPositioningMode.adjacent,
-                        verticalPositioningMode: AxisPositioningMode.inset,
-                        horizontalThreshold: 200,
-                        verticalThreshold: 60,
-                        scaleToFit: true,
+                        height: "1000px",
                     }}
                 >
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 1"
-                        displayString="Select option 1"
-                    />
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 2"
-                        displayString="Select option 2"
-                    />
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 3"
-                        displayString="Select option 3"
-                    />
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 4"
-                        displayString="Select option 4"
-                    />
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 1"
-                        displayString="Select option 1"
-                    />
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 2"
-                        displayString="Select option 2"
-                    />
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 3"
-                        displayString="Select option 3"
-                    />
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 4"
-                        displayString="Select option 4"
-                    />
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 1"
-                        displayString="Select option 1"
-                    />
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 2"
-                        displayString="Select option 2"
-                    />
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 3"
-                        displayString="Select option 3"
-                    />
-                    <SelectOption
-                        id={uniqueId()}
-                        value="Select option 4"
-                        displayString="Select option 4"
-                    />
-                </Select>
+                    <Select
+                        style={{
+                            margin: "350px 0 0 20px",
+                            width: "180px",
+                        }}
+                        placeholder="Select an option"
+                        onValueChange={action("onValueChange")}
+                        menuFlyoutConfig={{
+                            viewport: rootElement,
+                            horizontalPositioningMode: AxisPositioningMode.uncontrolled,
+                            verticalPositioningMode: AxisPositioningMode.adjacent,
+                            scaleToFit: true,
+                        }}
+                    >
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 1"
+                            displayString="Select option 1"
+                        />
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 2"
+                            displayString="Select option 2"
+                        />
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 3"
+                            displayString="Select option 3"
+                        />
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 4"
+                            displayString="Select option 4"
+                        />
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 1"
+                            displayString="Select option 1"
+                        />
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 2"
+                            displayString="Select option 2"
+                        />
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 3"
+                            displayString="Select option 3"
+                        />
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 4"
+                            displayString="Select option 4"
+                        />
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 1"
+                            displayString="Select option 1"
+                        />
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 2"
+                            displayString="Select option 2"
+                        />
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 3"
+                            displayString="Select option 3"
+                        />
+                        <SelectOption
+                            id={uniqueId()}
+                            value="Select option 4"
+                            displayString="Select option 4"
+                        />
+                    </Select>
+                </div>
             </div>
-        </div>
+        </Dialog>
     ))
     .add("Disabled", () => (
         <Select onValueChange={action("onValueChange")} disabled={true} />

--- a/packages/fast-components-react-msft/src/select/select.stories.tsx
+++ b/packages/fast-components-react-msft/src/select/select.stories.tsx
@@ -7,6 +7,8 @@ import { uniqueId } from "lodash-es";
 import { action } from "@storybook/addon-actions";
 import { AxisPositioningMode } from "@microsoft/fast-components-react-base";
 
+const rootElement: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
+
 storiesOf("Select", module)
     .add("Default", () => (
         <Select onValueChange={action("onValueChange")}>
@@ -181,6 +183,103 @@ storiesOf("Select", module)
                 displayString="Select option 4"
             />
         </Select>
+    ))
+    .add("Scaling", () => (
+        <div
+            ref={rootElement}
+            style={{
+                height: "400px",
+                width: "400px",
+                margin: "50px",
+                overflow: "scroll",
+            }}
+        >
+            <div
+                style={{
+                    height: "1200px",
+                    width: "1200px",
+                    padding: "500px",
+                    background: "blue",
+                }}
+            >
+                <Select
+                    style={{
+                        width: "180px",
+                    }}
+                    placeholder="Select an option"
+                    onValueChange={action("onValueChange")}
+                    menuFlyoutConfig={{
+                        viewport: rootElement,
+                        horizontalPositioningMode: AxisPositioningMode.adjacent,
+                        verticalPositioningMode: AxisPositioningMode.inset,
+                        horizontalThreshold: 200,
+                        verticalThreshold: 60,
+                        scaleToFit: true,
+                    }}
+                >
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 1"
+                        displayString="Select option 1"
+                    />
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 2"
+                        displayString="Select option 2"
+                    />
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 3"
+                        displayString="Select option 3"
+                    />
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 4"
+                        displayString="Select option 4"
+                    />
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 1"
+                        displayString="Select option 1"
+                    />
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 2"
+                        displayString="Select option 2"
+                    />
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 3"
+                        displayString="Select option 3"
+                    />
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 4"
+                        displayString="Select option 4"
+                    />
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 1"
+                        displayString="Select option 1"
+                    />
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 2"
+                        displayString="Select option 2"
+                    />
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 3"
+                        displayString="Select option 3"
+                    />
+                    <SelectOption
+                        id={uniqueId()}
+                        value="Select option 4"
+                        displayString="Select option 4"
+                    />
+                </Select>
+            </div>
+        </div>
     ))
     .add("Disabled", () => (
         <Select onValueChange={action("onValueChange")} disabled={true} />

--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -94,7 +94,7 @@ const styles: ComponentStyles<SelectClassNameContract, DesignSystem> = {
             "border-color": neutralOutlineRest,
         },
     },
-    select__menuPositioningWrapper: {
+    select__menuPositioningRegion: {
         display: "grid",
         "grid-template-columns": "1fr",
         "grid-template-rows": "1fr",

--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -101,7 +101,6 @@ const styles: ComponentStyles<SelectClassNameContract, DesignSystem> = {
     },
     select__menuPositionLeft: {
         "grid-template-columns": "1fr auto",
-
         "& $select_menu": {
             "grid-column": "2",
         },

--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -94,6 +94,39 @@ const styles: ComponentStyles<SelectClassNameContract, DesignSystem> = {
             "border-color": neutralOutlineRest,
         },
     },
+    select__menuPositioningWrapper: {
+        display: "grid",
+        "grid-template-columns": "1fr",
+        "grid-template-rows": "1fr",
+    },
+    select__menuPositionLeft: {
+        "grid-template-columns": "1fr auto",
+
+        "& $select_menu": {
+            "grid-column": "2",
+        },
+    },
+    select__menuPositionRight: {
+        "grid-template-columns": "auto 1fr",
+        "& $select_menu": {
+            "grid-column": "1",
+        },
+    },
+    select__menuPositionTop: {
+        "grid-template-rows": "1fr auto",
+
+        "& $select_menu": {
+            "grid-row": "2",
+            "margin-top": "12px",
+        },
+    },
+    select__menuPositionBottom: {
+        "grid-template-rows": "auto 1fr",
+        "& $select_menu": {
+            "grid-row": "1",
+            "margin-bottom": "12px",
+        },
+    },
 };
 
 export default styles;


### PR DESCRIPTION
# Description
Added a managed class to select and modified styles to support scaling menus.  Aside from tweaking styles and defaults they should essentially work now.

![image](https://user-images.githubusercontent.com/7649425/68164515-d1bf1a80-ff11-11e9-9c07-a6b532176c01.png)

![image](https://user-images.githubusercontent.com/7649425/68164471-b48a4c00-ff11-11e9-8ef0-bfa78423345c.png)

## Motivation & context
Being able to have select menus scale according to available space has been a requested feature.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
