### PR TITLE
feat: convert border-radius to use standard control plugin in css editor

### DIFF
--- a/packages/fast-tooling-react/README.md
+++ b/packages/fast-tooling-react/README.md
@@ -996,6 +996,41 @@ export class Example extends React.Component {
 }
 ```
 
+### Border Radius
+
+The `CSSBorderRadius` component shows an input and has a callback that will be fired when border radius values are set.
+
+Example:
+```jsx
+import React from "react";
+import { CSSBorderRadius } from "@microsoft/fast-tooling-react";
+
+export class Example extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            cssValues: "1px 1px 1px 1px"
+        }
+    }
+
+    render() {
+        return (
+            <CSSBorderRadius
+                value={this.state.cssValues}
+                onChange={this.handleCSSValueUpdate}
+            />
+        );
+    }
+
+    handleCSSValueUpdate = (updatedValues) => {
+        this.setState({
+            cssValues: updatedValues
+        });
+    }
+}
+```
+
 ## Form
 
 The required properties are the `data`, `schema`, and `onChange` function. The data should be tied to your state as the data will change when editing the form. The `onChange` is used as a callback, it should take one argument that is the data that should be updated when any data has been changed from within the generated form.

--- a/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.props.ts
+++ b/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.props.ts
@@ -1,5 +1,7 @@
 import { ManagedClasses } from "@microsoft/fast-jss-manager-react";
 import { CSSBorderRadiusClassNameContract } from "./border-radius.style";
+import { CommonControlConfig } from "../../form/templates";
+import { Omit } from "utility-types";
 
 export interface CSSBorderRadiusState {
     individualValues?: boolean;
@@ -20,20 +22,11 @@ export interface CSSBorderRadiusValues {
 }
 
 export interface CSSBorderRadiusUnhandledProps
-    extends React.HTMLAttributes<HTMLDivElement> {}
+    extends Omit<React.HTMLAttributes<HTMLDivElement>, "onChange"> {}
 
 export interface CSSBorderRadiusHandledProps
-    extends ManagedClasses<CSSBorderRadiusClassNameContract> {
-    /**
-     * The data
-     */
-    data?: CSSBorderRadiusValues;
-
-    /**
-     * The onChange callback
-     */
-    onChange?: (borderRadius: CSSBorderRadiusValues) => void;
-}
+    extends CommonControlConfig,
+        ManagedClasses<CSSBorderRadiusClassNameContract> {}
 
 export type CSSBorderRadiusProps = CSSBorderRadiusHandledProps &
     CSSBorderRadiusUnhandledProps;

--- a/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.spec.tsx
+++ b/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.spec.tsx
@@ -16,7 +16,7 @@ describe("CSSBorderRadius", () => {
         cssBorderRadius_input: "cssBorderRadius_input",
     };
 
-    const backgroundProps: CSSBorderRadiusProps = {
+    const borderRadiusProps: CSSBorderRadiusProps = {
         dataLocation: "",
         onChange: jest.fn(),
         value: "",
@@ -43,7 +43,7 @@ describe("CSSBorderRadius", () => {
         const borderRadiusValue: string = "12px 12px 12px 12px";
         const rendered: any = mount(
             <CSSBorderRadius
-                data={{ borderRadius: borderRadiusValue }}
+                value={{ borderRadius: borderRadiusValue }}
                 managedClasses={managedClasses}
                 onChange={jest.fn()}
             />
@@ -59,7 +59,7 @@ describe("CSSBorderRadius", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
             <CSSBorderRadius
-                data={{ borderRadius: borderRadiusValue }}
+                value={{ borderRadius: borderRadiusValue }}
                 managedClasses={managedClasses}
                 onChange={callback}
             />
@@ -72,7 +72,9 @@ describe("CSSBorderRadius", () => {
             .simulate("change", { target: { value: newBorderRadiusValue } });
 
         expect(callback).toHaveBeenCalledTimes(1);
-        expect(callback.mock.calls[0][0]).toEqual({ borderRadius: newBorderRadiusValue });
+        expect(callback.mock.calls[0][0]).toEqual({
+            value: { borderRadius: newBorderRadiusValue },
+        });
     });
     test("should not change the input from controlled to uncontrolled", () => {
         const borderRadiusValue: string = "12px 12px 12px 12px";
@@ -80,7 +82,7 @@ describe("CSSBorderRadius", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
             <CSSBorderRadius
-                data={{ borderRadius: borderRadiusValue }}
+                value={{ borderRadius: borderRadiusValue }}
                 managedClasses={managedClasses}
                 onChange={callback}
             />
@@ -93,10 +95,12 @@ describe("CSSBorderRadius", () => {
             .simulate("change", { target: { value: newBorderRadiusValue } });
 
         expect(callback).toHaveBeenCalledTimes(1);
-        expect(callback.mock.calls[0][0]).toEqual({ borderRadius: newBorderRadiusValue });
+        expect(callback.mock.calls[0][0]).toEqual({
+            value: { borderRadius: newBorderRadiusValue },
+        });
 
         rendered.setProps({
-            data: {},
+            value: {},
         });
 
         expect(
@@ -104,14 +108,14 @@ describe("CSSBorderRadius", () => {
         ).toBe("");
     });
 
-    test("should parse the `data` prop and assign individual values when 1 value is passed", () => {
+    test("should parse the `value` prop and assign individual values when 1 value is passed", () => {
         const borderRadiusValue: string = "12px";
         const rendered: any = mount(
-            <CSSBorderRadius managedClasses={managedClasses} onChange={jest.fn()} />
+            <CSSBorderRadius managedClasses={managedClasses} {...borderRadiusProps} />
         );
 
         rendered.setProps({
-            data: {
+            value: {
                 borderRadius: borderRadiusValue,
             },
         });
@@ -144,14 +148,14 @@ describe("CSSBorderRadius", () => {
         ).toBe("12px");
     });
 
-    test("should parse the `data` prop and assign individual values when 2 values are passed", () => {
+    test("should parse the `value` prop and assign individual values when 2 values are passed", () => {
         const borderRadiusValue: string = "12px 8px";
         const rendered: any = mount(
-            <CSSBorderRadius managedClasses={managedClasses} onChange={jest.fn()} />
+            <CSSBorderRadius managedClasses={managedClasses} {...borderRadiusProps} />
         );
 
         rendered.setProps({
-            data: {
+            value: {
                 borderRadius: borderRadiusValue,
             },
         });
@@ -184,14 +188,14 @@ describe("CSSBorderRadius", () => {
         ).toBe("8px");
     });
 
-    test("should parse the `data` prop and assign individual values when 3 values are passed", () => {
+    test("should parse the `value` prop and assign individual values when 3 values are passed", () => {
         const borderRadiusValue: string = "12px 8px 3px";
         const rendered: any = mount(
-            <CSSBorderRadius managedClasses={managedClasses} onChange={jest.fn()} />
+            <CSSBorderRadius managedClasses={managedClasses} {...borderRadiusProps} />
         );
 
         rendered.setProps({
-            data: {
+            value: {
                 borderRadius: borderRadiusValue,
             },
         });
@@ -224,14 +228,14 @@ describe("CSSBorderRadius", () => {
         ).toBe("8px");
     });
 
-    test("should parse the `data` prop and assign individual values when 4 values are passed", () => {
+    test("should parse the `value` prop and assign individual values when 4 values are passed", () => {
         const borderRadiusValue: string = "12px 8px 3px 7px";
         const rendered: any = mount(
-            <CSSBorderRadius managedClasses={managedClasses} onChange={jest.fn()} />
+            <CSSBorderRadius managedClasses={managedClasses} {...borderRadiusProps} />
         );
 
         rendered.setProps({
-            data: {
+            value: {
                 borderRadius: borderRadiusValue,
             },
         });
@@ -350,7 +354,7 @@ describe("CSSBorderRadius", () => {
             <CSSBorderRadius
                 managedClasses={managedClasses}
                 onChange={callback}
-                data={{ borderRadius: "1px 1px 1px 1px" }}
+                value={{ borderRadius: "1px 1px 1px 1px" }}
             />
         );
 
@@ -365,7 +369,7 @@ describe("CSSBorderRadius", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback.mock.calls[0][0]).toStrictEqual({
-            borderRadius: "10px 1px 1px 1px",
+            value: { borderRadius: "10px 1px 1px 1px" },
         });
     });
 
@@ -376,7 +380,7 @@ describe("CSSBorderRadius", () => {
             <CSSBorderRadius
                 managedClasses={managedClasses}
                 onChange={callback}
-                data={{ borderRadius: "1px 1px 1px 1px" }}
+                value={{ borderRadius: "1px 1px 1px 1px" }}
             />
         );
 
@@ -391,7 +395,7 @@ describe("CSSBorderRadius", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback.mock.calls[0][0]).toStrictEqual({
-            borderRadius: "1px 10px 1px 1px",
+            value: { borderRadius: "1px 10px 1px 1px" },
         });
     });
 
@@ -402,7 +406,7 @@ describe("CSSBorderRadius", () => {
             <CSSBorderRadius
                 managedClasses={managedClasses}
                 onChange={callback}
-                data={{ borderRadius: "1px 1px 1px 1px" }}
+                value={{ borderRadius: "1px 1px 1px 1px" }}
             />
         );
 
@@ -417,7 +421,7 @@ describe("CSSBorderRadius", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback.mock.calls[0][0]).toStrictEqual({
-            borderRadius: "1px 1px 10px 1px",
+            value: { borderRadius: "1px 1px 10px 1px" },
         });
     });
 
@@ -428,7 +432,7 @@ describe("CSSBorderRadius", () => {
             <CSSBorderRadius
                 managedClasses={managedClasses}
                 onChange={callback}
-                data={{ borderRadius: "1px 1px 1px 1px" }}
+                value={{ borderRadius: "1px 1px 1px 1px" }}
             />
         );
 
@@ -443,7 +447,7 @@ describe("CSSBorderRadius", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback.mock.calls[0][0]).toStrictEqual({
-            borderRadius: "1px 1px 1px 10px",
+            value: { borderRadius: "1px 1px 1px 10px" },
         });
     });
 });

--- a/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.spec.tsx
+++ b/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.spec.tsx
@@ -43,7 +43,7 @@ describe("CSSBorderRadius", () => {
         const borderRadiusValue: string = "12px 12px 12px 12px";
         const rendered: any = mount(
             <CSSBorderRadius
-                value={{ borderRadius: borderRadiusValue }}
+                value={borderRadiusValue}
                 managedClasses={managedClasses}
                 onChange={jest.fn()}
             />
@@ -59,7 +59,7 @@ describe("CSSBorderRadius", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
             <CSSBorderRadius
-                value={{ borderRadius: borderRadiusValue }}
+                value={borderRadiusValue}
                 managedClasses={managedClasses}
                 onChange={callback}
             />
@@ -73,7 +73,7 @@ describe("CSSBorderRadius", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback.mock.calls[0][0]).toEqual({
-            value: { borderRadius: newBorderRadiusValue },
+            value: newBorderRadiusValue,
         });
     });
     test("should not change the input from controlled to uncontrolled", () => {
@@ -82,7 +82,7 @@ describe("CSSBorderRadius", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
             <CSSBorderRadius
-                value={{ borderRadius: borderRadiusValue }}
+                value={borderRadiusValue}
                 managedClasses={managedClasses}
                 onChange={callback}
             />
@@ -96,11 +96,11 @@ describe("CSSBorderRadius", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback.mock.calls[0][0]).toEqual({
-            value: { borderRadius: newBorderRadiusValue },
+            value: newBorderRadiusValue,
         });
 
         rendered.setProps({
-            value: {},
+            value: "",
         });
 
         expect(
@@ -115,9 +115,7 @@ describe("CSSBorderRadius", () => {
         );
 
         rendered.setProps({
-            value: {
-                borderRadius: borderRadiusValue,
-            },
+            value: borderRadiusValue,
         });
 
         rendered.find("button").simulate("click");
@@ -155,9 +153,7 @@ describe("CSSBorderRadius", () => {
         );
 
         rendered.setProps({
-            value: {
-                borderRadius: borderRadiusValue,
-            },
+            value: borderRadiusValue,
         });
 
         rendered.find("button").simulate("click");
@@ -195,9 +191,7 @@ describe("CSSBorderRadius", () => {
         );
 
         rendered.setProps({
-            value: {
-                borderRadius: borderRadiusValue,
-            },
+            value: borderRadiusValue,
         });
 
         rendered.find("button").simulate("click");
@@ -235,9 +229,7 @@ describe("CSSBorderRadius", () => {
         );
 
         rendered.setProps({
-            value: {
-                borderRadius: borderRadiusValue,
-            },
+            value: borderRadiusValue,
         });
 
         rendered.find("button").simulate("click");
@@ -354,7 +346,7 @@ describe("CSSBorderRadius", () => {
             <CSSBorderRadius
                 managedClasses={managedClasses}
                 onChange={callback}
-                value={{ borderRadius: "1px 1px 1px 1px" }}
+                value={"1px 1px 1px 1px"}
             />
         );
 
@@ -369,7 +361,7 @@ describe("CSSBorderRadius", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback.mock.calls[0][0]).toStrictEqual({
-            value: { borderRadius: "10px 1px 1px 1px" },
+            value: "10px 1px 1px 1px",
         });
     });
 
@@ -380,7 +372,7 @@ describe("CSSBorderRadius", () => {
             <CSSBorderRadius
                 managedClasses={managedClasses}
                 onChange={callback}
-                value={{ borderRadius: "1px 1px 1px 1px" }}
+                value={"1px 1px 1px 1px"}
             />
         );
 
@@ -395,7 +387,7 @@ describe("CSSBorderRadius", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback.mock.calls[0][0]).toStrictEqual({
-            value: { borderRadius: "1px 10px 1px 1px" },
+            value: "1px 10px 1px 1px",
         });
     });
 
@@ -406,7 +398,7 @@ describe("CSSBorderRadius", () => {
             <CSSBorderRadius
                 managedClasses={managedClasses}
                 onChange={callback}
-                value={{ borderRadius: "1px 1px 1px 1px" }}
+                value={"1px 1px 1px 1px"}
             />
         );
 
@@ -421,7 +413,7 @@ describe("CSSBorderRadius", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback.mock.calls[0][0]).toStrictEqual({
-            value: { borderRadius: "1px 1px 10px 1px" },
+            value: "1px 1px 10px 1px",
         });
     });
 
@@ -432,7 +424,7 @@ describe("CSSBorderRadius", () => {
             <CSSBorderRadius
                 managedClasses={managedClasses}
                 onChange={callback}
-                value={{ borderRadius: "1px 1px 1px 1px" }}
+                value={"1px 1px 1px 1px"}
             />
         );
 
@@ -447,7 +439,7 @@ describe("CSSBorderRadius", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback.mock.calls[0][0]).toStrictEqual({
-            value: { borderRadius: "1px 1px 1px 10px" },
+            value: "1px 1px 1px 10px",
         });
     });
 });

--- a/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.spec.tsx
+++ b/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.spec.tsx
@@ -14,6 +14,13 @@ describe("CSSBorderRadius", () => {
     const managedClasses: CSSBorderRadiusClassNameContract = {
         cssBorderRadius: "cssBorderRadius",
         cssBorderRadius_input: "cssBorderRadius_input",
+        cssBorderRadius_individualInput: "cssBorderRadius_individualInput",
+        cssBorderRadius_toggleButton: "cssBorderRadius_toggleButton",
+        cssBorderRadius_toggleButton__selected: "cssBorderRadius_toggleButton__selected",
+        cssBorderRadius_toggleButtonGlyph: "cssBorderRadius_toggleButtonGlyph",
+        cssBorderRadius_toggleButtonGlyphPath__highlight:
+            "cssBorderRadius_toggleButtonGlyphPath__highlight",
+        cssBorderRadius__disabled: "cssBorderRadius__disabled",
     };
 
     const borderRadiusProps: CSSBorderRadiusProps = {

--- a/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.spec.tsx
+++ b/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.spec.tsx
@@ -3,7 +3,7 @@ import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import CSSBorderRadius from "./border-radius";
 import { CSSBorderRadiusClassNameContract } from "./border-radius.style";
-import { BorderRadiusValue } from "./border-radius.props";
+import { BorderRadiusValue, CSSBorderRadiusProps } from "./border-radius.props";
 
 /**
  * Configure Enzyme
@@ -13,9 +13,17 @@ configure({ adapter: new Adapter() });
 describe("CSSBorderRadius", () => {
     const managedClasses: CSSBorderRadiusClassNameContract = {
         cssBorderRadius: "cssBorderRadius",
-        cssBorderRadius_control: "cssBorderRadius_control",
         cssBorderRadius_input: "cssBorderRadius_input",
-        cssBorderRadius_label: "cssBorderRadius_label",
+    };
+
+    const backgroundProps: CSSBorderRadiusProps = {
+        dataLocation: "",
+        onChange: jest.fn(),
+        value: "",
+        disabled: false,
+        reportValidity: jest.fn(),
+        updateValidity: jest.fn(),
+        elementRef: null,
     };
 
     test("should not throw", () => {
@@ -23,15 +31,15 @@ describe("CSSBorderRadius", () => {
             shallow(<CSSBorderRadius />);
         }).not.toThrow();
     });
-    test("should not throw if data is empty", () => {
+    test("should not throw if value is empty", () => {
         expect(() => {
-            shallow(<CSSBorderRadius data={{}} />);
+            shallow(<CSSBorderRadius value={{}} />);
         }).not.toThrow();
     });
     test("should have a displayName that matches the component name", () => {
         expect((CSSBorderRadius as any).name).toBe(CSSBorderRadius.displayName);
     });
-    test("should use the `data` prop as the input value if the `borderRadius` is provided", () => {
+    test("should use the `value` prop as the input value if the `borderRadius` is provided", () => {
         const borderRadiusValue: string = "12px 12px 12px 12px";
         const rendered: any = mount(
             <CSSBorderRadius

--- a/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.style.ts
+++ b/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.style.ts
@@ -1,11 +1,5 @@
 import { ComponentStyles } from "@microsoft/fast-jss-manager-react";
-import {
-    applyControlRegion,
-    applyControlWrapper,
-    applyInputBackplateStyle,
-    applyInputStyle,
-    applyLabelStyle,
-} from "../../style";
+import { applyControlRegion, applyControlWrapper, applyInputStyle } from "../../style";
 
 export interface CSSBorderRadiusClassNameContract {
     cssBorderRadius?: string;
@@ -15,6 +9,7 @@ export interface CSSBorderRadiusClassNameContract {
     cssBorderRadius_toggleButton__selected?: string;
     cssBorderRadius_toggleButtonGlyph?: string;
     cssBorderRadius_toggleButtonGlyphPath__highlight?: string;
+    cssBorderRadius__disabled?: string;
 }
 
 const styles: ComponentStyles<CSSBorderRadiusClassNameContract, {}> = {
@@ -54,6 +49,7 @@ const styles: ComponentStyles<CSSBorderRadiusClassNameContract, {}> = {
         transform: "scale(1.5)",
         transition: "all 0.1s ease-in-out",
     },
+    cssBorderRadius__disabled: {},
 };
 
 export default styles;

--- a/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.style.ts
+++ b/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.style.ts
@@ -9,10 +9,8 @@ import {
 
 export interface CSSBorderRadiusClassNameContract {
     cssBorderRadius?: string;
-    cssBorderRadius_control?: string;
     cssBorderRadius_input?: string;
     cssBorderRadius_individualInput?: string;
-    cssBorderRadius_label?: string;
     cssBorderRadius_toggleButton?: string;
     cssBorderRadius_toggleButton__selected?: string;
     cssBorderRadius_toggleButtonGlyph?: string;
@@ -22,8 +20,6 @@ export interface CSSBorderRadiusClassNameContract {
 const styles: ComponentStyles<CSSBorderRadiusClassNameContract, {}> = {
     cssBorderRadius: {
         ...applyControlWrapper(),
-    },
-    cssBorderRadius_control: {
         ...applyControlRegion(),
     },
     cssBorderRadius_input: {
@@ -35,9 +31,6 @@ const styles: ComponentStyles<CSSBorderRadiusClassNameContract, {}> = {
         ...applyInputStyle(),
         marginRight: "4px",
         width: "inherit",
-    },
-    cssBorderRadius_label: {
-        ...applyLabelStyle(),
     },
     cssBorderRadius_toggleButton: {
         ...applyInputStyle(),

--- a/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.tsx
+++ b/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.tsx
@@ -1,9 +1,6 @@
 import React from "react";
-import { get, pick } from "lodash-es";
-import Foundation, {
-    FoundationProps,
-    HandledProps,
-} from "@microsoft/fast-components-foundation-react";
+import { pick } from "lodash-es";
+import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import {
     BorderRadiusValue,
     CSSBorderRadiusHandledProps,
@@ -13,6 +10,8 @@ import {
     CSSBorderRadiusValues,
 } from "./border-radius.props";
 import { parseCSSString } from "../../utilities/parse-css-string";
+import { CSSBorderRadiusClassNameContract } from "./border-radius.style";
+import { classNames } from "@microsoft/fast-web-utilities";
 
 export default class CSSBorderRadius extends Foundation<
     CSSBorderRadiusHandledProps,
@@ -49,7 +48,7 @@ export default class CSSBorderRadius extends Foundation<
 
     public render(): React.ReactNode {
         return (
-            <div className={get(this.props, "managedClasses.cssBorderRadius")}>
+            <div className={this.generateClassNames()}>
                 {this.renderInputs()}
                 <button
                     className={this.generateToggleClassNames()}
@@ -61,13 +60,25 @@ export default class CSSBorderRadius extends Foundation<
         );
     }
 
+    protected generateClassNames(): string {
+        const {
+            cssBorderRadius,
+            cssBorderRadius__disabled,
+        }: Partial<CSSBorderRadiusClassNameContract> = this.props.managedClasses;
+
+        return super.generateClassNames(
+            classNames(cssBorderRadius, [cssBorderRadius__disabled, this.props.disabled])
+        );
+    }
+
     private renderBorderRadiusGlyph(): React.ReactNode {
+        const {
+            cssBorderRadius_toggleButtonGlyph,
+        }: Partial<CSSBorderRadiusClassNameContract> = this.props.managedClasses;
+
         return (
             <svg
-                className={get(
-                    this.props,
-                    "managedClasses.cssBorderRadius_toggleButtonGlyph"
-                )}
+                className={cssBorderRadius_toggleButtonGlyph}
                 width="14"
                 height="14"
                 viewBox="0 0 14 14"
@@ -106,6 +117,10 @@ export default class CSSBorderRadius extends Foundation<
     }
 
     private renderInputs(): React.ReactFragment {
+        const {
+            cssBorderRadius_input,
+        }: Partial<CSSBorderRadiusClassNameContract> = this.props.managedClasses;
+
         if (this.state.individualValues === true) {
             const parsedString: string[] = parseCSSString(this.props.value);
             return (
@@ -132,7 +147,7 @@ export default class CSSBorderRadius extends Foundation<
 
         return (
             <input
-                className={get(this.props, "managedClasses.cssBorderRadius_input")}
+                className={cssBorderRadius_input}
                 type={"text"}
                 value={this.props.value}
                 onChange={this.handleBorderRadiusOnChange(BorderRadiusValue.borderRadius)}
@@ -149,12 +164,14 @@ export default class CSSBorderRadius extends Foundation<
         value: string
     ): React.ReactNode {
         const normalizedValue: string = value === "0" ? "" : value;
+
+        const {
+            cssBorderRadius_individualInput,
+        }: Partial<CSSBorderRadiusClassNameContract> = this.props.managedClasses;
+
         return (
             <input
-                className={get(
-                    this.props,
-                    "managedClasses.cssBorderRadius_individualInput"
-                )}
+                className={cssBorderRadius_individualInput}
                 onFocus={this.handleInputOnFocus(position)}
                 onBlur={this.handleInputBlur}
                 placeholder={"0"}
@@ -213,27 +230,27 @@ export default class CSSBorderRadius extends Foundation<
     };
 
     private generateToggleClassNames(): string {
-        let className: string = get(
-            this.props,
-            "managedClasses.cssBorderRadius_toggleButton"
-        );
+        const {
+            cssBorderRadius_toggleButton,
+            cssBorderRadius_toggleButton__selected,
+        }: Partial<CSSBorderRadiusClassNameContract> = this.props.managedClasses;
+
+        let className: string = cssBorderRadius_toggleButton;
 
         if (this.state.individualValues) {
-            className = `${className} ${get(
-                this.props,
-                "managedClasses.cssBorderRadius_toggleButton__selected"
-            )}`;
+            className = `${className} ${cssBorderRadius_toggleButton__selected}`;
         }
 
         return className;
     }
 
     private generatePathClassNames(cssKey: BorderRadiusValue): string {
+        const {
+            cssBorderRadius_toggleButtonGlyphPath__highlight,
+        }: Partial<CSSBorderRadiusClassNameContract> = this.props.managedClasses;
+
         if (this.state.hasFocus === cssKey) {
-            return get(
-                this.props,
-                "managedClasses.cssBorderRadius_toggleButtonGlyphPath__highlight"
-            );
+            return cssBorderRadius_toggleButtonGlyphPath__highlight;
         }
     }
 

--- a/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.tsx
+++ b/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.tsx
@@ -107,9 +107,7 @@ export default class CSSBorderRadius extends Foundation<
 
     private renderInputs(): React.ReactFragment {
         if (this.state.individualValues === true) {
-            const parsedString: string[] = parseCSSString(
-                get(this.props.value, "borderRadius", "")
-            );
+            const parsedString: string[] = parseCSSString(this.props.value);
             return (
                 <React.Fragment>
                     {this.renderIndividualInputs(
@@ -136,7 +134,7 @@ export default class CSSBorderRadius extends Foundation<
             <input
                 className={get(this.props, "managedClasses.cssBorderRadius_input")}
                 type={"text"}
-                value={get(this.props.value, "borderRadius", "")}
+                value={this.props.value}
                 onChange={this.handleBorderRadiusOnChange(BorderRadiusValue.borderRadius)}
                 disabled={this.props.disabled}
                 onFocus={this.props.reportValidity}
@@ -178,9 +176,7 @@ export default class CSSBorderRadius extends Foundation<
 
             const validatedValue: string = e.target.value === "" ? "0" : e.target.value;
 
-            const parsedString: string[] = parseCSSString(
-                get(this.props.value, "borderRadius", "")
-            );
+            const parsedString: string[] = parseCSSString(this.props.value);
             switch (cssKey) {
                 case BorderRadiusValue.borderRadius:
                     borderRadius.borderRadius = e.target.value;
@@ -206,7 +202,7 @@ export default class CSSBorderRadius extends Foundation<
                     } ${parsedString[3]}`;
                     break;
             }
-            this.props.onChange({ value: borderRadius });
+            this.props.onChange({ value: borderRadius.borderRadius });
         };
     }
 

--- a/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.tsx
+++ b/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.tsx
@@ -21,10 +21,20 @@ export default class CSSBorderRadius extends Foundation<
 > {
     public static displayName: string = "CSSBorderRadius";
 
+    public static defaultProps: Partial<CSSBorderRadiusProps> = {
+        value: "",
+        managedClasses: {},
+    };
+
     protected handledProps: HandledProps<CSSBorderRadiusHandledProps> = {
-        data: void 0,
         onChange: void 0,
         managedClasses: void 0,
+        dataLocation: void 0,
+        value: void 0,
+        disabled: void 0,
+        elementRef: void 0,
+        reportValidity: void 0,
+        updateValidity: void 0,
     };
 
     constructor(props: CSSBorderRadiusProps) {
@@ -33,29 +43,20 @@ export default class CSSBorderRadius extends Foundation<
         this.state = {
             individualValues: false,
             hasFocus: void 0,
-            data: this.props.data,
+            data: this.props.value,
         };
     }
 
     public render(): React.ReactNode {
         return (
             <div className={get(this.props, "managedClasses.cssBorderRadius")}>
-                <label
-                    className={get(this.props, "managedClasses.cssBorderRadius_label")}
+                {this.renderInputs()}
+                <button
+                    className={this.generateToggleClassNames()}
+                    onClick={this.toggleInputs}
                 >
-                    BorderRadius
-                </label>
-                <div
-                    className={get(this.props, "managedClasses.cssBorderRadius_control")}
-                >
-                    {this.renderInputs()}
-                    <button
-                        className={this.generateToggleClassNames()}
-                        onClick={this.toggleInputs}
-                    >
-                        {this.renderBorderRadiusGlyph()}
-                    </button>
-                </div>
+                    {this.renderBorderRadiusGlyph()}
+                </button>
             </div>
         );
     }

--- a/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.tsx
+++ b/packages/fast-tooling-react/src/css-editor/border-radius/border-radius.tsx
@@ -108,7 +108,7 @@ export default class CSSBorderRadius extends Foundation<
     private renderInputs(): React.ReactFragment {
         if (this.state.individualValues === true) {
             const parsedString: string[] = parseCSSString(
-                get(this.props.data, "borderRadius", "")
+                get(this.props.value, "borderRadius", "")
             );
             return (
                 <React.Fragment>
@@ -136,8 +136,12 @@ export default class CSSBorderRadius extends Foundation<
             <input
                 className={get(this.props, "managedClasses.cssBorderRadius_input")}
                 type={"text"}
-                value={get(this.props.data, "borderRadius", "")}
+                value={get(this.props.value, "borderRadius", "")}
                 onChange={this.handleBorderRadiusOnChange(BorderRadiusValue.borderRadius)}
+                disabled={this.props.disabled}
+                onFocus={this.props.reportValidity}
+                onBlur={this.props.updateValidity}
+                ref={this.props.elementRef as React.Ref<HTMLInputElement>}
             />
         );
     }
@@ -159,6 +163,7 @@ export default class CSSBorderRadius extends Foundation<
                 type={"text"}
                 value={normalizedValue}
                 onChange={this.handleBorderRadiusOnChange(position)}
+                disabled={this.props.disabled}
             />
         );
     }
@@ -167,14 +172,14 @@ export default class CSSBorderRadius extends Foundation<
         cssKey: BorderRadiusValue
     ): (e: React.ChangeEvent<HTMLInputElement>) => void {
         return (e: React.ChangeEvent<HTMLInputElement>): void => {
-            const borderRadius: CSSBorderRadiusValues = pick(this.props.data, [
+            const borderRadius: CSSBorderRadiusValues = pick(this.props.value, [
                 "borderRadius",
             ]);
 
             const validatedValue: string = e.target.value === "" ? "0" : e.target.value;
 
             const parsedString: string[] = parseCSSString(
-                get(this.props.data, "borderRadius", "")
+                get(this.props.value, "borderRadius", "")
             );
             switch (cssKey) {
                 case BorderRadiusValue.borderRadius:
@@ -201,7 +206,7 @@ export default class CSSBorderRadius extends Foundation<
                     } ${parsedString[3]}`;
                     break;
             }
-            this.props.onChange(borderRadius);
+            this.props.onChange({ value: borderRadius });
         };
     }
 

--- a/packages/fast-tooling-react/src/css-editor/editor-data.schema.ts
+++ b/packages/fast-tooling-react/src/css-editor/editor-data.schema.ts
@@ -1,7 +1,7 @@
 import {
     backgroundPlugInId,
-    boxShadowPlugInId,
     borderRadiusPlugInId,
+    boxShadowPlugInId,
     colorPlugInId,
     heightPluginId,
     widthPluginId,

--- a/packages/fast-tooling-react/src/css-editor/editor-data.schema.ts
+++ b/packages/fast-tooling-react/src/css-editor/editor-data.schema.ts
@@ -1,6 +1,7 @@
 import {
     backgroundPlugInId,
     boxShadowPlugInId,
+    borderRadiusPlugInId,
     colorPlugInId,
     heightPluginId,
     widthPluginId,
@@ -37,6 +38,11 @@ export default {
             title: "Shadow",
             type: "string",
             formControlId: boxShadowPlugInId,
+        },
+        borderRadius: {
+            title: "Border radius",
+            type: "string",
+            formControlId: borderRadiusPlugInId,
         },
     },
 };

--- a/packages/fast-tooling-react/src/css-editor/editor.constants.ts
+++ b/packages/fast-tooling-react/src/css-editor/editor.constants.ts
@@ -1,4 +1,5 @@
 export const backgroundPlugInId: string = "background";
+export const borderRadiusPlugInId: string = "borderRadius";
 export const colorPlugInId: string = "color";
 export const heightPluginId: string = "height";
 export const widthPluginId: string = "width";

--- a/packages/fast-tooling-react/src/css-editor/editor.schema.json
+++ b/packages/fast-tooling-react/src/css-editor/editor.schema.json
@@ -33,6 +33,11 @@
                     "title": "Shadow",
                     "type": "string",
                     "formControlId": "shadow"
+                },
+                "borderRadius": {
+                    "title": "Border radius",
+                    "type": "string",
+                    "formControlId": "borderRadius"
                 }
             }
         }

--- a/packages/fast-tooling-react/src/css-editor/editor.tsx
+++ b/packages/fast-tooling-react/src/css-editor/editor.tsx
@@ -14,8 +14,8 @@ import { CSSHeight } from "./height";
 import { ControlConfig, Form, StandardControlPlugin } from "../form/";
 import {
     backgroundPlugInId,
-    boxShadowPlugInId,
     borderRadiusPlugInId,
+    boxShadowPlugInId,
     colorPlugInId,
     heightPluginId,
     widthPluginId,

--- a/packages/fast-tooling-react/src/css-editor/editor.tsx
+++ b/packages/fast-tooling-react/src/css-editor/editor.tsx
@@ -7,6 +7,7 @@ import {
 } from "./editor.props";
 import cssEditorDataSchema from "./editor-data.schema";
 import { CSSBackground } from "./background";
+import { CSSBorderRadius } from "./border-radius";
 import { CSSColor } from "./color";
 import { CSSWidth } from "./width";
 import { CSSHeight } from "./height";
@@ -14,11 +15,13 @@ import { ControlConfig, Form, StandardControlPlugin } from "../form/";
 import {
     backgroundPlugInId,
     boxShadowPlugInId,
+    borderRadiusPlugInId,
     colorPlugInId,
     heightPluginId,
     widthPluginId,
 } from "./editor.constants";
 import { CSSBoxShadow } from "./box-shadow";
+import { CSSBorder } from "./border";
 
 export default class CSSEditor extends Foundation<
     CSSEditorHandledProps,
@@ -74,6 +77,12 @@ export default class CSSEditor extends Foundation<
                 id: boxShadowPlugInId,
                 control: (config: ControlConfig): React.ReactNode => {
                     return <CSSBoxShadow {...config} />;
+                },
+            }),
+            new StandardControlPlugin({
+                id: borderRadiusPlugInId,
+                control: (config: ControlConfig): React.ReactNode => {
+                    return <CSSBorderRadius {...config} />;
                 },
             }),
         ];


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

closes #2354

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->