### PR TITLE
fix: slider can miss dir setting on initial render.

### DIFF
--- a/packages/fast-components-react-base/src/slider-track-item/slider-track-item.spec.tsx
+++ b/packages/fast-components-react-base/src/slider-track-item/slider-track-item.spec.tsx
@@ -3,17 +3,9 @@ import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import SliderTrackItem, {
     SliderTrackItemAnchor,
-    SliderTrackItemHandledProps,
-    SliderTrackItemProps,
     SliderTrackItemUnhandledProps,
 } from "./slider-track-item";
-import {
-    SliderContext,
-    SliderMode,
-    SliderOrientation,
-    SliderRange,
-    SliderThumb,
-} from "../slider";
+import { SliderContext, SliderMode, SliderOrientation } from "../slider";
 import { DisplayNamePrefix } from "../utilities";
 import { SliderState } from "../slider/slider";
 import { Direction } from "@microsoft/fast-web-utilities";
@@ -36,6 +28,7 @@ describe("slider track item", (): void => {
         isIncrementing: false,
         incrementDirection: 1,
         usePageStep: false,
+        direction: Direction.ltr,
     };
 
     test("should have a displayName that matches the component name", () => {

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -21,11 +21,7 @@ import {
 } from "@microsoft/fast-web-utilities";
 import ReactDOM from "react-dom";
 import { SliderClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import {
-    classNames,
-    Direction,
-    DirectionAttributeName,
-} from "@microsoft/fast-web-utilities";
+import { classNames, Direction } from "@microsoft/fast-web-utilities";
 import { DisplayNamePrefix } from "../utilities";
 import { SliderContext, SliderContextType } from "./slider-context";
 import SliderTrackItem, {
@@ -70,6 +66,7 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
     private static minIncrementDelay: number = 100;
     private static incrementAcceleration: number = 50;
     private static rolePropName: string = "role";
+    private static DirectionAttributeName: string = "dir";
 
     protected handledProps: HandledProps<SliderHandledProps> = {
         disabled: void 0,
@@ -657,11 +654,11 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
         }
 
         const closest: Element = this.rootElement.current.closest(
-            `[${DirectionAttributeName}]`
+            `[${Slider.DirectionAttributeName}]`
         );
 
         return closest === null ||
-            closest.getAttribute(DirectionAttributeName) === Direction.ltr
+            closest.getAttribute(Slider.DirectionAttributeName) === Direction.ltr
             ? Direction.ltr
             : Direction.rtl;
     };

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -21,14 +21,17 @@ import {
 } from "@microsoft/fast-web-utilities";
 import ReactDOM from "react-dom";
 import { SliderClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
-import { Direction } from "@microsoft/fast-web-utilities";
+import {
+    classNames,
+    Direction,
+    DirectionAttributeName,
+} from "@microsoft/fast-web-utilities";
 import { DisplayNamePrefix } from "../utilities";
 import { SliderContext, SliderContextType } from "./slider-context";
 import SliderTrackItem, {
     SliderTrackItemAnchor,
     SliderTrackItemManagedClasses,
 } from "../slider-track-item";
-import { classNames } from "@microsoft/fast-web-utilities";
 
 export enum SliderThumb {
     upperThumb = "upperThumb",
@@ -67,7 +70,6 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
     private static minIncrementDelay: number = 100;
     private static incrementAcceleration: number = 50;
     private static rolePropName: string = "role";
-    private static dirPropName: string = "dir";
 
     protected handledProps: HandledProps<SliderHandledProps> = {
         disabled: void 0,
@@ -654,10 +656,12 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
             return Direction.ltr;
         }
 
-        const closest: Element = this.rootElement.current.closest(`[dir]`);
+        const closest: Element = this.rootElement.current.closest(
+            `[${DirectionAttributeName}]`
+        );
 
         return closest === null ||
-            closest.getAttribute(Slider.dirPropName) === Direction.ltr
+            closest.getAttribute(DirectionAttributeName) === Direction.ltr
             ? Direction.ltr
             : Direction.rtl;
     };

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -315,7 +315,7 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
                 [slider__incrementing, this.state.isIncrementing],
                 [slider__vertical, isVertical],
                 [slider__horizontal, !isVertical],
-                [slider__rtl, this.state.direction === "rtl"],
+                [slider__rtl, this.state.direction === Direction.rtl],
                 [slider__modeSingle, this.props.mode === SliderMode.singleValue],
                 [slider__modeAdjustUpper, this.props.mode === SliderMode.adustUpperValue],
                 [slider__modeAdjustLower, this.props.mode === SliderMode.adustLowerValue],
@@ -656,13 +656,10 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
 
         const closest: Element = this.rootElement.current.closest(`[dir]`);
 
-        if (closest === null) {
-            return Direction.ltr;
-        }
-
-        return closest.getAttribute(Slider.dirPropName) === "rtl"
-            ? Direction.rtl
-            : Direction.ltr;
+        return closest === null ||
+            closest.getAttribute(Slider.dirPropName) === Direction.ltr
+            ? Direction.ltr
+            : Direction.rtl;
     };
 
     /**
@@ -805,7 +802,7 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
         }
 
         if (
-            this.state.direction === "rtl" &&
+            this.state.direction === Direction.rtl &&
             this.props.orientation !== SliderOrientation.vertical
         ) {
             pct = 1 - pct;

--- a/packages/fast-web-utilities/src/localization.ts
+++ b/packages/fast-web-utilities/src/localization.ts
@@ -5,5 +5,3 @@ export enum Direction {
     ltr = "ltr",
     rtl = "rtl",
 }
-
-export const DirectionAttributeName: string = "dir";

--- a/packages/fast-web-utilities/src/localization.ts
+++ b/packages/fast-web-utilities/src/localization.ts
@@ -5,3 +5,5 @@ export enum Direction {
     ltr = "ltr",
     rtl = "rtl",
 }
+
+export const DirectionAttributeName: string = "dir";


### PR DESCRIPTION
## Description
Slider's mechanism for detecting direction (ltr/rtl) could fail to detect the correct setting on initial render.  We now check after mounting and after any renders.

## Motivation & context
Sliders would be incorrect on initial render in rtl scenarios.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.