### PR TITLE
fix: fix a bug causing luminance matching to fail if not grey

### DIFF
--- a/packages/fast-components-styles-msft/src/utilities/color/common.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/common.ts
@@ -198,7 +198,7 @@ export const contrast: (a: string, b: string) => number = memoize(
  * Returns the relative luminance of a color. If the value is not a color, -1 will be returned
  * Supports #RRGGBB and rgb(r, g, b) formats
  */
-export function luminance(color: any): number {
+export function luminance(color: string): number {
     return rgbToRelativeLuminance(parseColorString(color));
 }
 

--- a/packages/fast-components-styles-msft/src/utilities/color/palette.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/palette.ts
@@ -103,7 +103,7 @@ export function findClosestSwatchIndex(
         }
 
         try {
-            swatchLuminance = luminance(swatch);
+            swatchLuminance = luminance(resolvedSwatch);
         } catch (e) {
             swatchLuminance = -1;
         }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Fixed a problem attempting to parse a color string that was actually a function.

## Motivation & context

Resolves an issue with dynamic luminance with tinted neutral.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->