### PR TITLE
fix: modal dialogs do not move focus if already within

### DIFF
--- a/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
@@ -18,9 +18,7 @@ import { DisplayNamePrefix } from "../utilities";
  */
 configure({ adapter: new Adapter() });
 
-const container: HTMLDivElement = document.createElement("div");
-document.body.appendChild(container);
-
+/* tslint:disable:no-string-literal */
 describe("dialog", (): void => {
     const managedClasses: DialogClassNameContract = {
         dialog: "dialog-class",
@@ -242,5 +240,27 @@ describe("dialog", (): void => {
 
         expect(mockRemoveListenerFn).toHaveBeenCalledTimes(2);
         expect(mockRemoveListenerFn.mock.calls[1][0]).toBe("focusin");
+    });
+    test("shouldForceFocus correctly detects whether the prodided element is in or out of dialog", () => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const rendered: any = mount(
+            <div>
+                <Dialog managedClasses={managedClasses} modal={true} visible={true}>
+                    <button id="innerButton" />
+                </Dialog>
+                <button id="outerButton" />
+            </div>,
+            { attachTo: container }
+        );
+
+        const dialog: any = rendered.find("BaseDialog");
+        const innerButton: Element = document.getElementById("innerButton");
+        const outerButton: Element = document.getElementById("outerButton");
+        expect(dialog.instance()["shouldForceFocus"](innerButton)).toEqual(false);
+        expect(dialog.instance()["shouldForceFocus"](outerButton)).toEqual(true);
+
+        document.body.removeChild(container);
     });
 });

--- a/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
@@ -241,7 +241,7 @@ describe("dialog", (): void => {
         expect(mockRemoveListenerFn).toHaveBeenCalledTimes(2);
         expect(mockRemoveListenerFn.mock.calls[1][0]).toBe("focusin");
     });
-    test("shouldForceFocus correctly detects whether the prodided element is in or out of dialog", () => {
+    test("should detect whether the provided element is in or out of dialog", () => {
         const container: HTMLDivElement = document.createElement("div");
         document.body.appendChild(container);
 

--- a/packages/fast-components-react-base/src/dialog/dialog.stories.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.stories.tsx
@@ -2,6 +2,9 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 import Dialog from "./";
 import Button from "../button";
+import Select from "../select";
+import ListboxItem from "../listbox-item";
+import { uniqueId } from "lodash-es";
 
 storiesOf("Dialog", module)
     .add("Default", () => <Dialog />)
@@ -32,4 +35,37 @@ storiesOf("Dialog", module)
             <h2 id={"dialogLabelledBy01"}>Dialog</h2>
             <p id={"dialogDescribedBy"}>Dialog description</p>
         </Dialog>
+    ))
+    .add("Modal with autofocus select", () => (
+        <div>
+            <Button>Outside Button 1</Button>
+            <Dialog visible={true} modal={true}>
+                <Button>Button 1</Button>
+                <Button>Button 2</Button>
+                <Button>Button 3</Button>
+                <Select multiselectable={true} autoFocus={true}>
+                    <ListboxItem
+                        id={uniqueId()}
+                        value="Select option 1"
+                        children="Select option 1"
+                    />
+                    <ListboxItem
+                        id={uniqueId()}
+                        value="Select option 2"
+                        children="Select option 2"
+                    />
+                    <ListboxItem
+                        id={uniqueId()}
+                        value="Select option 3"
+                        children="Select option 3"
+                    />
+                    <ListboxItem
+                        id={uniqueId()}
+                        value="Select option 4"
+                        children="Select option 4"
+                    />
+                </Select>
+            </Dialog>
+            <Button>Outside Button 2</Button>
+        </div>
     ));

--- a/packages/fast-components-react-base/src/dialog/dialog.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.tsx
@@ -5,7 +5,7 @@ import { canUseDOM } from "exenv-es6";
 import React from "react";
 import { DisplayNamePrefix } from "../utilities";
 import { DialogHandledProps, DialogProps, DialogUnhandledProps } from "./dialog.props";
-import { isFunction } from "lodash-es";
+import { isFunction, isNil } from "lodash-es";
 import Tabbable from "tabbable";
 
 class Dialog extends Foundation<DialogHandledProps, DialogUnhandledProps, {}> {
@@ -81,7 +81,9 @@ class Dialog extends Foundation<DialogHandledProps, DialogUnhandledProps, {}> {
             }
             if (this.props.modal) {
                 document.addEventListener("focusin", this.handleDocumentFocus);
-                this.focusOnFirstElement();
+                if (this.shouldForceFocus(document.activeElement)) {
+                    this.focusOnFirstElement();
+                }
             }
         }
     }
@@ -231,16 +233,26 @@ class Dialog extends Foundation<DialogHandledProps, DialogUnhandledProps, {}> {
      */
     private handleDocumentFocus = (event: FocusEvent): void => {
         if (
-            this.props.visible &&
             !event.defaultPrevented &&
-            this.rootElement.current instanceof HTMLElement &&
-            !(this.rootElement.current as HTMLElement).contains(
-                event.target as HTMLElement
-            )
+            this.shouldForceFocus(event.target as HTMLElement)
         ) {
             this.focusOnFirstElement();
             event.preventDefault();
         }
+    };
+
+    /**
+     * test to avoid forcing focus when focus is already within
+     */
+    private shouldForceFocus = (currentFocusElement: Element): boolean => {
+        if (
+            this.props.visible &&
+            this.rootElement.current instanceof HTMLElement &&
+            !(this.rootElement.current as HTMLElement).contains(currentFocusElement)
+        ) {
+            return true;
+        }
+        return false;
     };
 
     /**

--- a/packages/fast-components-react-base/src/dialog/dialog.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.tsx
@@ -245,14 +245,11 @@ class Dialog extends Foundation<DialogHandledProps, DialogUnhandledProps, {}> {
      * test to avoid forcing focus when focus is already within
      */
     private shouldForceFocus = (currentFocusElement: Element): boolean => {
-        if (
+        return (
             this.props.visible &&
             this.rootElement.current instanceof HTMLElement &&
             !(this.rootElement.current as HTMLElement).contains(currentFocusElement)
-        ) {
-            return true;
-        }
-        return false;
+        );
     };
 
     /**


### PR DESCRIPTION
# Description
Modal dialogs were always focusing to the top of the tab queue on mount which was interfering with the autofocus option of other components.

## Motivation & context
https://github.com/microsoft/fast-dna/issues/2495

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.