### PR TITLE
fix: canUsedForcedColors should be called canUseForcedColors

### DIFF
--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -1,7 +1,7 @@
 import { CSSRules } from "@microsoft/fast-jss-manager";
 import { DesignSystem } from "../design-system";
 import { format, important, toPx } from "@microsoft/fast-jss-utilities";
-import { canUsedForcedColors } from "@microsoft/fast-web-utilities";
+import { canUseForcedColors } from "@microsoft/fast-web-utilities";
 import { focusOutlineWidth, outlineWidth } from "./design-system";
 
 export const highContrastSelector: string = "@media (-ms-high-contrast:active)";
@@ -29,7 +29,7 @@ export const highContrastOptOutProperty: CSSRules<{}> = applyhighContrastOptOutP
 
 // Function used to to set link color base on 'forced-color' query
 export function applyHighContrastLinkValue(): string {
-    return canUsedForcedColors() ? "LinkText !important" : "-ms-hotlight !important";
+    return canUseForcedColors() ? "LinkText !important" : "-ms-hotlight !important";
 }
 // Used to to set high contrast base on 'forced-color' query
 export const highContrastLinkValue: string = applyHighContrastLinkValue();

--- a/packages/fast-web-utilities/src/dom.spec.ts
+++ b/packages/fast-web-utilities/src/dom.spec.ts
@@ -1,9 +1,4 @@
-import {
-    canUseCssGrid,
-    canUsedForcedColors,
-    canUseFocusVisible,
-    getKeyCode,
-} from "./dom";
+import { canUseCssGrid, canUseFocusVisible, canUseForcedColors, getKeyCode } from "./dom";
 import { KeyCodes } from "./key-codes";
 
 describe("getKeyCode", () => {
@@ -194,7 +189,7 @@ describe("canUseForcedColors", () => {
         });
     });
     test("should return true if forced color is enabled", () => {
-        expect(canUsedForcedColors()).toBe(true);
+        expect(canUseForcedColors()).toBe(true);
     });
 });
 
@@ -209,6 +204,6 @@ describe("canUseForcedColors", () => {
         });
     });
     test("should return false if forced color is not enabled", () => {
-        expect(canUsedForcedColors()).toBe(false);
+        expect(canUseForcedColors()).toBe(false);
     });
 });

--- a/packages/fast-web-utilities/src/dom.ts
+++ b/packages/fast-web-utilities/src/dom.ts
@@ -55,10 +55,17 @@ export function canUseCssGrid(): boolean {
     return _canUseCssGrid;
 }
 
-export function canUsedForcedColors(): boolean {
+export function canUseForcedColors(): boolean {
     return (
         canUseDOM() &&
         (window.matchMedia("(forced-colors: none)").matches ||
             window.matchMedia("(forced-colors: active)").matches)
     );
+}
+
+/**
+ * @deprecated Use 'canUseForcedColors' instead
+ */
+export function canUsedForcedColors(): boolean {
+    return canUseForcedColors();
 }

--- a/packages/fast-web-utilities/src/dom.ts
+++ b/packages/fast-web-utilities/src/dom.ts
@@ -66,6 +66,4 @@ export function canUseForcedColors(): boolean {
 /**
  * @deprecated Use 'canUseForcedColors' instead
  */
-export function canUsedForcedColors(): boolean {
-    return canUseForcedColors();
-}
+export const canUsedForcedColors: typeof canUseForcedColors = canUseForcedColors;


### PR DESCRIPTION
There is a typo on canUsedForcedColors. It should be called canUseForcedColors

# Description

deprecated and replaced `canUsedForcedColors`

## Motivation & context

close #2380 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

