### PR TITLE
fix: adjust select Aria

### DIFF
--- a/packages/fast-components-react-base/src/select/select.spec.tsx
+++ b/packages/fast-components-react-base/src/select/select.spec.tsx
@@ -76,21 +76,6 @@ describe("select", (): void => {
         expect(rendered.state("selectedItems").length).toBe(0);
     });
 
-    test("default select aria tags are set correctly", (): void => {
-        const rendered: any = shallow(
-            <Select labelledBy="test-labelledBy">
-                {itemA}
-                {itemB}
-                {itemC}
-            </Select>
-        );
-        expect(rendered.first().prop("role")).toEqual("listbox");
-        expect(rendered.first().prop("aria-labelledby")).toEqual("test-labelledBy");
-        expect(rendered.first().prop("aria-describedby")).toContain("selecttrigger-");
-        expect(rendered.first().prop("aria-expanded")).toEqual(false);
-        expect(rendered.first().prop("aria-disabled")).toEqual(false);
-    });
-
     test("root element has a tabindex of -1", (): void => {
         const rendered: any = shallow(
             <Select>
@@ -112,14 +97,9 @@ describe("select", (): void => {
         );
 
         const trigger: any = rendered.find("button");
-        expect(trigger.prop("role")).toEqual("option");
         expect(trigger.prop("aria-expanded")).toEqual(false);
-        expect(trigger.prop("aria-atomic")).toEqual(true);
-        expect(trigger.prop("aria-label")).toEqual("a");
-        expect(trigger.prop("aria-expanded")).toEqual(false);
-        expect(trigger.prop("aria-selected")).toEqual(true);
-        expect(trigger.prop("aria-posinset")).toEqual(1);
-        expect(trigger.prop("aria-setsize")).toEqual(3);
+        expect(trigger.prop("aria-haspopup")).toEqual("listbox");
+        expect(trigger.prop("aria-live")).toEqual("polite");
     });
 
     test("menu should open and close on select click in single mode and aria-expanded is set properly", (): void => {

--- a/packages/fast-components-react-base/src/select/select.spec.tsx
+++ b/packages/fast-components-react-base/src/select/select.spec.tsx
@@ -89,17 +89,23 @@ describe("select", (): void => {
 
     test("default trigger aria tags are set correctly", (): void => {
         const rendered: any = mount(
-            <Select selectedItems={["a"]}>
+            <Select selectedItems={["a"]} labelledBy="testLabellledBy">
                 {itemA}
                 {itemB}
                 {itemC}
             </Select>
         );
 
+        const triggerId: string = rendered.instance().triggerId;
+
         const trigger: any = rendered.find("button");
         expect(trigger.prop("aria-expanded")).toEqual(false);
         expect(trigger.prop("aria-haspopup")).toEqual("listbox");
         expect(trigger.prop("aria-live")).toEqual("polite");
+        expect(trigger.prop("aria-labelledby").split(" ")).toEqual([
+            "testLabellledBy",
+            rendered.instance().triggerId,
+        ]);
     });
 
     test("menu should open and close on select click in single mode and aria-expanded is set properly", (): void => {

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -460,18 +460,15 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         if (props.multiselectable) {
             return null;
         }
-        const isItemSelected: boolean = state.selectedItemIndex !== 0;
+        const labelledBy: string = `${this.props.labelledBy} ${triggerId}`;
         return (
             <button
                 disabled={props.disabled}
                 id={triggerId}
-                role="option"
-                aria-atomic={true}
-                aria-label={state.displayString}
+                aria-haspopup="listbox"
+                aria-labelledby={labelledBy}
                 aria-expanded={state.isMenuOpen}
-                aria-selected={isItemSelected}
-                aria-posinset={isItemSelected ? state.selectedItemIndex : null}
-                aria-setsize={isItemSelected ? state.selectableItemCount : null}
+                aria-live="polite"
             >
                 {state.displayString}
             </button>

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -164,13 +164,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
                 className={this.generateClassNames()}
                 onKeyDown={this.handleKeydown}
                 onClick={this.handleClick}
-                onFocus={this.handleFocus}
                 tabIndex={-1}
-                role="listbox"
-                aria-disabled={this.props.disabled}
-                aria-expanded={this.state.isMenuOpen}
-                aria-labelledby={this.props.labelledBy || null}
-                aria-describedby={this.triggerId}
             >
                 {this.renderTrigger()}
                 {this.renderHiddenSelectElement()}
@@ -550,18 +544,6 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
                     this.incrementSelectedOption(-1);
                 }
                 break;
-        }
-    };
-
-    /**
-     * Handles focus
-     */
-    private handleFocus = (e: React.FocusEvent): void => {
-        if (this.props.disabled || e.defaultPrevented) {
-            return;
-        }
-        if (!this.props.multiselectable && this.state.selectedItems.length === 0) {
-            this.incrementSelectedOption(1);
         }
     };
 

--- a/packages/fast-components-react-msft/src/select/select.spec.tsx
+++ b/packages/fast-components-react-msft/src/select/select.spec.tsx
@@ -63,14 +63,9 @@ describe("button", (): void => {
         );
 
         const trigger: any = rendered.find("button");
-        expect(trigger.prop("role")).toEqual("option");
         expect(trigger.prop("aria-expanded")).toEqual(false);
-        expect(trigger.prop("aria-atomic")).toEqual(true);
-        expect(trigger.prop("aria-label")).toEqual("a");
-        expect(trigger.prop("aria-expanded")).toEqual(false);
-        expect(trigger.prop("aria-selected")).toEqual(true);
-        expect(trigger.prop("aria-posinset")).toEqual(1);
-        expect(trigger.prop("aria-setsize")).toEqual(3);
+        expect(trigger.prop("aria-haspopup")).toEqual("listbox");
+        expect(trigger.prop("aria-live")).toEqual("polite");
     });
 
     test("Custom menu render function is called", (): void => {

--- a/packages/fast-components-react-msft/src/select/select.tsx
+++ b/packages/fast-components-react-msft/src/select/select.tsx
@@ -63,20 +63,17 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, {}> {
             select_buttonDisplayText,
         }: SelectClassNameContract = this.props.managedClasses;
 
-        const isItemSelected: boolean = state.selectedItemIndex !== 0;
+        const labelledBy: string = `${this.props.labelledBy} ${triggerId}`;
 
         return (
             <button
+                id={triggerId}
                 disabled={props.disabled}
                 className={classNames(select_button)}
-                id={triggerId}
-                role="option"
-                aria-atomic={true}
-                aria-label={state.displayString}
+                aria-haspopup="listbox"
+                aria-labelledby={labelledBy}
                 aria-expanded={state.isMenuOpen}
-                aria-selected={isItemSelected}
-                aria-posinset={isItemSelected ? state.selectedItemIndex : null}
-                aria-setsize={isItemSelected ? state.selectableItemCount : null}
+                aria-live="polite"
             >
                 <span className={classNames(select_buttonContentRegion)}>
                     <div className={classNames(select_buttonDisplayText)}>


### PR DESCRIPTION
# Description
On focus the Select component was not providing desired info to assistive technologies. When a select menu is not open screen readers should recite: the label of the select control, the current value, the component name ("menu button" on Anaheim & Chrome, but "button" on spartan), that it is collapsed.

This is a second approach at this (https://github.com/microsoft/fast-dna/pull/2393);

## Motivation & context
Improve Select component accesibility

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->