### PR TITLE
fix: ensure categories are included when the schema also includes oneOf

### DIFF
--- a/packages/fast-tooling-react/src/__tests__/schemas/one-of.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/one-of.schema.json
@@ -109,6 +109,31 @@
             "required": [
                 "numberOrString"
             ]
+        },
+        {
+            "description": "category",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "foo": {
+                    "title": "string",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "foo"
+            ],
+            "formConfig": {
+                "categories": [
+                    {
+                        "title": "Category A",
+                        "expandable": true,
+                        "items": [
+                            "foo"
+                        ]
+                    }
+                ]
+            }
         }
     ]
 }

--- a/packages/fast-tooling-react/src/form/form-section.tsx
+++ b/packages/fast-tooling-react/src/form/form-section.tsx
@@ -237,9 +237,9 @@ class FormSection extends React.Component<
         );
         // All uncategorized properties
         const uncategorized: string[] = Object.keys(
-            get(this.props.schema, PropertyKeyword.reactProperties, {})
+            get(this.state.schema, PropertyKeyword.reactProperties, {})
         )
-            .concat(Object.keys(get(this.props.schema, PropertyKeyword.properties, {})))
+            .concat(Object.keys(get(this.state.schema, PropertyKeyword.properties, {})))
             .filter((category: string) => {
                 return categorized.indexOf(category) < 0;
             });
@@ -355,7 +355,7 @@ class FormSection extends React.Component<
             );
 
             return this.renderCategories(
-                get(this.props.schema, "formConfig.categories"),
+                get(schema, "formConfig.categories"),
                 formControls,
                 invalidMessage
             );
@@ -398,7 +398,7 @@ class FormSection extends React.Component<
      */
     private renderAdditionalProperties(invalidMessage: string): React.ReactNode {
         const schemaLocation: string = this.getSchemaLocation();
-        const schema: any = get(this.props.schema, schemaLocation, this.props.schema);
+        const schema: any = get(this.state.schema, schemaLocation, this.state.schema);
 
         if (typeof schema.additionalProperties === "object") {
             return (
@@ -406,7 +406,7 @@ class FormSection extends React.Component<
                     index={0}
                     controls={this.props.controls}
                     controlPlugins={this.props.controlPlugins}
-                    formControlId={this.props.schema.formControlId}
+                    formControlId={this.state.schema.formControlId}
                     dataLocation={this.props.dataLocation}
                     schemaLocation={schemaLocation}
                     examples={get(schema, "examples")}

--- a/packages/fast-tooling-react/src/form/form.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form.spec.tsx
@@ -542,4 +542,104 @@ describe("Form", () => {
 
         expect(rendered.find(`#${id1}`)).toHaveLength(2);
     });
+    test("should show controls in categories if categories are passed", () => {
+        const rendered: any = mount(
+            <BareForm
+                schema={{
+                    type: "object",
+                    properties: {
+                        foo: {
+                            type: "string",
+                        },
+                        bar: {
+                            type: "number",
+                        },
+                        bat: {
+                            type: "boolean",
+                        },
+                    },
+                    formConfig: {
+                        categories: [
+                            {
+                                title: "Category A",
+                                expandable: true,
+                                items: ["foo"],
+                            },
+                            {
+                                title: "Category B",
+                                items: ["bar"],
+                            },
+                        ],
+                    },
+                }}
+                data={{}}
+                onChange={jest.fn()}
+            />
+        );
+
+        const categories: any = rendered.find("FormCategory");
+
+        expect(categories).toHaveLength(2);
+        expect(categories.at(0).find("TextareaControl")).toHaveLength(1);
+        expect(categories.at(1).find("NumberFieldControl")).toHaveLength(1);
+        expect(rendered.find("CheckboxControl")).toHaveLength(1);
+    });
+    test("should update controls if oneOf select has a value change", () => {
+        const rendered: any = mount(
+            <BareForm
+                schema={{
+                    oneOf: [
+                        {
+                            type: "object",
+                            properties: {
+                                foo: {
+                                    type: "string",
+                                },
+                                bar: {
+                                    type: "number",
+                                },
+                                bat: {
+                                    type: "boolean",
+                                },
+                            },
+                            required: ["foo", "bar", "bat"],
+                            formConfig: {
+                                categories: [
+                                    {
+                                        title: "Category A",
+                                        expandable: true,
+                                        items: ["foo"],
+                                    },
+                                    {
+                                        title: "Category B",
+                                        items: ["bar"],
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                }}
+                data={undefined}
+                onChange={jest.fn()}
+            />
+        );
+
+        const categoriesBefore: any = rendered.find("FormCategory");
+
+        expect(categoriesBefore).toHaveLength(0);
+        expect(categoriesBefore.at(0).find("TextareaControl")).toHaveLength(0);
+        expect(categoriesBefore.at(1).find("NumberFieldControl")).toHaveLength(0);
+        expect(rendered.find("CheckboxControl")).toHaveLength(0);
+
+        const select: any = rendered.find("select");
+
+        select.simulate("change", { target: { value: "0" } });
+
+        const categoriesAfter: any = rendered.find("FormCategory");
+
+        expect(categoriesAfter).toHaveLength(2);
+        expect(categoriesAfter.at(0).find("TextareaControl")).toHaveLength(1);
+        expect(categoriesAfter.at(1).find("NumberFieldControl")).toHaveLength(1);
+        expect(rendered.find("CheckboxControl")).toHaveLength(1);
+    });
 });


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
The category update did not include checks for oneOf arrays in the schema.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->