### PR TITLE
feat: add display prop to Grid component for SSR support

### DIFF
--- a/packages/fast-layouts-react/src/grid/grid.no-css-grid.spec.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.no-css-grid.spec.tsx
@@ -84,24 +84,24 @@ describe("Grid - without CSS grid support but `display` prop is `grid`", (): voi
         grid: "grid",
     };
 
-    test("should set an inline style of `display: grid` when CSS grid is NOT supported but the `display` prop passed is `grid`", () => {
-        const rendered: any = shallow(<Grid display={"grid"} />);
+    test("should set an inline style of `display: grid` when CSS grid is NOT supported but the `displayType` prop passed is `grid`", () => {
+        const rendered: any = shallow(<Grid displayType={"grid"} />);
 
         expect(rendered.props().style.display).toEqual("grid");
     });
 
-    test("should set an inline style for `gridColumn` with a value equal to the `gridColumn` prop when  CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
+    test("should set an inline style for `gridColumn` with a value equal to the `gridColumn` prop when  CSS grid is NOT supported but the `displayType` prop passed is equal to `grid`", () => {
         const rendered: any = shallow(
-            <Grid display={"grid"} gridColumn={2} managedClasses={managedClasses} />
+            <Grid displayType={"grid"} gridColumn={2} managedClasses={managedClasses} />
         );
 
         expect(rendered.props().style.gridColumn).toBe(2);
         expect(rendered.props().style.msGridColumn).toBe(undefined);
     });
 
-    test("should set an inline style for `gridRow` with a value equal to the `gridColumn` prop when CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
+    test("should set an inline style for `gridRow` with a value equal to the `gridColumn` prop when CSS grid is NOT supported but the `displayType` prop passed is equal to `grid`", () => {
         const rendered: any = shallow(
-            <Grid display={"grid"} row={2} managedClasses={managedClasses} />
+            <Grid displayType={"grid"} row={2} managedClasses={managedClasses} />
         );
 
         expect(rendered.props().style.gridRow).toBe(2);
@@ -111,7 +111,7 @@ describe("Grid - without CSS grid support but `display` prop is `grid`", (): voi
     test("should set an inline style for alignItems with a value equal to the `verticalAlign` prop when CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
         const rendered: any = shallow(
             <Grid
-                display={"grid"}
+                displayType={"grid"}
                 verticalAlign={GridAlignment.center}
                 managedClasses={managedClasses}
             />
@@ -120,10 +120,10 @@ describe("Grid - without CSS grid support but `display` prop is `grid`", (): voi
         expect(rendered.props().style.alignItems).toBe(GridAlignment.center);
     });
 
-    test("should set an inline style for justifyItems with a value equal to the `horizontalAlign` prop when CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
+    test("should set an inline style for justifyItems with a value equal to the `horizontalAlign` prop when CSS grid is NOT supported but the `displayType` prop passed is equal to `grid`", () => {
         const rendered: any = shallow(
             <Grid
-                display={"grid"}
+                displayType={"grid"}
                 horizontalAlign={GridAlignment.center}
                 managedClasses={managedClasses}
             />
@@ -132,9 +132,9 @@ describe("Grid - without CSS grid support but `display` prop is `grid`", (): voi
         expect(rendered.props().style.justifyItems).toBe(GridAlignment.center);
     });
 
-    test("should set an inline style for gridTemplateColumns with a repeating column count equal to the `columnCount` prop when CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
+    test("should set an inline style for gridTemplateColumns with a repeating column count equal to the `columnCount` prop when CSS grid is NOT supported but the `displayType` prop passed is equal to `grid`", () => {
         const rendered: any = shallow(
-            <Grid display={"grid"} columnCount={5} managedClasses={managedClasses} />
+            <Grid displayType={"grid"} columnCount={5} managedClasses={managedClasses} />
         );
 
         expect(rendered.props().style.gridTemplateColumns).toBe(`repeat(5, 1fr)`);
@@ -142,7 +142,7 @@ describe("Grid - without CSS grid support but `display` prop is `grid`", (): voi
 
     test("should set an inline style for gridColumnGap in pixels equal to the `gutter` prop when passed", () => {
         const rendered: any = shallow(
-            <Grid display={"grid"} gutter={1} managedClasses={managedClasses} />
+            <Grid displayType={"grid"} gutter={1} managedClasses={managedClasses} />
         );
 
         expect(rendered.props().style.gridColumnGap).toBe("1px");

--- a/packages/fast-layouts-react/src/grid/grid.no-css-grid.spec.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.no-css-grid.spec.tsx
@@ -79,7 +79,7 @@ describe("Grid - without CSS grid support", (): void => {
     });
 });
 
-describe("Grid - without CSS grid support but `display` prop is `grid`", (): void => {
+describe("Grid - without CSS grid support but `cssGridPropertyName` prop is `grid`", (): void => {
     const managedClasses: GridClassNamesContract = {
         grid: "grid",
     };
@@ -112,7 +112,7 @@ describe("Grid - without CSS grid support but `display` prop is `grid`", (): voi
         expect(rendered.props().style.msGridRow).toBe(undefined);
     });
 
-    test("should set an inline style for alignItems with a value equal to the `verticalAlign` prop when CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
+    test("should set an inline style for alignItems with a value equal to the `verticalAlign` prop when CSS grid is NOT supported but the `cssGridPropertyName` prop passed is equal to `grid`", () => {
         const rendered: any = shallow(
             <Grid
                 cssGridPropertyName={"grid"}

--- a/packages/fast-layouts-react/src/grid/grid.no-css-grid.spec.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.no-css-grid.spec.tsx
@@ -78,3 +78,73 @@ describe("Grid - without CSS grid support", (): void => {
         expect(rendered.props().style.msGridColumn).toBe(2);
     });
 });
+
+describe("Grid - without CSS grid support but `display` prop is `grid`", (): void => {
+    const managedClasses: GridClassNamesContract = {
+        grid: "grid",
+    };
+
+    test("should set an inline style of `display: grid` when CSS grid is NOT supported but the `display` prop passed is `grid`", () => {
+        const rendered: any = shallow(<Grid display={"grid"} />);
+
+        expect(rendered.props().style.display).toEqual("grid");
+    });
+
+    test("should set an inline style for `gridColumn` with a value equal to the `gridColumn` prop when  CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
+        const rendered: any = shallow(
+            <Grid display={"grid"} gridColumn={2} managedClasses={managedClasses} />
+        );
+
+        expect(rendered.props().style.gridColumn).toBe(2);
+        expect(rendered.props().style.msGridColumn).toBe(undefined);
+    });
+
+    test("should set an inline style for `gridRow` with a value equal to the `gridColumn` prop when CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
+        const rendered: any = shallow(
+            <Grid display={"grid"} row={2} managedClasses={managedClasses} />
+        );
+
+        expect(rendered.props().style.gridRow).toBe(2);
+        expect(rendered.props().style.msGridRow).toBe(undefined);
+    });
+
+    test("should set an inline style for alignItems with a value equal to the `verticalAlign` prop when CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
+        const rendered: any = shallow(
+            <Grid
+                display={"grid"}
+                verticalAlign={GridAlignment.center}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(rendered.props().style.alignItems).toBe(GridAlignment.center);
+    });
+
+    test("should set an inline style for justifyItems with a value equal to the `horizontalAlign` prop when CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
+        const rendered: any = shallow(
+            <Grid
+                display={"grid"}
+                horizontalAlign={GridAlignment.center}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(rendered.props().style.justifyItems).toBe(GridAlignment.center);
+    });
+
+    test("should set an inline style for gridTemplateColumns with a repeating column count equal to the `columnCount` prop when CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
+        const rendered: any = shallow(
+            <Grid display={"grid"} columnCount={5} managedClasses={managedClasses} />
+        );
+
+        expect(rendered.props().style.gridTemplateColumns).toBe(`repeat(5, 1fr)`);
+    });
+
+    test("should set an inline style for gridColumnGap in pixels equal to the `gutter` prop when passed", () => {
+        const rendered: any = shallow(
+            <Grid display={"grid"} gutter={1} managedClasses={managedClasses} />
+        );
+
+        expect(rendered.props().style.gridColumnGap).toBe("1px");
+    });
+});

--- a/packages/fast-layouts-react/src/grid/grid.no-css-grid.spec.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.no-css-grid.spec.tsx
@@ -84,24 +84,28 @@ describe("Grid - without CSS grid support but `display` prop is `grid`", (): voi
         grid: "grid",
     };
 
-    test("should set an inline style of `display: grid` when CSS grid is NOT supported but the `displayType` prop passed is `grid`", () => {
-        const rendered: any = shallow(<Grid displayType={"grid"} />);
+    test("should set an inline style of `display: grid` when CSS grid is NOT supported but the `cssGridPropertyName` prop passed is `grid`", () => {
+        const rendered: any = shallow(<Grid cssGridPropertyName={"grid"} />);
 
         expect(rendered.props().style.display).toEqual("grid");
     });
 
-    test("should set an inline style for `gridColumn` with a value equal to the `gridColumn` prop when  CSS grid is NOT supported but the `displayType` prop passed is equal to `grid`", () => {
+    test("should set an inline style for `gridColumn` with a value equal to the `gridColumn` prop when  CSS grid is NOT supported but the `cssGridPropertyName` prop passed is equal to `grid`", () => {
         const rendered: any = shallow(
-            <Grid displayType={"grid"} gridColumn={2} managedClasses={managedClasses} />
+            <Grid
+                cssGridPropertyName={"grid"}
+                gridColumn={2}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.props().style.gridColumn).toBe(2);
         expect(rendered.props().style.msGridColumn).toBe(undefined);
     });
 
-    test("should set an inline style for `gridRow` with a value equal to the `gridColumn` prop when CSS grid is NOT supported but the `displayType` prop passed is equal to `grid`", () => {
+    test("should set an inline style for `gridRow` with a value equal to the `gridColumn` prop when CSS grid is NOT supported but the `cssGridPropertyName` prop passed is equal to `grid`", () => {
         const rendered: any = shallow(
-            <Grid displayType={"grid"} row={2} managedClasses={managedClasses} />
+            <Grid cssGridPropertyName={"grid"} row={2} managedClasses={managedClasses} />
         );
 
         expect(rendered.props().style.gridRow).toBe(2);
@@ -111,7 +115,7 @@ describe("Grid - without CSS grid support but `display` prop is `grid`", (): voi
     test("should set an inline style for alignItems with a value equal to the `verticalAlign` prop when CSS grid is NOT supported but the `display` prop passed is equal to `grid`", () => {
         const rendered: any = shallow(
             <Grid
-                displayType={"grid"}
+                cssGridPropertyName={"grid"}
                 verticalAlign={GridAlignment.center}
                 managedClasses={managedClasses}
             />
@@ -120,10 +124,10 @@ describe("Grid - without CSS grid support but `display` prop is `grid`", (): voi
         expect(rendered.props().style.alignItems).toBe(GridAlignment.center);
     });
 
-    test("should set an inline style for justifyItems with a value equal to the `horizontalAlign` prop when CSS grid is NOT supported but the `displayType` prop passed is equal to `grid`", () => {
+    test("should set an inline style for justifyItems with a value equal to the `horizontalAlign` prop when CSS grid is NOT supported but the `cssGridPropertyName` prop passed is equal to `grid`", () => {
         const rendered: any = shallow(
             <Grid
-                displayType={"grid"}
+                cssGridPropertyName={"grid"}
                 horizontalAlign={GridAlignment.center}
                 managedClasses={managedClasses}
             />
@@ -132,9 +136,13 @@ describe("Grid - without CSS grid support but `display` prop is `grid`", (): voi
         expect(rendered.props().style.justifyItems).toBe(GridAlignment.center);
     });
 
-    test("should set an inline style for gridTemplateColumns with a repeating column count equal to the `columnCount` prop when CSS grid is NOT supported but the `displayType` prop passed is equal to `grid`", () => {
+    test("should set an inline style for gridTemplateColumns with a repeating column count equal to the `columnCount` prop when CSS grid is NOT supported but the `cssGridPropertyName` prop passed is equal to `grid`", () => {
         const rendered: any = shallow(
-            <Grid displayType={"grid"} columnCount={5} managedClasses={managedClasses} />
+            <Grid
+                cssGridPropertyName={"grid"}
+                columnCount={5}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.props().style.gridTemplateColumns).toBe(`repeat(5, 1fr)`);
@@ -142,7 +150,11 @@ describe("Grid - without CSS grid support but `display` prop is `grid`", (): voi
 
     test("should set an inline style for gridColumnGap in pixels equal to the `gutter` prop when passed", () => {
         const rendered: any = shallow(
-            <Grid displayType={"grid"} gutter={1} managedClasses={managedClasses} />
+            <Grid
+                cssGridPropertyName={"grid"}
+                gutter={1}
+                managedClasses={managedClasses}
+            />
         );
 
         expect(rendered.props().style.gridColumnGap).toBe("1px");

--- a/packages/fast-layouts-react/src/grid/grid.props.ts
+++ b/packages/fast-layouts-react/src/grid/grid.props.ts
@@ -79,7 +79,7 @@ export interface GridHandledProps extends GridManagedClasses {
      * The CSS grid display, "grid" when true and "-ms-grid" when false
      * Provide this prop when doing server side rendering
      */
-    display?: GridDisplay;
+    displayType?: GridDisplay;
 }
 
 export type GridProps = GridHandledProps & GridUnhandledProps;

--- a/packages/fast-layouts-react/src/grid/grid.props.ts
+++ b/packages/fast-layouts-react/src/grid/grid.props.ts
@@ -30,6 +30,11 @@ export enum GridAlignment {
  */
 export type GridGutter = 0 | 2 | 3 | 6 | 12;
 
+/**
+ * The CSS grid display style
+ */
+export type GridDisplay = "grid" | "-ms-grid";
+
 export interface GridManagedClasses extends ManagedClasses<GridClassNamesContract> {}
 export interface GridUnhandledProps extends React.HTMLAttributes<HTMLElement> {}
 export interface GridHandledProps extends GridManagedClasses {
@@ -69,6 +74,12 @@ export interface GridHandledProps extends GridManagedClasses {
      * Use this property to support -ms-grid when Grid is a child of an element who's display property is set to -ms-grid
      */
     row?: number;
+
+    /**
+     * The CSS grid display, "grid" when true and "-ms-grid" when false
+     * Provide this prop when doing server side rendering
+     */
+    display?: GridDisplay;
 }
 
 export type GridProps = GridHandledProps & GridUnhandledProps;

--- a/packages/fast-layouts-react/src/grid/grid.props.ts
+++ b/packages/fast-layouts-react/src/grid/grid.props.ts
@@ -79,7 +79,7 @@ export interface GridHandledProps extends GridManagedClasses {
      * The CSS grid display, "grid" when true and "-ms-grid" when false
      * Provide this prop when doing server side rendering
      */
-    displayType?: GridDisplay;
+    cssGridPropertyName?: GridDisplay;
 }
 
 export type GridProps = GridHandledProps & GridUnhandledProps;

--- a/packages/fast-layouts-react/src/grid/grid.spec.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.spec.tsx
@@ -233,17 +233,17 @@ describe("Grid", (): void => {
         expect(rendered.props().columnCount).toBe(5);
     });
 
-    test("should set a display value equal to the `displayType` prop when passed", () => {
+    test("should set a display value equal to the `cssGridPropertyName` prop when passed", () => {
         const rendered: any = mount(
-            <Grid displayType={"-ms-grid"} managedClasses={managedClasses} />
+            <Grid cssGridPropertyName={"-ms-grid"} managedClasses={managedClasses} />
         );
 
-        expect(rendered.props().displayType).toBe("-ms-grid");
+        expect(rendered.props().cssGridPropertyName).toBe("-ms-grid");
     });
 
-    test("should set the CSS display style to a value that equals the `displayType` prop when passed", () => {
+    test("should set the CSS display style to a value that equals the `cssGridPropertyName` prop when passed", () => {
         const rendered: any = shallow(
-            <Grid displayType={"-ms-grid"} managedClasses={managedClasses} />
+            <Grid cssGridPropertyName={"-ms-grid"} managedClasses={managedClasses} />
         );
 
         expect(rendered.props().style.display).toBe("-ms-grid");

--- a/packages/fast-layouts-react/src/grid/grid.spec.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.spec.tsx
@@ -233,17 +233,17 @@ describe("Grid", (): void => {
         expect(rendered.props().columnCount).toBe(5);
     });
 
-    test("should set a display value equal to the `display` prop when passed", () => {
+    test("should set a display value equal to the `displayType` prop when passed", () => {
         const rendered: any = mount(
-            <Grid display={"-ms-grid"} managedClasses={managedClasses} />
+            <Grid displayType={"-ms-grid"} managedClasses={managedClasses} />
         );
 
-        expect(rendered.props().display).toBe("-ms-grid");
+        expect(rendered.props().displayType).toBe("-ms-grid");
     });
 
-    test("should set the CSS display style to a value that equals the `display` prop when passed", () => {
+    test("should set the CSS display style to a value that equals the `displayType` prop when passed", () => {
         const rendered: any = shallow(
-            <Grid display={"-ms-grid"} managedClasses={managedClasses} />
+            <Grid displayType={"-ms-grid"} managedClasses={managedClasses} />
         );
 
         expect(rendered.props().style.display).toBe("-ms-grid");

--- a/packages/fast-layouts-react/src/grid/grid.spec.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.spec.tsx
@@ -232,4 +232,20 @@ describe("Grid", (): void => {
 
         expect(rendered.props().columnCount).toBe(5);
     });
+
+    test("should set a display value equal to the `display` prop when passed", () => {
+        const rendered: any = mount(
+            <Grid display={"-ms-grid"} managedClasses={managedClasses} />
+        );
+
+        expect(rendered.props().display).toBe("-ms-grid");
+    });
+
+    test("should set the CSS display style to a value that equals the `display` prop when passed", () => {
+        const rendered: any = shallow(
+            <Grid display={"-ms-grid"} managedClasses={managedClasses} />
+        );
+
+        expect(rendered.props().style.display).toBe("-ms-grid");
+    });
 });

--- a/packages/fast-layouts-react/src/grid/grid.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.tsx
@@ -47,7 +47,7 @@ export class Grid extends Foundation<GridHandledProps, GridUnhandledProps, {}> {
         managedClasses: void 0,
         tag: void 0,
         verticalAlign: void 0,
-        displayType: void 0,
+        cssGridPropertyName: void 0,
     };
 
     /**
@@ -136,7 +136,7 @@ export class Grid extends Foundation<GridHandledProps, GridUnhandledProps, {}> {
     };
 
     private generateStyleAttributes(): React.CSSProperties {
-        const displayStyle: GridDisplay = this.props.displayType || Grid.display;
+        const displayStyle: GridDisplay = this.props.cssGridPropertyName || Grid.display;
         return {
             display: displayStyle,
             ...(displayStyle === "grid" ? this.cssGridStyles() : this.msGridStyles()),

--- a/packages/fast-layouts-react/src/grid/grid.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.tsx
@@ -47,7 +47,7 @@ export class Grid extends Foundation<GridHandledProps, GridUnhandledProps, {}> {
         managedClasses: void 0,
         tag: void 0,
         verticalAlign: void 0,
-        display: void 0,
+        displayType: void 0,
     };
 
     /**
@@ -136,7 +136,7 @@ export class Grid extends Foundation<GridHandledProps, GridUnhandledProps, {}> {
     };
 
     private generateStyleAttributes(): React.CSSProperties {
-        const displayStyle: GridDisplay = this.props.display || Grid.display;
+        const displayStyle: GridDisplay = this.props.displayType || Grid.display;
         return {
             display: displayStyle,
             ...(displayStyle === "grid" ? this.cssGridStyles() : this.msGridStyles()),

--- a/packages/fast-layouts-react/src/grid/grid.tsx
+++ b/packages/fast-layouts-react/src/grid/grid.tsx
@@ -3,6 +3,7 @@ import BreakpointTracker from "../utilities/breakpoint-tracker";
 import { getValueByBreakpoint } from "../utilities/breakpoints";
 import {
     GridAlignment,
+    GridDisplay,
     GridHandledProps,
     GridProps,
     GridTag,
@@ -36,7 +37,7 @@ export class Grid extends Foundation<GridHandledProps, GridUnhandledProps, {}> {
         managedClasses: {},
     };
 
-    private static display: string = canUseCssGrid() ? "grid" : "-ms-grid";
+    private static display: GridDisplay = canUseCssGrid() ? "grid" : "-ms-grid";
 
     protected handledProps: HandledProps<GridHandledProps> = {
         columnCount: void 0,
@@ -46,6 +47,7 @@ export class Grid extends Foundation<GridHandledProps, GridUnhandledProps, {}> {
         managedClasses: void 0,
         tag: void 0,
         verticalAlign: void 0,
+        display: void 0,
     };
 
     /**
@@ -134,9 +136,10 @@ export class Grid extends Foundation<GridHandledProps, GridUnhandledProps, {}> {
     };
 
     private generateStyleAttributes(): React.CSSProperties {
+        const displayStyle: GridDisplay = this.props.display || Grid.display;
         return {
-            display: Grid.display,
-            ...(canUseCssGrid() ? this.cssGridStyles() : this.msGridStyles()),
+            display: displayStyle,
+            ...(displayStyle === "grid" ? this.cssGridStyles() : this.msGridStyles()),
             ...this.unhandledProps().style,
         };
     }

--- a/packages/fast-layouts-react/src/grid/index.ts
+++ b/packages/fast-layouts-react/src/grid/index.ts
@@ -4,6 +4,7 @@ import {
     Grid as BaseGrid,
     GridAlignment,
     GridClassNamesContract,
+    GridDisplay,
     GridGutter,
     GridHandledProps as BaseGridHandledProps,
     GridManagedClasses,
@@ -29,4 +30,5 @@ export {
     GridTag,
     GridAlignment,
     GridGutter,
+    GridDisplay,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2822,7 +2822,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^15", "@types/react@^15.0.24", "@types/react@^16.3.6", "@types/react@^16.4.18", "@types/react@^16.7.17", "@types/react@^16.8.19":
+"@types/react@*", "@types/react@^15", "@types/react@^15.0.24", "@types/react@^16.3.6", "@types/react@^16.4.18", "@types/react@^16.7.17", "@types/react@^16.8.0", "@types/react@^16.8.19":
   version "16.9.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.11.tgz#70e0b7ad79058a7842f25ccf2999807076ada120"
   integrity sha512-UBT4GZ3PokTXSWmdgC/GeCGEJXE5ofWyibCcecRLUVN2ZBpXQGVgQGtG2foS7CrTKFKlQVVswLvf7Js6XA/CVQ==
@@ -13389,7 +13389,7 @@ react-dom@^15.6.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-dom@^16.3.0, react-dom@^16.6.0, react-dom@^16.6.3, react-dom@^16.8.0, react-dom@^16.8.3:
+react-dom@^16.6.0, react-dom@^16.6.3, react-dom@^16.8.0, react-dom@^16.8.3:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
   integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==
@@ -13629,7 +13629,7 @@ react@^15.6.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react@^16.3.0, react@^16.6.0, react@^16.6.3, react@^16.8.0, react@^16.8.3, react@^16.8.6:
+react@^16.6.0, react@^16.6.3, react@^16.8.0, react@^16.8.3, react@^16.8.6:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
   integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Related to: [https://github.com/microsoft/fast-dna/issues/2408](https://github.com/microsoft/fast-dna/issues/2408)

For server side rendering we want to ensure we use the same grid styles that the client would produce. To do this we want to be able to set the grid styles ourselves instead of calling canUseCssGrid() which defaults to false on the server.

This change adds a new prop "display" to the grid component which can be one of "grid" or "-ms-grid". When provided this prop will be used to determine the styles that are used.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->