### PR TITLE
fix: delay rendering slider internals until after direction check

### DIFF
--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -7,6 +7,7 @@ import Slider, {
     SliderUnhandledProps,
 } from "./slider";
 import {
+    Direction,
     keyCodeArrowDown,
     keyCodeArrowLeft,
     keyCodeArrowRight,
@@ -767,7 +768,7 @@ describe("Slider", (): void => {
         document.body.removeChild(container);
     });
 
-    test("first render state flag is false after component has mounted", (): void => {
+    test("direction is set after component has mounted", (): void => {
         const container: HTMLDivElement = document.createElement("div");
         document.body.appendChild(container);
 
@@ -778,7 +779,7 @@ describe("Slider", (): void => {
             }
         );
 
-        expect(rendered.state("isFirstRender")).toBe(false);
+        expect(rendered.state("direction")).toBe(Direction.ltr);
         document.body.removeChild(container);
     });
 

--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -767,6 +767,21 @@ describe("Slider", (): void => {
         document.body.removeChild(container);
     });
 
+    test("first render state flag is false after component has mounted", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const rendered: any = mount(
+            <Slider managedClasses={managedClasses} initialValue={50} />,
+            {
+                attachTo: container,
+            }
+        );
+
+        expect(rendered.state("isFirstRender")).toBe(false);
+        document.body.removeChild(container);
+    });
+
     // tslint:disable-next-line:no-shadowed-variable
     window.removeEventListener = jest.fn((event: string, callback: any) => {
         map[event] = callback;

--- a/packages/fast-components-react-base/src/slider/slider.spec.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.spec.tsx
@@ -783,6 +783,25 @@ describe("Slider", (): void => {
         document.body.removeChild(container);
     });
 
+    test("slider internals do not render while direction state is null", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const rendered: any = mount(<Slider managedClasses={managedClasses} />, {
+            attachTo: container,
+        });
+
+        let renderResults: React.ReactElement<HTMLDivElement> = rendered
+            .instance()
+            ["render"]();
+        expect(React.Children.toArray(renderResults.props.children)).toHaveLength(1);
+        rendered.state().direction = null;
+        renderResults = rendered.instance()["render"]();
+        expect(React.Children.toArray(renderResults.props.children)).toHaveLength(0);
+
+        document.body.removeChild(container);
+    });
+
     // tslint:disable-next-line:no-shadowed-variable
     window.removeEventListener = jest.fn((event: string, callback: any) => {
         map[event] = callback;

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -44,8 +44,7 @@ export interface SliderState {
     isIncrementing: boolean;
     incrementDirection: number;
     usePageStep: boolean;
-    direction: Direction;
-    isFirstRender: boolean;
+    direction: Direction | null;
 }
 
 class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, SliderState> {
@@ -174,8 +173,7 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
             isIncrementing: false,
             incrementDirection: 1,
             usePageStep: false,
-            direction: Direction.ltr,
-            isFirstRender: true,
+            direction: null,
         };
     }
 
@@ -184,9 +182,6 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
      */
     public componentDidMount(): void {
         this.updateDirection();
-        this.setState({
-            isFirstRender: false,
-        });
     }
 
     public componentWillUnmount(): void {
@@ -286,7 +281,7 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
      * (avoids transition animations to get the layout right to begin with)
      */
     private renderSliderInternals = (): React.ReactNode => {
-        if (this.state.isFirstRender) {
+        if (this.state.direction === null) {
             return null;
         }
 

--- a/packages/fast-components-react-base/src/slider/slider.tsx
+++ b/packages/fast-components-react-base/src/slider/slider.tsx
@@ -45,6 +45,7 @@ export interface SliderState {
     incrementDirection: number;
     usePageStep: boolean;
     direction: Direction;
+    isFirstRender: boolean;
 }
 
 class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, SliderState> {
@@ -174,6 +175,7 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
             incrementDirection: 1,
             usePageStep: false,
             direction: Direction.ltr,
+            isFirstRender: true,
         };
     }
 
@@ -182,6 +184,9 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
      */
     public componentDidMount(): void {
         this.updateDirection();
+        this.setState({
+            isFirstRender: false,
+        });
     }
 
     public componentWillUnmount(): void {
@@ -229,55 +234,7 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
                 ref={this.rootElement}
                 className={this.generateClassNames()}
             >
-                <SliderContext.Provider
-                    value={{
-                        sliderOrientation: this.props.orientation,
-                        sliderMode: this.props.mode,
-                        sliderState: this.state,
-                        sliderConstrainedRange: this.props.constrainedRange,
-                        sliderValueAsPercent: this.valueAsPercent,
-                        sliderDirection: this.state.direction,
-                    }}
-                >
-                    <div
-                        className={classNames(
-                            this.props.managedClasses.slider_layoutRegion
-                        )}
-                        style={{
-                            position: "relative",
-                        }}
-                    >
-                        <div
-                            className={classNames(
-                                this.props.managedClasses.slider_backgroundTrack
-                            )}
-                            style={{
-                                position: "absolute",
-                            }}
-                        />
-                        <SliderTrackItem
-                            className={this.props.managedClasses.slider_foregroundTrack}
-                            maxValuePositionBinding={
-                                SliderTrackItemAnchor.selectedRangeMax
-                            }
-                            minValuePositionBinding={
-                                SliderTrackItemAnchor.selectedRangeMin
-                            }
-                        />
-                        <div
-                            ref={this.sliderTrackElement}
-                            onMouseDown={this.handleTrackMouseDown}
-                            className={classNames(this.props.managedClasses.slider_track)}
-                            style={{
-                                position: "absolute",
-                            }}
-                        />
-                        {this.props.children}
-                        {this.renderThumb(SliderThumb.upperThumb)}
-                        {this.renderThumb(SliderThumb.lowerThumb)}
-                    </div>
-                    {this.renderHiddenInputElement()}
-                </SliderContext.Provider>
+                {this.renderSliderInternals()}
             </div>
         );
     }
@@ -322,6 +279,63 @@ class Slider extends Foundation<SliderHandledProps, SliderUnhandledProps, Slider
             )
         );
     }
+
+    /**
+     * Renders the internals of the component but skips the
+     * first render so we can determine direction before doing layout
+     * (avoids transition animations to get the layout right to begin with)
+     */
+    private renderSliderInternals = (): React.ReactNode => {
+        if (this.state.isFirstRender) {
+            return null;
+        }
+
+        return (
+            <SliderContext.Provider
+                value={{
+                    sliderOrientation: this.props.orientation,
+                    sliderMode: this.props.mode,
+                    sliderState: this.state,
+                    sliderConstrainedRange: this.props.constrainedRange,
+                    sliderValueAsPercent: this.valueAsPercent,
+                    sliderDirection: this.state.direction,
+                }}
+            >
+                <div
+                    className={classNames(this.props.managedClasses.slider_layoutRegion)}
+                    style={{
+                        position: "relative",
+                    }}
+                >
+                    <div
+                        className={classNames(
+                            this.props.managedClasses.slider_backgroundTrack
+                        )}
+                        style={{
+                            position: "absolute",
+                        }}
+                    />
+                    <SliderTrackItem
+                        className={this.props.managedClasses.slider_foregroundTrack}
+                        maxValuePositionBinding={SliderTrackItemAnchor.selectedRangeMax}
+                        minValuePositionBinding={SliderTrackItemAnchor.selectedRangeMin}
+                    />
+                    <div
+                        ref={this.sliderTrackElement}
+                        onMouseDown={this.handleTrackMouseDown}
+                        className={classNames(this.props.managedClasses.slider_track)}
+                        style={{
+                            position: "absolute",
+                        }}
+                    />
+                    {this.props.children}
+                    {this.renderThumb(SliderThumb.upperThumb)}
+                    {this.renderThumb(SliderThumb.lowerThumb)}
+                </div>
+                {this.renderHiddenInputElement()}
+            </SliderContext.Provider>
+        );
+    };
 
     /**
      * Updates values when mode is switched in props


### PR DESCRIPTION
# Description
The slider component can only query the dom for direction until after it has mounted.  Previously we rendered in default ltr and if we detect rtl after the component mounted we reset the state and triggered a render to correct the layout to rtl.  This meant we ran layout logic twice in rtl and that css transitions could be triggered by the ltr to rtl layout changes.  With this change we only render the component root element on the first pass, check for direction on componentDidMount() and only render the component internals at that point.

## Motivation & context
Users reported seeing transition animations on rtl ui.  Slight perf gain on rtl by avoiding running layout twice.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
