### PR TITLE
fix: viewport positioner resets on anchor change

### DIFF
--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -186,7 +186,7 @@ describe("viewport positioner", (): void => {
         );
 
         const positioner: any = rendered.find("BaseViewportPositioner");
-        expect(positioner.instance()["getInitialState"]()).toEqual({
+        expect(positioner.instance()["generateInitialState"]()).toEqual({
             disabled: true,
             noObserverMode: false,
             xTransformOrigin: "left",

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -169,6 +169,45 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().state.disabled).toBe(true);
     });
 
+    test("initial state function returns correct initial state", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div>
+                <div ref={anchorElement} />
+                <ViewportPositioner
+                    viewport={document.firstElementChild as HTMLElement}
+                    anchor={anchorElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+        expect(positioner.instance()["getInitialState"]()).toEqual({
+            disabled: true,
+            noObserverMode: false,
+            xTransformOrigin: "left",
+            yTransformOrigin: "top",
+            xTranslate: 0,
+            yTranslate: 0,
+            top: null,
+            right: null,
+            bottom: null,
+            left: null,
+            currentHorizontalPosition: "undefined",
+            currentVerticalPosition: "undefined",
+            defaultHorizontalPosition: "undefined",
+            defaultVerticalPosition: "bottom",
+            horizontalSelectedPositionWidth: null,
+            verticalSelectedPositionHeight: null,
+            initialLayoutComplete: false,
+            validRefChecksRemaining: 2,
+        });
+    });
+
     test("positioning values applied correctly for specified default position - adjacent + top + left", (): void => {
         const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
@@ -1605,5 +1644,50 @@ describe("viewport positioner", (): void => {
             );
         expect(positionerDimension.width).toBe(110);
         expect(positionerDimension.height).toBe(110);
+    });
+
+    test("extractElementFromRef function returns element passed in directly", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div>
+                <div ref={anchorElement} />
+                <ViewportPositioner
+                    viewport={document.firstElementChild as HTMLElement}
+                    anchor={anchorElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+        const testElement: Element = document.createElement("div");
+        expect(positioner.instance()["extractElementFromRef"](testElement)).toBe(
+            testElement
+        );
+    });
+
+    test("extractElementFromRef function returns element passed in as a ref", (): void => {
+        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        const rendered: any = mount(
+            <div>
+                <div ref={anchorElement} />
+                <ViewportPositioner
+                    viewport={document.firstElementChild as HTMLElement}
+                    anchor={anchorElement}
+                    managedClasses={managedClasses}
+                />
+            </div>
+        );
+
+        const positioner: any = rendered.find("BaseViewportPositioner");
+        expect(positioner.instance()["extractElementFromRef"](anchorElement)).toBe(
+            anchorElement.current
+        );
     });
 });

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/react";
-import React from "react";
+import React, { ReactNode } from "react";
 import ViewportPositioner, {
     AxisPositioningMode,
     ViewportContext,
@@ -9,12 +9,17 @@ import Foundation from "@microsoft/fast-components-foundation-react";
 import { ViewportPositionerVerticalPosition } from "./viewport-positioner.props";
 
 const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
+const anchorElement2: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
 
 interface TestViewportProps {
-    positionerProps: ViewportPositionerProps;
+    positionerProps: ViewportPositionerProps[];
 }
 
-class TestViewport extends React.Component<TestViewportProps, {}> {
+interface TestViewportState {
+    currentDataSetIndex: number;
+}
+
+class TestViewport extends React.Component<TestViewportProps, TestViewportState> {
     private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
         HTMLDivElement
     >();
@@ -22,62 +27,99 @@ class TestViewport extends React.Component<TestViewportProps, {}> {
     constructor(props: TestViewportProps) {
         super(props);
 
-        this.state = {};
+        this.state = {
+            currentDataSetIndex: 0,
+        };
     }
 
     public render(): JSX.Element {
         return (
-            <ViewportContext.Provider
-                value={{
-                    viewport: this.rootElement,
+            <div
+                style={{
+                    height: "100%",
+                    width: "100%",
                 }}
             >
-                <div
-                    ref={this.rootElement}
-                    style={{
-                        height: "400px",
-                        width: "400px",
-                        margin: "50px",
-                        overflow: "scroll",
+                {this.renderSwitcherUi()}
+                <ViewportContext.Provider
+                    value={{
+                        viewport: this.rootElement,
                     }}
                 >
-                    {this.props.children}
                     <div
+                        ref={this.rootElement}
                         style={{
-                            height: "0",
-                            width: "0",
+                            height: "400px",
+                            width: "400px",
+                            margin: "50px",
+                            overflow: "scroll",
                         }}
                     >
-                        <ViewportPositioner {...this.props.positionerProps}>
-                            <div
-                                style={{
-                                    height: "100%",
-                                    width: "100%",
-                                    background: "yellow",
-                                }}
+                        {this.props.children}
+                        <div
+                            style={{
+                                height: "0",
+                                width: "0",
+                            }}
+                        >
+                            <ViewportPositioner
+                                {...this.props.positionerProps[
+                                    this.state.currentDataSetIndex
+                                ]}
                             >
-                                Positioner
-                            </div>
-                        </ViewportPositioner>
+                                <div
+                                    style={{
+                                        height: "100%",
+                                        width: "100%",
+                                        background: "yellow",
+                                    }}
+                                >
+                                    Positioner
+                                </div>
+                            </ViewportPositioner>
+                        </div>
                     </div>
-                </div>
-            </ViewportContext.Provider>
+                </ViewportContext.Provider>
+            </div>
         );
     }
+
+    private renderSwitcherUi = (): ReactNode => {
+        if (this.props.positionerProps.length < 2) {
+            return null;
+        }
+        return (
+            <div>
+                <button onClick={this.onClick}>Switch data</button>
+            </div>
+        );
+    };
+
+    private onClick = (event: React.MouseEvent): void => {
+        const nextDataSetIndex: number = this.state.currentDataSetIndex + 1;
+        this.setState({
+            currentDataSetIndex:
+                nextDataSetIndex < this.props.positionerProps.length
+                    ? nextDataSetIndex
+                    : 0,
+        });
+    };
 }
 
 storiesOf("Viewport Positioner", module)
     .add("Default", () => (
         <TestViewport
-            positionerProps={{
-                verticalPositioningMode: AxisPositioningMode.adjacent,
-                horizontalPositioningMode: AxisPositioningMode.adjacent,
-                anchor: anchorElement,
-                style: {
-                    height: "100px",
-                    width: "100px",
+            positionerProps={[
+                {
+                    verticalPositioningMode: AxisPositioningMode.adjacent,
+                    horizontalPositioningMode: AxisPositioningMode.adjacent,
+                    anchor: anchorElement,
+                    style: {
+                        height: "100px",
+                        width: "100px",
+                    },
                 },
-            }}
+            ]}
         >
             <div
                 style={{
@@ -102,13 +144,16 @@ storiesOf("Viewport Positioner", module)
     ))
     .add("Squishy region", () => (
         <TestViewport
-            positionerProps={{
-                verticalPositioningMode: AxisPositioningMode.adjacent,
-                horizontalPositioningMode: AxisPositioningMode.adjacent,
-                defaultVerticalPosition: ViewportPositionerVerticalPosition.uncontrolled,
-                scaleToFit: true,
-                anchor: anchorElement,
-            }}
+            positionerProps={[
+                {
+                    verticalPositioningMode: AxisPositioningMode.adjacent,
+                    horizontalPositioningMode: AxisPositioningMode.adjacent,
+                    defaultVerticalPosition:
+                        ViewportPositionerVerticalPosition.uncontrolled,
+                    scaleToFit: true,
+                    anchor: anchorElement,
+                },
+            ]}
         >
             <div
                 style={{
@@ -133,15 +178,18 @@ storiesOf("Viewport Positioner", module)
     ))
     .add("Squishy region with thresholds", () => (
         <TestViewport
-            positionerProps={{
-                verticalPositioningMode: AxisPositioningMode.adjacent,
-                horizontalPositioningMode: AxisPositioningMode.adjacent,
-                horizontalThreshold: 100,
-                verticalThreshold: 100,
-                defaultVerticalPosition: ViewportPositionerVerticalPosition.uncontrolled,
-                scaleToFit: true,
-                anchor: anchorElement,
-            }}
+            positionerProps={[
+                {
+                    verticalPositioningMode: AxisPositioningMode.adjacent,
+                    horizontalPositioningMode: AxisPositioningMode.adjacent,
+                    horizontalThreshold: 100,
+                    verticalThreshold: 100,
+                    defaultVerticalPosition:
+                        ViewportPositionerVerticalPosition.uncontrolled,
+                    scaleToFit: true,
+                    anchor: anchorElement,
+                },
+            ]}
         >
             <div
                 style={{
@@ -166,17 +214,19 @@ storiesOf("Viewport Positioner", module)
     ))
     .add("Always in view - adjacent", () => (
         <TestViewport
-            positionerProps={{
-                verticalPositioningMode: AxisPositioningMode.adjacent,
-                horizontalPositioningMode: AxisPositioningMode.adjacent,
-                verticalAlwaysInView: true,
-                horizontalAlwaysInView: true,
-                anchor: anchorElement,
-                style: {
-                    height: "100px",
-                    width: "100px",
+            positionerProps={[
+                {
+                    verticalPositioningMode: AxisPositioningMode.adjacent,
+                    horizontalPositioningMode: AxisPositioningMode.adjacent,
+                    verticalAlwaysInView: true,
+                    horizontalAlwaysInView: true,
+                    anchor: anchorElement,
+                    style: {
+                        height: "100px",
+                        width: "100px",
+                    },
                 },
-            }}
+            ]}
         >
             <div
                 style={{
@@ -201,13 +251,19 @@ storiesOf("Viewport Positioner", module)
     ))
     .add("Always in view - inset", () => (
         <TestViewport
-            positionerProps={{
-                verticalPositioningMode: AxisPositioningMode.inset,
-                horizontalPositioningMode: AxisPositioningMode.inset,
-                verticalAlwaysInView: true,
-                horizontalAlwaysInView: true,
-                anchor: anchorElement,
-            }}
+            positionerProps={[
+                {
+                    verticalPositioningMode: AxisPositioningMode.inset,
+                    horizontalPositioningMode: AxisPositioningMode.inset,
+                    verticalAlwaysInView: true,
+                    horizontalAlwaysInView: true,
+                    anchor: anchorElement,
+                    style: {
+                        height: "100px",
+                        width: "100px",
+                    },
+                },
+            ]}
         >
             <div
                 style={{
@@ -226,6 +282,61 @@ storiesOf("Viewport Positioner", module)
                     }}
                 >
                     Anchor
+                </div>
+            </div>
+        </TestViewport>
+    ))
+    .add("Change anchors", () => (
+        <TestViewport
+            positionerProps={[
+                {
+                    verticalPositioningMode: AxisPositioningMode.adjacent,
+                    horizontalPositioningMode: AxisPositioningMode.adjacent,
+                    anchor: anchorElement,
+                    style: {
+                        height: "100px",
+                        width: "100px",
+                    },
+                },
+                {
+                    verticalPositioningMode: AxisPositioningMode.adjacent,
+                    horizontalPositioningMode: AxisPositioningMode.adjacent,
+                    anchor: anchorElement2,
+                    style: {
+                        height: "100px",
+                        width: "100px",
+                    },
+                },
+            ]}
+        >
+            <div
+                style={{
+                    height: "1200px",
+                    width: "1200px",
+                    padding: "550px",
+                    background: "blue",
+                }}
+            >
+                <div
+                    ref={anchorElement}
+                    style={{
+                        height: "100px",
+                        width: "100px",
+                        background: "green",
+                    }}
+                >
+                    Anchor
+                </div>
+                <div
+                    ref={anchorElement2}
+                    style={{
+                        margin: "120px",
+                        height: "100px",
+                        width: "100px",
+                        background: "green",
+                    }}
+                >
+                    Anchor2
                 </div>
             </div>
         </TestViewport>

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -189,33 +189,7 @@ class ViewportPositioner extends Foundation<
     constructor(props: ViewportPositionerProps) {
         super(props);
 
-        this.state = {
-            disabled: true,
-            noObserverMode: false,
-            xTransformOrigin: Location.left,
-            yTransformOrigin: Location.top,
-            xTranslate: 0,
-            yTranslate: 0,
-            top: null,
-            right: null,
-            bottom: null,
-            left: null,
-            currentHorizontalPosition:
-                ViewportPositionerHorizontalPositionLabel.undefined,
-            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.undefined,
-            defaultHorizontalPosition: this.getHorizontalPositionToLabel(
-                this.props.horizontalPositioningMode,
-                this.props.defaultHorizontalPosition
-            ),
-            defaultVerticalPosition: this.getVerticalPositionToLabel(
-                this.props.verticalPositioningMode,
-                this.props.defaultVerticalPosition
-            ),
-            horizontalSelectedPositionWidth: null,
-            verticalSelectedPositionHeight: null,
-            initialLayoutComplete: false,
-            validRefChecksRemaining: 2,
-        };
+        this.state = this.getInitialState();
     }
 
     public componentDidMount(): void {
@@ -228,12 +202,27 @@ class ViewportPositioner extends Foundation<
     }
 
     public componentDidUpdate(prevProps: ViewportPositionerProps): void {
+        // if anchor or viewport changes the component needs to reset
+        if (
+            prevProps.anchor !== this.props.anchor ||
+            prevProps.viewport !== this.props.viewport
+        ) {
+            this.disconnectObservers();
+            this.disconnectViewport(prevProps.viewport);
+
+            this.setState(this.getInitialState());
+            return;
+        }
+
         if (
             prevProps.disabled !== this.props.disabled ||
             this.state.validRefChecksRemaining > 0
         ) {
             this.updateDisabledState();
+            return;
         }
+
+        this.requestFrame();
     }
 
     /**
@@ -353,7 +342,10 @@ class ViewportPositioner extends Foundation<
             return;
         }
 
-        if (this.getAnchorElement() === null || this.getViewportElement() === null) {
+        if (
+            this.getAnchorElement() === null ||
+            this.getViewportElement(this.props.viewport) === null
+        ) {
             if (this.state.validRefChecksRemaining > 0) {
                 this.setState({
                     validRefChecksRemaining: this.state.validRefChecksRemaining - 1,
@@ -370,7 +362,9 @@ class ViewportPositioner extends Foundation<
      *  Enable the component
      */
     private enableComponent = (): void => {
-        const viewportElement: HTMLElement | null = this.getViewportElement();
+        const viewportElement: HTMLElement | null = this.getViewportElement(
+            this.props.viewport
+        );
         const anchorElement: HTMLElement | null = this.getAnchorElement();
 
         if (
@@ -421,7 +415,7 @@ class ViewportPositioner extends Foundation<
      *  once to get correct initial placement
      */
     private setNoObserverMode = (): void => {
-        const viewportElement: HTMLElement = this.getViewportElement();
+        const viewportElement: HTMLElement = this.getViewportElement(this.props.viewport);
         const anchorElement: HTMLElement = this.getAnchorElement();
 
         if (isNil(viewportElement) || isNil(anchorElement)) {
@@ -457,17 +451,37 @@ class ViewportPositioner extends Foundation<
         if (this.state.disabled) {
             return;
         }
+
+        this.disconnectObservers();
+
+        this.disconnectViewport(this.props.viewport);
+
         this.setState({
             disabled: true,
             validRefChecksRemaining: 0,
         });
+    };
 
+    /**
+     *  removes event listeners from viewport
+     */
+    private disconnectViewport = (
+        viewportRef: React.RefObject<any> | HTMLElement
+    ): void => {
+        const viewPortElement: HTMLElement = this.getViewportElement(viewportRef);
+        if (!isNil(viewPortElement)) {
+            viewPortElement.removeEventListener("scroll", this.handleScroll);
+        }
+    };
+
+    /**
+     *  disconnect resize/intersection observer
+     */
+    private disconnectObservers = (): void => {
         if (
             this.collisionDetector &&
             typeof this.collisionDetector.disconnect === "function"
         ) {
-            this.collisionDetector.unobserve(this.rootElement.current);
-            this.collisionDetector.unobserve(this.getAnchorElement());
             this.collisionDetector.disconnect();
             this.collisionDetector = null;
         }
@@ -478,14 +492,8 @@ class ViewportPositioner extends Foundation<
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1272409
         // https://bugs.webkit.org/show_bug.cgi?id=157743
         if (this.resizeDetector && typeof this.resizeDetector.disconnect === "function") {
-            this.resizeDetector.unobserve(this.getAnchorElement());
             this.resizeDetector.disconnect();
             this.resizeDetector = null;
-        }
-
-        const viewPortElement: HTMLElement = this.getViewportElement();
-        if (!isNil(viewPortElement)) {
-            viewPortElement.removeEventListener("scroll", this.handleScroll);
         }
     };
 
@@ -626,7 +634,9 @@ class ViewportPositioner extends Foundation<
             }
         });
 
-        const viewPortElement: HTMLElement | null = this.getViewportElement();
+        const viewPortElement: HTMLElement | null = this.getViewportElement(
+            this.props.viewport
+        );
 
         if (!isNil(viewPortElement)) {
             this.scrollTop = viewPortElement.scrollTop;
@@ -810,7 +820,7 @@ class ViewportPositioner extends Foundation<
      * Check for scroll changes in viewport and adjust position data
      */
     private updateForScrolling = (): void => {
-        const scrollingContainer: Element = this.getViewportElement();
+        const scrollingContainer: Element = this.getViewportElement(this.props.viewport);
 
         if (isNil(scrollingContainer) || isNaN(scrollingContainer.scrollTop)) {
             return;
@@ -1137,32 +1147,21 @@ class ViewportPositioner extends Foundation<
         if (isNil(this.props.anchor)) {
             return null;
         }
-
-        if (this.props.anchor instanceof HTMLElement) {
-            return this.props.anchor;
-        } else {
-            return this.extractElementFromRef(this.props.anchor);
-        }
+        return this.extractElementFromRef(this.props.anchor);
     };
 
     /**
      * get the viewport element, prefer one provided in props, then context, then document root
      */
-    private getViewportElement = (): HTMLElement | null => {
-        if (!isNil(this.props.viewport)) {
-            if (this.props.viewport instanceof HTMLElement) {
-                return this.props.viewport;
-            } else {
-                return this.extractElementFromRef(this.props.viewport);
-            }
+    private getViewportElement = (
+        viewportRef: React.RefObject<any> | HTMLElement
+    ): HTMLElement | null => {
+        if (!isNil(viewportRef)) {
+            return this.extractElementFromRef(viewportRef);
         }
 
         if (!isNil(this.context.viewport)) {
-            if (this.context.viewport instanceof HTMLElement) {
-                return this.context.viewport;
-            } else {
-                return this.extractElementFromRef(this.context.viewport);
-            }
+            return this.extractElementFromRef(this.context.viewport);
         }
 
         if (document.scrollingElement instanceof HTMLElement) {
@@ -1175,8 +1174,11 @@ class ViewportPositioner extends Foundation<
      * returns an html element from a ref
      */
     private extractElementFromRef = (
-        sourceRef: React.RefObject<any>
+        sourceRef: React.RefObject<any> | HTMLElement
     ): HTMLElement | null => {
+        if (sourceRef instanceof HTMLElement) {
+            return sourceRef;
+        }
         if (!isNil(sourceRef.current)) {
             if (sourceRef.current instanceof HTMLElement) {
                 return sourceRef.current;
@@ -1244,6 +1246,39 @@ class ViewportPositioner extends Foundation<
             case AxisPositioningMode.uncontrolled:
                 return ViewportPositionerVerticalPositionLabel.undefined;
         }
+    };
+
+    /**
+     * Gets the uninitialized state
+     */
+    private getInitialState = (): ViewportPositionerState => {
+        return {
+            disabled: true,
+            noObserverMode: false,
+            xTransformOrigin: Location.left,
+            yTransformOrigin: Location.top,
+            xTranslate: 0,
+            yTranslate: 0,
+            top: null,
+            right: null,
+            bottom: null,
+            left: null,
+            currentHorizontalPosition:
+                ViewportPositionerHorizontalPositionLabel.undefined,
+            currentVerticalPosition: ViewportPositionerVerticalPositionLabel.undefined,
+            defaultHorizontalPosition: this.getHorizontalPositionToLabel(
+                this.props.horizontalPositioningMode,
+                this.props.defaultHorizontalPosition
+            ),
+            defaultVerticalPosition: this.getVerticalPositionToLabel(
+                this.props.verticalPositioningMode,
+                this.props.defaultVerticalPosition
+            ),
+            horizontalSelectedPositionWidth: null,
+            verticalSelectedPositionHeight: null,
+            initialLayoutComplete: false,
+            validRefChecksRemaining: 2,
+        };
     };
 }
 ViewportPositioner.contextType = ViewportContext;

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -207,8 +207,7 @@ class ViewportPositioner extends Foundation<
             prevProps.anchor !== this.props.anchor ||
             prevProps.viewport !== this.props.viewport
         ) {
-            this.disconnectObservers();
-            this.disconnectViewport(prevProps.viewport);
+            this.detachListeners(prevProps.viewport);
 
             this.setState(this.getInitialState());
             return;
@@ -452,9 +451,7 @@ class ViewportPositioner extends Foundation<
             return;
         }
 
-        this.disconnectObservers();
-
-        this.disconnectViewport(this.props.viewport);
+        this.detachListeners(this.props.viewport);
 
         this.setState({
             disabled: true,
@@ -463,21 +460,14 @@ class ViewportPositioner extends Foundation<
     };
 
     /**
-     *  removes event listeners from viewport
+     *  removes event listeners and observers when component is being unmounted or reset
      */
-    private disconnectViewport = (
-        viewportRef: React.RefObject<any> | HTMLElement
-    ): void => {
+    private detachListeners = (viewportRef: React.RefObject<any> | HTMLElement): void => {
         const viewPortElement: HTMLElement = this.getViewportElement(viewportRef);
         if (!isNil(viewPortElement)) {
             viewPortElement.removeEventListener("scroll", this.handleScroll);
         }
-    };
 
-    /**
-     *  disconnect resize/intersection observer
-     */
-    private disconnectObservers = (): void => {
         if (
             this.collisionDetector &&
             typeof this.collisionDetector.disconnect === "function"

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -189,7 +189,7 @@ class ViewportPositioner extends Foundation<
     constructor(props: ViewportPositionerProps) {
         super(props);
 
-        this.state = this.getInitialState();
+        this.state = this.generateInitialState();
     }
 
     public componentDidMount(): void {
@@ -209,7 +209,7 @@ class ViewportPositioner extends Foundation<
         ) {
             this.detachListeners(prevProps.viewport);
 
-            this.setState(this.getInitialState());
+            this.setState(this.generateInitialState());
             return;
         }
 
@@ -1241,7 +1241,7 @@ class ViewportPositioner extends Foundation<
     /**
      * Gets the uninitialized state
      */
-    private getInitialState = (): ViewportPositionerState => {
+    private generateInitialState = (): ViewportPositionerState => {
         return {
             disabled: true,
             noObserverMode: false,

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -1243,6 +1243,10 @@ class ViewportPositioner extends Foundation<
      */
     private generateInitialState = (): ViewportPositionerState => {
         return {
+            // Note: when the component is initialized or reset we start with a the disabled state set to true.
+            // This gets set to fals during component initialization assuming the disabled prop is not set to true and
+            // that required resources load correctly (ie an invalid anchor or viewport ref could prevent the component
+            // from ever becoming enabled regardless of the disable prop)
             disabled: true,
             noObserverMode: false,
             xTransformOrigin: Location.left,


### PR DESCRIPTION
# Description
Viewport positioner was not resetting on anchor change.  This fix causes it to check for anchor changes and reposition if required.

## Motivation & context
Users had encountered issue with positioner not reacting to anchor change.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
