### PR TITLE
fix: lightweight button looks like plain text in high contrast mode

### DIFF
--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -40,7 +40,7 @@ import {
 import { applyDisabledState } from "../utilities/disabled";
 import {
     highContrastAccent,
-    highContrastBackground,
+    HighContrastColor,
     highContrastDisabledBorder,
     highContrastDisabledForeground,
     highContrastDoubleFocus,
@@ -73,13 +73,19 @@ const applyTransparentBackplateStyles: CSSRules<DesignSystem> = {
     ...applyFocusVisible({
         "border-color": "transparent",
         "box-shadow": "none",
+        ...highContrastHighlightForeground,
         "& $button_contentRegion::before": {
             background: neutralForegroundRest,
             height: toPx<DesignSystem>(focusOutlineWidth),
-            ...highContrastBackground,
+            ...highContrastHighlightBackground,
         },
     }),
     // Underline
+    "& $button_contentRegion::before": {
+        [highContrastSelector]: {
+            background: HighContrastColor.buttonText,
+        },
+    },
     "&:hover $button_contentRegion::before": {
         background: accentForegroundHover,
         ...highContrastHighlightBackground,
@@ -249,6 +255,11 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
+            },
+            "& $button_contentRegion::before": {
+                [highContrastSelector]: {
+                    background: "transparent",
+                },
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -11,7 +11,6 @@ import {
 import { applyFocusVisible, toPx } from "@microsoft/fast-jss-utilities";
 import { focusOutlineWidth } from "../utilities/design-system";
 import {
-    highContrastBackground,
     HighContrastColor,
     highContrastDisabledForeground,
     highContrastHighlightBackground,
@@ -34,14 +33,20 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
         ...applyFocusVisible({
             "border-color": "transparent",
             "box-shadow": "none",
+            ...highContrastHighlightForeground,
             "& $button_contentRegion::before": {
                 background: neutralForegroundRest,
                 height: toPx<DesignSystem>(focusOutlineWidth),
-                ...highContrastBackground,
+                ...highContrastHighlightBackground,
             },
         }),
         "a&, button&": {},
         // Underline
+        "& $button_contentRegion::before": {
+            [highContrastSelector]: {
+                background: HighContrastColor.buttonText,
+            },
+        },
         "&:hover $button_contentRegion::before": {
             background: accentForegroundHover,
             ...highContrastHighlightBackground,
@@ -51,6 +56,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
         },
         "&:active $button_contentRegion::before": {
             background: accentForegroundActive,
+            ...highContrastHighlightBackground,
         },
         "&$button__disabled, &$button__disabled $button_contentRegion::before": {
             "background-color": "transparent",
@@ -80,6 +86,11 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             },
             "&:hover$button__disabled": {
                 ...highContrastDisabledForeground,
+            },
+            "& $button_contentRegion::before": {
+                [highContrastSelector]: {
+                    background: "transparent",
+                },
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -84,9 +84,6 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             "&:hover $button_contentRegion::before": {
                 background: highContrastLinkValue,
             },
-            "&:hover$button__disabled": {
-                ...highContrastDisabledForeground,
-            },
             "& $button_contentRegion::before": {
                 [highContrastSelector]: {
                     background: "transparent",


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Bug: 
Accessibility: MAS4.3.1: HighContrast:  "Back to extensions home" button looks like static text in High contrast themes.
https://microsoft.visualstudio.com/Edge/_workitems/edit/24461248/

In high contrast mode, the lightweight button looks like plain text, so I added the underline.

High Contrast Black
rest
![image](https://user-images.githubusercontent.com/37851220/72092768-ddd7a780-32c7-11ea-8565-f867b3196eef.png)
hover
![image](https://user-images.githubusercontent.com/37851220/72092804-f051e100-32c7-11ea-819c-75731510258e.png)

High Contrast White
rest
![image](https://user-images.githubusercontent.com/37851220/72092823-fba50c80-32c7-11ea-97fd-1a552e613186.png)
hover
![image](https://user-images.githubusercontent.com/37851220/72092834-01025700-32c8-11ea-8cc4-99068758dbc5.png)


## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->