### PR TITLE
feat: convert box-shadow to use standard control plugin in css editor

### DIFF
--- a/packages/fast-tooling-react/README.md
+++ b/packages/fast-tooling-react/README.md
@@ -961,14 +961,14 @@ export class Example extends React.Component {
 }
 ```
 
-### Shadow
+### Box Shadow
 
-The `CSSBoxShadow` component shows an input for a color picker and has a callback that will be fired when the value is updated. In addition, there are also inputs to adjust the, opacity, X, Y, and blur properties on the box-shadow.
+The `CSSBoxShadow` component shows an input for a color picker and has a callback that will be fired when the value is updated. In addition, there are also inputs to adjust the opacity, X, Y, and blur properties on the box-shadow.
 
 Example:
 ```jsx
 import React from "react";
-import { CSSColor } from "@microsoft/fast-tooling-react";
+import { CSSBoxShadow } from "@microsoft/fast-tooling-react";
 
 export class Example extends React.Component {
     constructor(props) {

--- a/packages/fast-tooling-react/README.md
+++ b/packages/fast-tooling-react/README.md
@@ -975,7 +975,7 @@ export class Example extends React.Component {
         super(props);
 
         this.state = {
-            cssValues: "#000000"
+            cssValues: "0 4px 4px rgba(0,0,0,0.25)"
         }
     }
 

--- a/packages/fast-tooling-react/README.md
+++ b/packages/fast-tooling-react/README.md
@@ -961,6 +961,41 @@ export class Example extends React.Component {
 }
 ```
 
+### Shadow
+
+The `CSSBoxShadow` component shows an input for a color picker and has a callback that will be fired when the value is updated. In addition, there are also inputs to adjust the, opacity, X, Y, and blur properties on the box-shadow.
+
+Example:
+```jsx
+import React from "react";
+import { CSSColor } from "@microsoft/fast-tooling-react";
+
+export class Example extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            cssValues: "#000000"
+        }
+    }
+
+    render() {
+        return (
+            <CSSBoxShadow
+                value={this.state.cssValues}
+                onChange={this.handleCSSValueUpdate}
+            />
+        );
+    }
+
+    handleCSSValueUpdate = (updatedValues) => {
+        this.setState({
+            cssValues: updatedValues
+        });
+    }
+}
+```
+
 ## Form
 
 The required properties are the `data`, `schema`, and `onChange` function. The data should be tied to your state as the data will change when editing the form. The `onChange` is used as a callback, it should take one argument that is the data that should be updated when any data has been changed from within the generated form.

--- a/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.props.tsx
+++ b/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.props.tsx
@@ -1,5 +1,7 @@
 import { ManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { CSSBoxShadowClassNameContract } from "./box-shadow.style";
+import { CommonControlConfig } from "../../form/templates";
+import { Omit } from "utility-types";
 
 export interface CSSBoxShadowState {
     boxShadowColor?: string;
@@ -14,19 +16,10 @@ export interface CSSBoxShadowValues {
 }
 
 export interface CSSBoxShadowUnhandledProps
-    extends React.HTMLAttributes<HTMLDivElement> {}
+    extends Omit<React.HTMLAttributes<HTMLDivElement>, "onChange"> {}
 
 export interface CSSBoxShadowHandledProps
-    extends ManagedClasses<CSSBoxShadowClassNameContract> {
-    /**
-     * The data
-     */
-    data?: CSSBoxShadowValues;
-
-    /**
-     * The onChange callback
-     */
-    onChange?: (boxShadow: CSSBoxShadowValues) => void;
-}
+    extends CommonControlConfig,
+        ManagedClasses<CSSBoxShadowClassNameContract> {}
 
 export type CSSBoxShadowProps = CSSBoxShadowHandledProps & CSSBoxShadowUnhandledProps;

--- a/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.style.ts
+++ b/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.style.ts
@@ -28,6 +28,7 @@ const styles: ComponentStyles<CSSBoxShadowClassNameContract, {}> = {
         borderRadius: "2px",
         boxShadow: "0 0 0 1px inset rgba(255, 255, 255, 0.19)",
         width: "49%",
+        height: "29px",
         position: "relative",
         "&::after": {
             fontFamily: "Segoe UI, SegoeUI, Helvetica Neue, Helvetica, Arial, sans-serif",

--- a/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.style.ts
+++ b/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.style.ts
@@ -35,7 +35,7 @@ const styles: ComponentStyles<CSSBoxShadowClassNameContract, {}> = {
             fontSize: "12px",
             position: "absolute",
             right: "-38px",
-            top: "4px",
+            top: "6px",
             pointerEvents: "none",
         },
     },
@@ -54,19 +54,20 @@ const styles: ComponentStyles<CSSBoxShadowClassNameContract, {}> = {
     cssBoxShadow_opacityInput: {
         ...applyInputStyle(),
         width: "51%",
-        height: "25px",
+        height: "27px",
+        marginLeft: "4px",
     },
     cssBoxShadow_xInput: {
         ...applyInputStyle(),
-        height: "25px",
+        height: "27px",
     },
     cssBoxShadow_yInput: {
         ...applyInputStyle(),
-        height: "25px",
+        height: "27px",
     },
     cssBoxShadow_blurInput: {
         ...applyInputStyle(),
-        height: "25px",
+        height: "27px",
     },
     cssBoxShadow_label: {
         ...applyLabelStyle(),

--- a/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.style.ts
+++ b/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.style.ts
@@ -1,22 +1,28 @@
 import { ComponentStyles } from "@microsoft/fast-jss-manager-react";
-import { applyControlRegion, applyInputStyle, applyLabelStyle } from "../../style";
+import {
+    applyControlRegion,
+    applyControlWrapper,
+    applyInputStyle,
+    applyLabelStyle,
+} from "../../style";
 
 export interface CSSBoxShadowClassNameContract {
     cssBoxShadow?: string;
     cssBoxShadow_colorInputRegion?: string;
     cssBoxShadow_control?: string;
     cssBoxShadow_controlRegion?: string;
-    cssBoxShadow_colorRegion?: string;
     cssBoxShadow_opacityInput?: string;
     cssBoxShadow_xInput?: string;
     cssBoxShadow_yInput?: string;
     cssBoxShadow_blurInput?: string;
     cssBoxShadow_label?: string;
+    cssBoxShadow__disabled?: string;
 }
 
 const styles: ComponentStyles<CSSBoxShadowClassNameContract, {}> = {
     cssBoxShadow: {
-        display: "flex",
+        ...applyControlWrapper(),
+        ...applyControlRegion(),
     },
     cssBoxShadow_colorInputRegion: {
         borderRadius: "2px",
@@ -33,11 +39,11 @@ const styles: ComponentStyles<CSSBoxShadowClassNameContract, {}> = {
             pointerEvents: "none",
         },
     },
-    cssBoxShadow_colorRegion: {
-        width: "37%",
-    },
     cssBoxShadow_control: {
         ...applyControlRegion(),
+        display: "flex",
+        alignItems: "flex-end",
+        width: "37%",
     },
     cssBoxShadow_controlRegion: {
         display: "flex",
@@ -65,6 +71,7 @@ const styles: ComponentStyles<CSSBoxShadowClassNameContract, {}> = {
     cssBoxShadow_label: {
         ...applyLabelStyle(),
     },
+    cssBoxShadow__disabled: {},
 };
 
 export default styles;

--- a/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.tsx
+++ b/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.tsx
@@ -108,6 +108,7 @@ export default class CSSBoxShadow extends Foundation<
                             disabled={this.props.disabled}
                             onFocus={this.props.reportValidity}
                             onBlur={this.props.updateValidity}
+                            ref={this.props.elementRef as React.Ref<HTMLInputElement>}
                         />
                     </div>
                     <input
@@ -120,9 +121,6 @@ export default class CSSBoxShadow extends Foundation<
                         value={Math.round(this.state.boxShadowOpacity * 100)}
                         onChange={this.handleBoxShadowOpacityOnChange}
                         disabled={this.props.disabled}
-                        onFocus={this.props.reportValidity}
-                        onBlur={this.props.updateValidity}
-                        ref={this.props.elementRef as React.Ref<HTMLInputElement>}
                     />
                 </div>
                 <div className={cssBoxShadow_controlRegion}>
@@ -134,9 +132,6 @@ export default class CSSBoxShadow extends Foundation<
                         value={this.state.boxShadowOffsetX}
                         onChange={this.handleBoxShadowXOnChange}
                         disabled={this.props.disabled}
-                        onFocus={this.props.reportValidity}
-                        onBlur={this.props.updateValidity}
-                        ref={this.props.elementRef as React.Ref<HTMLInputElement>}
                     />
                 </div>
                 <div className={cssBoxShadow_controlRegion}>
@@ -148,9 +143,6 @@ export default class CSSBoxShadow extends Foundation<
                         value={this.state.boxShadowOffsetY}
                         onChange={this.handleBoxShadowYOnChange}
                         disabled={this.props.disabled}
-                        onFocus={this.props.reportValidity}
-                        onBlur={this.props.updateValidity}
-                        ref={this.props.elementRef as React.Ref<HTMLInputElement>}
                     />
                 </div>
                 <div className={cssBoxShadow_controlRegion}>
@@ -162,9 +154,6 @@ export default class CSSBoxShadow extends Foundation<
                         value={this.state.boxShadowBlurRadius}
                         onChange={this.handleBoxShadowBlurOnChange}
                         disabled={this.props.disabled}
-                        onFocus={this.props.reportValidity}
-                        onBlur={this.props.updateValidity}
-                        ref={this.props.elementRef as React.Ref<HTMLInputElement>}
                     />
                 </div>
             </div>

--- a/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.tsx
+++ b/packages/fast-tooling-react/src/css-editor/box-shadow/box-shadow.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { get } from "lodash-es";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {
     CSSBoxShadowHandledProps,
@@ -7,6 +6,8 @@ import {
     CSSBoxShadowState,
     CSSBoxShadowUnhandledProps,
 } from "./box-shadow.props";
+import { CSSBoxShadowClassNameContract } from "./box-shadow.style";
+import { classNames } from "@microsoft/fast-web-utilities";
 import { ColorRGBA64, parseColorHexRGB } from "@microsoft/fast-colors";
 
 export default class CSSBoxShadow extends Foundation<
@@ -16,10 +17,20 @@ export default class CSSBoxShadow extends Foundation<
 > {
     public static displayName: string = "CSSBoxShadow";
 
+    public static defaultProps: Partial<CSSBoxShadowProps> = {
+        value: "",
+        managedClasses: {},
+    };
+
     protected handledProps: HandledProps<CSSBoxShadowHandledProps> = {
-        data: void 0,
         onChange: void 0,
         managedClasses: void 0,
+        dataLocation: void 0,
+        value: void 0,
+        disabled: void 0,
+        elementRef: void 0,
+        reportValidity: void 0,
+        updateValidity: void 0,
     };
 
     private defaultBoxShadowColor: string = "#000";
@@ -61,7 +72,7 @@ export default class CSSBoxShadow extends Foundation<
             ];
 
             this.props.onChange({
-                boxShadow: boxShadowArray.reduce(
+                value: boxShadowArray.reduce(
                     (accum: string, current: string): string => {
                         return current.length ? accum.concat(" ", current.trim()) : accum;
                     }
@@ -71,109 +82,103 @@ export default class CSSBoxShadow extends Foundation<
     }
 
     public render(): React.ReactNode {
+        const {
+            cssBoxShadow_control,
+            cssBoxShadow_colorInputRegion,
+            cssBoxShadow_opacityInput,
+            cssBoxShadow_controlRegion,
+            cssBoxShadow_label,
+            cssBoxShadow_xInput,
+            cssBoxShadow_yInput,
+            cssBoxShadow_blurInput,
+        }: Partial<CSSBoxShadowClassNameContract> = this.props.managedClasses;
+
         return (
-            <div className={get(this.props, "managedClasses.cssBoxShadow")}>
-                <div
-                    className={get(this.props, "managedClasses.cssBoxShadow_colorRegion")}
-                >
-                    <label
-                        className={get(this.props, "managedClasses.cssBoxShadow_label")}
-                    >
-                        Shadow
-                    </label>
+            <div className={this.generateClassNames()}>
+                <div className={cssBoxShadow_control}>
                     <div
-                        className={get(this.props, "managedClasses.cssBoxShadow_control")}
+                        className={cssBoxShadow_colorInputRegion}
+                        style={{ background: this.state.boxShadowColor }}
                     >
-                        <div
-                            className={get(
-                                this.props,
-                                "managedClasses.cssBoxShadow_colorInputRegion"
-                            )}
-                            style={{ background: this.state.boxShadowColor }}
-                        >
-                            <input
-                                type={"color"}
-                                style={{ opacity: 0, width: "100%" }}
-                                value={this.state.boxShadowColor}
-                                onChange={this.handleBoxShadowColorOnChange}
-                            />
-                        </div>
                         <input
-                            className={get(
-                                this.props,
-                                "managedClasses.cssBoxShadow_opacityInput"
-                            )}
-                            type={"number"}
-                            min={0}
-                            max={100}
-                            step={1}
-                            placeholder={"50"}
-                            value={Math.round(this.state.boxShadowOpacity * 100)}
-                            onChange={this.handleBoxShadowOpacityOnChange}
+                            type={"color"}
+                            style={{ opacity: 0, width: "100%" }}
+                            value={this.state.boxShadowColor}
+                            onChange={this.handleBoxShadowColorOnChange}
+                            disabled={this.props.disabled}
+                            onFocus={this.props.reportValidity}
+                            onBlur={this.props.updateValidity}
                         />
                     </div>
-                </div>
-                <div
-                    className={get(
-                        this.props,
-                        "managedClasses.cssBoxShadow_controlRegion"
-                    )}
-                >
-                    <label
-                        className={get(this.props, "managedClasses.cssBoxShadow_label")}
-                    >
-                        X
-                    </label>
                     <input
-                        className={get(this.props, "managedClasses.cssBoxShadow_xInput")}
+                        className={cssBoxShadow_opacityInput}
+                        type={"number"}
+                        min={0}
+                        max={100}
+                        step={1}
+                        placeholder={"50"}
+                        value={Math.round(this.state.boxShadowOpacity * 100)}
+                        onChange={this.handleBoxShadowOpacityOnChange}
+                        disabled={this.props.disabled}
+                        onFocus={this.props.reportValidity}
+                        onBlur={this.props.updateValidity}
+                        ref={this.props.elementRef as React.Ref<HTMLInputElement>}
+                    />
+                </div>
+                <div className={cssBoxShadow_controlRegion}>
+                    <label className={cssBoxShadow_label}>X</label>
+                    <input
+                        className={cssBoxShadow_xInput}
                         type={"text"}
                         placeholder={"5px"}
                         value={this.state.boxShadowOffsetX}
                         onChange={this.handleBoxShadowXOnChange}
+                        disabled={this.props.disabled}
+                        onFocus={this.props.reportValidity}
+                        onBlur={this.props.updateValidity}
+                        ref={this.props.elementRef as React.Ref<HTMLInputElement>}
                     />
                 </div>
-                <div
-                    className={get(
-                        this.props,
-                        "managedClasses.cssBoxShadow_controlRegion"
-                    )}
-                >
-                    <label
-                        className={get(this.props, "managedClasses.cssBoxShadow_label")}
-                    >
-                        Y
-                    </label>
+                <div className={cssBoxShadow_controlRegion}>
+                    <label className={cssBoxShadow_label}>Y</label>
                     <input
-                        className={get(this.props, "managedClasses.cssBoxShadow_yInput")}
+                        className={cssBoxShadow_yInput}
                         type={"text"}
                         placeholder={"5px"}
                         value={this.state.boxShadowOffsetY}
                         onChange={this.handleBoxShadowYOnChange}
+                        disabled={this.props.disabled}
+                        onFocus={this.props.reportValidity}
+                        onBlur={this.props.updateValidity}
+                        ref={this.props.elementRef as React.Ref<HTMLInputElement>}
                     />
                 </div>
-                <div
-                    className={get(
-                        this.props,
-                        "managedClasses.cssBoxShadow_controlRegion"
-                    )}
-                >
-                    <label
-                        className={get(this.props, "managedClasses.cssBoxShadow_label")}
-                    >
-                        Blur
-                    </label>
+                <div className={cssBoxShadow_controlRegion}>
+                    <label className={cssBoxShadow_label}>Blur</label>
                     <input
-                        className={get(
-                            this.props,
-                            "managedClasses.cssBoxShadow_blurInput"
-                        )}
+                        className={cssBoxShadow_blurInput}
                         type={"text"}
                         placeholder={"0"}
                         value={this.state.boxShadowBlurRadius}
                         onChange={this.handleBoxShadowBlurOnChange}
+                        disabled={this.props.disabled}
+                        onFocus={this.props.reportValidity}
+                        onBlur={this.props.updateValidity}
+                        ref={this.props.elementRef as React.Ref<HTMLInputElement>}
                     />
                 </div>
             </div>
+        );
+    }
+
+    protected generateClassNames(): string {
+        const {
+            cssBoxShadow,
+            cssBoxShadow__disabled,
+        }: Partial<CSSBoxShadowClassNameContract> = this.props.managedClasses;
+
+        return super.generateClassNames(
+            classNames(cssBoxShadow, [cssBoxShadow__disabled, this.props.disabled])
         );
     }
 

--- a/packages/fast-tooling-react/src/css-editor/editor-data.schema.ts
+++ b/packages/fast-tooling-react/src/css-editor/editor-data.schema.ts
@@ -32,6 +32,7 @@ export default {
             title: "Width",
             type: "string",
             formControlId: widthPluginId,
+        },
         shadow: {
             title: "Shadow",
             type: "string",

--- a/packages/fast-tooling-react/src/css-editor/editor-data.schema.ts
+++ b/packages/fast-tooling-react/src/css-editor/editor-data.schema.ts
@@ -33,7 +33,7 @@ export default {
             type: "string",
             formControlId: widthPluginId,
         },
-        shadow: {
+        boxShadow: {
             title: "Shadow",
             type: "string",
             formControlId: boxShadowPlugInId,

--- a/packages/fast-tooling-react/src/css-editor/editor-data.schema.ts
+++ b/packages/fast-tooling-react/src/css-editor/editor-data.schema.ts
@@ -1,5 +1,6 @@
 import {
     backgroundPlugInId,
+    boxShadowPlugInId,
     colorPlugInId,
     heightPluginId,
     widthPluginId,
@@ -31,6 +32,10 @@ export default {
             title: "Width",
             type: "string",
             formControlId: widthPluginId,
+        shadow: {
+            title: "Shadow",
+            type: "string",
+            formControlId: boxShadowPlugInId,
         },
     },
 };

--- a/packages/fast-tooling-react/src/css-editor/editor.constants.ts
+++ b/packages/fast-tooling-react/src/css-editor/editor.constants.ts
@@ -2,3 +2,4 @@ export const backgroundPlugInId: string = "background";
 export const colorPlugInId: string = "color";
 export const heightPluginId: string = "height";
 export const widthPluginId: string = "width";
+export const boxShadowPlugInId: string = "shadow";

--- a/packages/fast-tooling-react/src/css-editor/editor.schema.json
+++ b/packages/fast-tooling-react/src/css-editor/editor.schema.json
@@ -29,7 +29,7 @@
                     "type": "string",
                     "formControlId": "width"
                 },
-                "boxSshadow": {
+                "boxShadow": {
                     "title": "Shadow",
                     "type": "string",
                     "formControlId": "shadow"

--- a/packages/fast-tooling-react/src/css-editor/editor.schema.json
+++ b/packages/fast-tooling-react/src/css-editor/editor.schema.json
@@ -29,7 +29,7 @@
                     "type": "string",
                     "formControlId": "width"
                 },
-                "shadow": {
+                "boxSshadow": {
                     "title": "Shadow",
                     "type": "string",
                     "formControlId": "shadow"

--- a/packages/fast-tooling-react/src/css-editor/editor.schema.json
+++ b/packages/fast-tooling-react/src/css-editor/editor.schema.json
@@ -28,6 +28,11 @@
                     "title": "Width",
                     "type": "string",
                     "formControlId": "width"
+                },
+                "shadow": {
+                    "title": "Shadow",
+                    "type": "string",
+                    "formControlId": "shadow"
                 }
             }
         }

--- a/packages/fast-tooling-react/src/css-editor/editor.tsx
+++ b/packages/fast-tooling-react/src/css-editor/editor.tsx
@@ -73,7 +73,7 @@ export default class CSSEditor extends Foundation<
             new StandardControlPlugin({
                 id: boxShadowPlugInId,
                 control: (config: ControlConfig): React.ReactNode => {
-                    return <CSSBoxShadow value={this.props.data} {...config} />;
+                    return <CSSBoxShadow {...config} />;
                 },
             }),
         ];

--- a/packages/fast-tooling-react/src/css-editor/editor.tsx
+++ b/packages/fast-tooling-react/src/css-editor/editor.tsx
@@ -13,10 +13,12 @@ import { CSSHeight } from "./height";
 import { ControlConfig, Form, StandardControlPlugin } from "../form/";
 import {
     backgroundPlugInId,
+    boxShadowPlugInId,
     colorPlugInId,
     heightPluginId,
     widthPluginId,
 } from "./editor.constants";
+import { CSSBoxShadow } from "./box-shadow";
 
 export default class CSSEditor extends Foundation<
     CSSEditorHandledProps,
@@ -67,6 +69,12 @@ export default class CSSEditor extends Foundation<
                 control: (config: ControlConfig): React.ReactNode => {
                     return <CSSWidth value={this.props.data} {...config} />;
                 },
+            }),
+            new StandardControlPlugin({
+                id: boxShadowPlugInId,
+                control: (config: ControlConfig): React.ReactNode => {
+                    return <CSSBoxShadow value={this.props.data} {...config} />;
+                }
             }),
         ];
     }

--- a/packages/fast-tooling-react/src/css-editor/editor.tsx
+++ b/packages/fast-tooling-react/src/css-editor/editor.tsx
@@ -74,7 +74,7 @@ export default class CSSEditor extends Foundation<
                 id: boxShadowPlugInId,
                 control: (config: ControlConfig): React.ReactNode => {
                     return <CSSBoxShadow value={this.props.data} {...config} />;
-                }
+                },
             }),
         ];
     }

--- a/packages/fast-tooling-react/src/css-editor/editor.tsx
+++ b/packages/fast-tooling-react/src/css-editor/editor.tsx
@@ -49,25 +49,25 @@ export default class CSSEditor extends Foundation<
             new StandardControlPlugin({
                 id: backgroundPlugInId,
                 control: (config: ControlConfig): React.ReactNode => {
-                    return <CSSBackground value={this.props.data} {...config} />;
+                    return <CSSBackground {...config} />;
                 },
             }),
             new StandardControlPlugin({
                 id: colorPlugInId,
                 control: (config: ControlConfig): React.ReactNode => {
-                    return <CSSColor value={this.props.data} {...config} />;
+                    return <CSSColor {...config} />;
                 },
             }),
             new StandardControlPlugin({
                 id: heightPluginId,
                 control: (config: ControlConfig): React.ReactNode => {
-                    return <CSSHeight value={this.props.data} {...config} />;
+                    return <CSSHeight {...config} />;
                 },
             }),
             new StandardControlPlugin({
                 id: widthPluginId,
                 control: (config: ControlConfig): React.ReactNode => {
-                    return <CSSWidth value={this.props.data} {...config} />;
+                    return <CSSWidth {...config} />;
                 },
             }),
             new StandardControlPlugin({

--- a/packages/fast-tooling-react/src/css-editor/index.ts
+++ b/packages/fast-tooling-react/src/css-editor/index.ts
@@ -19,3 +19,4 @@ export * from "./height";
 export * from "./width";
 export * from "./color";
 export * from "./background";
+export * from "./box-shadow";


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

closes #2353 

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->