### PR TITLE
feat: deprecate the form plugins and onSchemaChange callback

### DIFF
--- a/packages/fast-tooling-react/README.md
+++ b/packages/fast-tooling-react/README.md
@@ -1013,6 +1013,8 @@ ControlTypes.textarea
 
 ### Using form schema plugins
 
+**NOTE: Schema plugins are DEPRECATED and will be removed in the 2.0.0**
+
 Plugins may be created to determine if a form should change based on data. You can identify a piece of schema that should be updated by adding a unique key to your JSON schema `formPluginId`. When you initialize a custom plugin you will need to pass that same id to the plugin as part of its configuration.
 
 Example schema:
@@ -1069,6 +1071,8 @@ export class MyCustomSchemaPlugin extends FormPlugin {
 Example implementation with the `Form`:
 
 *Note: When the plugins are used the schema used to render the `Form` is internally updated. To get the plugin-modified schema, you can optionally add the `onSchemaChange` callback which will return the newly updated schema.*
+
+**NOTE: The `onSchemaChange` callback is DEPRECATED and will be removed in the 2.0.0**
 
 ```jsx
 import Form from "@microsoft/fast-tooling-react";

--- a/packages/fast-tooling-react/src/form/form.props.ts
+++ b/packages/fast-tooling-react/src/form/form.props.ts
@@ -70,11 +70,13 @@ export interface FormProps {
 
     /**
      * The plugins to update the schema
+     * @deprecated
      */
     plugins?: Array<FormPlugin<FormPluginProps>>;
 
     /**
      * The change event for updating the schema
+     * @deprecated
      */
     onSchemaChange?: SchemaOnChange;
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Mark the props for form plugins and the `onSchemaChange` callback as deprecated to be removed in 2.0.0.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Preparation for #2509 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->