### PR TITLE
DRAFT: option for auto suggest menu item interactions to not change value

### DIFF
--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.props.ts
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.props.ts
@@ -72,9 +72,16 @@ export interface AutoSuggestHandledProps extends AutoSuggestManagedClasses {
     listboxId: string;
 
     /**
-     * Specifies whether the suggestions should filter
+     * Specifies whether the suggestions should filter, default is false
      */
     filterSuggestions?: boolean;
+
+    /**
+     * Specifies whether interactions with the menu items change the component value
+     * (ie. when false the items can still be invoked and acted upon, but the value of the component does not change because of it)
+     * default is true
+     */
+    menuItemsAffectValue?: boolean;
 }
 
 export type AutoSuggestProps = AutoSuggestHandledProps & AutoSuggestUnhandledProps;

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
@@ -461,4 +461,65 @@ describe("auto suggest", (): void => {
 
         expect(rendered.find(Listbox.displayName).get(0).props.children).toHaveLength(2);
     });
+
+    test("onInvoked event handler called on keydown of list item when menuItemsAffectValue set to false", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const onInvoked: any = jest.fn();
+        const rendered: any = mount(
+            <AutoSuggest
+                listboxId="listboxId"
+                onInvoked={onInvoked}
+                menuItemsAffectValue={false}
+            >
+                {itemA}
+                {itemB}
+                {itemC}
+            </AutoSuggest>,
+            { attachTo: container }
+        );
+
+        expect(onInvoked).toHaveBeenCalledTimes(0);
+        const input: any = rendered.find("input");
+        input.simulate("keydown", { keyCode: keyCodeArrowDown });
+        rendered
+            .find({ id: "a" })
+            .find(ListboxItem.displayName)
+            .simulate("keydown", { keyCode: keyCodeEnter });
+        expect(onInvoked).toHaveBeenCalledTimes(1);
+
+        document.body.removeChild(container);
+    });
+
+    test("traversing the listbox with arrow keys does not change component value when menuItemsAffectValue set to false", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const rendered: any = mount(
+            <AutoSuggest
+                listboxId="listboxId"
+                initialValue="search"
+                menuItemsAffectValue={false}
+            >
+                {itemA}
+                {itemB}
+                {itemC}
+            </AutoSuggest>,
+            { attachTo: container }
+        );
+        const input: any = rendered.find("input");
+        expect(document.activeElement.id).toBe("");
+        expect(rendered.state("value")).toEqual("search");
+        input.simulate("keydown", { keyCode: keyCodeArrowDown });
+        expect(document.activeElement.id).toBe("a");
+        expect(rendered.state("value")).toEqual("search");
+        rendered
+            .find({ id: "a" })
+            .find(ListboxItem.displayName)
+            .simulate("keydown", { keyCode: keyCodeArrowDown });
+        expect(document.activeElement.id).toBe("b");
+        expect(rendered.state("value")).toEqual("search");
+        document.body.removeChild(container);
+    });
 });

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.stories.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.stories.tsx
@@ -131,4 +131,22 @@ storiesOf("AutoSuggest", module)
                 Turtle
             </ListboxItem>
         </AutoSuggest>
+    ))
+    .add("menu items don't affect value", () => (
+        <AutoSuggest
+            {...favoriteAnimalProps}
+            onValueChange={action("onValueChange")}
+            onInvoked={action("onInvoked")}
+            menuItemsAffectValue={false}
+        >
+            <ListboxItem id={uniqueId()} value="Cat">
+                Cat
+            </ListboxItem>
+            <ListboxItem id={uniqueId()} value="Dog">
+                Dog
+            </ListboxItem>
+            <ListboxItem id={uniqueId()} value="Turtle">
+                Turtle
+            </ListboxItem>
+        </AutoSuggest>
     ));

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
@@ -38,6 +38,7 @@ class AutoSuggest extends Foundation<
         placeholder: "",
         managedClasses: {},
         filterSuggestions: false,
+        menuItemsAffectValue: true,
     };
 
     private static valuePropertyKey: string = "value";
@@ -58,6 +59,7 @@ class AutoSuggest extends Foundation<
         placeholder: void 0,
         listboxId: void 0,
         filterSuggestions: void 0,
+        menuItemsAffectValue: void 0,
     };
 
     private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
@@ -335,7 +337,11 @@ class AutoSuggest extends Foundation<
             this.props.onValueChange(newValue, isFromSuggestedOption);
         }
 
-        if (!isNil(this.props.value) || newValue !== this.state.value) {
+        if (
+            isNil(this.props.value) &&
+            newValue !== this.state.value &&
+            !(!this.props.menuItemsAffectValue && isFromSuggestedOption)
+        ) {
             this.toggleMenu(true);
             this.setState({
                 value: newValue,


### PR DESCRIPTION
# Description
Currently, interacting with auto-suggest menu options changes the value of the component.  This proposed change would add a "menuItemsAffectValue" prop which, when set to false, would prevent interactions with menu items from changing the value. The component would still call the "onInvoked" callback prop when a menu item was clicked or invoked via keyboard.

Does this make sense from an accessibility context?
Is this useful or redundant given that value can be controlled with a prop anyway?

## Motivation & context
Investigating if this is a useful approach to making some developer tasks easier.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
