### PR TITLE
fix: remove cursor pointer from typography and apply to semantic components

### DIFF
--- a/packages/fast-components-styles-msft/src/heading/index.ts
+++ b/packages/fast-components-styles-msft/src/heading/index.ts
@@ -2,10 +2,12 @@ import { DesignSystem } from "../design-system";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { HeadingClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { applyFontWeightSemiBold } from "../utilities/fonts";
+import { applyCursorDefault } from "../utilities/cursor";
 
 const styles: ComponentStyles<HeadingClassNameContract, DesignSystem> = {
     heading: {
         "&$heading__1, &$heading__2, &$heading__3, &$heading__4, &$heading__5, &$heading__6, &$heading__7": {
+            ...applyCursorDefault(),
             ...applyFontWeightSemiBold(),
         },
     },

--- a/packages/fast-components-styles-msft/src/paragraph/index.ts
+++ b/packages/fast-components-styles-msft/src/paragraph/index.ts
@@ -2,9 +2,11 @@ import { DesignSystem } from "../design-system";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { ParagraphClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { applyFontWeightNormal } from "../utilities/fonts";
+import { applyCursorDefault } from "../utilities/cursor";
 
 const styles: ComponentStyles<ParagraphClassNameContract, DesignSystem> = {
     paragraph: {
+        ...applyCursorDefault(),
         ...applyFontWeightNormal(),
     },
     paragraph__1: {},

--- a/packages/fast-components-styles-msft/src/subheading/index.ts
+++ b/packages/fast-components-styles-msft/src/subheading/index.ts
@@ -2,10 +2,12 @@ import { DesignSystem } from "../design-system";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { SubheadingClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { applyFontWeightNormal } from "../utilities/fonts";
+import { applyCursorDefault } from "../utilities/cursor";
 
 const styles: ComponentStyles<SubheadingClassNameContract, DesignSystem> = {
     subheading: {
         "&$subheading__1, &$subheading__2, &$subheading__3, &$subheading__4, &$subheading__5, &$subheading__6, &$subheading__7": {
+            ...applyCursorDefault(),
             ...applyFontWeightNormal(),
         },
     },

--- a/packages/fast-components-styles-msft/src/typography/index.ts
+++ b/packages/fast-components-styles-msft/src/typography/index.ts
@@ -3,11 +3,9 @@ import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { TypographyClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
 import { applyScaledTypeRamp } from "../utilities/typography";
 import { neutralForegroundRest } from "../utilities/color";
-import { applyCursorDefault } from "../utilities/cursor";
 
 const styles: ComponentStyles<TypographyClassNameContract, DesignSystem> = {
     typography: {
-        ...applyCursorDefault(),
         color: neutralForegroundRest,
         "margin-top": "0",
         "margin-bottom": "0",


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
closes #2465 

## Motivation & context
This changes fixes issues related to applying default cursor styles to ALL instances of the typography component. A common scenario for users is to wrap the typography component within a button or hypertext component. With the cursor applied to typography, this would cause the element to appear as though it was not clickable and require overrides by the implementor. By all intents and purposes, applying this wholesale is "buggy" behavior and this PR is intended to fix it.

The default cursor is valuable from a design system standpoint with semantic elements such as Heading, Subheading, and Paragraph. The Typography component, however, is more of a utility component which maps to the visual type ramp. The utility itself exists to provide visible weight, and applying the cursor value adds opinion which should be applied at the semantic level (Heading, Paragraph, Subheading)

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->