### PR TITLE
fix: account for nested oneOfs when generating example data

### DIFF
--- a/packages/fast-tooling-react/src/data-utilities/generate.spec.ts
+++ b/packages/fast-tooling-react/src/data-utilities/generate.spec.ts
@@ -364,4 +364,30 @@ describe("getDataFromSchema", () => {
             foo: { id: "bar", props: { text: "Hello world" } },
         });
     });
+    test("should return data when the schema contains nested oneOfs", () => {
+        const schemaWithNestedOneOfs: any = {
+            type: "object",
+            properties: {
+                foo: {
+                    oneOf: [
+                        {
+                            type: "string",
+                        },
+                        {
+                            type: "boolean",
+                        },
+                    ],
+                },
+                bar: {
+                    type: "boolean",
+                },
+            },
+            required: ["foo", "bar"],
+        };
+
+        expect(getDataFromSchema(schemaWithNestedOneOfs, [])).toEqual({
+            foo: "example text",
+            bar: true,
+        });
+    });
 });

--- a/packages/fast-tooling-react/src/data-utilities/generate.ts
+++ b/packages/fast-tooling-react/src/data-utilities/generate.ts
@@ -2,6 +2,7 @@ import { get } from "lodash-es";
 import { CombiningKeyword, DataType, PropertyKeyword } from "./types";
 import { ChildOptionItem } from ".";
 import { getChildOptionBySchemaId } from "./location";
+import { oneOfAnyOfType } from "../form/form-section.props";
 
 /**
  * This file contains all functionality for generating data
@@ -42,6 +43,15 @@ function getDataFromSchema(schema: any, childOptions?: ChildOptionItem[]): any {
         }
 
         return exampleData;
+    }
+
+    if (isOneOfAnyOf(schema)) {
+        const oneOfAnyOf: oneOfAnyOfType =
+            schema[oneOfAnyOfType.oneOf] !== undefined
+                ? oneOfAnyOfType.oneOf
+                : oneOfAnyOfType.anyOf;
+
+        return getDataFromSchema(schema[oneOfAnyOf][0], childOptions);
     }
 
     return getDataFromSchemaByDataType(schema);
@@ -143,6 +153,10 @@ function getDefaultOrExample(schema: any): any | void {
     if (hasConst(schema)) {
         return schema.const;
     }
+}
+
+function isOneOfAnyOf(schema: any): boolean {
+    return schema[oneOfAnyOfType.oneOf] || schema[oneOfAnyOfType.anyOf];
 }
 
 function isObjectDataType(schema: any): boolean {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Addresses an issue where nested oneOf/anyOfs inside of a provided schema would not be accounted for when generating data.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Closes #2508 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->