### PR TITLE
feat: allow an object to be disabled, which will disable all of its properties and sub-properties

### DIFF
--- a/packages/fast-tooling-react/src/__tests__/schemas/objects.schema.json
+++ b/packages/fast-tooling-react/src/__tests__/schemas/objects.schema.json
@@ -73,6 +73,24 @@
             "default": {
                 "foo": "bar"
             }
+        },
+        "optionalObjectDisabled": {
+            "title": "object disabled",
+            "type": "object",
+            "disabled": true,
+            "properties": {
+                "foo": {
+                    "title": "Disabled textarea",
+                    "type": "string"
+                },
+                "bar": {
+                    "title": "Disabled numberfield",
+                    "type": "number"
+                }
+            },
+            "default": {
+                "foo": "bar"
+            }
         }
     },
     "required": [

--- a/packages/fast-tooling-react/src/form/form-control-switch.tsx
+++ b/packages/fast-tooling-react/src/form/form-control-switch.tsx
@@ -249,7 +249,7 @@ class FormControlSwitch extends React.Component<FormControlSwitchProps, {}> {
             required: this.props.required,
             label: schema.title || schema.description || this.props.untitled,
             labelTooltip: schema.description,
-            disabled: schema.disabled,
+            disabled: this.props.disabled || schema.disabled,
             onChange: this.props.onChange,
             default: schema.default || this.props.default,
             const: schema.const || this.props.const,

--- a/packages/fast-tooling-react/src/form/form-section.props.ts
+++ b/packages/fast-tooling-react/src/form/form-section.props.ts
@@ -12,6 +12,7 @@ import { SingleLineControlPlugin } from "./templates/plugin.control.single-line"
  */
 export interface FormSectionClassNameContract {
     formSection: string;
+    formSection__disabled: string;
     formSection_invalidMessage: string;
 }
 
@@ -142,6 +143,11 @@ export interface FormSectionProps {
     schema: any;
 
     /**
+     * The disabled prop which is passed down to each control
+     */
+    disabled: boolean;
+
+    /**
      * The onChange event to trigger a data update
      */
     onChange: (config: OnChangeConfig) => void;
@@ -221,9 +227,19 @@ export interface FormControlParameters {
     isRequired: boolean;
 
     /**
+     * The disabled status of this property
+     */
+    isDisabled: boolean;
+
+    /**
      * The title, to be used as a label or as a breadcrumb
      */
     title: string;
+
+    /**
+     * The invalid message for this property
+     */
+    invalidMessage: string;
 }
 
 export interface AssignedCategoryParams {

--- a/packages/fast-tooling-react/src/form/form-section.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form-section.spec.tsx
@@ -23,6 +23,7 @@ const formSectionProps: FormSectionProps = {
     controls,
     childOptions: [],
     schema: {},
+    disabled: false,
     data: "",
     untitled: "",
     onChange: jest.fn(),
@@ -33,6 +34,7 @@ const formSectionProps: FormSectionProps = {
 
 const managedClasses: FormSectionClassNameContract = {
     formSection: "formSection",
+    formSection__disabled: "formSection__disabeld",
     formSection_invalidMessage: "formSection_invalidMessage",
 };
 
@@ -41,6 +43,136 @@ describe("FormSection", () => {
         expect(() => {
             mount(<TestFormSection {...formSectionProps} />);
         }).not.toThrow();
+    });
+    test("should contain a root level fieldset element", () => {
+        const schema: any = {
+            type: "object",
+        };
+        const rendered: any = mount(
+            <FormSection
+                {...formSectionProps}
+                managedClasses={managedClasses}
+                schema={schema}
+            />
+        );
+
+        expect(rendered.find("fieldset").prop("className")).toEqual(
+            managedClasses.formSection
+        );
+    });
+    test("should not be disabled if the disabled prop has not been passed", () => {
+        const schema: any = {
+            type: "object",
+        };
+        const rendered: any = mount(
+            <FormSection
+                {...formSectionProps}
+                managedClasses={managedClasses}
+                schema={schema}
+            />
+        );
+
+        expect(rendered.find(`.${managedClasses.formSection}`).prop("disabled")).toEqual(
+            undefined
+        );
+    });
+    test("should not add a disabled class if the disabled prop is not passed", () => {
+        const schema: any = {
+            type: "object",
+        };
+        const rendered: any = mount(
+            <FormSection
+                {...formSectionProps}
+                managedClasses={managedClasses}
+                schema={schema}
+            />
+        );
+
+        expect(rendered.find(`.${managedClasses.formSection__disabled}`)).toHaveLength(0);
+    });
+    test("should not be disabled if the disabled prop is false", () => {
+        const schema: any = {
+            type: "object",
+            disabled: false,
+        };
+        const rendered: any = mount(
+            <FormSection
+                {...formSectionProps}
+                managedClasses={managedClasses}
+                schema={schema}
+            />
+        );
+
+        expect(rendered.find(`.${managedClasses.formSection}`).prop("disabled")).toEqual(
+            false
+        );
+    });
+    test("should not add the disabled class if the disabled prop is false", () => {
+        const schema: any = {
+            type: "object",
+            disabled: false,
+        };
+        const rendered: any = mount(
+            <FormSection
+                {...formSectionProps}
+                managedClasses={managedClasses}
+                schema={schema}
+            />
+        );
+
+        expect(rendered.find(`.${managedClasses.formSection__disabled}`)).toHaveLength(0);
+    });
+    test("should be disabled if the disabled prop is true", () => {
+        const schema: any = {
+            type: "object",
+            disabled: true,
+        };
+        const rendered: any = mount(
+            <FormSection
+                {...formSectionProps}
+                managedClasses={managedClasses}
+                schema={schema}
+            />
+        );
+
+        expect(rendered.find(`.${managedClasses.formSection}`).prop("disabled")).toEqual(
+            true
+        );
+    });
+    test("should add a disabled class if the disabled prop is true", () => {
+        const schema: any = {
+            type: "object",
+            disabled: true,
+        };
+        const rendered: any = mount(
+            <FormSection
+                {...formSectionProps}
+                managedClasses={managedClasses}
+                schema={schema}
+            />
+        );
+
+        expect(rendered.find(`.${managedClasses.formSection__disabled}`)).toHaveLength(1);
+    });
+    test("should pass the disabled prop to the FormControlSwitch", () => {
+        const schema: any = {
+            type: "object",
+            properties: {
+                foo: {
+                    type: "string",
+                },
+            },
+            disabled: true,
+        };
+        const rendered: any = mount(
+            <FormSection
+                {...formSectionProps}
+                managedClasses={managedClasses}
+                schema={schema}
+            />
+        );
+
+        expect(rendered.find("FormControlSwitch").prop("disabled")).toEqual(true);
     });
     test("should show an invalid message if validation errors have been passed", () => {
         const schema: any = {

--- a/packages/fast-tooling-react/src/form/form-section.style.ts
+++ b/packages/fast-tooling-react/src/form/form-section.style.ts
@@ -3,7 +3,12 @@ import { applyInvalidMessage, error } from "../style";
 import { FormSectionClassNameContract } from "./form-section.props";
 
 const styles: ComponentStyles<FormSectionClassNameContract, {}> = {
-    formSection: {},
+    formSection: {
+        margin: "0",
+        padding: "0",
+        border: "none",
+    },
+    formSection__disabled: {},
     formSection_invalidMessage: {
         ...applyInvalidMessage(),
         border: `1px solid ${error}`,

--- a/packages/fast-tooling-react/src/form/form-section.tsx
+++ b/packages/fast-tooling-react/src/form/form-section.tsx
@@ -20,6 +20,7 @@ import { get, omit } from "lodash-es";
 import {
     FormCategoryConfig,
     FormControlItem,
+    FormControlParameters,
     FormControlsWithConfigOptions,
     FormSectionClassNameContract,
     FormSectionProps,
@@ -69,12 +70,19 @@ class FormSection extends React.Component<
             this.props.dataLocation,
             this.props.validationErrors
         );
+        const isDisabled: boolean = this.isDisabled();
 
         return (
-            <div className={classNames(this.props.managedClasses.formSection)}>
+            <fieldset
+                className={classNames(this.props.managedClasses.formSection, [
+                    this.props.managedClasses.formSection__disabled,
+                    isDisabled,
+                ])}
+                disabled={isDisabled}
+            >
                 {this.renderFormValidation(invalidMessage)}
                 {this.renderFormSection(invalidMessage)}
-            </div>
+            </fieldset>
         );
     }
 
@@ -141,6 +149,7 @@ class FormSection extends React.Component<
         schemaLocation: string,
         dataLocation: string,
         required: boolean,
+        disabled: boolean,
         label: string,
         invalidMessage: string | null
     ): React.ReactNode => {
@@ -156,6 +165,7 @@ class FormSection extends React.Component<
                 controlPlugins={this.props.controlPlugins}
                 untitled={this.props.untitled}
                 required={required}
+                disabled={disabled}
                 default={get(this.props.default, propertyName)}
                 label={getLabel(label, this.state.schema.title)}
                 data={getData(propertyName, this.props.data)}
@@ -305,17 +315,14 @@ class FormSection extends React.Component<
                                 : propertyName;
 
                         if (!isNotRequired) {
-                            const params: any = {
-                                property: schema[propertyKey][propertyName],
+                            const params: FormControlParameters = {
                                 index,
                                 schemaLocation,
                                 dataLocation,
                                 propertyName,
-                                schema: get(
-                                    this.state.schema,
-                                    `${propertyKey}.${propertyName}`
-                                ),
+                                schema: schema[propertyKey][propertyName],
                                 isRequired,
+                                isDisabled: this.isDisabled(),
                                 title:
                                     schema[propertyKey][propertyName].title ||
                                     this.props.untitled,
@@ -328,11 +335,12 @@ class FormSection extends React.Component<
                             formControls.items.push({
                                 propertyName: params.propertyName,
                                 render: this.renderFormControl(
-                                    params.property,
+                                    params.schema,
                                     params.propertyName,
                                     params.schemaLocation,
                                     params.dataLocation,
                                     params.isRequired,
+                                    params.isDisabled,
                                     params.title,
                                     params.invalidMessage
                                 ),
@@ -463,6 +471,7 @@ class FormSection extends React.Component<
                         this.getSchemaLocation(),
                         this.props.dataLocation,
                         true,
+                        this.props.disabled || this.state.schema.disabled,
                         "",
                         invalidMessage
                     )}
@@ -491,6 +500,10 @@ class FormSection extends React.Component<
         } else {
             return this.props.schemaLocation;
         }
+    }
+
+    private isDisabled(): boolean {
+        return this.props.disabled || this.state.schema.disabled;
     }
 }
 

--- a/packages/fast-tooling-react/src/form/form.tsx
+++ b/packages/fast-tooling-react/src/form/form.tsx
@@ -537,6 +537,7 @@ class Form extends React.Component<
                 data={this.getData("data", "props")}
                 schemaLocation={lastNavigationItem.schemaLocation}
                 default={lastNavigationItem.default}
+                disabled={currentSchema.disabled}
                 dataLocation={this.state.activeDataLocation}
                 untitled={this.untitled}
                 childOptions={this.props.childOptions}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
This feature changes the wrapping element for a JSON schema type `object` to `fieldset` and passes a `disabled` state down to any sub properties it may have.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

Closes #1841, closes  #1842 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->