### PR TITLE
fix: Change dismissals on pointer down instead of click

### DIFF
--- a/packages/fast-components-react-msft/src/flyout/flyout.spec.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.spec.tsx
@@ -113,7 +113,7 @@ describe("flyout", (): void => {
         ).toEqual(describedby);
     });
 
-    test("should call the `onDismiss` callback after a click event on the window when `visible` prop is true", () => {
+    test("should call the `onDismiss` callback after a pointer down event on the window when `visible` prop is true", () => {
         const onDismiss: any = jest.fn();
         const map: any = {};
 
@@ -129,7 +129,7 @@ describe("flyout", (): void => {
             </div>
         );
 
-        map.click({});
+        map.pointerdown({});
 
         expect(onDismiss).toHaveBeenCalledTimes(1);
     });
@@ -201,7 +201,7 @@ describe("flyout", (): void => {
         expect(onDismiss).toHaveBeenCalledTimes(1);
     });
 
-    test("should add click event listener for the `onDismiss` callback if `onDismiss` prop is added to the component", () => {
+    test("should add pointer down event listener for the `onDismiss` callback if `onDismiss` prop is added to the component", () => {
         const onDismiss: any = jest.fn();
         const map: any = {};
 
@@ -214,12 +214,12 @@ describe("flyout", (): void => {
 
         // map does not exist
         /* tslint:disable-next-line:no-string-literal */
-        expect(map["click"]).toBe(undefined);
+        expect(map["pointerdown"]).toBe(undefined);
 
         rendered.setProps({ onDismiss });
 
         // map exists
-        map.click({});
+        map.pointerdown({});
 
         expect(onDismiss).toHaveBeenCalledTimes(1);
     });
@@ -254,7 +254,7 @@ describe("flyout", (): void => {
         expect(onDismiss).toHaveBeenCalledTimes(1);
     });
 
-    test("should remove click event listener for the `onDismiss` callback if `onDismiss` prop is removed from the component", () => {
+    test("should remove pointer down event listener for the `onDismiss` callback if `onDismiss` prop is removed from the component", () => {
         const onDismiss: any = jest.fn();
         const map: any = {};
 
@@ -273,14 +273,14 @@ describe("flyout", (): void => {
         );
 
         // map exists
-        map.click({});
+        map.pointerdown({});
 
         expect(onDismiss).toHaveBeenCalledTimes(1);
 
         rendered.setProps({ onDismiss: void 0 });
 
         /* tslint:disable-next-line:no-string-literal */
-        map.click({});
+        map.pointerdown({});
 
         expect(onDismiss).toHaveBeenCalledTimes(1);
     });

--- a/packages/fast-components-react-msft/src/flyout/flyout.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.tsx
@@ -130,7 +130,7 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
     public componentDidMount(): void {
         if (canUseDOM() && this.props.onDismiss) {
             window.addEventListener("keydown", this.handleWindowKeyDown);
-            window.addEventListener("click", this.handleWindowClick);
+            window.addEventListener("pointerdown", this.handleWindowPointerDown);
         }
     }
 
@@ -141,10 +141,10 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
         if (canUseDOM()) {
             if (!prevProps.onDismiss && this.props.onDismiss) {
                 window.addEventListener("keydown", this.handleWindowKeyDown);
-                window.addEventListener("click", this.handleWindowClick);
+                window.addEventListener("pointerdown", this.handleWindowPointerDown);
             } else if (prevProps.onDismiss && !this.props.onDismiss) {
                 window.removeEventListener("keydown", this.handleWindowKeyDown);
-                window.removeEventListener("click", this.handleWindowClick);
+                window.removeEventListener("pointerdown", this.handleWindowPointerDown);
             }
         }
     }
@@ -155,7 +155,7 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
     public componentWillUnmount(): void {
         if (canUseDOM() && this.props.onDismiss) {
             window.removeEventListener("keydown", this.handleWindowKeyDown);
-            window.removeEventListener("click", this.handleWindowClick);
+            window.removeEventListener("pointerdown", this.handleWindowPointerDown);
         }
     }
 
@@ -181,7 +181,7 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
         };
     }
 
-    private handleWindowClick = (event: MouseEvent): void => {
+    private handleWindowPointerDown = (event: PointerEvent): void => {
         const anchor: React.RefObject<any> | HTMLElement =
             this.props.anchor instanceof HTMLElement
                 ? this.props.anchor


### PR DESCRIPTION
# Description

In this PR we change the following behavior:
1. We changed the click handling to pointer down. The flyouts will get dismissed on pointer down and not pointer up. This will ensure, that while flyout is open, and the user starts interacting outside the flyout where the events are (pointer down -> move -> up) which will not generate a click event, will also dismiss the flyout
2. I changed mouse to pointer events, so that we are dismissing the flyout from mouse interactions as well as pen interactions.

## Motivation & context

Motivation: For inking scenarios in PDF, we are using this component. Now there is a user scenario that user selects some inking settings and then if he starts inking without first dismissing the flyout, he will be ale to ink, but flyout will be taking some of the area. And now once he finishes drawing first stroke, then the flyout goes away.
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->