### PR TITLE
fix: autosuggest opens menu when suggestions added 

### DIFF
--- a/packages/fast-components-react-base/src/auto-suggest/README.md
+++ b/packages/fast-components-react-base/src/auto-suggest/README.md
@@ -10,5 +10,7 @@ The expected usage pattern of the component is for authors to watch the "onValue
 
 The input region of the component can be customized using the component's "inputRegion" render prop.
 
+The "isMenuOpen" prop enables authors to take control of when the menu is open.  Setting "isMenuOpen" to false keeps the menu closed, and setting it to true keeps it open (unless there are no children, in which case it is always closed).
+
 ### Accessibility
 *Auto suggest* implements the recommended keyboard navigation scheme described [here](https://www.w3.org/TR/wai-aria-practices-1.1/#Listbox) for interacting with the listbox.

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.spec.tsx
@@ -473,4 +473,29 @@ describe("auto suggest", (): void => {
 
         expect(rendered.find(Listbox.displayName).get(0).props.children).toHaveLength(2);
     });
+
+    test("closing menu focuses on input element", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const rendered: any = mount(
+            <AutoSuggest listboxId="listboxId" initialValue="search">
+                {itemA}
+                {itemB}
+                {itemC}
+            </AutoSuggest>,
+            { attachTo: container }
+        );
+        const input: any = rendered.find("input");
+        expect(document.activeElement.id).toBe("");
+        expect(rendered.state("value")).toEqual("search");
+        input.simulate("keydown", { keyCode: keyCodeArrowDown });
+        expect(document.activeElement.id).toBe("a");
+        rendered
+            .find({ id: "a" })
+            .find(ListboxItem.displayName)
+            .simulate("keydown", { keyCode: keyCodeEscape });
+        expect(document.activeElement.getAttribute("role")).toBe("combobox");
+        document.body.removeChild(container);
+    });
 });

--- a/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
+++ b/packages/fast-components-react-base/src/auto-suggest/auto-suggest.tsx
@@ -101,8 +101,6 @@ class AutoSuggest extends Foundation<
             updatedMenuVisibility = true;
         }
 
-        updatedMenuVisibility = this.validateMenuState(updatedMenuVisibility);
-
         if (updatedMenuVisibility !== this.state.isMenuOpen) {
             this.toggleMenu(updatedMenuVisibility);
         }


### PR DESCRIPTION
# Description
Auto suggest does not open menu when suggestions come in after some latency as may happen with when a server query is involved.  This change opens the menu when new suggestions come in to a previously empty component and the component has focus.

## Motivation & context
Developer feedback

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.