### PR TITLE
feat: Add new elementToFocusOnUnmount prop to base dialog

### DIFF
--- a/packages/fast-components-react-base/src/dialog/dialog.props.ts
+++ b/packages/fast-components-react-base/src/dialog/dialog.props.ts
@@ -56,6 +56,13 @@ export interface DialogHandledProps extends DialogManagedClasses {
      * If true, aria-hidden is false
      */
     visible?: boolean;
+
+    /**
+     * Element to focus after the dialog is unmounted.
+     * Used to bypass the document focus listener which traps focus inside
+     * the modal while it is valid.
+     */
+    elementToFocusOnUnmount?: { focus: () => void };
 }
 
 export type DialogProps = DialogHandledProps & DialogUnhandledProps;

--- a/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
@@ -263,4 +263,55 @@ describe("dialog", (): void => {
 
         document.body.removeChild(container);
     });
+    test("should focus an element on unmount of non-modal dialogs", () => {
+        // tslint:disable-next-line: typedef
+        const mockFocusableElement = {
+            focus: jest.fn(),
+        };
+
+        const rendered: any = mount(
+            <Dialog
+                managedClasses={managedClasses}
+                modal={false}
+                visible={true}
+                elementToFocusOnUnmount={mockFocusableElement}
+            />
+        );
+
+        rendered.unmount();
+        expect(mockFocusableElement.focus).toHaveBeenCalledTimes(1);
+    });
+    test("should focus an element after unregistering 'focusin' on unmount of modal dialogs", () => {
+        let listenerRemoved: boolean = false;
+
+        const mockRemoveListenerFn: any = jest.fn((event: string, callback: any) => {
+            listenerRemoved = true;
+        });
+
+        // tslint:disable-next-line: typedef
+        const mockFocusableElement = {
+            focus: jest.fn(
+                (): void => {
+                    expect(listenerRemoved).toBeTruthy();
+                }
+            ),
+        };
+
+        document.removeEventListener = mockRemoveListenerFn;
+
+        const rendered: any = mount(
+            <Dialog
+                managedClasses={managedClasses}
+                modal={true}
+                visible={true}
+                elementToFocusOnUnmount={mockFocusableElement}
+            />
+        );
+
+        rendered.unmount();
+
+        expect(mockRemoveListenerFn).toHaveBeenCalledTimes(2);
+        expect(mockRemoveListenerFn.mock.calls[1][0]).toBe("focusin");
+        expect(mockFocusableElement.focus).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/fast-components-react-base/src/dialog/dialog.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.tsx
@@ -20,6 +20,7 @@ class Dialog extends Foundation<DialogHandledProps, DialogUnhandledProps, {}> {
 
     protected handledProps: HandledProps<DialogHandledProps> = {
         describedBy: void 0,
+        elementToFocusOnUnmount: void 0,
         label: void 0,
         labelledBy: void 0,
         contentWidth: void 0,
@@ -125,6 +126,15 @@ class Dialog extends Foundation<DialogHandledProps, DialogUnhandledProps, {}> {
 
             if (this.props.modal) {
                 document.removeEventListener("focusin", this.handleDocumentFocus);
+            }
+
+            // Must be after the focusin listener is removed else the modal
+            // will take focus again
+            if (
+                this.props.elementToFocusOnUnmount &&
+                typeof this.props.elementToFocusOnUnmount.focus === "function"
+            ) {
+                this.props.elementToFocusOnUnmount.focus();
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Implements changes discussed in #2536

## Motivation & context

Provides a way to control where focus goes after a dialog is unmounted

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.