### PR TITLE
fix: Auto suggest value prop overrides interaction with component

### DIFF
--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
@@ -64,6 +64,18 @@ describe("auto suggest", (): void => {
         expect(rendered.state("isMenuOpen")).toBe(false);
     });
 
+    test("value prop is applied", (): void => {
+        const rendered: any = mount(
+            <AutoSuggest listboxId="listboxId" value="test value">
+                {itemA}
+                {itemB}
+                {itemC}
+            </AutoSuggest>
+        );
+
+        expect(rendered.state("value")).toBe("test value");
+    });
+
     test("input region accessibility attributes are set correctly (autocomplete='both', )", (): void => {
         const rendered: any = mount(
             <AutoSuggest listboxId="listboxId">

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
@@ -335,7 +335,7 @@ class AutoSuggest extends Foundation<
             this.props.onValueChange(newValue, isFromSuggestedOption);
         }
 
-        if (!isNil(this.props.value) || newValue !== this.state.value) {
+        if (isNil(this.props.value) && newValue !== this.state.value) {
             this.toggleMenu(true);
             this.setState({
                 value: newValue,


### PR DESCRIPTION
# Description
Setting the value prop on the auto select component was not fully controlling the value as the user interacted with it

## Motivation & context
User found a bug.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.