### PR TITLE
feat: show additional properties when false and present a way to remove them

### DIFF
--- a/packages/fast-tooling-react/src/__tests__/datasets/dictionary.ts
+++ b/packages/fast-tooling-react/src/__tests__/datasets/dictionary.ts
@@ -1,4 +1,9 @@
 export default {
-    a: "foo",
+    additionalFalse: {
+        foo: 1,
+        bar: "bat",
+    },
+    ad: "foo",
     b: "bar",
+    c: "bat",
 };

--- a/packages/fast-tooling-react/src/form/form-control-switch.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form-control-switch.spec.tsx
@@ -131,6 +131,13 @@ describe("FormControlSwitch", () => {
             mount(<TestFormControlSwitch {...formControlSwitchProps} />);
         }).not.toThrow();
     });
+    test("should NOT render any controls when the schema is false", () => {
+        const rendered: any = mount(
+            <TestFormControlSwitch {...formControlSwitchProps} schema={false} />
+        );
+
+        expect(rendered.html()).toEqual("");
+    });
     test("should render a number field when a number type is available", () => {
         const rendered: any = mount(
             <TestFormControlSwitch

--- a/packages/fast-tooling-react/src/form/form-control-switch.tsx
+++ b/packages/fast-tooling-react/src/form/form-control-switch.tsx
@@ -60,6 +60,10 @@ class FormControlSwitch extends React.Component<FormControlSwitchProps, {}> {
             );
         }
 
+        if (this.props.schema === false) {
+            return null;
+        }
+
         switch (this.props.schema.type) {
             case "boolean":
                 return this.renderCheckbox(

--- a/packages/fast-tooling-react/src/form/form-dictionary.props.ts
+++ b/packages/fast-tooling-react/src/form/form-dictionary.props.ts
@@ -1,8 +1,11 @@
 import { ControlTemplateUtilitiesProps, StandardControlPlugin } from "./templates";
 import { FormChildOptionItem } from "./form.props";
 import { Controls } from "./form-section.props";
+import { Omit } from "utility-types";
+import ajv from "ajv";
 
-export interface FormDictionaryProps extends ControlTemplateUtilitiesProps {
+export interface FormDictionaryProps
+    extends Omit<ControlTemplateUtilitiesProps, "invalidMessage"> {
     /**
      * The possible child options
      */
@@ -46,6 +49,11 @@ export interface FormDictionaryProps extends ControlTemplateUtilitiesProps {
      * The additional properties in JSON schema
      */
     additionalProperties: any;
+
+    /**
+     * The validation errors
+     */
+    validationErrors: ajv.ErrorObject[] | void;
 }
 
 export interface FormDictionaryState {

--- a/packages/fast-tooling-react/src/form/form-dictionary.spec.tsx
+++ b/packages/fast-tooling-react/src/form/form-dictionary.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
-import { configure, mount, shallow } from "enzyme";
+import { configure, mount, render, shallow } from "enzyme";
 import { controls } from "./form-control-switch.spec";
 import { FormDictionary } from "./form-dictionary";
 import { FormDictionaryProps } from "./form-dictionary.props";
@@ -31,7 +31,6 @@ const dictionaryProps: FormDictionaryProps = {
     label: "",
     onChange: jest.fn(),
     onUpdateSection: jest.fn(),
-    invalidMessage: "",
     examples: void 0,
     propertyLabel: "",
     additionalProperties: {
@@ -39,6 +38,7 @@ const dictionaryProps: FormDictionaryProps = {
     },
     enumeratedProperties: [],
     childOptions: [],
+    validationErrors: undefined,
 };
 
 describe("FormDictionary", () => {
@@ -276,5 +276,28 @@ describe("FormDictionary", () => {
         const formControls: any = rendered.find("TextareaControl");
 
         expect(formControls).toHaveLength(2);
+    });
+    test("should show only property key inputs if the additionalProperties is false", () => {
+        const rendered: any = mount(
+            <FormDictionary
+                {...dictionaryProps}
+                managedClasses={managedClasses}
+                data={{
+                    a: "foo",
+                    b: "bar",
+                }}
+                additionalProperties={false}
+            />
+        );
+
+        const propertyKeyInputs: any = rendered.find(
+            `.${managedClasses.formDictionary_itemControlInput}`
+        );
+        const formControlSwitch: any = rendered.find(
+            `.${managedClasses.formDictionary_controlRegion}`
+        );
+
+        expect(propertyKeyInputs).toHaveLength(2);
+        expect(formControlSwitch).toHaveLength(0);
     });
 });

--- a/packages/fast-tooling-react/src/form/form-dictionary.tsx
+++ b/packages/fast-tooling-react/src/form/form-dictionary.tsx
@@ -5,7 +5,7 @@ import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-
 import styles, { FormDictionaryClassNameContract } from "./form-dictionary.style";
 import { FormDictionaryProps, FormDictionaryState } from "./form-dictionary.props";
 import FormControlSwitch from "./form-control-switch";
-import { generateExampleData } from "./utilities";
+import { generateExampleData, getErrorFromDataLocation } from "./utilities";
 
 /**
  * Form control definition
@@ -15,6 +15,10 @@ class FormDictionary extends React.Component<
     FormDictionaryState
 > {
     public static displayName: string = "FormDictionary";
+
+    private elementRef: React.RefObject<HTMLDivElement> = React.createRef<
+        HTMLDivElement
+    >();
 
     constructor(props: FormDictionaryProps) {
         super(props);
@@ -27,11 +31,38 @@ class FormDictionary extends React.Component<
 
     public render(): React.ReactNode {
         return (
-            <div className={this.props.managedClasses.formDictionary}>
+            <div
+                className={this.props.managedClasses.formDictionary}
+                ref={this.elementRef}
+            >
                 {this.renderControl()}
                 {this.renderFormControls()}
             </div>
         );
+    }
+
+    public componentDidMount(): void {
+        this.updateValidity();
+    }
+
+    public componentDidUpdate(): void {
+        this.updateValidity();
+    }
+
+    private updateValidity(): void {
+        if (this.props.additionalProperties === false) {
+            const {
+                formDictionary_itemControlInput,
+            }: FormDictionaryClassNameContract = this.props.managedClasses;
+
+            this.elementRef.current
+                .querySelectorAll<HTMLInputElement>(`.${formDictionary_itemControlInput}`)
+                .forEach((itemControlInput: HTMLInputElement) => {
+                    itemControlInput.setCustomValidity(
+                        "should NOT have additional properties"
+                    );
+                });
+        }
     }
 
     private renderControl(): React.ReactNode {
@@ -42,20 +73,22 @@ class FormDictionary extends React.Component<
             formDictionary_controlRegion,
         }: FormDictionaryClassNameContract = this.props.managedClasses;
 
-        return (
-            <div className={formDictionary_controlRegion}>
-                <div className={formDictionary_control}>
-                    <label className={formDictionary_controlLabel}>
-                        {this.props.label}
-                    </label>
+        if (typeof this.props.additionalProperties === "object") {
+            return (
+                <div className={formDictionary_controlRegion}>
+                    <div className={formDictionary_control}>
+                        <label className={formDictionary_controlLabel}>
+                            {this.props.label}
+                        </label>
+                    </div>
+                    <button
+                        className={formDictionary_controlAddTrigger}
+                        aria-label={"Select to add item"}
+                        onClick={this.handleOnAddItem}
+                    />
                 </div>
-                <button
-                    className={formDictionary_controlAddTrigger}
-                    aria-label={"Select to add item"}
-                    onClick={this.handleOnAddItem}
-                />
-            </div>
-        );
+            );
+        }
     }
 
     private renderItemControl(propertyName: string): React.ReactNode {
@@ -105,6 +138,13 @@ class FormDictionary extends React.Component<
                 index: number
             ): React.ReactNode => {
                 if (!this.props.enumeratedProperties.includes(currentKey)) {
+                    const invalidMessage: string = getErrorFromDataLocation(
+                        `${this.props.dataLocation}${
+                            this.props.dataLocation !== "" ? "." : ""
+                        }${currentKey}`,
+                        this.props.validationErrors
+                    );
+
                     return (
                         <React.Fragment>
                             {accumulator}
@@ -121,10 +161,11 @@ class FormDictionary extends React.Component<
                                     dataLocation={this.getDataLocation(currentKey)}
                                     data={this.getData(currentKey)}
                                     schema={this.props.additionalProperties}
+                                    disabled={this.props.additionalProperties === false}
                                     onUpdateSection={this.props.onUpdateSection}
                                     childOptions={this.props.childOptions}
                                     required={this.isRequired(currentKey)}
-                                    invalidMessage={this.props.invalidMessage}
+                                    invalidMessage={invalidMessage}
                                     softRemove={false}
                                 />
                             </div>

--- a/packages/fast-tooling-react/src/form/form-dictionary.tsx
+++ b/packages/fast-tooling-react/src/form/form-dictionary.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { uniqueId } from "lodash-es";
+import { isPlainObject, uniqueId } from "lodash-es";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import styles, { FormDictionaryClassNameContract } from "./form-dictionary.style";
@@ -16,7 +16,7 @@ class FormDictionary extends React.Component<
 > {
     public static displayName: string = "FormDictionary";
 
-    private elementRef: React.RefObject<HTMLDivElement> = React.createRef<
+    private rootElementRef: React.RefObject<HTMLDivElement> = React.createRef<
         HTMLDivElement
     >();
 
@@ -33,7 +33,7 @@ class FormDictionary extends React.Component<
         return (
             <div
                 className={this.props.managedClasses.formDictionary}
-                ref={this.elementRef}
+                ref={this.rootElementRef}
             >
                 {this.renderControl()}
                 {this.renderFormControls()}
@@ -55,7 +55,7 @@ class FormDictionary extends React.Component<
                 formDictionary_itemControlInput,
             }: FormDictionaryClassNameContract = this.props.managedClasses;
 
-            this.elementRef.current
+            this.rootElementRef.current
                 .querySelectorAll<HTMLInputElement>(`.${formDictionary_itemControlInput}`)
                 .forEach((itemControlInput: HTMLInputElement) => {
                     itemControlInput.setCustomValidity(
@@ -73,7 +73,7 @@ class FormDictionary extends React.Component<
             formDictionary_controlRegion,
         }: FormDictionaryClassNameContract = this.props.managedClasses;
 
-        if (typeof this.props.additionalProperties === "object") {
+        if (isPlainObject(this.props.additionalProperties)) {
             return (
                 <div className={formDictionary_controlRegion}>
                     <div className={formDictionary_control}>

--- a/packages/fast-tooling-react/src/form/form-section.tsx
+++ b/packages/fast-tooling-react/src/form/form-section.tsx
@@ -480,11 +480,9 @@ class FormSection extends React.Component<
      * Get all enumerated properties for the object
      */
     private getEnumeratedProperties(schema: any): string[] {
-        if (schema.properties === undefined) {
-            return [];
-        }
-
-        return Object.keys(schema.properties);
+        return Object.keys(schema.properties || {}).concat(
+            Object.keys(schema.reactProperties || {})
+        );
     }
 
     private getSchemaLocation(): string {

--- a/packages/fast-tooling-react/src/form/form-section.tsx
+++ b/packages/fast-tooling-react/src/form/form-section.tsx
@@ -127,15 +127,10 @@ class FormSection extends React.Component<
     /**
      * Renders the form
      */
-    private renderRootObject(
-        dataLocation: string,
-        schema: any,
-        invalidMessage: string
-    ): React.ReactNode {
+    private renderRootObject(schema: any): React.ReactNode {
         return this.generateFormObject(
             schema,
             schema.required || undefined,
-            invalidMessage,
             schema.not ? schema.not.required : undefined
         );
     }
@@ -155,7 +150,7 @@ class FormSection extends React.Component<
     ): React.ReactNode => {
         // if this is a root level object use it to generate the form and do not generate a link
         if (schema.type === "object" && propertyName === "") {
-            return this.renderRootObject(propertyName, schema, invalidMessage);
+            return this.renderRootObject(schema);
         }
 
         return (
@@ -190,8 +185,7 @@ class FormSection extends React.Component<
      */
     private renderCategories(
         categories: FormCategoryConfig[] = [],
-        controls: FormControlsWithConfigOptions,
-        invalidMessage: string
+        controls: FormControlsWithConfigOptions
     ): React.ReactNode {
         return this.getAllCategories(categories).map(
             (category: FormCategoryConfig, index: number): React.ReactNode => {
@@ -200,7 +194,7 @@ class FormSection extends React.Component<
                         .concat([
                             {
                                 propertyName: void 0,
-                                render: this.renderAdditionalProperties(invalidMessage),
+                                render: this.renderAdditionalProperties(),
                             },
                         ])
                         .map(
@@ -360,7 +354,6 @@ class FormSection extends React.Component<
     private generateFormObject(
         schema: any,
         required: string[],
-        invalidMessage: string,
         not?: string[]
     ): React.ReactNode {
         let formControls: FormControlsWithConfigOptions;
@@ -375,8 +368,7 @@ class FormSection extends React.Component<
 
             return this.renderCategories(
                 get(schema, "formConfig.categories"),
-                formControls,
-                invalidMessage
+                formControls
             );
         }
     }
@@ -415,11 +407,14 @@ class FormSection extends React.Component<
     /**
      * Renders additional properties if they have been declared
      */
-    private renderAdditionalProperties(invalidMessage: string): React.ReactNode {
+    private renderAdditionalProperties(): React.ReactNode {
         const schemaLocation: string = this.getSchemaLocation();
         const schema: any = get(this.state.schema, schemaLocation, this.state.schema);
 
-        if (typeof schema.additionalProperties === "object") {
+        if (
+            typeof schema.additionalProperties === "object" ||
+            schema.additionalProperties === false
+        ) {
             return (
                 <FormDictionary
                     index={0}
@@ -439,7 +434,7 @@ class FormSection extends React.Component<
                     childOptions={this.props.childOptions}
                     onChange={this.props.onChange}
                     onUpdateSection={this.props.onUpdateSection}
-                    invalidMessage={invalidMessage}
+                    validationErrors={this.props.validationErrors}
                     displayValidationBrowserDefault={
                         this.props.displayValidationBrowserDefault
                     }

--- a/packages/fast-tooling-react/src/form/form.tsx
+++ b/packages/fast-tooling-react/src/form/form.tsx
@@ -365,7 +365,7 @@ class Form extends React.Component<
             // the correct schema is used for state navigation
             this.rootSchema = updatedSchema;
 
-            state.validationErrors = this.getValidationErrors(props);
+            state.validationErrors = getValidationErrors(this.rootSchema, props.data);
 
             if (typeof props.onSchemaChange === "function") {
                 props.onSchemaChange(this.rootSchema);

--- a/packages/fast-tooling-react/src/form/form.tsx
+++ b/packages/fast-tooling-react/src/form/form.tsx
@@ -365,6 +365,8 @@ class Form extends React.Component<
             // the correct schema is used for state navigation
             this.rootSchema = updatedSchema;
 
+            state.validationErrors = this.getValidationErrors(props);
+
             if (typeof props.onSchemaChange === "function") {
                 props.onSchemaChange(this.rootSchema);
             }

--- a/packages/fast-tooling-react/src/form/utilities/form.tsx
+++ b/packages/fast-tooling-react/src/form/utilities/form.tsx
@@ -1,13 +1,9 @@
 import React from "react";
-import { cloneDeep, get, mergeWith, omit, set, unset } from "lodash-es";
-import { getDataFromSchema } from "../../data-utilities";
 import {
-    getChildOptionBySchemaId,
-    normalizeDataLocationToDotNotation,
-    squareBracketsRegex,
-} from "../../data-utilities/location";
-import ajv, { ErrorObject, ValidationError } from "ajv";
-import { AttributeSettingsMappingToPropertyNames, FormChildOptionItem, FormState } from "../form.props";
+    AttributeSettingsMappingToPropertyNames,
+    FormChildOptionItem,
+    FormState,
+} from "../form.props";
 import {
     FormSectionProps,
     InitialOneOfAnyOfState,
@@ -17,13 +13,11 @@ import {
 import { cloneDeep, get, mergeWith, omit, set, unset } from "lodash-es";
 import {
     getChildOptionBySchemaId,
+    normalizeDataLocationToDotNotation,
     squareBracketsRegex,
 } from "../../data-utilities/location";
-
-import { AttributeSettingsMappingToPropertyNames } from "../form.props";
 import { ErrorObject } from "ajv";
 import { FormControlSwitchProps } from "../form-control-switch.props";
-import React from "react";
 import { getDataFromSchema } from "../../data-utilities";
 import { reactChildrenStringSchema } from "../controls/control.children.text";
 import stringify from "fast-json-stable-stringify";

--- a/packages/fast-tooling-react/src/form/utilities/form.tsx
+++ b/packages/fast-tooling-react/src/form/utilities/form.tsx
@@ -600,17 +600,12 @@ export function getErrorFromDataLocation(
                     const dataLocationItems: string[] = `.${normalizeDataLocationToDotNotation(
                         validationError.dataPath
                     )}`.split(".");
-                    let containsInvalidData: boolean = false;
-
-                    dataLocationItems.forEach(
-                        (dataLocationItem: string, index: number) => {
-                            if (
+                    const containsInvalidData: boolean = dataLocationItems.some(
+                        (value: string, index: number) => {
+                            return (
                                 matchingDataLocationToDataPath ===
                                 dataLocationItems.slice(0, index + 1).join(".")
-                            ) {
-                                containsInvalidData = true;
-                                return;
-                            }
+                            );
                         }
                     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,11 +2598,6 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/fast-json-stable-stringify@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#40363bb847cb86b2c2e1599f1398d11e8329c921"
-  integrity sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==
-
 "@types/filesystem@*":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.29.tgz#ee3748eb5be140dcf980c3bd35f11aec5f7a3748"


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Adds the ability to see additional property keys in an object if the schema specifies `additionalProperties: false`. This gives the user the ability to remove them and ensure the data is valid.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Closes #2478 2452

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->