### PR TITLE
feat: horizontal overflow smooth scrolling

### DIFF
--- a/packages/fast-components-react-base/src/horizontal-overflow/README.md
+++ b/packages/fast-components-react-base/src/horizontal-overflow/README.md
@@ -14,8 +14,7 @@ The "onOverflowChange" callback is provided to enable developers to react to cha
 
  The "scrollDuration" prop enables authors to specify a custom duration for scroll animations in milliseconds.  Default is 500ms.
 
- The "nextItemPeek" prop defines how many pixels of the next or previous item is partially visible when the component scrolls content.  The default value is 50 pixels.  The component only provides this peek if there is ennough room to accomodate the currently focused item.  Developers should note that when focus goes to an item that is fully offscreen browsers will rapidly move the item into view and bypass this component's scroll animations.
-
+ The "nextItemPeek" prop defines how many pixels of the next or previous item is partially visible when the component scrolls content.  The default value is 50 pixels.  The component only provides this peek if there is ennough room to accomodate the currently focused item. 
 
 ## Accessibility
 The 'next' and 'previous' buttons are only useful for sighted users, since overflow is a purely visual construct, so they should be hidden from screen readers.

--- a/packages/fast-components-react-base/src/horizontal-overflow/README.md
+++ b/packages/fast-components-react-base/src/horizontal-overflow/README.md
@@ -4,5 +4,18 @@ The *horizontal overflow* component accepts items as children. A child can have 
 ### Usage guidance
 The *horizontal overflow* component always initializes at the start of the overflow content &mdash; left side in LTR and right side in RTL. Several callbacks are supplied to provide the consumer with overflow and scroll data. The not fully supported [ResizeObserver](https://developers.google.com/web/updates/2016/10/resizeobserver) is used (supported in Chrome), so it is necessary to apply a polyfill if more thorough browser support is needed (Safari and Firefox). Full adaptation is expected soon.
 
+The "onOverflowChange" callback is provided to enable developers to react to changes in overflow.  The retured "OverflowChange" object describes overflow as follows
+ - When both "onOverflowChange" and "overflowEnd" are false, there is no overflow
+ - When both are true, there is overflow on either side
+ - 'overflowStart' is true when there are items to the left in LTR (right in RTL)
+ - 'overflowEnd' is true when there are items to the right in LTR (left in RTL)
+
+ The "onScrollChange" callback is expected to be depracated in a future release and should be avoided, use "onOverflowChange" instead.
+
+ The "scrollDuration" prop enables authors to specify a custom duration for scroll animations in milliseconds.  Default is 500ms.
+
+ The "nextItemPeek" prop defines how many pixels of the next or previous item is partially visible when the component scrolls content.  The default value is 50 pixels.  The component only provides this peek if there is ennough room to accomodate the currently focused item.  Developers should note that when focus goes to an item that is fully offscreen browsers will rapidly move the item into view and bypass this component's scroll animations.
+
+
 ## Accessibility
 The 'next' and 'previous' buttons are only useful for sighted users, since overflow is a purely visual construct, so they should be hidden from screen readers.

--- a/packages/fast-components-react-base/src/horizontal-overflow/README.md
+++ b/packages/fast-components-react-base/src/horizontal-overflow/README.md
@@ -4,17 +4,17 @@ The *horizontal overflow* component accepts items as children. A child can have 
 ### Usage guidance
 The *horizontal overflow* component always initializes at the start of the overflow content &mdash; left side in LTR and right side in RTL. Several callbacks are supplied to provide the consumer with overflow and scroll data. The not fully supported [ResizeObserver](https://developers.google.com/web/updates/2016/10/resizeobserver) is used (supported in Chrome), so it is necessary to apply a polyfill if more thorough browser support is needed (Safari and Firefox). Full adaptation is expected soon.
 
-The "onOverflowChange" callback is provided to enable developers to react to changes in overflow.  The retured "OverflowChange" object describes overflow as follows
- - When both "onOverflowChange" and "overflowEnd" are false, there is no overflow
- - When both are true, there is overflow on either side
- - 'overflowStart' is true when there are items to the left in LTR (right in RTL)
- - 'overflowEnd' is true when there are items to the right in LTR (left in RTL)
+The "onOverflowChange" callback is provided to enable developers to react to changes in overflow.  The returned "OverflowChange" object describes overflow as follows:
+ - When both "onOverflowChange" and "overflowEnd" are `false`, there is no overflow
+ - When both are `true`, there is overflow on either side
+ - 'overflowStart' is `true` when there are items to the left in LTR (right in RTL)
+ - 'overflowEnd' is `true` when there are items to the right in LTR (left in RTL)
 
- The "onScrollChange" callback is expected to be depracated in a future release and should be avoided, use "onOverflowChange" instead.
+ The "onScrollChange" callback is expected to be deprecated in a future release and should be avoided, use "onOverflowChange" instead.
 
  The "scrollDuration" prop enables authors to specify a custom duration for scroll animations in milliseconds.  Default is 500ms.
 
- The "nextItemPeek" prop defines how many pixels of the next or previous item is partially visible when the component scrolls content.  The default value is 50 pixels.  The component only provides this peek if there is ennough room to accomodate the currently focused item. 
+ The "nextItemPeek" prop defines how many pixels of the next or previous item is partially visible when the component scrolls content.  The default value is 50 pixels.  The component only provides this peek if there is enough room to accommodate the currently focused item. 
 
 ## Accessibility
 The 'next' and 'previous' buttons are only useful for sighted users, since overflow is a purely visual construct, so they should be hidden from screen readers.

--- a/packages/fast-components-react-base/src/horizontal-overflow/README.md
+++ b/packages/fast-components-react-base/src/horizontal-overflow/README.md
@@ -5,7 +5,7 @@ The *horizontal overflow* component accepts items as children. A child can have 
 The *horizontal overflow* component always initializes at the start of the overflow content &mdash; left side in LTR and right side in RTL. Several callbacks are supplied to provide the consumer with overflow and scroll data. The not fully supported [ResizeObserver](https://developers.google.com/web/updates/2016/10/resizeobserver) is used (supported in Chrome), so it is necessary to apply a polyfill if more thorough browser support is needed (Safari and Firefox). Full adaptation is expected soon.
 
 The "onOverflowChange" callback is provided to enable developers to react to changes in overflow.  The returned "OverflowChange" object describes overflow as follows:
- - When both "onOverflowChange" and "overflowEnd" are `false`, there is no overflow
+ - When both "onOverflowStart" and "overflowEnd" are `false`, there is no overflow
  - When both are `true`, there is overflow on either side
  - 'overflowStart' is `true` when there are items to the left in LTR (right in RTL)
  - 'overflowEnd' is `true` when there are items to the right in LTR (left in RTL)

--- a/packages/fast-components-react-base/src/horizontal-overflow/README.md
+++ b/packages/fast-components-react-base/src/horizontal-overflow/README.md
@@ -5,12 +5,12 @@ The *horizontal overflow* component accepts items as children. A child can have 
 The *horizontal overflow* component always initializes at the start of the overflow content &mdash; left side in LTR and right side in RTL. Several callbacks are supplied to provide the consumer with overflow and scroll data. The not fully supported [ResizeObserver](https://developers.google.com/web/updates/2016/10/resizeobserver) is used (supported in Chrome), so it is necessary to apply a polyfill if more thorough browser support is needed (Safari and Firefox). Full adaptation is expected soon.
 
 The "onOverflowChange" callback is provided to enable developers to react to changes in overflow.  The returned "OverflowChange" object describes overflow as follows:
- - When both "onOverflowStart" and "overflowEnd" are `false`, there is no overflow
+ - When both "overflowStart" and "overflowEnd" are `false`, there is no overflow
  - When both are `true`, there is overflow on either side
  - 'overflowStart' is `true` when there are items to the left in LTR (right in RTL)
  - 'overflowEnd' is `true` when there are items to the right in LTR (left in RTL)
 
- The "onScrollChange" callback is expected to be deprecated in a future release and should be avoided, use "onOverflowChange" instead.
+ The "onScrollChange" callback is deprecated and should be avoided, use "onOverflowChange" instead.
 
  The "scrollDuration" prop enables authors to specify a custom duration for scroll animations in milliseconds.  Default is 500ms.
 

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.props.ts
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.props.ts
@@ -61,6 +61,13 @@ export interface HorizontalOverflowHandledProps extends HorizontalOverflowManage
      * Use `onScrollChange` to receive if scroll is at the start or end of the overflow set
      */
     onScrollChange?: (scrollObject: PositionChange) => void;
+
+    /**
+     * When the component scrolls focused content into view how many pixels should the next item "peek" into view
+     * Default is 50. Note that peek values that are too small can result in browsers rapidly moving focused items into
+     * view and skipping the scroll animation
+     */
+    nextItemPeek?: number;
 }
 
 export type HorizontalOverflowProps = HorizontalOverflowHandledProps &

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.schema.ts
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.schema.ts
@@ -10,6 +10,10 @@ export default {
             title: "Scroll duration",
             type: "number",
         },
+        nextItemPeek: {
+            title: "Next item peek",
+            type: "number",
+        },
     },
     reactProperties: {
         children: {

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -224,35 +224,39 @@ describe("horizontal overflow", (): void => {
             </HorizontalOverflow>
         );
 
+        renderedWithImages.instance()["getAvailableWidth"] = (): number => 50;
+        renderedWithImages.instance()["getMaxScrollDistance"] = (): number => 70;
+        renderedWithImages.instance()["getScrollPeek"] = (): number => 0;
         expect(
             renderedWithImages
                 .instance()
                 ["getScrollDistanceFromButtonDirection"](
                     ButtonDirection.next,
-                    50,
                     [10, 20, 20, 50, 20],
                     0
                 )
         ).toBe(50);
 
         // reaches the max distance and uses that instead
+        renderedWithImages.instance()["getAvailableWidth"] = (): number => 40;
+        renderedWithImages.instance()["getMaxScrollDistance"] = (): number => 60;
         expect(
             renderedWithImages
                 .instance()
                 ["getScrollDistanceFromButtonDirection"](
                     ButtonDirection.next,
-                    40,
                     [10, 20, 10, 30, 20, 10],
                     30
                 )
         ).toBe(60);
 
+        renderedWithImages.instance()["getAvailableWidth"] = (): number => 40;
+        renderedWithImages.instance()["getMaxScrollDistance"] = (): number => 90;
         expect(
             renderedWithImages
                 .instance()
                 ["getScrollDistanceFromButtonDirection"](
                     ButtonDirection.next,
-                    40,
                     [10, 20, 10, 30, 20, 10, 20, 10],
                     30
                 )
@@ -263,7 +267,6 @@ describe("horizontal overflow", (): void => {
                 .instance()
                 ["getScrollDistanceFromButtonDirection"](
                     ButtonDirection.next,
-                    40,
                     [10, 20, 10, 30, 20, 10, 20, 10],
                     40
                 )
@@ -277,12 +280,15 @@ describe("horizontal overflow", (): void => {
             </HorizontalOverflow>
         );
 
+        renderedWithImages.instance()["getAvailableWidth"] = (): number => 50;
+        renderedWithImages.instance()["getMaxScrollDistance"] = (): number => 71;
+        renderedWithImages.instance()["getScrollPeek"] = (): number => 0;
+
         expect(
             renderedWithImages
                 .instance()
                 ["getScrollDistanceFromButtonDirection"](
                     ButtonDirection.next,
-                    50,
                     [10.01, 20.3, 20.5, 50.2, 20.9],
                     0
                 )
@@ -296,23 +302,25 @@ describe("horizontal overflow", (): void => {
             </HorizontalOverflow>
         );
 
+        renderedWithImages.instance()["getAvailableWidth"] = (): number => 50;
+        renderedWithImages.instance()["getMaxScrollDistance"] = (): number => 70;
+        renderedWithImages.instance()["getScrollPeek"] = (): number => 0;
         expect(
             renderedWithImages
                 .instance()
                 ["getScrollDistanceFromButtonDirection"](
                     ButtonDirection.previous,
-                    50,
                     [10, 20, 20, 50, 20],
                     10
                 )
         ).toBe(0);
 
+        renderedWithImages.instance()["getMaxScrollDistance"] = (): number => 150;
         expect(
             renderedWithImages
                 .instance()
                 ["getScrollDistanceFromButtonDirection"](
                     ButtonDirection.previous,
-                    50,
                     [50, 50, 50, 50],
                     100
                 )
@@ -352,11 +360,19 @@ describe("horizontal overflow", (): void => {
             </HorizontalOverflow>
         );
 
+        renderedWithImagesAndNextAndPrevious.instance()[
+            "getAvailableWidth"
+        ] = (): number => 500;
+        renderedWithImagesAndNextAndPrevious.instance()[
+            "getMaxScrollDistance"
+        ] = (): number => 1600;
+        renderedWithImagesAndNextAndPrevious.instance()["getScrollPeek"] = (): number =>
+            0;
+
         expect(
             renderedWithImagesAndNextAndPrevious
                 .instance()
                 ["getNextDistance"](
-                    500,
                     [120, 140, 80, 220, 210, 100, 90, 200, 190, 170, 180, 210, 190],
                     0
                 )
@@ -366,7 +382,6 @@ describe("horizontal overflow", (): void => {
             renderedWithImagesAndNextAndPrevious
                 .instance()
                 ["getNextDistance"](
-                    500,
                     [120, 140, 80, 220, 210, 100, 90, 200, 190, 170, 180, 210, 190],
                     2100
                 )
@@ -376,7 +391,6 @@ describe("horizontal overflow", (): void => {
             renderedWithImagesAndNextAndPrevious
                 .instance()
                 ["getPreviousDistance"](
-                    500,
                     [120, 140, 80, 220, 210, 100, 90, 200, 190, 170, 180, 210, 190],
                     560
                 )
@@ -386,7 +400,6 @@ describe("horizontal overflow", (): void => {
             renderedWithImagesAndNextAndPrevious
                 .instance()
                 ["getPreviousDistance"](
-                    500,
                     [120, 140, 80, 220, 210, 100, 90, 200, 190, 170, 180, 210, 190],
                     0
                 )
@@ -395,7 +408,7 @@ describe("horizontal overflow", (): void => {
         expect(
             renderedWithImagesAndNextAndPrevious
                 .instance()
-                ["getScrollDistanceFromButtonDirection"]("next", 500, [], 0)
+                ["getScrollDistanceFromButtonDirection"]("next", [], 0)
         ).toBe(0);
     });
     test("getNextDistance should not get hung up on elements wider than the viewport", () => {
@@ -448,7 +461,7 @@ describe("horizontal overflow", (): void => {
         const renderedWithImagesAndNextAndPrevious: any = mount(
             <HorizontalOverflow managedClasses={managedClasses}>
                 <button id="testButtonNext" slot="next">
-                    next
+                    nexte4
                 </button>
                 <button id="testButtonPrevious" slot="previous">
                     previous
@@ -457,16 +470,23 @@ describe("horizontal overflow", (): void => {
             </HorizontalOverflow>
         );
 
-        expect(
-            renderedWithImagesAndNextAndPrevious
-                .instance()
-                ["getWithinMaxDistance"](400, 500, [], 400)
-        ).toBe(400);
+        renderedWithImagesAndNextAndPrevious.instance()[
+            "getAvailableWidth"
+        ] = (): number => 500;
+        renderedWithImagesAndNextAndPrevious.instance()[
+            "getMaxScrollDistance"
+        ] = (): number => 400;
+        renderedWithImagesAndNextAndPrevious.instance()["getScrollPeek"] = (): number =>
+            0;
 
         expect(
             renderedWithImagesAndNextAndPrevious
                 .instance()
-                ["getWithinMinDistance"](0, 500, [])
+                ["getWithinMaxDistance"](400, [])
+        ).toBe(400);
+
+        expect(
+            renderedWithImagesAndNextAndPrevious.instance()["getWithinMinDistance"](0, [])
         ).toBe(0);
     });
     test("should have an `onLoad` method", () => {

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -738,5 +738,42 @@ describe("horizontal overflow", (): void => {
             end: true,
         });
     });
+    test("getDirection returns correct value when set to ltr", (): void => {
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses} dir="ltr">
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+        expect(rendered.instance()["getDirection"]()).toEqual("ltr");
+    });
+    test("getDirection returns correct value when set to rtl", (): void => {
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses} dir="rtl">
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+        expect(rendered.instance()["getDirection"]()).toEqual("rtl");
+    });
+    test("settting and getting scroll position works correctly in ltr", (): void => {
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses} dir="ltr">
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(0);
+        rendered.instance()["setScrollPosition"](100);
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(100);
+    });
+    test("getting and setting scroll position returns 0 when horizontalOverflowItemsRef isn't populated ", (): void => {
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses}>
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+        rendered.instance().horizontalOverflowItemsRef.current = null;
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(0);
+        rendered.instance()["setScrollPosition"](100);
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(0);
+    });
 });
 /* tslint:enable:no-string-literal */

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -347,6 +347,21 @@ describe("horizontal overflow", (): void => {
             0.0004
         );
     });
+    test("getScrollAnimPosition returns correct start and end values", () => {
+        const renderedWithImages: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses}>
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+
+        renderedWithImages.instance().currentScrollAnimStartPosition = 0;
+        renderedWithImages.instance().currentScrollAnimEndPosition = 100;
+
+        expect(renderedWithImages.instance()["getScrollAnimPosition"](0, 1000)).toBe(0);
+        expect(renderedWithImages.instance()["getScrollAnimPosition"](1000, 1000)).toBe(
+            100
+        );
+    });
     test("should get the distance when moving next/previous", () => {
         const renderedWithImagesAndNextAndPrevious: any = mount(
             <HorizontalOverflow managedClasses={managedClasses}>
@@ -774,6 +789,48 @@ describe("horizontal overflow", (): void => {
         expect(rendered.instance()["getScrollPosition"]()).toEqual(0);
         rendered.instance()["setScrollPosition"](100);
         expect(rendered.instance()["getScrollPosition"]()).toEqual(0);
+    });
+    test("getDirection returns correct direction in ltr mode", (): void => {
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses} dir="ltr">
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+        expect(rendered.instance()["getDirection"]()).toEqual("ltr");
+    });
+    test("getDirection returns correct direction in rtl mode", (): void => {
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses} dir="rtl">
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+        expect(rendered.instance()["getDirection"]()).toEqual("rtl");
+    });
+    test("getDirection defaults to ltr when no valid ref", (): void => {
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses} dir="rtl">
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+        rendered.instance().horizontalOverflowItemsRef.current = null;
+        expect(rendered.instance()["getDirection"]()).toEqual("ltr");
+    });
+    test("updateScrollAnimation marks scrollAnimating as complete when time reaches duration", (): void => {
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses}>
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+
+        let currentTime: number = new Date().getTime();
+        rendered.instance().currentScrollAnimStartTime = currentTime;
+        rendered.instance().isScrollAnimating = true;
+        const targetDelayTime: number = currentTime + 500;
+        while (currentTime < targetDelayTime) {
+            currentTime = new Date().getTime();
+        }
+        rendered.instance()["updateScrollAnimation"]();
+        expect(rendered.instance().isScrollAnimating).toEqual(false);
     });
 });
 /* tslint:enable:no-string-literal */

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -347,7 +347,7 @@ describe("horizontal overflow", (): void => {
             0.0004
         );
     });
-    test("getScrollAnimPosition returns correct start and end values", () => {
+    test("getScrollAnimationPosition returns correct start and end values", () => {
         const renderedWithImages: any = mount(
             <HorizontalOverflow managedClasses={managedClasses}>
                 {imageSet1}
@@ -357,10 +357,12 @@ describe("horizontal overflow", (): void => {
         renderedWithImages.instance().currentScrollAnimStartPosition = 0;
         renderedWithImages.instance().currentScrollAnimEndPosition = 100;
 
-        expect(renderedWithImages.instance()["getScrollAnimPosition"](0, 1000)).toBe(0);
-        expect(renderedWithImages.instance()["getScrollAnimPosition"](1000, 1000)).toBe(
-            100
+        expect(renderedWithImages.instance()["getScrollAnimationPosition"](0, 1000)).toBe(
+            0
         );
+        expect(
+            renderedWithImages.instance()["getScrollAnimationPosition"](1000, 1000)
+        ).toBe(100);
     });
     test("should get the distance when moving next/previous", () => {
         const renderedWithImagesAndNextAndPrevious: any = mount(
@@ -790,7 +792,7 @@ describe("horizontal overflow", (): void => {
         rendered.instance()["setScrollPosition"](100);
         expect(rendered.instance()["getScrollPosition"]()).toEqual(0);
     });
-    test("getDirection returns correct direction in ltr mode", (): void => {
+    test("getDirection should return direction value when the ltr prop is passed", (): void => {
         const rendered: any = mount(
             <HorizontalOverflow managedClasses={managedClasses} dir="ltr">
                 {imageSet1}
@@ -798,7 +800,7 @@ describe("horizontal overflow", (): void => {
         );
         expect(rendered.instance()["getDirection"]()).toEqual("ltr");
     });
-    test("getDirection returns correct direction in rtl mode", (): void => {
+    test("getDirection should return direction value when the rtl prop is passed", (): void => {
         const rendered: any = mount(
             <HorizontalOverflow managedClasses={managedClasses} dir="rtl">
                 {imageSet1}
@@ -806,7 +808,7 @@ describe("horizontal overflow", (): void => {
         );
         expect(rendered.instance()["getDirection"]()).toEqual("rtl");
     });
-    test("getDirection defaults to ltr when no valid ref", (): void => {
+    test("getDirection should return direction ltr when current ref is invalid", (): void => {
         const rendered: any = mount(
             <HorizontalOverflow managedClasses={managedClasses} dir="rtl">
                 {imageSet1}

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -441,11 +441,13 @@ describe("horizontal overflow", (): void => {
             </HorizontalOverflow>
         );
 
+        renderedWithImagesAndNextAndPrevious.instance()["getScrollPeek"] = (): number =>
+            0;
+
         expect(
             renderedWithImagesAndNextAndPrevious
                 .instance()
                 ["getNextDistance"](
-                    500,
                     [120, 1400, 80, 220, 210, 100, 90, 200, 190, 170, 180, 210, 190],
                     120
                 )
@@ -464,11 +466,19 @@ describe("horizontal overflow", (): void => {
             </HorizontalOverflow>
         );
 
+        renderedWithImagesAndNextAndPrevious.instance()[
+            "getAvailableWidth"
+        ] = (): number => 500;
+        renderedWithImagesAndNextAndPrevious.instance()[
+            "getMaxScrollDistance"
+        ] = (): number => 2860;
+        renderedWithImagesAndNextAndPrevious.instance()["getScrollPeek"] = (): number =>
+            0;
+
         expect(
             renderedWithImagesAndNextAndPrevious
                 .instance()
                 ["getPreviousDistance"](
-                    500,
                     [120, 1400, 80, 220, 210, 100, 90, 200, 190, 170, 180, 210, 190],
                     1520
                 )

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.stories.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.stories.tsx
@@ -89,4 +89,40 @@ storiesOf("Horizontal overflow", module)
         <div dir="rtl">
             <TestOverflow>{images}</TestOverflow>
         </div>
+    ))
+    .add("With buttons", () => (
+        <HorizontalOverflow>
+            <Button slot="previous">Previous</Button>
+            <Button slot="next">Next</Button>
+            <Button>
+                <img src="https://placehold.it/220x100/414141/?text=1" />
+            </Button>
+            <Button>
+                <img src="https://placehold.it/220x100/414141/?text=2" />
+            </Button>
+            <Button>
+                <img src="https://placehold.it/220x100/414141/?text=3" />
+            </Button>
+            <Button>
+                <img src="https://placehold.it/220x100/414141/?text=4" />
+            </Button>
+            <Button>
+                <img src="https://placehold.it/220x100/414141/?text=5" />
+            </Button>
+            <Button>
+                <img src="https://placehold.it/220x100/414141/?text=6" />
+            </Button>
+            <Button>
+                <img src="https://placehold.it/220x100/414141/?text=7" />
+            </Button>
+            <Button>
+                <img src="https://placehold.it/420x100/414141/?text=8" />
+            </Button>
+            <Button>
+                <img src="https://placehold.it/120x100/414141/?text=9" />
+            </Button>
+            <Button>
+                <img src="https://placehold.it/220x100/414141/?text=10" />
+            </Button>
+        </HorizontalOverflow>
     ));

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -44,7 +44,7 @@ class HorizontalOverflow extends Foundation<
         nextItemPeek: 50,
     };
     private static DirectionAttributeName: string = "dir";
-    private static defaultScrollAnimDuration: number = 500;
+    private static defaultScrollAnimationDuration: number = 500;
 
     protected handledProps: HandledProps<HorizontalOverflowHandledProps> = {
         scrollDuration: void 0,
@@ -319,7 +319,7 @@ class HorizontalOverflow extends Foundation<
         if (this.isScrollAnimating) {
             const duration: number = this.props.scrollDuration
                 ? this.props.scrollDuration
-                : HorizontalOverflow.defaultScrollAnimDuration;
+                : HorizontalOverflow.defaultScrollAnimationDuration;
             const currentDate: number = new Date().getTime();
             const currentTime: number = currentDate - this.currentScrollAnimStartTime;
 
@@ -731,7 +731,7 @@ class HorizontalOverflow extends Foundation<
         this.openRequestAnimationFrame = null;
         const duration: number = this.props.scrollDuration
             ? this.props.scrollDuration
-            : HorizontalOverflow.defaultScrollAnimDuration;
+            : HorizontalOverflow.defaultScrollAnimationDuration;
         const currentDate: number = new Date().getTime();
         const currentTime: number = currentDate - this.currentScrollAnimStartTime;
 

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -106,6 +106,14 @@ class HorizontalOverflow extends Foundation<
      */
     private currentScrollAnimStartTime: number;
 
+    /**
+     * Flag indicates if a scroll animation is in progress
+     */
+    private isScrollAnimating: boolean = false;
+
+    /**
+     * Stores last scroll position from scroll events
+     */
     private lastRecordedScroll: number = 0;
 
     /**
@@ -284,6 +292,9 @@ class HorizontalOverflow extends Foundation<
         );
     }
 
+    /**
+     * Track scroll position
+     */
     private onScrollCapture = (event: React.UIEvent): void => {
         this.lastRecordedScroll = this.getScrollPosition();
     };
@@ -303,10 +314,22 @@ class HorizontalOverflow extends Foundation<
         const viewportWidth: number = this.getAvailableWidth();
         const peek: number = this.getScrollPeek(itemWidth);
 
+        let scrollStart: number = this.lastRecordedScroll;
+
+        if (this.isScrollAnimating) {
+            const duration: number = this.props.scrollDuration
+                ? this.props.scrollDuration
+                : HorizontalOverflow.defaultScrollAnimDuration;
+            const currentDate: number = new Date().getTime();
+            const currentTime: number = currentDate - this.currentScrollAnimStartTime;
+
+            scrollStart = this.getScrollAnimPosition(currentTime, duration);
+        }
+
         if (itemLeft - this.lastRecordedScroll < 0) {
-            this.scrollContent(itemLeft - peek);
-        } else if (itemRight - this.lastRecordedScroll > viewportWidth) {
-            this.scrollContent(itemRight - viewportWidth + peek);
+            this.scrollContent(scrollStart, itemLeft - peek);
+        } else if (itemRight - scrollStart > viewportWidth) {
+            this.scrollContent(scrollStart, itemRight - viewportWidth + peek);
         }
     };
 
@@ -612,6 +635,7 @@ class HorizontalOverflow extends Foundation<
      */
     private handleClick(buttonDirection: ButtonDirection): void {
         this.scrollContent(
+            this.getScrollPosition(),
             this.getScrollDistanceFromButtonDirection(
                 buttonDirection,
                 this.getItemWidths(),
@@ -673,13 +697,17 @@ class HorizontalOverflow extends Foundation<
     /**
      * Scrolls the container for the items list
      */
-    private scrollContent(scrollPosition: number): void {
+    private scrollContent(
+        startScrollPosition: number,
+        targetScrollPosition: number
+    ): void {
         const newScrollPosition: number = Math.max(
             0,
-            Math.min(scrollPosition, this.getMaxScrollDistance())
+            Math.min(targetScrollPosition, this.getMaxScrollDistance())
         );
 
-        this.currentScrollAnimStartPosition = this.lastRecordedScroll;
+        this.isScrollAnimating = true;
+        this.currentScrollAnimStartPosition = startScrollPosition;
         this.currentScrollAnimEndPosition = newScrollPosition;
         this.currentScrollAnimStartTime = new Date().getTime();
         this.requestFrame();
@@ -707,19 +735,28 @@ class HorizontalOverflow extends Foundation<
         const currentDate: number = new Date().getTime();
         const currentTime: number = currentDate - this.currentScrollAnimStartTime;
 
+        this.setScrollPosition(this.getScrollAnimPosition(currentTime, duration));
+
         if (currentTime < duration) {
-            this.setScrollPosition(
-                this.easeInOutQuad(
-                    currentTime,
-                    this.currentScrollAnimStartPosition,
-                    this.currentScrollAnimEndPosition -
-                        this.currentScrollAnimStartPosition,
-                    duration
-                )
-            );
             this.requestFrame();
         } else {
-            this.setScrollPosition(this.currentScrollAnimEndPosition);
+            this.isScrollAnimating = false;
+        }
+    };
+
+    /**
+     *  get scroll animation position for the provided time
+     */
+    private getScrollAnimPosition = (currentTime: number, duration: number): number => {
+        if (currentTime < duration) {
+            return this.easeInOutQuad(
+                currentTime,
+                this.currentScrollAnimStartPosition,
+                this.currentScrollAnimEndPosition - this.currentScrollAnimStartPosition,
+                duration
+            );
+        } else {
+            return this.currentScrollAnimEndPosition;
         }
     };
 

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -323,7 +323,7 @@ class HorizontalOverflow extends Foundation<
             const currentDate: number = new Date().getTime();
             const currentTime: number = currentDate - this.currentScrollAnimStartTime;
 
-            scrollStart = this.getScrollAnimPosition(currentTime, duration);
+            scrollStart = this.getScrollAnimationPosition(currentTime, duration);
         }
 
         if (itemLeft - this.lastRecordedScroll < 0) {
@@ -735,7 +735,7 @@ class HorizontalOverflow extends Foundation<
         const currentDate: number = new Date().getTime();
         const currentTime: number = currentDate - this.currentScrollAnimStartTime;
 
-        this.setScrollPosition(this.getScrollAnimPosition(currentTime, duration));
+        this.setScrollPosition(this.getScrollAnimationPosition(currentTime, duration));
 
         if (currentTime < duration) {
             this.requestFrame();
@@ -747,7 +747,10 @@ class HorizontalOverflow extends Foundation<
     /**
      *  get scroll animation position for the provided time
      */
-    private getScrollAnimPosition = (currentTime: number, duration: number): number => {
+    private getScrollAnimationPosition = (
+        currentTime: number,
+        duration: number
+    ): number => {
         if (currentTime < duration) {
             return this.easeInOutQuad(
                 currentTime,

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -41,14 +41,17 @@ class HorizontalOverflow extends Foundation<
 
     public static defaultProps: Partial<HorizontalOverflowProps> = {
         managedClasses: {},
+        nextItemPeek: 50,
     };
     private static DirectionAttributeName: string = "dir";
+    private static defaultScrollAnimDuration: number = 500;
 
     protected handledProps: HandledProps<HorizontalOverflowHandledProps> = {
         scrollDuration: void 0,
         managedClasses: void 0,
         onScrollChange: void 0,
         onOverflowChange: void 0,
+        nextItemPeek: void 0,
     };
 
     private horizontalOverflowItemsRef: React.RefObject<HTMLUListElement>;
@@ -82,6 +85,26 @@ class HorizontalOverflow extends Foundation<
      * Store a reference to a constructed resize observer
      */
     private resizeObserver?: ResizeObserverClassDefinition;
+
+    /**
+     * Stores pending animation frame requests
+     */
+    private openRequestAnimationFrame: number | null = null;
+
+    /**
+     *  The position the current scroll animation started at
+     */
+    private currentScrollAnimStartPosition: number;
+
+    /**
+     * The target position of the current scroll animation
+     */
+    private currentScrollAnimEndPosition: number;
+
+    /**
+     * Start time for current scroll animation
+     */
+    private currentScrollAnimStartTime: number;
 
     /**
      * Constructor
@@ -258,6 +281,45 @@ class HorizontalOverflow extends Foundation<
     }
 
     /**
+     * A child item got focus make sure it is in view
+     */
+    private onItemFocus = (event: React.FocusEvent): void => {
+        if (!this.isOverflow()) {
+            return;
+        }
+
+        const scrollPosition: number = this.getScrollPosition();
+        const itemLeft: number = (event.currentTarget as HTMLElement).offsetLeft;
+        const itemWidth: number = (event.currentTarget as HTMLElement).clientWidth;
+        const itemRight: number = itemLeft + itemWidth;
+
+        const viewportWidth: number = this.getAvailableWidth();
+        const peek: number = this.getScrollPeek(itemWidth);
+
+        if (itemLeft - scrollPosition < 0) {
+            this.scrollContent(itemLeft - peek);
+        } else if (itemRight - scrollPosition > viewportWidth) {
+            this.scrollContent(itemRight - viewportWidth + peek);
+        }
+    };
+
+    /**
+     *  Compares viewport width, item width and desired peek value to come up with
+     *  peek value to use. We don't want to clip focused item to get peek on next/previous item.
+     */
+    private getScrollPeek = (itemWidth: number): number => {
+        const viewportWidth: number = this.getAvailableWidth();
+
+        let maxPeek: number = viewportWidth - itemWidth;
+        maxPeek = maxPeek < 0 ? 0 : maxPeek;
+
+        const peek: number =
+            this.props.nextItemPeek > maxPeek ? maxPeek : this.props.nextItemPeek;
+
+        return peek;
+    };
+
+    /**
      * Callback for on scroll change
      */
     private onScrollChange = (): void => {
@@ -282,6 +344,9 @@ class HorizontalOverflow extends Foundation<
      * Get the scroll change data
      */
     private getPositionData = (): PositionChange => {
+        if (isNil(this.horizontalOverflowItemsRef.current)) {
+            return { start: true, end: true };
+        }
         const scrollPosition: number = this.getScrollPosition();
 
         const isAtBeginning: boolean = scrollPosition === 0;
@@ -370,6 +435,7 @@ class HorizontalOverflow extends Foundation<
      */
     private getItemMaxHeight(): number {
         let itemMaxHeight: number = 0;
+
         const children: HTMLElement = get(
             this.horizontalOverflowItemsRef,
             "current.childNodes"
@@ -398,9 +464,13 @@ class HorizontalOverflow extends Foundation<
     private getItems(): React.ReactNode {
         return React.Children.map(
             this.withoutSlot([ButtonDirection.previous, ButtonDirection.next]),
-            (child: React.ReactNode): React.ReactElement<HTMLLIElement> => {
+            (
+                child: React.ReactNode,
+                index: number
+            ): React.ReactElement<HTMLLIElement> => {
                 return (
                     <li
+                        onFocusCapture={this.onItemFocus}
                         className={classNames(
                             this.props.managedClasses.horizontalOverflow_item
                         )}
@@ -418,7 +488,6 @@ class HorizontalOverflow extends Foundation<
      */
     private getScrollDistanceFromButtonDirection(
         buttonDirection: ButtonDirection,
-        availableWidth: number,
         itemWidths: number[],
         scrollPosition: number
     ): number {
@@ -427,21 +496,11 @@ class HorizontalOverflow extends Foundation<
         }
 
         let distance: number = 0;
-        const maxDistance: number = this.getMaxScrollDistance(availableWidth, itemWidths);
 
         if (buttonDirection === ButtonDirection.next) {
-            distance = this.getWithinMaxDistance(
-                scrollPosition,
-                availableWidth,
-                itemWidths,
-                maxDistance
-            );
+            distance = this.getWithinMaxDistance(scrollPosition, itemWidths);
         } else {
-            distance = this.getWithinMinDistance(
-                scrollPosition,
-                availableWidth,
-                itemWidths
-            );
+            distance = this.getWithinMinDistance(scrollPosition, itemWidths);
         }
 
         return Math.ceil(distance);
@@ -450,21 +509,13 @@ class HorizontalOverflow extends Foundation<
     /**
      * Gets the distance unless it is over the maximum distance, then use maximum distance instead
      */
-    private getWithinMaxDistance(
-        scrollPosition: number,
-        availableWidth: number,
-        itemWidths: number[],
-        maxDistance: number
-    ): number {
+    private getWithinMaxDistance(scrollPosition: number, itemWidths: number[]): number {
+        const maxDistance: number = this.getMaxScrollDistance();
         if (scrollPosition === maxDistance) {
             return maxDistance;
         }
 
-        const distance: number = this.getNextDistance(
-            availableWidth,
-            itemWidths,
-            scrollPosition
-        );
+        const distance: number = this.getNextDistance(itemWidths, scrollPosition);
 
         return distance >= maxDistance ? maxDistance : distance;
     }
@@ -472,31 +523,19 @@ class HorizontalOverflow extends Foundation<
     /**
      * Gets the distance unless it is under the minimum distance, then use minimum distance instead
      */
-    private getWithinMinDistance(
-        scrollPosition: number,
-        availableWidth: number,
-        itemWidths: number[]
-    ): number {
+    private getWithinMinDistance(scrollPosition: number, itemWidths: number[]): number {
         if (scrollPosition === 0) {
             return 0;
         }
 
-        const distance: number = this.getPreviousDistance(
-            availableWidth,
-            itemWidths,
-            scrollPosition
-        );
+        const distance: number = this.getPreviousDistance(itemWidths, scrollPosition);
         return distance <= 0 ? 0 : distance;
     }
 
     /**
      * Gets the distance to scroll if the next button has been clicked
      */
-    private getNextDistance(
-        availableWidth: number,
-        itemWidths: number[],
-        scrollPosition: number
-    ): number {
+    private getNextDistance(itemWidths: number[], scrollPosition: number): number {
         let distance: number = 0;
 
         for (
@@ -505,49 +544,46 @@ class HorizontalOverflow extends Foundation<
             i++
         ) {
             if (
-                distance + itemWidths[i] > scrollPosition + availableWidth &&
+                distance + itemWidths[i] > scrollPosition + this.getAvailableWidth() &&
                 distance !== scrollPosition
             ) {
-                return distance;
+                return distance + this.getScrollPeek(itemWidths[i]);
             }
-
             distance += itemWidths[i];
         }
-
         return distance;
     }
 
     /**
      * Gets the distance to scroll if the previous button has been clicked
      */
-    private getPreviousDistance(
-        availableWidth: number,
-        itemWidths: number[],
-        scrollPosition: number
-    ): number {
-        let distance: number =
-            this.getMaxScrollDistance(availableWidth, itemWidths) + availableWidth;
+    private getPreviousDistance(itemWidths: number[], scrollPosition: number): number {
+        const availableWidth: number = this.getAvailableWidth();
+
+        let distance: number = this.getMaxScrollDistance() + availableWidth;
 
         for (let i: number = itemWidths.length - 1; i >= 0; i--) {
             if (
                 distance - itemWidths[i] < scrollPosition - availableWidth &&
                 distance !== scrollPosition
             ) {
-                return distance;
+                return distance - this.getScrollPeek(itemWidths[i]);
             }
-
             distance -= itemWidths[i];
         }
-
         return distance;
     }
 
     /**
      * Gets the maximum distance that can be scrolled
      */
-    private getMaxScrollDistance(availableWidth: number, itemWidths: number[]): number {
-        const totalWidth: number = itemWidths.reduce((a: number, b: number) => a + b);
-        return totalWidth - availableWidth;
+    private getMaxScrollDistance(): number {
+        if (isNil(this.horizontalOverflowItemsRef.current)) {
+            return 0;
+        }
+        return (
+            this.horizontalOverflowItemsRef.current.scrollWidth - this.getAvailableWidth()
+        );
     }
 
     /**
@@ -568,10 +604,9 @@ class HorizontalOverflow extends Foundation<
      * Handler for the click event fired after next or previous has been clicked
      */
     private handleClick(buttonDirection: ButtonDirection): void {
-        this.setScrollDistance(
+        this.scrollContent(
             this.getScrollDistanceFromButtonDirection(
                 buttonDirection,
-                this.getAvailableWidth(),
                 this.getItemWidths(),
                 this.getScrollPosition()
             )
@@ -582,13 +617,19 @@ class HorizontalOverflow extends Foundation<
      * Returns the available content region width
      */
     private getAvailableWidth(): number {
-        return getClientRectWithMargin(this.horizontalOverflowItemsRef.current).width;
+        if (isNil(this.horizontalOverflowItemsRef.current)) {
+            return 0;
+        }
+        return this.horizontalOverflowItemsRef.current.clientWidth;
     }
 
     /**
      * Returns the items widths
      */
     private getItemWidths(): number[] {
+        if (isNil(this.horizontalOverflowItemsRef.current)) {
+            return null;
+        }
         const items: HTMLElement[] = Array.prototype.slice.call(
             this.horizontalOverflowItemsRef.current.childNodes
         );
@@ -599,16 +640,6 @@ class HorizontalOverflow extends Foundation<
         }
 
         return itemWidths;
-    }
-
-    /**
-     * Sets the scroll distance for the items list
-     */
-    private setScrollDistance(updatedDistance: number): void {
-        this.scrollContent(
-            updatedDistance,
-            this.props.scrollDuration ? this.props.scrollDuration : 500
-        );
     }
 
     /**
@@ -635,27 +666,55 @@ class HorizontalOverflow extends Foundation<
     /**
      * Scrolls the container for the items list
      */
-    private scrollContent(scrollPosition: number, duration: number): void {
-        const start: number = this.getScrollPosition();
-        const change: number = scrollPosition - start;
-        const startDate: number = new Date().getTime();
-        const animateScroll: () => void = (): void => {
-            const currentDate: number = new Date().getTime();
-            const currentTime: number = currentDate - startDate;
+    private scrollContent(scrollPosition: number): void {
+        const newScrollPosition: number = Math.max(
+            0,
+            Math.min(scrollPosition, this.getMaxScrollDistance())
+        );
 
-            this.setScrollPosition(
-                this.easeInOutQuad(currentTime, start, change, duration)
-            );
-
-            if (currentTime < duration) {
-                requestAnimationFrame(animateScroll);
-            } else {
-                this.setScrollPosition(scrollPosition);
-            }
-        };
-
-        animateScroll();
+        this.currentScrollAnimStartPosition = this.getScrollPosition();
+        this.currentScrollAnimEndPosition = newScrollPosition;
+        this.currentScrollAnimStartTime = new Date().getTime();
+        this.requestFrame();
     }
+
+    /**
+     * Request's an animation frame if there are currently no open animation frame requests
+     */
+    private requestFrame = (): void => {
+        if (this.openRequestAnimationFrame === null) {
+            this.openRequestAnimationFrame = window.requestAnimationFrame(
+                this.updateScrollAnimation
+            );
+        }
+    };
+
+    /**
+     *  Animate one frame of scrolling
+     */
+    private updateScrollAnimation = (): void => {
+        this.openRequestAnimationFrame = null;
+        const duration: number = this.props.scrollDuration
+            ? this.props.scrollDuration
+            : HorizontalOverflow.defaultScrollAnimDuration;
+        const currentDate: number = new Date().getTime();
+        const currentTime: number = currentDate - this.currentScrollAnimStartTime;
+
+        if (currentTime < duration) {
+            this.setScrollPosition(
+                this.easeInOutQuad(
+                    currentTime,
+                    this.currentScrollAnimStartPosition,
+                    this.currentScrollAnimEndPosition -
+                        this.currentScrollAnimStartPosition,
+                    duration
+                )
+            );
+            this.requestFrame();
+        } else {
+            this.setScrollPosition(this.currentScrollAnimEndPosition);
+        }
+    };
 
     /**
      *  Gets the scroll position and accounts for direction
@@ -675,11 +734,11 @@ class HorizontalOverflow extends Foundation<
     /**
      *  Sets the scroll position and accounts for direction
      */
-    private setScrollPosition = (newScrollValue: number): void => {
+    private setScrollPosition = (scrollValue: number): void => {
         if (!isNil(this.horizontalOverflowItemsRef.current)) {
             RtlScrollConverter.setScrollLeft(
                 this.horizontalOverflowItemsRef.current,
-                this.state.direction === Direction.rtl ? -newScrollValue : newScrollValue,
+                this.state.direction === Direction.rtl ? -scrollValue : scrollValue,
                 this.state.direction
             );
         }


### PR DESCRIPTION
# Description
This started as a fix to some browsers not scrolling focused elements into view when user tabbed to them, but that seems to be getting fixed in the browser (chromium at least).  This change should address any remnants of that issue but additionally it significantly modifies the scroll behavior to the component such that content should always smooth scroll into view even if users navigate through content quickly either by clicking the previous/next buttons or rapidly tabbing.

This change also adds a configurable "peek" property which moves the focused item away from the edge of the viewport if there is available space such that the next/previous item is partially visible.

## Motivation & context
https://github.com/microsoft/fast-dna/issues/2126

And a desire to improve how our components animate to create a premium experience.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
