### PR TITLE
fix: allow empty strings in the textarea form control for value and default

### DIFF
--- a/packages/fast-tooling-react/src/form/controls/control.textarea.spec.tsx
+++ b/packages/fast-tooling-react/src/form/controls/control.textarea.spec.tsx
@@ -106,4 +106,59 @@ describe("TextareaControl", () => {
                 .prop("value")
         ).toBe(value);
     });
+    test("should show value if value is empty string", () => {
+        const value: string = "";
+        const defaultValue: string = "bar";
+        const rendered: any = mount(
+            <TextareaControl
+                {...textareaProps}
+                managedClasses={managedClasses}
+                value={value}
+                default={defaultValue}
+            />
+        );
+        expect(
+            rendered
+                .find("textarea")
+                .at(0)
+                .prop("value")
+        ).toBe(value);
+    });
+    test("should show default if value is undefined and default is an empty string", () => {
+        const value: string = void 0;
+        const defaultValue: string = "";
+        const rendered: any = mount(
+            <TextareaControl
+                {...textareaProps}
+                managedClasses={managedClasses}
+                value={value}
+                default={defaultValue}
+            />
+        );
+        expect(
+            rendered
+                .find("textarea")
+                .at(0)
+                .prop("value")
+        ).toBe(defaultValue);
+    });
+    test("should show empty string if value or default is not provided", () => {
+        const value: string = void 0;
+        const defaultValue: string = void 0;
+        const emptyString: string = "";
+        const rendered: any = mount(
+            <TextareaControl
+                {...textareaProps}
+                managedClasses={managedClasses}
+                value={value}
+                default={defaultValue}
+            />
+        );
+        expect(
+            rendered
+                .find("textarea")
+                .at(0)
+                .prop("value")
+        ).toBe(emptyString);
+    });
 });

--- a/packages/fast-tooling-react/src/form/controls/control.textarea.tsx
+++ b/packages/fast-tooling-react/src/form/controls/control.textarea.tsx
@@ -46,7 +46,11 @@ class TextareaControl extends React.Component<
     }
 
     private getValue(): string {
-        return this.props.value || this.props.default || "";
+        return typeof this.props.value === "string"
+            ? this.props.value
+            : typeof this.props.default === "string"
+                ? this.props.default
+                : "";
     }
 
     private handleChange = (): ((e: React.ChangeEvent<HTMLTextAreaElement>) => void) => {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Accept empty strings as the value and as default values provided, previously they were evaluated as falsey, causing some unexpected behavior when entering an empty string which would fall back to default values.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->