### PR TITLE
fix: color explorer marker colors don't show on light colors

### DIFF
--- a/packages/fast-color-explorer/app/control-pane.tsx
+++ b/packages/fast-color-explorer/app/control-pane.tsx
@@ -79,6 +79,7 @@ const styles: any = (
             body: {
                 fontFamily: '"Segoe UI", Arial, sans-serif',
                 fontSize: "14px",
+                margin: "0",
             },
             ".sketch-picker": {
                 display: "flex",

--- a/packages/fast-color-explorer/app/gradient.tsx
+++ b/packages/fast-color-explorer/app/gradient.tsx
@@ -22,7 +22,7 @@ const styles: any = {
             content: "''",
             opacity: "0.7",
             position: "relative",
-            border: "solid 1px currentColor",
+            border: "solid 1px currentcolor",
             borderRadius: "50%",
             display: "block",
             alignSelf: "center",

--- a/packages/fast-color-explorer/app/gradient.tsx
+++ b/packages/fast-color-explorer/app/gradient.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import manageJss from "@microsoft/fast-jss-manager-react";
 import { isEqual } from "lodash-es";
+import { DesignSystemDefaults, isDarkMode } from "@microsoft/fast-components-styles-msft";
 
 const styles: any = {
     gradient: {
@@ -19,9 +20,9 @@ const styles: any = {
             height: "6px",
             margin: "0 auto",
             content: "''",
-            opacity: "0.5",
+            opacity: "0.7",
             position: "relative",
-            border: "solid 1px white",
+            border: "solid 1px currentColor",
             borderRadius: "50%",
             display: "block",
             alignSelf: "center",
@@ -68,6 +69,13 @@ class BaseGradient extends React.Component<GradientProps, {}> {
                     className={classNames}
                     style={{
                         background: this.props.colors[index],
+                        color: isDarkMode(
+                            Object.assign({}, DesignSystemDefaults, {
+                                backgroundColor: this.props.colors[index],
+                            })
+                        )
+                            ? "white"
+                            : "black",
                     }}
                     title={index.toString().concat(": ", item.toUpperCase())}
                     href={this.props.createAnchors ? `${item.toUpperCase()}` : undefined}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Updated the marker dot to show when the base color is light.

Now:
![image](https://user-images.githubusercontent.com/47367562/68894133-7fcd8000-06db-11ea-91ea-ae718fc38452.png)

## Motivation & context

The marker was previously a white dot, which was usually visible, although not always accessible, unless the base color was very light.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->