### PR TITLE
fix: simplify viewport-positioner flicker avoidance logic and remove dom ref

### DIFF
--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -95,7 +95,6 @@ describe("viewport positioner", (): void => {
             },
         };
         const expectedStyles: Partial<React.CSSProperties> = {
-            opacity: 0,
             position: "relative",
             transformOrigin: "left top",
             transform: `translate(

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -160,8 +160,8 @@ class ViewportPositioner extends Foundation<
 
     private openRequestAnimationFrame: number = null;
 
-    private collisionDetector: IntersectionObserver = null;
-    private resizeDetector: ResizeObserverClassDefinition = null;
+    private collisionDetector: IntersectionObserver;
+    private resizeDetector: ResizeObserverClassDefinition;
 
     private viewportRect: ClientRect | DOMRect;
 

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -357,8 +357,7 @@ class ViewportPositioner extends Foundation<
             if (this.state.validRefChecksRemaining > 0) {
                 this.setState({
                     validRefChecksRemaining: this.state.validRefChecksRemaining - 1,
-                    initialLayoutComplete:
-                        this.state.validRefChecksRemaining > 1 ? false : true,
+                    initialLayoutComplete: this.state.validRefChecksRemaining <= 1,
                 });
                 return;
             }


### PR DESCRIPTION
# Description
viewport positioner sets it's opacity to 0 until after initial placement is complete.  This change simplifies that logic and removes code that checked that dom during render which was generating a React warning.

## Motivation & context
Looking at the dom during render bad, simpler logic good

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->