### PR TITLE
feat: add stack panel to base component set

### DIFF
--- a/packages/fast-components-class-name-contracts-base/src/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/index.ts
@@ -21,6 +21,7 @@ export * from "./radio";
 export * from "./select";
 export * from "./slider";
 export * from "./slider-track-item";
+export * from "./stack-panel";
 export * from "./tabs";
 export * from "./text-area";
 export * from "./text-field";

--- a/packages/fast-components-class-name-contracts-base/src/stack-panel/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/stack-panel/index.ts
@@ -16,14 +16,4 @@ export interface StackPanelClassNameContract {
      *
      */
     stackPanel__isScrolling?: string;
-
-    /**
-     *
-     */
-    stackPanel_item?: string;
-
-    /**
-     *
-     */
-    stackPanel_item__focusWithin?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/stack-panel/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/stack-panel/index.ts
@@ -13,7 +13,8 @@ export interface StackPanelClassNameContract {
     stackPanel_items?: string;
 
     /**
-     *
+     * indicates that the panel is scrollable
+     * (ie. contents exceed height of container)
      */
-    stackPanel__isScrolling?: string;
+    stackPanel__scrolling?: string;
 }

--- a/packages/fast-components-class-name-contracts-base/src/stack-panel/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/stack-panel/index.ts
@@ -10,7 +10,7 @@ export interface StackPanelClassNameContract {
     /**
      * the container that contains the stack panel items
      */
-    stackPanel_itemContainer?: string;
+    stackPanel_items?: string;
 
     /**
      *

--- a/packages/fast-components-class-name-contracts-base/src/stack-panel/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/stack-panel/index.ts
@@ -1,0 +1,29 @@
+/**
+ * The class name contract for the stackpanel component
+ */
+export interface StackPanelClassNameContract {
+    /**
+     * The root of the stackpanel component
+     */
+    stackPanel?: string;
+
+    /**
+     * the container that contains the stack panel items
+     */
+    stackPanel_itemContainer?: string;
+
+    /**
+     *
+     */
+    stackPanel__isScrolling?: string;
+
+    /**
+     *
+     */
+    stackPanel_item?: string;
+
+    /**
+     *
+     */
+    stackPanel_item__focusWithin?: string;
+}

--- a/packages/fast-components-class-name-contracts-base/src/stack-panel/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/stack-panel/index.ts
@@ -13,8 +13,7 @@ export interface StackPanelClassNameContract {
     stackPanel_items?: string;
 
     /**
-     * indicates that the panel is scrollable
-     * (ie. contents exceed height of container)
+     * Applied if the stack panel is scrollable
      */
-    stackPanel__scrolling?: string;
+    stackPanel__scrollable?: string;
 }

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -347,6 +347,24 @@ describe("horizontal overflow", (): void => {
             0.0004
         );
     });
+    test("should ease the animation correctly when at animation start time", () => {
+        const renderedWithImages: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses}>
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+
+        expect(renderedWithImages.instance()["easeInOutQuad"](0, 0, 0.5, 50)).toBe(0);
+    });
+    test("should ease the animation correctly when at animation end time", () => {
+        const renderedWithImages: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses}>
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+
+        expect(renderedWithImages.instance()["easeInOutQuad"](50, 0, 0.5, 50)).toBe(0.5);
+    });
     test("getScrollAnimationPosition returns correct start and end values", () => {
         const renderedWithImages: any = mount(
             <HorizontalOverflow managedClasses={managedClasses}>
@@ -534,19 +552,6 @@ describe("horizontal overflow", (): void => {
         renderedWithImages.find("div.foo").simulate("load", {});
 
         expect(renderedWithImages.instance().state.itemsHeight).toBe(0);
-    });
-    test("should execute a scroll animation on the element", () => {
-        const renderedWithImages: any = mount(
-            <HorizontalOverflow managedClasses={managedClasses}>
-                {imageSet1}
-            </HorizontalOverflow>
-        );
-
-        const itemsElement: HTMLDivElement = renderedWithImages.find(
-            ".horizontal-overflow-items-class"
-        );
-
-        expect(renderedWithImages.instance()["scrollContent"](50, 0)).toBe(undefined);
     });
     test("should allow clicks on previous and next buttons", () => {
         const renderedWithImagesAndNextAndPrevious: any = mount(
@@ -791,6 +796,16 @@ describe("horizontal overflow", (): void => {
         rendered.instance()["setScrollPosition"](100);
         expect(rendered.instance()["getScrollPosition"]()).toEqual(100);
     });
+    test("settting and getting scroll position works correctly in rtl", (): void => {
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses} dir="rtl">
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(-0);
+        rendered.instance()["setScrollPosition"](100);
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(100);
+    });
     test("getting and setting scroll position returns 0 when horizontalOverflowItemsRef isn't populated ", (): void => {
         const rendered: any = mount(
             <HorizontalOverflow managedClasses={managedClasses}>
@@ -843,6 +858,23 @@ describe("horizontal overflow", (): void => {
         }
         rendered.instance()["updateScrollAnimation"]();
         expect(rendered.instance().isScrollAnimating).toEqual(false);
+    });
+    test("scrollContent properly configures a smooth scrolling animation", () => {
+        const maxScrollFn: any = jest.fn();
+        maxScrollFn.mockReturnValue(1000);
+
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses}>
+                {imageSet1}
+            </HorizontalOverflow>
+        );
+        expect(rendered.instance().isScrollAnimating).toEqual(false);
+        rendered.instance().getMaxScrollDistance = maxScrollFn;
+        rendered.instance().requestFrame = jest.fn();
+        rendered.instance()["scrollContent"](0, 100);
+        expect(rendered.instance().isScrollAnimating).toEqual(true);
+        expect(rendered.instance().currentScrollAnimStartPosition).toEqual(0);
+        expect(rendered.instance().currentScrollAnimEndPosition).toEqual(100);
     });
 });
 /* tslint:enable:no-string-literal */

--- a/packages/fast-components-react-base/src/index.ts
+++ b/packages/fast-components-react-base/src/index.ts
@@ -86,6 +86,10 @@ import SliderTrackItem from "./slider-track-item";
 export { SliderTrackItem };
 export * from "./slider-track-item";
 
+import StackPanel from "./stack-panel";
+export { StackPanel };
+export * from "./stack-panel";
+
 import Tabs from "./tabs";
 export { Tabs };
 export * from "./tabs";

--- a/packages/fast-components-react-base/src/index.ts
+++ b/packages/fast-components-react-base/src/index.ts
@@ -86,9 +86,9 @@ import SliderTrackItem from "./slider-track-item";
 export { SliderTrackItem };
 export * from "./slider-track-item";
 
-import StackPanel from "./stack-panel";
-export { StackPanel };
-export * from "./stack-panel";
+// import StackPanel from "./stack-panel";
+// export { StackPanel };
+// export * from "./stack-panel";
 
 import Tabs from "./tabs";
 export { Tabs };

--- a/packages/fast-components-react-base/src/stack-panel/README.md
+++ b/packages/fast-components-react-base/src/stack-panel/README.md
@@ -12,6 +12,8 @@ Smooth scrolling: When smooth scrolling is enabled the component monitors focus 
 
 Authors should be aware that this component writes to the width/left or top/height css style attributes of children on render depending on the orientation of the stack panel.
 
+Keys: authors should strongly consider providing keys (https://reactjs.org/docs/lists-and-keys.html) to child elements to maintain stable identies for child items. 
+
 ### Props
 
  enableVirtualization:  Whether child elements are virtualized or not. Defaults to true.

--- a/packages/fast-components-react-base/src/stack-panel/README.md
+++ b/packages/fast-components-react-base/src/stack-panel/README.md
@@ -1,0 +1,1 @@
+## Stack Panel

--- a/packages/fast-components-react-base/src/stack-panel/README.md
+++ b/packages/fast-components-react-base/src/stack-panel/README.md
@@ -1,5 +1,7 @@
 ## Stack Panel
 
+NOTE: this component is in initial development and should not yet be considered stable.
+
 The *stack panel* component is a container that enables smooth scrolling and virtualization of child elements arranged horizontally or vertically.
 
 ### Usage

--- a/packages/fast-components-react-base/src/stack-panel/README.md
+++ b/packages/fast-components-react-base/src/stack-panel/README.md
@@ -7,3 +7,32 @@ The *stack panel* component is a container that enables smooth scrolling and vir
 Virtualization:  When virtualization is enabled the component does not render child items that are not in the viewport or within the defined buffer zone (ie one or more items outside the viewport).
 
 Smooth scrolling: When smooth scrolling is enabled the component monitors focus changes in child elements and will scroll the element that gains focus into view.  Note that virtualized elements can't get focus so typically authors will want at least one out of view item instanciated otherwise it will not be possible to tab outside of the viewport.
+
+Authors should be aware that this component writes to the width/left or top/height css style attributes of children on render depending on the orientation of the stack panel.
+
+### Props
+
+ enableVirtualization:  Whether child elements are virtualized or not. Defaults to true.
+
+ neverVirtualizeIndexes: Authors can provide an array of indexes which flag child indexes that should not be virtualized.  For example providing [0, 10] to this prop would mean that child items at indexes 0 and 10 would be rendered.
+
+ defaultItemSpan:  The default span of the child items in pixels, this can be overriden on an item by item basis using the "itemSpanOverrides" prop. Default is 100. 
+
+ itemSpanOverrides: An object where the keys correspond to child indexes and the values to the span to be used to calculate layout for the child at that index. For example {1:200, 5:500} would specify that the child item at index 1 has a span of 200 pixels and the one at index 5 has a span of 500 pixels.
+
+preloadBufferLength: How many out of view child items to render on either side of the viewport. Default is 1.
+
+orientation: Whether the child elements stack vertically or horizontally.  Default is vertical.
+
+onScrollChange:  Callback for when the component scrolls.
+
+nextItemPeek:  When the component scrolls focused content into view how many pixels should the next item "peek" into view.  Note that the component will clip the peek value applied based on available viewport size.  Default is 50.
+
+enableSmoothScrolling:  Whether smooth scrolling is enabled or not.  When disabled focused items will be brought into view by the browser (ie. not animated).  Default is true.
+
+scrollDuration: The lenght of the scroll animation in milliseconds.  Default is 500.
+
+initiallyVisibleItemIndex:  When provided the component will initially render with the child at that index scrolled into view.  After the component is initialzed if this value is changed 
+
+
+

--- a/packages/fast-components-react-base/src/stack-panel/README.md
+++ b/packages/fast-components-react-base/src/stack-panel/README.md
@@ -1,1 +1,9 @@
 ## Stack Panel
+
+The *stack panel* component is a container that enables smooth scrolling and virtualization of child elements arranged horizontally or vertically.
+
+### Usage
+
+Virtualization:  When virtualization is enabled the component does not render child items that are not in the viewport or within the defined buffer zone (ie one or more items outside the viewport).
+
+Smooth scrolling: When smooth scrolling is enabled the component monitors focus changes in child elements and will scroll the element that gains focus into view.  Note that virtualized elements can't get focus so typically authors will want at least one out of view item instanciated otherwise it will not be possible to tab outside of the viewport.

--- a/packages/fast-components-react-base/src/stack-panel/README.md
+++ b/packages/fast-components-react-base/src/stack-panel/README.md
@@ -18,11 +18,11 @@ Keys: authors should strongly consider providing keys (https://reactjs.org/docs/
 
  enableVirtualization:  Whether child elements are virtualized or not. Defaults to true.
 
- neverVirtualizeIndexes: Authors can provide an array of indexes which flag child indexes that should not be virtualized.  For example providing [0, 10] to this prop would mean that child items at indexes 0 and 10 would be rendered.
+ neverVirtualizeIndexes: Authors can provide an array of indexes which flag child indexes that should not be virtualized.  For example providing "[0, 10]" to this prop would mean that child items at indexes 0 and 10 would be rendered.
 
  defaultItemSpan:  The default span of the child items in pixels, this can be overriden on an item by item basis using the "itemSpanOverrides" prop. Default is 100. 
 
- itemSpanOverrides: An object where the keys correspond to child indexes and the values to the span to be used to calculate layout for the child at that index. For example {1:200, 5:500} would specify that the child item at index 1 has a span of 200 pixels and the one at index 5 has a span of 500 pixels.
+ itemSpanOverrides: An object where the keys correspond to child indexes and the values to the span to be used to calculate layout for the child at that index.
 
 preloadBufferLength: How many out of view child items to render on either side of the viewport. Default is 1.
 

--- a/packages/fast-components-react-base/src/stack-panel/README.md
+++ b/packages/fast-components-react-base/src/stack-panel/README.md
@@ -2,7 +2,7 @@
 
 NOTE: this component is in initial development and should not yet be considered stable.
 
-The *stack panel* component is a container that enables smooth scrolling and virtualization of child elements arranged horizontally or vertically.
+The *stack panel* component is a container that enables smooth scrolling and virtualization of child elements arranged in a horizontal or vertical linear 'stack'. 
 
 ### Usage
 
@@ -37,6 +37,8 @@ enableSmoothScrolling:  Whether smooth scrolling is enabled or not.  When disabl
 scrollDuration: The lenght of the scroll animation in milliseconds.  Default is 500.
 
 initiallyVisibleItemIndex:  When provided the component will initially render with the child at that index scrolled into view.  After the component is initialzed if this value is changed 
+
+scrollLayoutUpdateDelay: Enables authors to delay updateing layout (ie. instanciating items) while there is a continuous scroll operation in progress.  The value corresponds to the time interval between dom generated scroll events that must pass before the component updates item layout.  Default is 0 (off).
 
 
 

--- a/packages/fast-components-react-base/src/stack-panel/README.md
+++ b/packages/fast-components-react-base/src/stack-panel/README.md
@@ -2,13 +2,13 @@
 
 NOTE: this component is in initial development and should not yet be considered stable.
 
-The *stack panel* component is a container that enables smooth scrolling and virtualization of child elements arranged in a horizontal or vertical linear 'stack'. 
+The *stack panel* component is a container that enables virtualization of child elements arranged in a horizontal or vertical linear 'stack'. 
 
 ### Usage
 
 Virtualization:  When virtualization is enabled the component does not render child items that are not in the viewport or within the defined buffer zone (ie one or more items outside the viewport).
 
-Smooth scrolling: When smooth scrolling is enabled the component monitors focus changes in child elements and will scroll the element that gains focus into view.  Note that virtualized elements can't get focus so typically authors will want at least one out of view item instanciated otherwise it will not be possible to tab outside of the viewport.
+Note that virtualized elements can't get focus so typically authors will want at least one out of view item instanciated otherwise it will not be possible to tab outside of the viewport.
 
 Authors should be aware that this component writes to the width/left or top/height css style attributes of children on render depending on the orientation of the stack panel.
 
@@ -30,13 +30,8 @@ orientation: Whether the child elements stack vertically or horizontally.  Defau
 
 onScrollChange:  Callback for when the component scrolls.
 
-nextItemPeek:  When the component scrolls focused content into view how many pixels should the next item "peek" into view.  Note that the component will clip the peek value applied based on available viewport size.  Default is 50.
-
-enableSmoothScrolling:  Whether smooth scrolling is enabled or not.  When disabled focused items will be brought into view by the browser (ie. not animated).  Default is true.
-
-scrollDuration: The lenght of the scroll animation in milliseconds.  Default is 500.
-
-initiallyVisibleItemIndex:  When provided the component will initially render with the child at that index scrolled into view.  After the component is initialzed if this value is changed 
+initiallyVisibleItemIndex:  When provided the component will initially render with the child at that index scrolled into view.  After the component is initialzed if this is changed to a non-null value the component will 
+scroll that item into view.
 
 scrollLayoutUpdateDelay: Enables authors to delay updateing layout (ie. instanciating items) while there is a continuous scroll operation in progress.  The value corresponds to the time interval between dom generated scroll events that must pass before the component updates item layout.  Default is 0 (off).
 

--- a/packages/fast-components-react-base/src/stack-panel/index.ts
+++ b/packages/fast-components-react-base/src/stack-panel/index.ts
@@ -1,0 +1,6 @@
+import StackPanel from "./stack-panel";
+import StackPanelSchema from "./stack-panel.schema";
+
+export { StackPanelSchema };
+export default StackPanel;
+export * from "./stack-panel";

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
@@ -49,14 +49,10 @@ export interface StackPanelHandledProps extends StackPanelManagedClasses {
     /**
      * Callback for when scroll values change
      */
-    onScrollChange?: (newScrollValue: number, scrollMaxValue: number) => void;
-
-    /**
-     * Callback for when the range of rendered items changes
-     */
-    onRenderedRangeChange?: (
-        renderedRangeStart: number,
-        renderedRangeEnd: number
+    onScrollChange?: (
+        newScrollValue: number,
+        scrollMaxValue: number,
+        viewportSpan: number
     ) => void;
 
     /**

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
@@ -61,6 +61,14 @@ export interface StackPanelHandledProps extends StackPanelManagedClasses {
     onScrollChange?: (newScrollValue: number, scrollMaxValue: number) => void;
 
     /**
+     * Callback for when the range of rendered items changes
+     */
+    onRenderedRangeChange?: (
+        renderedRangeStart: number,
+        renderedRangeEnd: number
+    ) => void;
+
+    /**
      * When the component scrolls focused content into view how many pixels should the next item "peek" into view
      */
     nextItemPeek?: number;

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
@@ -74,6 +74,12 @@ export interface StackPanelHandledProps extends StackPanelManagedClasses {
      * The index of the item initially in view
      */
     initiallyVisibleItemIndex?: number;
+
+    /**
+     * Delay in ms before viewport contents updated after scrolling stops
+     * default is 50
+     */
+    scrollLayoutUpdateDelay?: number;
 }
 
 export type StackPanelProps = StackPanelHandledProps & StackPanelUnhandledProps;

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
@@ -3,15 +3,11 @@ import {
     ManagedClasses,
     StackPanelClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-base";
+import { Orientation } from "@microsoft/fast-web-utilities";
 
 export interface StackPanelManagedClasses
     extends ManagedClasses<StackPanelClassNameContract> {}
 export interface StackPanelUnhandledProps extends React.HTMLAttributes<HTMLDivElement> {}
-
-export enum stackPanelOrientation {
-    horizontal = "horizontal",
-    vertical = "vertical",
-}
 
 export interface ItemSpanOverride {
     [key: number]: number;
@@ -48,12 +44,7 @@ export interface StackPanelHandledProps extends StackPanelManagedClasses {
     /**
      * The orientation of the stackpanel
      */
-    orientation?: stackPanelOrientation;
-
-    /**
-     * The children of the panel
-     */
-    children?: React.ReactNode;
+    orientation?: Orientation;
 
     /**
      * Callback for when scroll values change

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
@@ -9,10 +9,6 @@ export interface StackPanelManagedClasses
     extends ManagedClasses<StackPanelClassNameContract> {}
 export interface StackPanelUnhandledProps extends React.HTMLAttributes<HTMLDivElement> {}
 
-export interface ItemSpanOverride {
-    [key: number]: number;
-}
-
 export interface StackPanelHandledProps extends StackPanelManagedClasses {
     /**
      * Whether items outside the viewport should be rendered or not
@@ -26,15 +22,12 @@ export interface StackPanelHandledProps extends StackPanelManagedClasses {
     neverVirtualizeIndexes?: number[];
 
     /**
-     *  The default span of each item (width in horizontal orientation, height in vertical)
+     * The default span of each item in pixels (width in horizontal orientation, height in vertical)
+     * Provide a single value for panels where all items have the same value, or an array in the case where
+     * items have varying spans.
+     * default is 100
      */
-    defaultItemSpan?: number;
-
-    /**
-     * An object whose entries specifies the height of items that differ from the default height.
-     * Format is {itemIndex: heightValue}
-     */
-    itemSpanOverrides?: ItemSpanOverride;
+    itemSpan?: number | number[];
 
     /**
      * How many items to preload before and after the range defined by viewportMaxHeight

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
@@ -1,0 +1,84 @@
+import React from "react";
+import {
+    ManagedClasses,
+    StackPanelClassNameContract,
+} from "@microsoft/fast-components-class-name-contracts-base";
+
+export interface StackPanelManagedClasses
+    extends ManagedClasses<StackPanelClassNameContract> {}
+export interface StackPanelUnhandledProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export enum stackPanelOrientation {
+    horizontal = "horizontal",
+    vertical = "vertical",
+}
+
+export interface ItemSpanOverride {
+    [key: number]: number;
+}
+
+export interface StackPanelHandledProps extends StackPanelManagedClasses {
+    /**
+     * Whether items outside the viewport should be rendered or not
+     * default is true
+     */
+    enableVirtualization?: boolean;
+
+    /**
+     *  the indexes of children that should always be rendered
+     */
+    neverVirtualizeIndexes?: number[];
+
+    /**
+     *  The default span of each item (width in horizontal orientation, height in vertical)
+     */
+    defaultItemSpan?: number;
+
+    /**
+     * An object whose entries specifies the height of items that differ from the default height.
+     * Format is {itemIndex: heightValue}
+     */
+    itemSpanOverrides?: ItemSpanOverride;
+
+    /**
+     * How many items to preload before and after the range defined by viewportMaxHeight
+     */
+    preloadBufferLength?: number;
+
+    /**
+     * The orientation of the stackpanel
+     */
+    orientation?: stackPanelOrientation;
+
+    /**
+     * The children of the panel
+     */
+    children?: React.ReactNode;
+
+    /**
+     * Callback for when scroll values change
+     */
+    onScrollChange?: (newScrollValue: number, scrollMaxValue: number) => void;
+
+    /**
+     * When the component scrolls focused content into view how many pixels should the next item "peek" into view
+     */
+    nextItemPeek?: number;
+
+    /**
+     * Whether to enable smooth scrolling
+     */
+    enableSmoothScrolling?: boolean;
+
+    /**
+     * The duration the scroll movement should last
+     */
+    scrollDuration?: number;
+
+    /**
+     * The index of the item initially in view
+     */
+    initiallyVisibleItemIndex?: number;
+}
+
+export type StackPanelProps = StackPanelHandledProps & StackPanelUnhandledProps;

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
@@ -22,7 +22,7 @@ export interface StackPanelHandledProps extends StackPanelManagedClasses {
      * Whether items outside the viewport should be rendered or not
      * default is true
      */
-    enableVirtualization?: boolean;
+    virtualize?: boolean;
 
     /**
      *  the indexes of children that should always be rendered

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
@@ -70,7 +70,9 @@ export interface StackPanelHandledProps extends StackPanelManagedClasses {
 
     /**
      * Delay in ms before viewport contents updated after scrolling stops
-     * default is 50
+     * This allows developers to block updating children while scroll operations
+     * are in progress
+     * default is 0
      */
     scrollLayoutUpdateDelay?: number;
 }

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.props.ts
@@ -49,21 +49,6 @@ export interface StackPanelHandledProps extends StackPanelManagedClasses {
     ) => void;
 
     /**
-     * When the component scrolls focused content into view how many pixels should the next item "peek" into view
-     */
-    nextItemPeek?: number;
-
-    /**
-     * Whether to enable smooth scrolling
-     */
-    enableSmoothScrolling?: boolean;
-
-    /**
-     * The duration the scroll movement should last
-     */
-    scrollDuration?: number;
-
-    /**
      * The index of the item initially in view
      */
     initiallyVisibleItemIndex?: number;

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.schema.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.schema.ts
@@ -14,14 +14,10 @@ export default {
             title: "Indexes of items not to virtualize",
             type: "array",
         },
-        defaultItemSpan: {
+        itemSpan: {
             title: "Default item span",
-            type: "number",
+            type: "number | array",
             default: 100,
-        },
-        itemSpanOverrides: {
-            title: "Item span overrides",
-            type: "array",
         },
         preloadBufferLength: {
             title: "Preload buffer length",

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.schema.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.schema.ts
@@ -1,13 +1,14 @@
 export default {
     $schema: "http://json-schema.org/schema#",
-    title: " stack panel",
+    title: "Stack panel",
     description: "A  stack panel component's schema definition.",
     type: "object",
     id: "@microsoft/fast-components-react-base/stack-panel",
     properties: {
-        enableVirtualization: {
+        virtualize: {
             title: "Enable virtualization",
             type: "boolean",
+            default: true,
         },
         neverVirtualizeIndexes: {
             title: "Indexes of items not to virtualize",
@@ -16,6 +17,7 @@ export default {
         defaultItemSpan: {
             title: "Default item span",
             type: "number",
+            default: 100,
         },
         itemSpanOverrides: {
             title: "Item span overrides",
@@ -24,28 +26,37 @@ export default {
         preloadBufferLength: {
             title: "Preload buffer length",
             type: "number",
+            default: 1,
         },
         orientation: {
             title: "Orientation",
             type: "string",
-            default: "horizontal",
+            default: "vertical",
             enum: ["horizontal", "vertical"],
         },
         nextItemPeek: {
             title: "Next item peek",
             type: "number",
+            default: 50,
         },
         enableSmoothScrolling: {
             title: "Enable smooth scrolling",
             type: "boolean",
+            default: true,
         },
         scrollDuration: {
             title: "Scroll duration",
             type: "number",
+            default: 500,
         },
         initiallyVisibleItemIndex: {
             title: "Initially visible item index",
             type: "number",
+        },
+        scrollLayoutUpdateDelay: {
+            title: "Delay in ms before viewport contents updated after scrolling stops",
+            type: "number",
+            default: 50,
         },
     },
     reactProperties: {

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.schema.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.schema.ts
@@ -1,0 +1,15 @@
+export default {
+    $schema: "http://json-schema.org/schema#",
+    title: " stack panel",
+    description: "A  stack panel component's schema definition.",
+    type: "object",
+    id: "@microsoft/fast-components-react-base/stack-panel",
+    properties: {},
+    reactProperties: {
+        children: {
+            title: "Children",
+            type: "children",
+            defaults: ["text"],
+        },
+    },
+};

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.schema.ts
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.schema.ts
@@ -4,7 +4,50 @@ export default {
     description: "A  stack panel component's schema definition.",
     type: "object",
     id: "@microsoft/fast-components-react-base/stack-panel",
-    properties: {},
+    properties: {
+        enableVirtualization: {
+            title: "Enable virtualization",
+            type: "boolean",
+        },
+        neverVirtualizeIndexes: {
+            title: "Indexes of items not to virtualize",
+            type: "array",
+        },
+        defaultItemSpan: {
+            title: "Default item span",
+            type: "number",
+        },
+        itemSpanOverrides: {
+            title: "Item span overrides",
+            type: "array",
+        },
+        preloadBufferLength: {
+            title: "Preload buffer length",
+            type: "number",
+        },
+        orientation: {
+            title: "Orientation",
+            type: "string",
+            default: "horizontal",
+            enum: ["horizontal", "vertical"],
+        },
+        nextItemPeek: {
+            title: "Next item peek",
+            type: "number",
+        },
+        enableSmoothScrolling: {
+            title: "Enable smooth scrolling",
+            type: "boolean",
+        },
+        scrollDuration: {
+            title: "Scroll duration",
+            type: "number",
+        },
+        initiallyVisibleItemIndex: {
+            title: "Initially visible item index",
+            type: "number",
+        },
+    },
     reactProperties: {
         children: {
             title: "Children",

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
+import { configure, mount, shallow } from "enzyme";
+import Button from "../button";
+
+/*
+ * Configure Enzyme
+ */
+configure({ adapter: new Adapter() });
+
+/* tslint:disable:no-string-literal */
+describe("stack panel", (): void => {
+    // test("should have a displayName that matches the component name", () => {
+    //     expect(`${DisplayNamePrefix}${(ViewportPositioner as any).name}`).toBe(
+    //         ViewportPositioner.displayName
+    //     );
+    // });
+    // test("should not throw if managedClasses are not provided", () => {
+    //     expect(() => {
+    //         shallow(<ViewportPositioner />);
+    //     }).not.toThrow();
+    // });
+    // test("should implement unhandledProps", (): void => {
+    //     const unhandledProps: ViewportPositionerUnhandledProps = {
+    //         "aria-label": "label",
+    //     };
+    //     const rendered: any = shallow(<ViewportPositioner {...unhandledProps} />);
+    //     expect(rendered.first().prop("aria-label")).toEqual("label");
+    // });
+});

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -17,7 +17,7 @@ configure({ adapter: new Adapter() });
 const managedClasses: StackPanelClassNameContract = {
     stackPanel: "stackPanel",
     stackPanel__isScrolling: "stackPanel__isScrolling",
-    stackPanel_itemContainer: "stackPanel_itemContainer",
+    stackPanel_items: "stackPanel_itemContainer",
 };
 
 const itemSpans: ItemSpanOverride = {
@@ -452,7 +452,7 @@ describe("stack panel", (): void => {
             </StackPanel>
         );
         expect(rendered.instance().itemContainerElement.current.className).toContain(
-            managedClasses.stackPanel_itemContainer
+            managedClasses.stackPanel_items
         );
     });
 

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -16,7 +16,7 @@ configure({ adapter: new Adapter() });
 
 const managedClasses: StackPanelClassNameContract = {
     stackPanel: "stackPanel",
-    stackPanel__isScrolling: "stackPanel__isScrolling",
+    stackPanel__scrolling: "stackPanel__scrolling",
     stackPanel_items: "stackPanel_itemContainer",
 };
 
@@ -441,7 +441,7 @@ describe("stack panel", (): void => {
             managedClasses.stackPanel
         );
         expect(rendered.instance().rootElement.current.className).toContain(
-            managedClasses.stackPanel__isScrolling
+            managedClasses.stackPanel__scrolling
         );
     });
 
@@ -459,7 +459,7 @@ describe("stack panel", (): void => {
     test("isScrolling classname not applied when component does not need to scroll", () => {
         const rendered: any = mount(<StackPanel managedClasses={managedClasses} />);
         expect(rendered.instance().rootElement.current.className).not.toContain(
-            managedClasses.stackPanel__isScrolling
+            managedClasses.stackPanel__scrolling
         );
     });
 });

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -3,13 +3,22 @@ import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import Button from "../button";
 import { ConstructibleResizeObserver, DisplayNamePrefix } from "../utilities";
-import StackPanel, { StackPanelUnhandledProps } from "./stack-panel";
+import StackPanel, {
+    StackPanelClassNameContract,
+    StackPanelUnhandledProps,
+} from "./stack-panel";
 import { ItemSpanOverride, stackPanelOrientation } from "./stack-panel.props";
 
 /*
  * Configure Enzyme
  */
 configure({ adapter: new Adapter() });
+
+const managedClasses: StackPanelClassNameContract = {
+    stackPanel: "stackPanel",
+    stackPanel__isScrolling: "stackPanel__isScrolling",
+    stackPanel_itemContainer: "stackPanel_itemContainer",
+};
 
 const itemSpans: ItemSpanOverride = {
     0: 120,

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -406,7 +406,7 @@ describe("stack panel", (): void => {
         expect(scrollContentFn.mock.calls[0][1]).toBe(350);
     });
 
-    test("on onItemFocus correctly scrolls content - horizontal, element left of viewport ", () => {
+    test("on onItemFocus correctly scrolls content - horizontal, element left of viewport", () => {
         const rendered: any = mount(
             <StackPanel orientation={stackPanelOrientation.horizontal} nextItemPeek={0}>
                 {sampleStackPanelItems}
@@ -429,5 +429,37 @@ describe("stack panel", (): void => {
         });
         expect(scrollContentFn.mock.calls[0][0]).toBe(300);
         expect(scrollContentFn.mock.calls[0][1]).toBe(100);
+    });
+
+    test("Root classnames are applied", () => {
+        const rendered: any = mount(
+            <StackPanel managedClasses={managedClasses}>
+                {sampleStackPanelItems}
+            </StackPanel>
+        );
+        expect(rendered.instance().rootElement.current.className).toContain(
+            managedClasses.stackPanel
+        );
+        expect(rendered.instance().rootElement.current.className).toContain(
+            managedClasses.stackPanel__isScrolling
+        );
+    });
+
+    test("Item container classname is applied", () => {
+        const rendered: any = mount(
+            <StackPanel managedClasses={managedClasses}>
+                {sampleStackPanelItems}
+            </StackPanel>
+        );
+        expect(rendered.instance().itemContainerElement.current.className).toContain(
+            managedClasses.stackPanel_itemContainer
+        );
+    });
+
+    test("isScrolling classname not applied when component does not need to scroll", () => {
+        const rendered: any = mount(<StackPanel managedClasses={managedClasses} />);
+        expect(rendered.instance().rootElement.current.className).not.toContain(
+            managedClasses.stackPanel__isScrolling
+        );
     });
 });

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -2,29 +2,423 @@ import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
 import Button from "../button";
+import { ConstructibleResizeObserver, DisplayNamePrefix } from "../utilities";
+import StackPanel, { StackPanelUnhandledProps } from "./stack-panel";
+import { ItemSpanOverride, stackPanelOrientation } from "./stack-panel.props";
 
 /*
  * Configure Enzyme
  */
 configure({ adapter: new Adapter() });
 
+const itemSpans: ItemSpanOverride = {
+    0: 120,
+    1: 180,
+    2: 240,
+    3: 120,
+    4: 640,
+    5: 200,
+    6: 220,
+    7: 170,
+    8: 160,
+    9: 240,
+    10: 110,
+    11: 270,
+};
+
+const sampleStackPanelItems: JSX.Element[] = [
+    "item1",
+    "item2",
+    "item3",
+    "item4",
+    "item5",
+    "item6",
+    "item7",
+    "item8",
+    "item9",
+    "item10",
+    "item11",
+    "item12",
+].map(
+    (src: string, index: number): JSX.Element => {
+        return (
+            <div
+                key={index}
+                style={{
+                    padding: "0px",
+                    width: "100px",
+                    height: "100px",
+                }}
+            >
+                {src}
+            </div>
+        );
+    }
+);
+
 /* tslint:disable:no-string-literal */
 describe("stack panel", (): void => {
-    // test("should have a displayName that matches the component name", () => {
-    //     expect(`${DisplayNamePrefix}${(ViewportPositioner as any).name}`).toBe(
-    //         ViewportPositioner.displayName
-    //     );
-    // });
-    // test("should not throw if managedClasses are not provided", () => {
-    //     expect(() => {
-    //         shallow(<ViewportPositioner />);
-    //     }).not.toThrow();
-    // });
-    // test("should implement unhandledProps", (): void => {
-    //     const unhandledProps: ViewportPositionerUnhandledProps = {
-    //         "aria-label": "label",
-    //     };
-    //     const rendered: any = shallow(<ViewportPositioner {...unhandledProps} />);
-    //     expect(rendered.first().prop("aria-label")).toEqual("label");
-    // });
+    test("should have a displayName that matches the component name", () => {
+        expect(`${DisplayNamePrefix}${(StackPanel as any).name}`).toBe(
+            StackPanel.displayName
+        );
+    });
+    test("should not throw if managedClasses are not provided", () => {
+        expect(() => {
+            shallow(<StackPanel />);
+        }).not.toThrow();
+    });
+    test("should implement unhandledProps", (): void => {
+        const unhandledProps: StackPanelUnhandledProps = {
+            "aria-label": "label",
+        };
+        const rendered: any = shallow(<StackPanel {...unhandledProps} />);
+        expect(rendered.first().prop("aria-label")).toEqual("label");
+    });
+
+    test("getViewportSpan returns correct value when orientation is vertical", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        const rendered: any = mount(
+            <StackPanel orientation={stackPanelOrientation.vertical}>item</StackPanel>
+        );
+
+        rendered.first().instance().rootElement.current = {
+            clientHeight: 100,
+            clientWidth: 200,
+        };
+        expect(
+            rendered
+                .first()
+                .instance()
+                ["getViewportSpan"]()
+        ).toBe(100);
+    });
+
+    test("getViewportSpan returns correct value when orientation is horizontal", (): void => {
+        const rendered: any = mount(
+            <StackPanel orientation={stackPanelOrientation.horizontal}>item</StackPanel>
+        );
+
+        rendered.first().instance().rootElement.current = {
+            clientHeight: 100,
+            clientWidth: 200,
+        };
+        expect(
+            rendered
+                .first()
+                .instance()
+                ["getViewportSpan"]()
+        ).toBe(200);
+    });
+    test("getScrollIntoViewPosition returns correct value", (): void => {
+        const rendered: any = mount(
+            <StackPanel itemSpanOverrides={itemSpans}>{sampleStackPanelItems}</StackPanel>
+        );
+
+        rendered.first().instance().viewPortSpan = 200;
+        expect(
+            rendered
+                .first()
+                .instance()
+                ["getScrollIntoViewPosition"](0)
+        ).toBe(0);
+        expect(
+            rendered
+                .first()
+                .instance()
+                ["getScrollIntoViewPosition"](4)
+        ).toBe(660);
+        expect(
+            rendered
+                .first()
+                .instance()
+                ["getScrollIntoViewPosition"](11)
+        ).toBe(2400);
+    });
+
+    test("getMaxScrollDistance returns correct value", (): void => {
+        const rendered: any = mount(
+            <StackPanel itemSpanOverrides={itemSpans}>{sampleStackPanelItems}</StackPanel>
+        );
+
+        rendered.first().instance().viewPortSpan = 200;
+        expect(
+            rendered
+                .first()
+                .instance()
+                ["getMaxScrollDistance"]()
+        ).toBe(2470);
+    });
+
+    test("getMaxScrollDistance returns 0 when there are no items", (): void => {
+        const rendered: any = mount(<StackPanel />);
+
+        rendered.first().instance().viewPortSpan = 200;
+        expect(
+            rendered
+                .first()
+                .instance()
+                ["getMaxScrollDistance"]()
+        ).toBe(0);
+    });
+
+    test("should create a resize observer if it is available", (): void => {
+        const ActualObserver: ConstructibleResizeObserver = (window as WindowWithResizeObserver)
+            .ResizeObserver;
+        const construct: jest.Mock<any, any> = jest.fn();
+        // Mock the resize observer
+        class MockObserver {
+            public observe: jest.Mock<any, any> = jest.fn();
+            public unobserve: jest.Mock<any, any> = jest.fn();
+            public disconnect: jest.Mock<any, any> = jest.fn();
+            constructor() {
+                construct();
+            }
+        }
+        (window as WindowWithResizeObserver).ResizeObserver = MockObserver;
+
+        // Render the component
+        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
+
+        expect(construct).toBeCalledTimes(1);
+        // Replace the window to it's original state
+        (window as WindowWithResizeObserver).ResizeObserver = ActualObserver;
+    });
+
+    test("should disconnect the resize observer when unmounted", (): void => {
+        const ActualObserver: ConstructibleResizeObserver = (window as WindowWithResizeObserver)
+            .ResizeObserver;
+        const disconnect: jest.Mock<any, any> = jest.fn();
+        // Mock the resize observer
+        // tslint:disable-next-line:max-classes-per-file
+        class MockObserver {
+            public observe: jest.Mock<any, any> = jest.fn();
+            public unobserve: jest.Mock<any, any> = jest.fn();
+            public disconnect: jest.Mock<any, any> = disconnect;
+        }
+        (window as WindowWithResizeObserver).ResizeObserver = MockObserver;
+
+        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
+        // Unmount the component to trigger lifecycle methods
+        rendered.unmount();
+
+        expect(disconnect).toBeCalledTimes(1);
+        // Replace the window to it's original state
+        (window as WindowWithResizeObserver).ResizeObserver = ActualObserver;
+    });
+
+    test("updateScrollAnimation marks scrollAnimating as complete when time reaches duration", (): void => {
+        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
+
+        let currentTime: number = new Date().getTime();
+        rendered.instance().currentScrollAnimStartTime = currentTime;
+        rendered.instance().isScrollAnimating = true;
+        const targetDelayTime: number = currentTime + 500;
+        while (currentTime < targetDelayTime) {
+            currentTime = new Date().getTime();
+        }
+        rendered.instance()["updateScrollAnimation"]();
+        expect(rendered.instance().isScrollAnimating).toEqual(false);
+    });
+
+    test("getDirection should return direction value when the ltr prop is passed", (): void => {
+        const rendered: any = mount(
+            <StackPanel dir="ltr" orientation={stackPanelOrientation.horizontal}>
+                {sampleStackPanelItems}
+            </StackPanel>
+        );
+        expect(rendered.instance()["getDirection"]()).toEqual("ltr");
+    });
+
+    test("getDirection should return direction value when the rtl prop is passed", (): void => {
+        const rendered: any = mount(
+            <StackPanel dir="rtl" orientation={stackPanelOrientation.horizontal}>
+                {sampleStackPanelItems}
+            </StackPanel>
+        );
+        expect(rendered.instance()["getDirection"]()).toEqual("rtl");
+    });
+
+    test("getDirection should return direction ltr when current ref is invalid", (): void => {
+        const rendered: any = mount(
+            <StackPanel dir="rtl" orientation={stackPanelOrientation.horizontal}>
+                {sampleStackPanelItems}
+            </StackPanel>
+        );
+        rendered.instance().rootElement.current = null;
+        expect(rendered.instance()["getDirection"]()).toEqual("ltr");
+    });
+    test("should ease the animation correctly when moving the scroll position", () => {
+        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
+
+        expect(rendered.instance()["easeInOutQuad"](1, 0, 0.5, 50)).toBe(0.0004);
+    });
+    test("should ease the animation correctly when at animation start time", () => {
+        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
+
+        expect(rendered.instance()["easeInOutQuad"](0, 0, 0.5, 50)).toBe(0);
+    });
+    test("should ease the animation correctly when at animation end time", () => {
+        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
+
+        expect(rendered.instance()["easeInOutQuad"](50, 0, 0.5, 50)).toBe(0.5);
+    });
+    test("should ease the animation correctly when moving the scroll position", () => {
+        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
+
+        expect(rendered.instance()["easeInOutQuad"](1, 0, 0.5, 50)).toBe(0.0004);
+    });
+    test("getScrollAnimationPosition returns correct start and end values", () => {
+        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
+
+        rendered.instance().currentScrollAnimStartPosition = 0;
+        rendered.instance().currentScrollAnimEndPosition = 100;
+
+        expect(rendered.instance()["getScrollAnimationPosition"](0, 1000)).toBe(0);
+        expect(rendered.instance()["getScrollAnimationPosition"](1000, 1000)).toBe(100);
+    });
+    test("settting and getting scroll position works correctly in ltr", (): void => {
+        const rendered: any = mount(
+            <StackPanel dir="ltr">{sampleStackPanelItems}</StackPanel>
+        );
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(0);
+        rendered.instance()["setScrollPosition"](100);
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(100);
+    });
+    test("settting and getting scroll position works correctly in rtl", (): void => {
+        const rendered: any = mount(
+            <StackPanel dir="rtl">{sampleStackPanelItems}</StackPanel>
+        );
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(0);
+        rendered.instance()["setScrollPosition"](100);
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(100);
+    });
+    test("getScrollIntoViewPosition returns 0 when there are no children", (): void => {
+        const rendered: any = mount(<StackPanel />);
+        expect(rendered.instance()["getScrollIntoViewPosition"](0)).toEqual(0);
+    });
+    test("should ease the animation correctly when moving the scroll position", () => {
+        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
+        expect(rendered.instance()["easeInOutQuad"](1, 0, 0.5, 50)).toBe(0.0004);
+    });
+    test("scrollContent properly configures a smooth scrolling animation", () => {
+        const rendered: any = mount(
+            <StackPanel enableSmoothScrolling={true}>{sampleStackPanelItems}</StackPanel>
+        );
+        expect(rendered.instance().isScrollAnimating).toEqual(false);
+        rendered.requestFrame = jest.fn();
+        rendered.instance()["scrollContent"](0, 100);
+        expect(rendered.instance().isScrollAnimating).toEqual(true);
+        expect(rendered.instance().currentScrollAnimStartPosition).toEqual(0);
+        expect(rendered.instance().currentScrollAnimEndPosition).toEqual(100);
+    });
+    test("scrollContent does not start smooth scrolling animation and sets scroll value when smooth scrolling disabled", () => {
+        const rendered: any = mount(
+            <StackPanel enableSmoothScrolling={false}>{sampleStackPanelItems}</StackPanel>
+        );
+        expect(rendered.instance().isScrollAnimating).toEqual(false);
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(0);
+        rendered.instance()["scrollContent"](0, 100);
+        expect(rendered.instance().isScrollAnimating).toEqual(false);
+        expect(rendered.instance()["getScrollPosition"]()).toEqual(100);
+    });
+    test("on onItemFocus correctly scrolls content - vertical, element below viewport ", () => {
+        const rendered: any = mount(
+            <StackPanel orientation={stackPanelOrientation.vertical} nextItemPeek={0}>
+                {sampleStackPanelItems}
+            </StackPanel>
+        );
+
+        const scrollContentFn: any = jest.fn();
+        rendered.instance().scrollContent = scrollContentFn;
+        rendered.instance().lastRecordedScroll = 0;
+        rendered.instance().isScrollAnimating = false;
+        rendered.instance().viewportSpan = 100;
+        rendered.instance().isScrolling = true;
+        rendered.instance()["onItemFocus"]({
+            currentTarget: {
+                clientHeight: 100,
+                clientWidth: 0,
+                offsetTop: 250,
+                offsetLeft: 0,
+            },
+        });
+        expect(scrollContentFn.mock.calls[0][0]).toBe(0);
+        expect(scrollContentFn.mock.calls[0][1]).toBe(350);
+    });
+
+    test("on onItemFocus correctly scrolls content - vertical, element above viewport ", () => {
+        const rendered: any = mount(
+            <StackPanel orientation={stackPanelOrientation.vertical} nextItemPeek={0}>
+                {sampleStackPanelItems}
+            </StackPanel>
+        );
+
+        const scrollContentFn: any = jest.fn();
+        rendered.instance().scrollContent = scrollContentFn;
+        rendered.instance().lastRecordedScroll = 300;
+        rendered.instance().isScrollAnimating = false;
+        rendered.instance().viewportSpan = 100;
+        rendered.instance().isScrolling = true;
+        rendered.instance()["onItemFocus"]({
+            currentTarget: {
+                clientHeight: 100,
+                clientWidth: 0,
+                offsetTop: 100,
+                offsetLeft: 0,
+            },
+        });
+        expect(scrollContentFn.mock.calls[0][0]).toBe(300);
+        expect(scrollContentFn.mock.calls[0][1]).toBe(100);
+    });
+
+    test("on onItemFocus correctly scrolls content - horizontal, element right of viewport ", () => {
+        const rendered: any = mount(
+            <StackPanel orientation={stackPanelOrientation.horizontal} nextItemPeek={0}>
+                {sampleStackPanelItems}
+            </StackPanel>
+        );
+
+        const scrollContentFn: any = jest.fn();
+        rendered.instance().scrollContent = scrollContentFn;
+        rendered.instance().lastRecordedScroll = 0;
+        rendered.instance().isScrollAnimating = false;
+        rendered.instance().viewportSpan = 100;
+        rendered.instance().isScrolling = true;
+        rendered.instance()["onItemFocus"]({
+            currentTarget: {
+                clientHeight: 0,
+                clientWidth: 100,
+                offsetTop: 0,
+                offsetLeft: 250,
+            },
+        });
+        expect(scrollContentFn.mock.calls[0][0]).toBe(0);
+        expect(scrollContentFn.mock.calls[0][1]).toBe(350);
+    });
+
+    test("on onItemFocus correctly scrolls content - horizontal, element left of viewport ", () => {
+        const rendered: any = mount(
+            <StackPanel orientation={stackPanelOrientation.horizontal} nextItemPeek={0}>
+                {sampleStackPanelItems}
+            </StackPanel>
+        );
+
+        const scrollContentFn: any = jest.fn();
+        rendered.instance().scrollContent = scrollContentFn;
+        rendered.instance().lastRecordedScroll = 300;
+        rendered.instance().isScrollAnimating = false;
+        rendered.instance().viewportSpan = 100;
+        rendered.instance().isScrolling = true;
+        rendered.instance()["onItemFocus"]({
+            currentTarget: {
+                clientHeight: 0,
+                clientWidth: 100,
+                offsetTop: 0,
+                offsetLeft: 100,
+            },
+        });
+        expect(scrollContentFn.mock.calls[0][0]).toBe(300);
+        expect(scrollContentFn.mock.calls[0][1]).toBe(100);
+    });
 });

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -7,7 +7,8 @@ import StackPanel, {
     StackPanelClassNameContract,
     StackPanelUnhandledProps,
 } from "./stack-panel";
-import { ItemSpanOverride, stackPanelOrientation } from "./stack-panel.props";
+import { ItemSpanOverride } from "./stack-panel.props";
+import { Orientation } from "@microsoft/fast-web-utilities";
 
 /*
  * Configure Enzyme
@@ -88,7 +89,7 @@ describe("stack panel", (): void => {
     test("getViewportSpan returns correct value when orientation is vertical", (): void => {
         const container: HTMLDivElement = document.createElement("div");
         const rendered: any = mount(
-            <StackPanel orientation={stackPanelOrientation.vertical}>item</StackPanel>
+            <StackPanel orientation={Orientation.vertical}>item</StackPanel>
         );
 
         rendered.first().instance().rootElement.current = {
@@ -105,7 +106,7 @@ describe("stack panel", (): void => {
 
     test("getViewportSpan returns correct value when orientation is horizontal", (): void => {
         const rendered: any = mount(
-            <StackPanel orientation={stackPanelOrientation.horizontal}>item</StackPanel>
+            <StackPanel orientation={Orientation.horizontal}>item</StackPanel>
         );
 
         rendered.first().instance().rootElement.current = {
@@ -232,7 +233,7 @@ describe("stack panel", (): void => {
 
     test("getDirection should return direction value when the ltr prop is passed", (): void => {
         const rendered: any = mount(
-            <StackPanel dir="ltr" orientation={stackPanelOrientation.horizontal}>
+            <StackPanel dir="ltr" orientation={Orientation.horizontal}>
                 {sampleStackPanelItems}
             </StackPanel>
         );
@@ -241,7 +242,7 @@ describe("stack panel", (): void => {
 
     test("getDirection should return direction value when the rtl prop is passed", (): void => {
         const rendered: any = mount(
-            <StackPanel dir="rtl" orientation={stackPanelOrientation.horizontal}>
+            <StackPanel dir="rtl" orientation={Orientation.horizontal}>
                 {sampleStackPanelItems}
             </StackPanel>
         );
@@ -250,7 +251,7 @@ describe("stack panel", (): void => {
 
     test("getDirection should return direction ltr when current ref is invalid", (): void => {
         const rendered: any = mount(
-            <StackPanel dir="rtl" orientation={stackPanelOrientation.horizontal}>
+            <StackPanel dir="rtl" orientation={Orientation.horizontal}>
                 {sampleStackPanelItems}
             </StackPanel>
         );
@@ -333,7 +334,7 @@ describe("stack panel", (): void => {
     });
     test("on onItemFocus correctly scrolls content - vertical, element below viewport ", () => {
         const rendered: any = mount(
-            <StackPanel orientation={stackPanelOrientation.vertical} nextItemPeek={0}>
+            <StackPanel orientation={Orientation.vertical} nextItemPeek={0}>
                 {sampleStackPanelItems}
             </StackPanel>
         );
@@ -358,7 +359,7 @@ describe("stack panel", (): void => {
 
     test("on onItemFocus correctly scrolls content - vertical, element above viewport ", () => {
         const rendered: any = mount(
-            <StackPanel orientation={stackPanelOrientation.vertical} nextItemPeek={0}>
+            <StackPanel orientation={Orientation.vertical} nextItemPeek={0}>
                 {sampleStackPanelItems}
             </StackPanel>
         );
@@ -383,7 +384,7 @@ describe("stack panel", (): void => {
 
     test("on onItemFocus correctly scrolls content - horizontal, element right of viewport ", () => {
         const rendered: any = mount(
-            <StackPanel orientation={stackPanelOrientation.horizontal} nextItemPeek={0}>
+            <StackPanel orientation={Orientation.horizontal} nextItemPeek={0}>
                 {sampleStackPanelItems}
             </StackPanel>
         );
@@ -408,7 +409,7 @@ describe("stack panel", (): void => {
 
     test("on onItemFocus correctly scrolls content - horizontal, element left of viewport", () => {
         const rendered: any = mount(
-            <StackPanel orientation={stackPanelOrientation.horizontal} nextItemPeek={0}>
+            <StackPanel orientation={Orientation.horizontal} nextItemPeek={0}>
                 {sampleStackPanelItems}
             </StackPanel>
         );

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -432,7 +432,7 @@ describe("stack panel", (): void => {
         expect(scrollContentFn.mock.calls[0][1]).toBe(100);
     });
 
-    test("Root classnames are applied", () => {
+    test("Root classname is applied", () => {
         const rendered: any = mount(
             <StackPanel managedClasses={managedClasses}>
                 {sampleStackPanelItems}
@@ -440,9 +440,6 @@ describe("stack panel", (): void => {
         );
         expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.stackPanel
-        );
-        expect(rendered.instance().rootElement.current.className).toContain(
-            managedClasses.stackPanel__scrolling
         );
     });
 

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
-import Button from "../button";
 import { ConstructibleResizeObserver, DisplayNamePrefix } from "../utilities";
 import StackPanel, {
     StackPanelClassNameContract,
@@ -86,7 +85,7 @@ describe("stack panel", (): void => {
         expect(rendered.first().prop("aria-label")).toEqual("label");
     });
 
-    test("getViewportSpan returns correct value when orientation is vertical", (): void => {
+    test("getViewportSpan returns expected value when orientation is vertical", (): void => {
         const container: HTMLDivElement = document.createElement("div");
         const rendered: any = mount(
             <StackPanel orientation={Orientation.vertical}>item</StackPanel>
@@ -104,7 +103,7 @@ describe("stack panel", (): void => {
         ).toBe(100);
     });
 
-    test("getViewportSpan returns correct value when orientation is horizontal", (): void => {
+    test("getViewportSpan returns expected value when orientation is horizontal", (): void => {
         const rendered: any = mount(
             <StackPanel orientation={Orientation.horizontal}>item</StackPanel>
         );
@@ -120,7 +119,7 @@ describe("stack panel", (): void => {
                 ["getViewportSpan"]()
         ).toBe(200);
     });
-    test("getScrollIntoViewPosition returns correct value", (): void => {
+    test("getScrollIntoViewPosition returns expected values", (): void => {
         const rendered: any = mount(
             <StackPanel itemSpanOverrides={itemSpans}>{sampleStackPanelItems}</StackPanel>
         );
@@ -146,7 +145,7 @@ describe("stack panel", (): void => {
         ).toBe(2400);
     });
 
-    test("getMaxScrollDistance returns correct value", (): void => {
+    test("getMaxScrollDistance returns value corresponding to height of items and viewport", (): void => {
         const rendered: any = mount(
             <StackPanel itemSpanOverrides={itemSpans}>{sampleStackPanelItems}</StackPanel>
         );
@@ -258,27 +257,27 @@ describe("stack panel", (): void => {
         rendered.instance().rootElement.current = null;
         expect(rendered.instance()["getDirection"]()).toEqual("ltr");
     });
-    test("should ease the animation correctly when moving the scroll position", () => {
+    test("should ease the animation when moving the scroll position", () => {
         const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
 
         expect(rendered.instance()["easeInOutQuad"](1, 0, 0.5, 50)).toBe(0.0004);
     });
-    test("should ease the animation correctly when at animation start time", () => {
+    test("should ease the animation when at animation start time", () => {
         const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
 
         expect(rendered.instance()["easeInOutQuad"](0, 0, 0.5, 50)).toBe(0);
     });
-    test("should ease the animation correctly when at animation end time", () => {
+    test("should ease the animation when at animation end time", () => {
         const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
 
         expect(rendered.instance()["easeInOutQuad"](50, 0, 0.5, 50)).toBe(0.5);
     });
-    test("should ease the animation correctly when moving the scroll position", () => {
+    test("should ease the animation when moving the scroll position", () => {
         const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
 
         expect(rendered.instance()["easeInOutQuad"](1, 0, 0.5, 50)).toBe(0.0004);
     });
-    test("getScrollAnimationPosition returns correct start and end values", () => {
+    test("getScrollAnimationPosition returns expected start and end values", () => {
         const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
 
         rendered.instance().currentScrollAnimStartPosition = 0;
@@ -287,7 +286,7 @@ describe("stack panel", (): void => {
         expect(rendered.instance()["getScrollAnimationPosition"](0, 1000)).toBe(0);
         expect(rendered.instance()["getScrollAnimationPosition"](1000, 1000)).toBe(100);
     });
-    test("settting and getting scroll position works correctly in ltr", (): void => {
+    test("settting and getting scroll position returns expected scroll values in ltr", (): void => {
         const rendered: any = mount(
             <StackPanel dir="ltr">{sampleStackPanelItems}</StackPanel>
         );
@@ -295,7 +294,7 @@ describe("stack panel", (): void => {
         rendered.instance()["setScrollPosition"](100);
         expect(rendered.instance()["getScrollPosition"]()).toEqual(100);
     });
-    test("settting and getting scroll position works correctly in rtl", (): void => {
+    test("settting and getting scroll position works in rtl", (): void => {
         const rendered: any = mount(
             <StackPanel dir="rtl">{sampleStackPanelItems}</StackPanel>
         );
@@ -307,7 +306,7 @@ describe("stack panel", (): void => {
         const rendered: any = mount(<StackPanel />);
         expect(rendered.instance()["getScrollIntoViewPosition"](0)).toEqual(0);
     });
-    test("should ease the animation correctly when moving the scroll position", () => {
+    test("should ease the animation when moving the scroll position", () => {
         const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
         expect(rendered.instance()["easeInOutQuad"](1, 0, 0.5, 50)).toBe(0.0004);
     });
@@ -332,7 +331,7 @@ describe("stack panel", (): void => {
         expect(rendered.instance().isScrollAnimating).toEqual(false);
         expect(rendered.instance()["getScrollPosition"]()).toEqual(100);
     });
-    test("on onItemFocus correctly scrolls content - vertical, element below viewport ", () => {
+    test("on onItemFocus scrolls content into view - vertical, element below viewport ", () => {
         const rendered: any = mount(
             <StackPanel orientation={Orientation.vertical} nextItemPeek={0}>
                 {sampleStackPanelItems}
@@ -357,7 +356,7 @@ describe("stack panel", (): void => {
         expect(scrollContentFn.mock.calls[0][1]).toBe(250);
     });
 
-    test("on onItemFocus correctly scrolls content - vertical, element above viewport ", () => {
+    test("on onItemFocus scrolls content into view - vertical, element above viewport ", () => {
         const rendered: any = mount(
             <StackPanel orientation={Orientation.vertical} nextItemPeek={0}>
                 {sampleStackPanelItems}
@@ -382,7 +381,7 @@ describe("stack panel", (): void => {
         expect(scrollContentFn.mock.calls[0][1]).toBe(100);
     });
 
-    test("on onItemFocus correctly scrolls content - horizontal, element right of viewport ", () => {
+    test("on onItemFocus scrolls content into view - horizontal, element right of viewport ", () => {
         const rendered: any = mount(
             <StackPanel orientation={Orientation.horizontal} nextItemPeek={0}>
                 {sampleStackPanelItems}
@@ -407,7 +406,7 @@ describe("stack panel", (): void => {
         expect(scrollContentFn.mock.calls[0][1]).toBe(250);
     });
 
-    test("on onItemFocus correctly scrolls content - horizontal, element left of viewport", () => {
+    test("on onItemFocus scrolls content into view - horizontal, element left of viewport", () => {
         const rendered: any = mount(
             <StackPanel orientation={Orientation.horizontal} nextItemPeek={0}>
                 {sampleStackPanelItems}

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -6,7 +6,6 @@ import StackPanel, {
     StackPanelClassNameContract,
     StackPanelUnhandledProps,
 } from "./stack-panel";
-import { ItemSpanOverride } from "./stack-panel.props";
 import { Orientation } from "@microsoft/fast-web-utilities";
 
 /*
@@ -20,20 +19,7 @@ const managedClasses: StackPanelClassNameContract = {
     stackPanel_items: "stackPanel_itemContainer",
 };
 
-const itemSpans: ItemSpanOverride = {
-    0: 120,
-    1: 180,
-    2: 240,
-    3: 120,
-    4: 640,
-    5: 200,
-    6: 220,
-    7: 170,
-    8: 160,
-    9: 240,
-    10: 110,
-    11: 270,
-};
+const itemSpans: number[] = [120, 180, 240, 120, 640, 200, 220, 170, 160, 240, 110, 270];
 
 const sampleStackPanelItems: JSX.Element[] = [
     "item1",
@@ -121,7 +107,7 @@ describe("stack panel", (): void => {
     });
     test("getScrollIntoViewPosition returns expected values", (): void => {
         const rendered: any = mount(
-            <StackPanel itemSpanOverrides={itemSpans}>{sampleStackPanelItems}</StackPanel>
+            <StackPanel itemSpan={itemSpans}>{sampleStackPanelItems}</StackPanel>
         );
 
         rendered.first().instance().viewportSpan = 200;
@@ -147,7 +133,7 @@ describe("stack panel", (): void => {
 
     test("getMaxScrollDistance returns value corresponding to height of items and viewport", (): void => {
         const rendered: any = mount(
-            <StackPanel itemSpanOverrides={itemSpans}>{sampleStackPanelItems}</StackPanel>
+            <StackPanel itemSpan={itemSpans}>{sampleStackPanelItems}</StackPanel>
         );
 
         rendered.first().instance().viewportSpan = 200;

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -125,7 +125,7 @@ describe("stack panel", (): void => {
             <StackPanel itemSpanOverrides={itemSpans}>{sampleStackPanelItems}</StackPanel>
         );
 
-        rendered.first().instance().viewPortSpan = 200;
+        rendered.first().instance().viewportSpan = 200;
         expect(
             rendered
                 .first()
@@ -151,7 +151,7 @@ describe("stack panel", (): void => {
             <StackPanel itemSpanOverrides={itemSpans}>{sampleStackPanelItems}</StackPanel>
         );
 
-        rendered.first().instance().viewPortSpan = 200;
+        rendered.first().instance().viewportSpan = 200;
         expect(
             rendered
                 .first()
@@ -163,7 +163,7 @@ describe("stack panel", (): void => {
     test("getMaxScrollDistance returns 0 when there are no items", (): void => {
         const rendered: any = mount(<StackPanel />);
 
-        rendered.first().instance().viewPortSpan = 200;
+        rendered.first().instance().viewportSpan = 200;
         expect(
             rendered
                 .first()
@@ -354,7 +354,7 @@ describe("stack panel", (): void => {
             },
         });
         expect(scrollContentFn.mock.calls[0][0]).toBe(0);
-        expect(scrollContentFn.mock.calls[0][1]).toBe(350);
+        expect(scrollContentFn.mock.calls[0][1]).toBe(250);
     });
 
     test("on onItemFocus correctly scrolls content - vertical, element above viewport ", () => {
@@ -404,7 +404,7 @@ describe("stack panel", (): void => {
             },
         });
         expect(scrollContentFn.mock.calls[0][0]).toBe(0);
-        expect(scrollContentFn.mock.calls[0][1]).toBe(350);
+        expect(scrollContentFn.mock.calls[0][1]).toBe(250);
     });
 
     test("on onItemFocus correctly scrolls content - horizontal, element left of viewport", () => {

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -15,7 +15,7 @@ configure({ adapter: new Adapter() });
 
 const managedClasses: StackPanelClassNameContract = {
     stackPanel: "stackPanel",
-    stackPanel__scrolling: "stackPanel__scrolling",
+    stackPanel__scrollable: "stackPanel__scrollable",
     stackPanel_items: "stackPanel_itemContainer",
 };
 
@@ -442,7 +442,7 @@ describe("stack panel", (): void => {
     test("isScrolling classname not applied when component does not need to scroll", () => {
         const rendered: any = mount(<StackPanel managedClasses={managedClasses} />);
         expect(rendered.instance().rootElement.current.className).not.toContain(
-            managedClasses.stackPanel__scrolling
+            managedClasses.stackPanel__scrollable
         );
     });
 });

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -202,20 +202,6 @@ describe("stack panel", (): void => {
         (window as WindowWithResizeObserver).ResizeObserver = ActualObserver;
     });
 
-    test("updateScrollAnimation marks scrollAnimating as complete when time reaches duration", (): void => {
-        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
-
-        let currentTime: number = new Date().getTime();
-        rendered.instance().currentScrollAnimStartTime = currentTime;
-        rendered.instance().isScrollAnimating = true;
-        const targetDelayTime: number = currentTime + 500;
-        while (currentTime < targetDelayTime) {
-            currentTime = new Date().getTime();
-        }
-        rendered.instance()["updateScrollAnimation"]();
-        expect(rendered.instance().isScrollAnimating).toEqual(false);
-    });
-
     test("getDirection should return direction value when the ltr prop is passed", (): void => {
         const rendered: any = mount(
             <StackPanel dir="ltr" orientation={Orientation.horizontal}>
@@ -243,36 +229,8 @@ describe("stack panel", (): void => {
         rendered.instance().rootElement.current = null;
         expect(rendered.instance()["getDirection"]()).toEqual("ltr");
     });
-    test("should ease the animation when moving the scroll position", () => {
-        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
 
-        expect(rendered.instance()["easeInOutQuad"](1, 0, 0.5, 50)).toBe(0.0004);
-    });
-    test("should ease the animation when at animation start time", () => {
-        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
-
-        expect(rendered.instance()["easeInOutQuad"](0, 0, 0.5, 50)).toBe(0);
-    });
-    test("should ease the animation when at animation end time", () => {
-        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
-
-        expect(rendered.instance()["easeInOutQuad"](50, 0, 0.5, 50)).toBe(0.5);
-    });
-    test("should ease the animation when moving the scroll position", () => {
-        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
-
-        expect(rendered.instance()["easeInOutQuad"](1, 0, 0.5, 50)).toBe(0.0004);
-    });
-    test("getScrollAnimationPosition returns expected start and end values", () => {
-        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
-
-        rendered.instance().currentScrollAnimStartPosition = 0;
-        rendered.instance().currentScrollAnimEndPosition = 100;
-
-        expect(rendered.instance()["getScrollAnimationPosition"](0, 1000)).toBe(0);
-        expect(rendered.instance()["getScrollAnimationPosition"](1000, 1000)).toBe(100);
-    });
-    test("settting and getting scroll position returns expected scroll values in ltr", (): void => {
+    test("setting and getting scroll position returns expected scroll values in ltr", (): void => {
         const rendered: any = mount(
             <StackPanel dir="ltr">{sampleStackPanelItems}</StackPanel>
         );
@@ -280,7 +238,8 @@ describe("stack panel", (): void => {
         rendered.instance()["setScrollPosition"](100);
         expect(rendered.instance()["getScrollPosition"]()).toEqual(100);
     });
-    test("settting and getting scroll position works in rtl", (): void => {
+
+    test("setting and getting scroll position works in rtl", (): void => {
         const rendered: any = mount(
             <StackPanel dir="rtl">{sampleStackPanelItems}</StackPanel>
         );
@@ -288,133 +247,10 @@ describe("stack panel", (): void => {
         rendered.instance()["setScrollPosition"](100);
         expect(rendered.instance()["getScrollPosition"]()).toEqual(100);
     });
+
     test("getScrollIntoViewPosition returns 0 when there are no children", (): void => {
         const rendered: any = mount(<StackPanel />);
         expect(rendered.instance()["getScrollIntoViewPosition"](0)).toEqual(0);
-    });
-    test("should ease the animation when moving the scroll position", () => {
-        const rendered: any = mount(<StackPanel>{sampleStackPanelItems}</StackPanel>);
-        expect(rendered.instance()["easeInOutQuad"](1, 0, 0.5, 50)).toBe(0.0004);
-    });
-    test("scrollContent properly configures a smooth scrolling animation", () => {
-        const rendered: any = mount(
-            <StackPanel enableSmoothScrolling={true}>{sampleStackPanelItems}</StackPanel>
-        );
-        expect(rendered.instance().isScrollAnimating).toEqual(false);
-        rendered.requestFrame = jest.fn();
-        rendered.instance()["scrollContent"](0, 100);
-        expect(rendered.instance().isScrollAnimating).toEqual(true);
-        expect(rendered.instance().currentScrollAnimStartPosition).toEqual(0);
-        expect(rendered.instance().currentScrollAnimEndPosition).toEqual(100);
-    });
-    test("scrollContent does not start smooth scrolling animation and sets scroll value when smooth scrolling disabled", () => {
-        const rendered: any = mount(
-            <StackPanel enableSmoothScrolling={false}>{sampleStackPanelItems}</StackPanel>
-        );
-        expect(rendered.instance().isScrollAnimating).toEqual(false);
-        expect(rendered.instance()["getScrollPosition"]()).toEqual(0);
-        rendered.instance()["scrollContent"](0, 100);
-        expect(rendered.instance().isScrollAnimating).toEqual(false);
-        expect(rendered.instance()["getScrollPosition"]()).toEqual(100);
-    });
-    test("on onItemFocus scrolls content into view - vertical, element below viewport ", () => {
-        const rendered: any = mount(
-            <StackPanel orientation={Orientation.vertical} nextItemPeek={0}>
-                {sampleStackPanelItems}
-            </StackPanel>
-        );
-
-        const scrollContentFn: any = jest.fn();
-        rendered.instance().scrollContent = scrollContentFn;
-        rendered.instance().lastRecordedScroll = 0;
-        rendered.instance().isScrollAnimating = false;
-        rendered.instance().viewportSpan = 100;
-        rendered.instance().isScrolling = true;
-        rendered.instance()["onItemFocus"]({
-            currentTarget: {
-                clientHeight: 100,
-                clientWidth: 0,
-                offsetTop: 250,
-                offsetLeft: 0,
-            },
-        });
-        expect(scrollContentFn.mock.calls[0][0]).toBe(0);
-        expect(scrollContentFn.mock.calls[0][1]).toBe(250);
-    });
-
-    test("on onItemFocus scrolls content into view - vertical, element above viewport ", () => {
-        const rendered: any = mount(
-            <StackPanel orientation={Orientation.vertical} nextItemPeek={0}>
-                {sampleStackPanelItems}
-            </StackPanel>
-        );
-
-        const scrollContentFn: any = jest.fn();
-        rendered.instance().scrollContent = scrollContentFn;
-        rendered.instance().lastRecordedScroll = 300;
-        rendered.instance().isScrollAnimating = false;
-        rendered.instance().viewportSpan = 100;
-        rendered.instance().isScrolling = true;
-        rendered.instance()["onItemFocus"]({
-            currentTarget: {
-                clientHeight: 100,
-                clientWidth: 0,
-                offsetTop: 100,
-                offsetLeft: 0,
-            },
-        });
-        expect(scrollContentFn.mock.calls[0][0]).toBe(300);
-        expect(scrollContentFn.mock.calls[0][1]).toBe(100);
-    });
-
-    test("on onItemFocus scrolls content into view - horizontal, element right of viewport ", () => {
-        const rendered: any = mount(
-            <StackPanel orientation={Orientation.horizontal} nextItemPeek={0}>
-                {sampleStackPanelItems}
-            </StackPanel>
-        );
-
-        const scrollContentFn: any = jest.fn();
-        rendered.instance().scrollContent = scrollContentFn;
-        rendered.instance().lastRecordedScroll = 0;
-        rendered.instance().isScrollAnimating = false;
-        rendered.instance().viewportSpan = 100;
-        rendered.instance().isScrolling = true;
-        rendered.instance()["onItemFocus"]({
-            currentTarget: {
-                clientHeight: 0,
-                clientWidth: 100,
-                offsetTop: 0,
-                offsetLeft: 250,
-            },
-        });
-        expect(scrollContentFn.mock.calls[0][0]).toBe(0);
-        expect(scrollContentFn.mock.calls[0][1]).toBe(250);
-    });
-
-    test("on onItemFocus scrolls content into view - horizontal, element left of viewport", () => {
-        const rendered: any = mount(
-            <StackPanel orientation={Orientation.horizontal} nextItemPeek={0}>
-                {sampleStackPanelItems}
-            </StackPanel>
-        );
-
-        const scrollContentFn: any = jest.fn();
-        rendered.instance().scrollContent = scrollContentFn;
-        rendered.instance().lastRecordedScroll = 300;
-        rendered.instance().isScrollAnimating = false;
-        rendered.instance().viewportSpan = 100;
-        rendered.instance().isScrolling = true;
-        rendered.instance()["onItemFocus"]({
-            currentTarget: {
-                clientHeight: 0,
-                clientWidth: 100,
-                offsetTop: 0,
-                offsetLeft: 100,
-            },
-        });
-        expect(scrollContentFn.mock.calls[0][0]).toBe(300);
-        expect(scrollContentFn.mock.calls[0][1]).toBe(100);
     });
 
     test("Root classname is applied", () => {
@@ -439,7 +275,7 @@ describe("stack panel", (): void => {
         );
     });
 
-    test("isScrolling classname not applied when component does not need to scroll", () => {
+    test("isScrollable classname not applied when component does not need to scroll", () => {
         const rendered: any = mount(<StackPanel managedClasses={managedClasses} />);
         expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.stackPanel__scrollable

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
@@ -1,0 +1,338 @@
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import StackPanel, { StackPanelProps } from "./";
+import { isNil } from "lodash-es";
+import Foundation from "@microsoft/fast-components-foundation-react";
+import { stackPanelOrientation, ItemSpanOverride } from "./stack-panel.props";
+import Button from "../button";
+
+const itemSpans: ItemSpanOverride = {
+    0: 120,
+    1: 180,
+    2: 240,
+    3: 120,
+    4: 640,
+    5: 200,
+    6: 220,
+    7: 170,
+    8: 160,
+    9: 240,
+    10: 110,
+    11: 270,
+};
+
+const horizontalImages: JSX.Element[] = [
+    "https://placehold.it/120x100/414141/?text=1",
+    "https://placehold.it/180x100?text=2",
+    "https://placehold.it/240x100/414141/?text=3",
+    "https://placehold.it/120x100?text=4",
+    "https://placehold.it/640x100/414141/?text=5",
+    "https://placehold.it/200x100?text=6",
+    "https://placehold.it/220x100/414141/?text=7",
+    "https://placehold.it/170x100?text=8",
+    "https://placehold.it/160x100/414141/?text=9",
+    "https://placehold.it/240x100?text=10",
+    "https://placehold.it/110x100/414141/?text=11",
+    "https://placehold.it/270x100?text=12",
+].map(
+    (src: string): JSX.Element => {
+        return (
+            <Button
+                style={{
+                    padding: "0px",
+                    height: "100px",
+                }}
+            >
+                <img
+                    src={src}
+                    alt="Placeholder image"
+                    style={{
+                        height: "100px",
+                    }}
+                />
+                ;
+            </Button>
+        );
+    }
+);
+
+const verticalImages: JSX.Element[] = [
+    "https://placehold.it/100x120/414141/?text=1",
+    "https://placehold.it/100x180?text=2",
+    "https://placehold.it/100x240/414141/?text=3",
+    "https://placehold.it/100x120?text=4",
+    "https://placehold.it/100x640/414141/?text=5",
+    "https://placehold.it/100x200?text=6",
+    "https://placehold.it/100x220/414141/?text=7",
+    "https://placehold.it/100x170?text=8",
+    "https://placehold.it/100x160/414141/?text=9",
+    "https://placehold.it/100x240?text=10",
+    "https://placehold.it/100x110/414141/?text=11",
+    "https://placehold.it/100x270?text=12",
+].map(
+    (src: string): JSX.Element => {
+        return (
+            <Button
+                style={{
+                    padding: "0px",
+                    width: "100px",
+                }}
+            >
+                <img
+                    src={src}
+                    alt="Placeholder image"
+                    style={{
+                        width: "100px",
+                    }}
+                />
+                ;
+            </Button>
+        );
+    }
+);
+
+const uniformImages: JSX.Element[] = [
+    "https://placehold.it/100x100/414141/?text=1",
+    "https://placehold.it/100x100?text=2",
+    "https://placehold.it/100x100/414141/?text=3",
+    "https://placehold.it/100x100?text=4",
+    "https://placehold.it/100x100/414141/?text=5",
+    "https://placehold.it/100x100?text=6",
+    "https://placehold.it/100x100/414141/?text=7",
+    "https://placehold.it/100x100?text=8",
+    "https://placehold.it/100x100/414141/?text=9",
+    "https://placehold.it/100x100?text=10",
+    "https://placehold.it/100x100/414141/?text=11",
+    "https://placehold.it/100x100?text=12",
+].map(
+    (src: string): JSX.Element => {
+        return (
+            <Button
+                style={{
+                    padding: "0px",
+                    width: "100px",
+                    height: "100px",
+                }}
+            >
+                <img
+                    src={src}
+                    alt="Placeholder image"
+                    style={{
+                        width: "100px",
+                        height: "100px",
+                    }}
+                />
+                ;
+            </Button>
+        );
+    }
+);
+
+interface TestStackPanelProps {
+    stackPanelProps?: StackPanelProps;
+    itemCount: number;
+}
+
+class TestStackPanel extends React.Component<TestStackPanelProps, {}> {
+    constructor(props: TestStackPanelProps) {
+        super(props);
+
+        this.state = {};
+    }
+
+    public render(): JSX.Element {
+        return (
+            <StackPanel
+                style={{
+                    width: "117px",
+                    height: "400px",
+                    overflowY: "scroll",
+                }}
+                {...this.props.stackPanelProps}
+            >
+                {this.generateItems()}
+            </StackPanel>
+        );
+    }
+
+    private generateItems = (): React.ReactFragment[] => {
+        const items: React.ReactFragment[] = [];
+
+        const defaultSpan: number = isNil(this.props.stackPanelProps.defaultItemSpan)
+            ? 100
+            : this.props.stackPanelProps.defaultItemSpan;
+
+        const overrideKeys: string[] = isNil(this.props.stackPanelProps.itemSpanOverrides)
+            ? []
+            : Object.keys(this.props.stackPanelProps.itemSpanOverrides);
+
+        for (let i: number = 0; i < this.props.itemCount; i++) {
+            const thisSpan: number = overrideKeys.includes(`${i}`)
+                ? this.props.stackPanelProps.itemSpanOverrides[i]
+                : defaultSpan;
+
+            const thisHeight: number =
+                this.props.stackPanelProps.orientation ===
+                stackPanelOrientation.horizontal
+                    ? 100
+                    : thisSpan;
+
+            const thisWidth: number =
+                this.props.stackPanelProps.orientation ===
+                stackPanelOrientation.horizontal
+                    ? thisSpan
+                    : 100;
+
+            items.push(this.generateItem(i, thisHeight, thisWidth));
+        }
+
+        return items;
+    };
+
+    private generateItem = (
+        index: number,
+        height: number,
+        width: number
+    ): React.ReactChild => {
+        return (
+            <Button
+                tabIndex={index + 1}
+                key={index}
+                style={{
+                    padding: "0px",
+                    width: `${width}px`,
+                    height: `${height}px`,
+                }}
+            >
+                <img
+                    src={`https://placehold.it/${width}x${height}?text=${index + 1}`}
+                    alt="Placeholder image"
+                    style={{
+                        width: `${width}px`,
+                        height: `${height}px`,
+                    }}
+                />
+            </Button>
+        );
+    };
+}
+
+storiesOf("Stack Panel", module)
+    .add("Disable virtualization", () => (
+        <StackPanel
+            defaultItemSpan={100}
+            enableVirtualization={false}
+            style={{
+                width: "117px",
+                height: "400px",
+                overflowY: "scroll",
+            }}
+        >
+            {uniformImages}
+        </StackPanel>
+    ))
+    .add("Vertical uniform", () => (
+        <StackPanel
+            defaultItemSpan={100}
+            style={{
+                width: "117px",
+                height: "400px",
+                overflowY: "scroll",
+            }}
+        >
+            {uniformImages}
+        </StackPanel>
+    ))
+    .add("Horizontal uniform", () => (
+        <StackPanel
+            defaultItemSpan={100}
+            orientation={stackPanelOrientation.horizontal}
+            style={{
+                width: "400px",
+                height: "117px",
+                overflowX: "scroll",
+            }}
+        >
+            {uniformImages}
+        </StackPanel>
+    ))
+    .add("Vertical variable height", () => (
+        <StackPanel
+            defaultItemSpan={100}
+            itemSpanOverrides={itemSpans}
+            style={{
+                width: "117px",
+                height: "400px",
+                overflowY: "scroll",
+            }}
+        >
+            {verticalImages}
+        </StackPanel>
+    ))
+    .add("Horizontal variable width", () => (
+        <StackPanel
+            defaultItemSpan={100}
+            itemSpanOverrides={itemSpans}
+            orientation={stackPanelOrientation.horizontal}
+            style={{
+                width: "400px",
+                height: "117px",
+                overflowX: "scroll",
+            }}
+        >
+            {horizontalImages}
+        </StackPanel>
+    ))
+    .add("Never virtualize first and last", () => (
+        <StackPanel
+            defaultItemSpan={100}
+            itemSpanOverrides={itemSpans}
+            neverVirtualizeIndexes={[0, 11]}
+            style={{
+                width: "117px",
+                height: "400px",
+                overflowY: "scroll",
+            }}
+        >
+            {verticalImages}
+        </StackPanel>
+    ))
+    .add("Disable smooth scrolling", () => (
+        <StackPanel
+            enableSmoothScrolling={false}
+            defaultItemSpan={100}
+            itemSpanOverrides={itemSpans}
+            neverVirtualizeIndexes={[0, 11]}
+            style={{
+                width: "117px",
+                height: "400px",
+                overflowY: "scroll",
+            }}
+        >
+            {verticalImages}
+        </StackPanel>
+    ))
+    .add("Initially visible item set", () => (
+        <StackPanel
+            defaultItemSpan={100}
+            initiallyVisibleItemIndex={6}
+            style={{
+                width: "117px",
+                height: "400px",
+                overflowY: "scroll",
+            }}
+        >
+            {uniformImages}
+        </StackPanel>
+    ))
+    .add("Many items", () => (
+        <TestStackPanel
+            stackPanelProps={{
+                itemSpanOverrides: itemSpans,
+                enableVirtualization: true,
+                preloadBufferLength: 6,
+                neverVirtualizeIndexes: [0, 9999],
+            }}
+            itemCount={10000}
+        />
+    ));

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
@@ -3,24 +3,11 @@ import React from "react";
 import StackPanel, { StackPanelProps } from "./";
 import { isNil } from "lodash-es";
 import Foundation from "@microsoft/fast-components-foundation-react";
-import { ItemSpanOverride } from "./stack-panel.props";
 import Button from "../button";
 import { Orientation } from "@microsoft/fast-web-utilities";
+import { isArray } from "util";
 
-const itemSpans: ItemSpanOverride = {
-    0: 120,
-    1: 180,
-    2: 240,
-    3: 120,
-    4: 640,
-    5: 200,
-    6: 220,
-    7: 170,
-    8: 160,
-    9: 240,
-    10: 110,
-    11: 270,
-};
+const itemSpans: number[] = [120, 180, 240, 120, 640, 200, 220, 170, 160, 240, 110, 270];
 
 const horizontalImages: JSX.Element[] = [
     "https://placehold.it/120x100/414141/?text=1",
@@ -162,18 +149,12 @@ class TestStackPanel extends React.Component<TestStackPanelProps, {}> {
     private generateItems = (): React.ReactFragment[] => {
         const items: React.ReactFragment[] = [];
 
-        const defaultSpan: number = isNil(this.props.stackPanelProps.defaultItemSpan)
-            ? 100
-            : this.props.stackPanelProps.defaultItemSpan;
-
-        const overrideKeys: string[] = isNil(this.props.stackPanelProps.itemSpanOverrides)
-            ? []
-            : Object.keys(this.props.stackPanelProps.itemSpanOverrides);
-
         for (let i: number = 0; i < this.props.itemCount; i++) {
-            const thisSpan: number = overrideKeys.includes(`${i}`)
-                ? this.props.stackPanelProps.itemSpanOverrides[i]
-                : defaultSpan;
+            const thisSpan: number = isArray(this.props.stackPanelProps.itemSpan)
+                ? this.props.stackPanelProps.itemSpan[i]
+                : isNil(this.props.stackPanelProps.itemSpan)
+                    ? 100
+                    : this.props.stackPanelProps.itemSpan;
 
             const thisHeight: number =
                 this.props.stackPanelProps.orientation === Orientation.horizontal
@@ -222,7 +203,7 @@ class TestStackPanel extends React.Component<TestStackPanelProps, {}> {
 storiesOf("Stack Panel", module)
     .add("Disable virtualization", () => (
         <StackPanel
-            defaultItemSpan={100}
+            itemSpan={100}
             virtualize={false}
             style={{
                 width: "117px",
@@ -235,7 +216,7 @@ storiesOf("Stack Panel", module)
     ))
     .add("Vertical uniform", () => (
         <StackPanel
-            defaultItemSpan={100}
+            itemSpan={100}
             style={{
                 width: "117px",
                 height: "400px",
@@ -247,7 +228,7 @@ storiesOf("Stack Panel", module)
     ))
     .add("Horizontal uniform", () => (
         <StackPanel
-            defaultItemSpan={100}
+            itemSpan={100}
             orientation={Orientation.horizontal}
             style={{
                 width: "400px",
@@ -260,8 +241,7 @@ storiesOf("Stack Panel", module)
     ))
     .add("Vertical variable height", () => (
         <StackPanel
-            defaultItemSpan={100}
-            itemSpanOverrides={itemSpans}
+            itemSpan={itemSpans}
             style={{
                 width: "117px",
                 height: "400px",
@@ -273,8 +253,7 @@ storiesOf("Stack Panel", module)
     ))
     .add("Horizontal variable width", () => (
         <StackPanel
-            defaultItemSpan={100}
-            itemSpanOverrides={itemSpans}
+            itemSpan={itemSpans}
             orientation={Orientation.horizontal}
             style={{
                 width: "400px",
@@ -287,8 +266,7 @@ storiesOf("Stack Panel", module)
     ))
     .add("Never virtualize first and last", () => (
         <StackPanel
-            defaultItemSpan={100}
-            itemSpanOverrides={itemSpans}
+            itemSpan={itemSpans}
             neverVirtualizeIndexes={[0, 11]}
             style={{
                 width: "117px",
@@ -302,8 +280,7 @@ storiesOf("Stack Panel", module)
     .add("Disable smooth scrolling", () => (
         <StackPanel
             enableSmoothScrolling={false}
-            defaultItemSpan={100}
-            itemSpanOverrides={itemSpans}
+            itemSpan={itemSpans}
             neverVirtualizeIndexes={[0, 11]}
             style={{
                 width: "117px",
@@ -316,7 +293,7 @@ storiesOf("Stack Panel", module)
     ))
     .add("Initially visible item set", () => (
         <StackPanel
-            defaultItemSpan={100}
+            itemSpan={100}
             initiallyVisibleItemIndex={8}
             style={{
                 width: "117px",
@@ -330,7 +307,6 @@ storiesOf("Stack Panel", module)
     .add("Many items", () => (
         <TestStackPanel
             stackPanelProps={{
-                itemSpanOverrides: itemSpans,
                 virtualize: true,
                 preloadBufferLength: 6,
                 neverVirtualizeIndexes: [0, 9999],

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import StackPanel, { StackPanelProps } from "./";
 import { isNil } from "lodash-es";
 import Foundation from "@microsoft/fast-components-foundation-react";
-import { stackPanelOrientation, ItemSpanOverride } from "./stack-panel.props";
+import { ItemSpanOverride, stackPanelOrientation } from "./stack-panel.props";
 import Button from "../button";
 
 const itemSpans: ItemSpanOverride = {
@@ -35,9 +35,10 @@ const horizontalImages: JSX.Element[] = [
     "https://placehold.it/110x100/414141/?text=11",
     "https://placehold.it/270x100?text=12",
 ].map(
-    (src: string): JSX.Element => {
+    (src: string, index: number): JSX.Element => {
         return (
             <Button
+                key={index}
                 style={{
                     padding: "0px",
                     height: "100px",
@@ -70,9 +71,10 @@ const verticalImages: JSX.Element[] = [
     "https://placehold.it/100x110/414141/?text=11",
     "https://placehold.it/100x270?text=12",
 ].map(
-    (src: string): JSX.Element => {
+    (src: string, index: number): JSX.Element => {
         return (
             <Button
+                key={index}
                 style={{
                     padding: "0px",
                     width: "100px",
@@ -105,9 +107,10 @@ const uniformImages: JSX.Element[] = [
     "https://placehold.it/100x100/414141/?text=11",
     "https://placehold.it/100x100?text=12",
 ].map(
-    (src: string): JSX.Element => {
+    (src: string, index: number): JSX.Element => {
         return (
             <Button
+                key={index}
                 style={{
                     padding: "0px",
                     width: "100px",

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
@@ -317,7 +317,7 @@ storiesOf("Stack Panel", module)
     .add("Initially visible item set", () => (
         <StackPanel
             defaultItemSpan={100}
-            initiallyVisibleItemIndex={6}
+            initiallyVisibleItemIndex={8}
             style={{
                 width: "117px",
                 height: "400px",

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
@@ -224,7 +224,7 @@ storiesOf("Stack Panel", module)
     .add("Disable virtualization", () => (
         <StackPanel
             defaultItemSpan={100}
-            enableVirtualization={false}
+            virtualize={false}
             style={{
                 width: "117px",
                 height: "400px",
@@ -332,7 +332,7 @@ storiesOf("Stack Panel", module)
         <TestStackPanel
             stackPanelProps={{
                 itemSpanOverrides: itemSpans,
-                enableVirtualization: true,
+                virtualize: true,
                 preloadBufferLength: 6,
                 neverVirtualizeIndexes: [0, 9999],
             }}

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
@@ -3,8 +3,9 @@ import React from "react";
 import StackPanel, { StackPanelProps } from "./";
 import { isNil } from "lodash-es";
 import Foundation from "@microsoft/fast-components-foundation-react";
-import { ItemSpanOverride, stackPanelOrientation } from "./stack-panel.props";
+import { ItemSpanOverride } from "./stack-panel.props";
 import Button from "../button";
+import { Orientation } from "@microsoft/fast-web-utilities";
 
 const itemSpans: ItemSpanOverride = {
     0: 120,
@@ -175,14 +176,12 @@ class TestStackPanel extends React.Component<TestStackPanelProps, {}> {
                 : defaultSpan;
 
             const thisHeight: number =
-                this.props.stackPanelProps.orientation ===
-                stackPanelOrientation.horizontal
+                this.props.stackPanelProps.orientation === Orientation.horizontal
                     ? 100
                     : thisSpan;
 
             const thisWidth: number =
-                this.props.stackPanelProps.orientation ===
-                stackPanelOrientation.horizontal
+                this.props.stackPanelProps.orientation === Orientation.horizontal
                     ? thisSpan
                     : 100;
 
@@ -249,7 +248,7 @@ storiesOf("Stack Panel", module)
     .add("Horizontal uniform", () => (
         <StackPanel
             defaultItemSpan={100}
-            orientation={stackPanelOrientation.horizontal}
+            orientation={Orientation.horizontal}
             style={{
                 width: "400px",
                 height: "117px",
@@ -276,7 +275,7 @@ storiesOf("Stack Panel", module)
         <StackPanel
             defaultItemSpan={100}
             itemSpanOverrides={itemSpans}
-            orientation={stackPanelOrientation.horizontal}
+            orientation={Orientation.horizontal}
             style={{
                 width: "400px",
                 height: "117px",

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
@@ -239,6 +239,20 @@ storiesOf("Stack Panel", module)
             {uniformImages}
         </StackPanel>
     ))
+    .add("Horizontal rtl", () => (
+        <StackPanel
+            dir="rtl"
+            itemSpan={100}
+            orientation={Orientation.horizontal}
+            style={{
+                width: "400px",
+                height: "117px",
+                overflowX: "scroll",
+            }}
+        >
+            {uniformImages}
+        </StackPanel>
+    ))
     .add("Vertical variable height", () => (
         <StackPanel
             itemSpan={itemSpans}
@@ -298,5 +312,25 @@ storiesOf("Stack Panel", module)
                 neverVirtualizeIndexes: [0, 9999],
             }}
             itemCount={10000}
+        />
+    ))
+    .add("200 items no virtualization", () => (
+        <TestStackPanel
+            stackPanelProps={{
+                virtualize: false,
+                preloadBufferLength: 6,
+                neverVirtualizeIndexes: [0, 199],
+            }}
+            itemCount={200}
+        />
+    ))
+    .add("200 items virtualized", () => (
+        <TestStackPanel
+            stackPanelProps={{
+                virtualize: true,
+                preloadBufferLength: 6,
+                neverVirtualizeIndexes: [0, 199],
+            }}
+            itemCount={200}
         />
     ));

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.stories.tsx
@@ -277,20 +277,6 @@ storiesOf("Stack Panel", module)
             {verticalImages}
         </StackPanel>
     ))
-    .add("Disable smooth scrolling", () => (
-        <StackPanel
-            enableSmoothScrolling={false}
-            itemSpan={itemSpans}
-            neverVirtualizeIndexes={[0, 11]}
-            style={{
-                width: "117px",
-                height: "400px",
-                overflowY: "scroll",
-            }}
-        >
-            {verticalImages}
-        </StackPanel>
-    ))
     .add("Initially visible item set", () => (
         <StackPanel
             itemSpan={100}

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -130,6 +130,10 @@ class StackPanel extends Foundation<
      * Renders the component
      */
     public render(): React.ReactElement<HTMLDivElement> {
+        const {
+            stackPanel_itemContainer,
+        }: StackPanelClassNameContract = this.props.managedClasses;
+
         return (
             <div
                 {...this.unhandledProps()}
@@ -139,7 +143,7 @@ class StackPanel extends Foundation<
                 onScrollCapture={this.onScrollCapture}
             >
                 <div
-                    // className={classNames(stackPanel_itemContainer)}
+                    className={classNames(stackPanel_itemContainer)}
                     ref={this.itemContainerElement}
                     tabIndex={-1}
                     style={{
@@ -238,9 +242,14 @@ class StackPanel extends Foundation<
      * Create class-names
      */
     protected generateClassNames(): string {
-        const { stackPanel }: StackPanelClassNameContract = this.props.managedClasses;
+        const {
+            stackPanel,
+            stackPanel__isScrolling,
+        }: StackPanelClassNameContract = this.props.managedClasses;
 
-        return super.generateClassNames(classNames(stackPanel));
+        return super.generateClassNames(
+            classNames(stackPanel, [stackPanel__isScrolling, this.state.isScrolling])
+        );
     }
 
     /**

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -21,13 +21,16 @@ import {
 import { isFunction } from "util";
 
 export interface StackPanelState {
-    disabled: boolean;
     isScrolling: boolean;
     renderedRangeStartIndex: number;
     renderedRangeEndIndex: number;
     direction: Direction;
 }
 
+/**
+ * Used to store the pixel coordinates and span of items
+ * along the stackpanel's axis
+ */
 interface ItemPosition {
     start: number;
     span: number;
@@ -118,7 +121,6 @@ class StackPanel extends Foundation<
         this.updateItemPositions();
 
         this.state = {
-            disabled: false,
             renderedRangeStartIndex: 0,
             renderedRangeEndIndex: 0,
             direction: Direction.ltr,
@@ -131,21 +133,19 @@ class StackPanel extends Foundation<
      */
     public render(): React.ReactElement<HTMLDivElement> {
         const {
-            stackPanel_itemContainer,
+            stackPanel_items,
         }: StackPanelClassNameContract = this.props.managedClasses;
 
         return (
             <div
                 {...this.unhandledProps()}
-                tabIndex={-1}
                 ref={this.rootElement}
                 className={this.generateClassNames()}
                 onScrollCapture={this.onScrollCapture}
             >
                 <div
-                    className={classNames(stackPanel_itemContainer)}
+                    className={classNames(stackPanel_items)}
                     ref={this.itemContainerElement}
-                    tabIndex={-1}
                     style={{
                         position: "relative",
                         ...(this.props.orientation === stackPanelOrientation.horizontal

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -14,9 +14,9 @@ import {
 } from "../utilities";
 import {
     StackPanelHandledProps,
+    stackPanelOrientation,
     StackPanelProps,
     StackPanelUnhandledProps,
-    stackPanelOrientation,
 } from "./stack-panel.props";
 import { isFunction } from "util";
 
@@ -40,7 +40,6 @@ class StackPanel extends Foundation<
     StackPanelState
 > {
     public static displayName: string = `${DisplayNamePrefix}StackPanel`;
-    private static DirectionAttributeName: string = "dir";
 
     public static defaultProps: Partial<StackPanelProps> = {
         managedClasses: {},
@@ -54,6 +53,8 @@ class StackPanel extends Foundation<
         enableSmoothScrolling: true,
         scrollDuration: 500,
     };
+
+    private static DirectionAttributeName: string = "dir";
 
     protected handledProps: HandledProps<StackPanelHandledProps> = {
         nextItemPeek: void 0,
@@ -331,6 +332,9 @@ class StackPanel extends Foundation<
      *  Get the size of the viewport along the panel's axis
      */
     private getViewportSpan = (): number => {
+        if (isNil(this.rootElement.current)) {
+            return 0;
+        }
         if (this.props.orientation === stackPanelOrientation.horizontal) {
             return this.rootElement.current.clientWidth;
         } else {
@@ -706,13 +710,11 @@ class StackPanel extends Foundation<
      * (including peek)
      */
     private getScrollIntoViewPosition = (index: number): number => {
-        if (this.itemPositions.length < this.props.initiallyVisibleItemIndex) {
+        if (index >= this.itemPositions.length) {
             return 0;
         }
 
-        const itemPosition: ItemPosition = this.itemPositions[
-            this.props.initiallyVisibleItemIndex
-        ];
+        const itemPosition: ItemPosition = this.itemPositions[index];
         const peek: number = this.getScrollPeek(itemPosition.span);
         const newScrollPosition: number = Math.max(
             0,

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -2,13 +2,12 @@ import { StackPanelClassNameContract } from "@microsoft/fast-components-class-na
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { classNames, Direction, RtlScrollConverter } from "@microsoft/fast-web-utilities";
 import { canUseDOM } from "exenv-es6";
-import { get, isEqual, isNil, memoize, merge } from "lodash-es";
+import { get, isNil, merge } from "lodash-es";
 import React from "react";
 import ReactDOM from "react-dom";
 import { toPx } from "@microsoft/fast-jss-utilities";
 import {
     DisplayNamePrefix,
-    IntersectionObserverEntry,
     ResizeObserverClassDefinition,
     ResizeObserverEntry,
 } from "../utilities";
@@ -246,11 +245,14 @@ class StackPanel extends Foundation<
     protected generateClassNames(): string {
         const {
             stackPanel,
-            stackPanel__isScrolling,
-        }: StackPanelClassNameContract = this.props.managedClasses;
+        }: // stackPanel__scrolling,
+        StackPanelClassNameContract = this.props.managedClasses;
 
         return super.generateClassNames(
-            classNames(stackPanel, [stackPanel__isScrolling, this.state.isScrolling])
+            classNames(
+                stackPanel
+                // [stackPanel__scrolling, this.state.isScrolling]
+            )
         );
     }
 

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -13,11 +13,11 @@ import {
 } from "../utilities";
 import {
     StackPanelHandledProps,
-    stackPanelOrientation,
     StackPanelProps,
     StackPanelUnhandledProps,
 } from "./stack-panel.props";
 import { isFunction } from "util";
+import { Orientation } from "@microsoft/fast-web-utilities";
 
 export interface StackPanelState {
     isScrolling: boolean;
@@ -49,7 +49,7 @@ class StackPanel extends Foundation<
         neverVirtualizeIndexes: [],
         defaultItemSpan: 100,
         preloadBufferLength: 1,
-        orientation: stackPanelOrientation.vertical,
+        orientation: Orientation.vertical,
         nextItemPeek: 50,
         itemSpanOverrides: {},
         enableSmoothScrolling: true,
@@ -149,7 +149,7 @@ class StackPanel extends Foundation<
                     ref={this.itemContainerElement}
                     style={{
                         position: "relative",
-                        ...(this.props.orientation === stackPanelOrientation.horizontal
+                        ...(this.props.orientation === Orientation.horizontal
                             ? {
                                   height: "100%",
                                   width: `${this.itemContainerSpan}px`,
@@ -282,7 +282,7 @@ class StackPanel extends Foundation<
 
         const newStyleProps: React.CSSProperties = {
             position: "absolute",
-            ...(this.props.orientation === stackPanelOrientation.horizontal
+            ...(this.props.orientation === Orientation.horizontal
                 ? {
                       width: toPx(this.itemPositions[index].span),
                       left: toPx(this.itemPositions[index].start),
@@ -348,7 +348,7 @@ class StackPanel extends Foundation<
         if (isNil(this.rootElement.current)) {
             return 0;
         }
-        if (this.props.orientation === stackPanelOrientation.horizontal) {
+        if (this.props.orientation === Orientation.horizontal) {
             return this.rootElement.current.clientWidth;
         } else {
             return this.rootElement.current.clientHeight;
@@ -385,7 +385,7 @@ class StackPanel extends Foundation<
             return;
         }
 
-        if (this.props.orientation === stackPanelOrientation.horizontal) {
+        if (this.props.orientation === Orientation.horizontal) {
             this.updateDirection();
         }
 
@@ -563,7 +563,7 @@ class StackPanel extends Foundation<
 
         let scrollPos: number = 0;
 
-        if (this.props.orientation === stackPanelOrientation.vertical) {
+        if (this.props.orientation === Orientation.vertical) {
             scrollPos = this.rootElement.current.scrollTop;
         } else {
             scrollPos = RtlScrollConverter.getScrollLeft(
@@ -584,7 +584,7 @@ class StackPanel extends Foundation<
             return;
         }
 
-        if (this.props.orientation === stackPanelOrientation.vertical) {
+        if (this.props.orientation === Orientation.vertical) {
             this.rootElement.current.scrollTop = scrollValue;
         } else {
             RtlScrollConverter.setScrollLeft(
@@ -619,12 +619,12 @@ class StackPanel extends Foundation<
 
         // smooth scroll into view
         const itemStart: number =
-            this.props.orientation === stackPanelOrientation.horizontal
+            this.props.orientation === Orientation.horizontal
                 ? (event.currentTarget as HTMLElement).offsetLeft
                 : (event.currentTarget as HTMLElement).offsetTop;
 
         const itemSpan: number =
-            this.props.orientation === stackPanelOrientation.horizontal
+            this.props.orientation === Orientation.horizontal
                 ? (event.currentTarget as HTMLElement).clientWidth
                 : (event.currentTarget as HTMLElement).clientHeight;
         const itemEnd: number = itemStart + itemSpan;

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -46,7 +46,7 @@ class StackPanel extends Foundation<
 
     public static defaultProps: Partial<StackPanelProps> = {
         managedClasses: {},
-        enableVirtualization: true,
+        virtualize: true,
         neverVirtualizeIndexes: [],
         defaultItemSpan: 100,
         preloadBufferLength: 1,
@@ -62,7 +62,7 @@ class StackPanel extends Foundation<
     protected handledProps: HandledProps<StackPanelHandledProps> = {
         nextItemPeek: void 0,
         defaultItemSpan: void 0,
-        enableVirtualization: void 0,
+        virtualize: void 0,
         neverVirtualizeIndexes: void 0,
         itemSpanOverrides: void 0,
         preloadBufferLength: void 0,
@@ -268,7 +268,7 @@ class StackPanel extends Foundation<
      */
     private renderItem = (item: React.ReactNode, index: number): React.ReactChild => {
         if (
-            this.props.enableVirtualization &&
+            this.props.virtualize &&
             !this.props.neverVirtualizeIndexes.includes(index) &&
             (index < this.state.renderedRangeStartIndex ||
                 index > this.state.renderedRangeEndIndex)

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -1,0 +1,727 @@
+import { StackPanelClassNameContract } from "@microsoft/fast-components-class-name-contracts-base";
+import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
+import { classNames, Direction, RtlScrollConverter } from "@microsoft/fast-web-utilities";
+import { canUseDOM } from "exenv-es6";
+import { get, isEqual, isNil, memoize, merge } from "lodash-es";
+import React from "react";
+import ReactDOM from "react-dom";
+import { toPx } from "@microsoft/fast-jss-utilities";
+import {
+    DisplayNamePrefix,
+    IntersectionObserverEntry,
+    ResizeObserverClassDefinition,
+    ResizeObserverEntry,
+} from "../utilities";
+import {
+    StackPanelHandledProps,
+    StackPanelProps,
+    StackPanelUnhandledProps,
+    stackPanelOrientation,
+} from "./stack-panel.props";
+import { isFunction } from "util";
+
+export interface StackPanelState {
+    disabled: boolean;
+    isScrolling: boolean;
+    renderedRangeStartIndex: number;
+    renderedRangeEndIndex: number;
+    direction: Direction;
+}
+
+interface ItemPosition {
+    start: number;
+    span: number;
+    end: number;
+}
+
+class StackPanel extends Foundation<
+    StackPanelHandledProps,
+    StackPanelUnhandledProps,
+    StackPanelState
+> {
+    public static displayName: string = `${DisplayNamePrefix}StackPanel`;
+    private static DirectionAttributeName: string = "dir";
+
+    public static defaultProps: Partial<StackPanelProps> = {
+        managedClasses: {},
+        enableVirtualization: true,
+        neverVirtualizeIndexes: [],
+        defaultItemSpan: 100,
+        preloadBufferLength: 1,
+        orientation: stackPanelOrientation.vertical,
+        nextItemPeek: 50,
+        itemSpanOverrides: {},
+        enableSmoothScrolling: true,
+        scrollDuration: 500,
+    };
+
+    protected handledProps: HandledProps<StackPanelHandledProps> = {
+        nextItemPeek: void 0,
+        defaultItemSpan: void 0,
+        enableVirtualization: void 0,
+        neverVirtualizeIndexes: void 0,
+        itemSpanOverrides: void 0,
+        preloadBufferLength: void 0,
+        orientation: void 0,
+        enableSmoothScrolling: void 0,
+        scrollDuration: void 0,
+        managedClasses: void 0,
+        initiallyVisibleItemIndex: void 0,
+    };
+
+    private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
+        HTMLDivElement
+    >();
+
+    private itemContainerElement: React.RefObject<HTMLDivElement> = React.createRef<
+        HTMLDivElement
+    >();
+
+    private openRequestAnimationFrame: number = null;
+    private resizeDetector: ResizeObserverClassDefinition;
+    private itemPositions: ItemPosition[];
+    private viewPortSpan: number = 0;
+    private itemContainerSpan: number = 0;
+
+    /**
+     *  The position the current scroll animation started at
+     */
+    private currentScrollAnimStartPosition: number;
+
+    /**
+     * The target position of the current scroll animation
+     */
+    private currentScrollAnimEndPosition: number;
+
+    /**
+     * Start time for current scroll animation
+     */
+    private currentScrollAnimStartTime: number;
+
+    /**
+     * Flag indicates if a scroll animation is in progress
+     */
+    private isScrollAnimating: boolean = false;
+
+    /**
+     * Stores last scroll position from scroll events
+     */
+    private lastRecordedScroll: number = 0;
+
+    /**
+     * constructor
+     */
+    constructor(props: StackPanelProps) {
+        super(props);
+
+        this.updateItemPositions();
+
+        this.state = {
+            disabled: false,
+            renderedRangeStartIndex: 0,
+            renderedRangeEndIndex: 0,
+            direction: Direction.ltr,
+            isScrolling: false,
+        };
+    }
+
+    /**
+     * Renders the component
+     */
+    public render(): React.ReactElement<HTMLDivElement> {
+        return (
+            <div
+                {...this.unhandledProps()}
+                tabIndex={-1}
+                ref={this.rootElement}
+                className={this.generateClassNames()}
+                onScrollCapture={this.onScrollCapture}
+            >
+                <div
+                    // className={classNames(stackPanel_itemContainer)}
+                    ref={this.itemContainerElement}
+                    tabIndex={-1}
+                    style={{
+                        position: "relative",
+                        ...(this.props.orientation === stackPanelOrientation.horizontal
+                            ? {
+                                  height: "100%",
+                                  width: `${this.itemContainerSpan}px`,
+                                  overflow: "hidden",
+                              }
+                            : {
+                                  width: "100%",
+                                  height: `${this.itemContainerSpan}px`,
+                                  overflow: "hidden",
+                              }),
+                    }}
+                >
+                    {this.renderItems()}
+                </div>
+            </div>
+        );
+    }
+
+    /**
+     * React life-cycle method
+     */
+    public componentDidMount(): void {
+        if (!isNil(this.rootElement.current)) {
+            if (((window as unknown) as WindowWithResizeObserver).ResizeObserver) {
+                this.resizeDetector = new ((window as unknown) as WindowWithResizeObserver).ResizeObserver(
+                    this.handleResize
+                );
+                this.resizeDetector.observe(this.rootElement.current);
+            }
+        }
+
+        this.viewPortSpan = this.getViewportSpan();
+
+        if (
+            !isNil(this.props.initiallyVisibleItemIndex) &&
+            this.itemPositions.length > this.props.initiallyVisibleItemIndex
+        ) {
+            const newScrollPosition: number = this.getScrollIntoViewPosition(
+                this.props.initiallyVisibleItemIndex
+            );
+            this.setScrollPosition(newScrollPosition);
+        }
+
+        this.updateLayout();
+    }
+
+    /**
+     * React life-cycle method
+     */
+    public componentDidUpdate(prevProps: StackPanelProps): void {
+        if (prevProps.orientation !== this.props.orientation) {
+            this.viewPortSpan = this.getViewportSpan();
+        }
+
+        if (
+            prevProps.itemSpanOverrides !== this.props.itemSpanOverrides ||
+            prevProps.defaultItemSpan !== this.props.defaultItemSpan ||
+            prevProps.orientation !== this.props.orientation ||
+            prevProps.children !== this.props.children
+        ) {
+            this.updateItemPositions();
+            this.updateLayout();
+        }
+
+        if (
+            prevProps.initiallyVisibleItemIndex !==
+                this.props.initiallyVisibleItemIndex &&
+            !isNil(this.props.initiallyVisibleItemIndex) &&
+            this.itemPositions.length > this.props.initiallyVisibleItemIndex
+        ) {
+            const newScrollPosition: number = this.getScrollIntoViewPosition(
+                this.props.initiallyVisibleItemIndex
+            );
+            this.scrollContent(this.getScrollPosition(), newScrollPosition);
+        }
+    }
+
+    /**
+     * React life-cycle method
+     */
+    public componentWillUnmount(): void {
+        if (!isNil(this.rootElement.current)) {
+            if (((window as unknown) as WindowWithResizeObserver).ResizeObserver) {
+                this.resizeDetector.disconnect();
+                this.resizeDetector = null;
+            }
+        }
+    }
+
+    /**
+     * Create class-names
+     */
+    protected generateClassNames(): string {
+        const { stackPanel }: StackPanelClassNameContract = this.props.managedClasses;
+
+        return super.generateClassNames(classNames(stackPanel));
+    }
+
+    /**
+     * Render the items
+     */
+    private renderItems(): React.ReactFragment[] {
+        return React.Children.map(this.props.children, this.renderItem);
+    }
+
+    private isClonableElement(node: React.ReactNode): node is React.ReactElement<any> {
+        return React.isValidElement(node);
+    }
+
+    /**
+     * Render a single item
+     */
+    private renderItem = (item: React.ReactNode, index: number): React.ReactChild => {
+        if (
+            this.props.enableVirtualization &&
+            !this.props.neverVirtualizeIndexes.includes(index) &&
+            (index < this.state.renderedRangeStartIndex ||
+                index > this.state.renderedRangeEndIndex)
+        ) {
+            return;
+        }
+
+        const newStyleProps: React.CSSProperties = {
+            position: "absolute",
+            ...(this.props.orientation === stackPanelOrientation.horizontal
+                ? {
+                      width: toPx(this.itemPositions[index].span),
+                      left: toPx(this.itemPositions[index].start),
+                  }
+                : {
+                      height: toPx(this.itemPositions[index].span),
+                      top: toPx(this.itemPositions[index].start),
+                  }),
+        };
+
+        if (this.isClonableElement(item)) {
+            const styleProps: React.CSSProperties = get(item.props, "style");
+            return React.cloneElement(item, {
+                onFocusCapture: this.onItemFocus,
+                style: merge({}, styleProps, newStyleProps),
+            });
+        }
+
+        // it's a string, so wrap it in a div for positioning
+        return (
+            <div onFocusCapture={this.onItemFocus} style={newStyleProps}>
+                {item}
+            </div>
+        );
+    };
+
+    /**
+     * Builds a list of positioning data for all items
+     */
+    private updateItemPositions = (): void => {
+        const itemPositions: ItemPosition[] = [];
+        let currentItemTop: number = 0;
+        const childrenAsArray: React.ReactNode[] = React.Children.toArray(
+            this.props.children
+        );
+        const itemCount: number = childrenAsArray.length;
+        const keys: string[] = Object.keys(this.props.itemSpanOverrides);
+
+        for (let i: number = 0; i < itemCount; i++) {
+            const itemKey: string = i.toString();
+            const itemHeight: number = keys.includes(itemKey)
+                ? this.props.itemSpanOverrides[itemKey]
+                : this.props.defaultItemSpan;
+            const itemBottom: number = currentItemTop + itemHeight;
+            itemPositions.push({
+                span: itemHeight,
+                start: currentItemTop,
+                end: itemBottom,
+            });
+
+            currentItemTop = itemBottom;
+        }
+
+        this.itemPositions = itemPositions;
+        this.itemContainerSpan =
+            this.itemPositions.length > 0 ? this.itemPositions[itemCount - 1].end : 0;
+    };
+
+    /**
+     *  Get the size of the viewport along the panel's axis
+     */
+    private getViewportSpan = (): number => {
+        if (this.props.orientation === stackPanelOrientation.horizontal) {
+            return this.rootElement.current.clientWidth;
+        } else {
+            return this.rootElement.current.clientHeight;
+        }
+    };
+
+    /**
+     * Request's an animation frame if there are currently no open animation frame requests
+     */
+    private requestFrame = (): void => {
+        if (this.openRequestAnimationFrame === null) {
+            this.openRequestAnimationFrame = window.requestAnimationFrame(
+                this.gotAnimationFrame
+            );
+        }
+    };
+
+    /**
+     * Got an animation frame
+     */
+    private gotAnimationFrame = (): void => {
+        this.openRequestAnimationFrame = null;
+        this.updateLayout();
+        if (this.isScrollAnimating) {
+            this.updateScrollAnimation();
+        }
+    };
+
+    /**
+     * Recalculates the layout
+     */
+    private updateLayout = (): void => {
+        if (isNil(this.rootElement.current) || isNil(this.itemContainerElement.current)) {
+            return;
+        }
+
+        if (this.props.orientation === stackPanelOrientation.horizontal) {
+            this.updateDirection();
+        }
+
+        const scrollPos: number = this.getScrollPosition();
+        const lastIndex: number =
+            this.itemPositions.length === 0 ? 0 : this.itemPositions.length - 1;
+
+        const effectiveViewportSpan: number =
+            this.viewPortSpan >= this.props.defaultItemSpan
+                ? this.viewPortSpan
+                : this.props.defaultItemSpan;
+
+        const visibleRangeStartIndex: number = this.getThresholdItemIndex(
+            this.itemPositions,
+            0,
+            scrollPos
+        );
+        const visibleRangeEndIndex: number = this.getThresholdItemIndex(
+            this.itemPositions,
+            visibleRangeStartIndex,
+            scrollPos + effectiveViewportSpan
+        );
+
+        const bufferLength: number = this.getBufferLength();
+
+        let renderStartIndex: number = visibleRangeStartIndex - bufferLength;
+        if (renderStartIndex < 0) {
+            renderStartIndex = 0;
+        }
+
+        let renderEndIndex: number = visibleRangeEndIndex + bufferLength;
+        if (renderEndIndex > lastIndex) {
+            renderEndIndex = lastIndex;
+        }
+        this.setState({
+            renderedRangeStartIndex: renderStartIndex,
+            renderedRangeEndIndex: renderEndIndex,
+            isScrolling: this.itemContainerSpan > this.viewPortSpan ? true : false,
+        });
+    };
+
+    /**
+     *  Animate one frame of scrolling
+     */
+    private updateScrollAnimation = (): void => {
+        const currentDate: number = new Date().getTime();
+        const currentTime: number = currentDate - this.currentScrollAnimStartTime;
+
+        this.setScrollPosition(
+            this.getScrollAnimationPosition(currentTime, this.props.scrollDuration)
+        );
+
+        if (currentTime < this.props.scrollDuration) {
+            this.requestFrame();
+        } else {
+            this.isScrollAnimating = false;
+        }
+    };
+
+    /**
+     * gets the first row where the row bottom exceeds the threshold value
+     * returns final item index if no rows reach threshold value
+     */
+    private getThresholdItemIndex = (
+        itemPositions: ItemPosition[],
+        startIndex: number,
+        threshold: number
+    ): number => {
+        if (itemPositions.length === 0) {
+            return 0;
+        }
+        let thresholdIndex: number = itemPositions.length - 1;
+        for (
+            let i: number = startIndex, rowCount: number = itemPositions.length;
+            i < rowCount;
+            i++
+        ) {
+            const thisItemPosition: ItemPosition = itemPositions[i];
+            if (thisItemPosition.end >= threshold) {
+                thresholdIndex = i;
+                break;
+            }
+        }
+
+        return thresholdIndex;
+    };
+
+    /**
+     * gets the current buffer size (number of items to render outside the viewport)
+     */
+    private getBufferLength = (): number => {
+        if (
+            !isNil(this.props.preloadBufferLength) &&
+            this.props.preloadBufferLength >= 0
+        ) {
+            return Math.floor(this.props.preloadBufferLength);
+        }
+
+        if (!isNil(this.rootElement) && !isNil(this.rootElement.current)) {
+            // one page is default
+            const bufferSize: number = Math.ceil(
+                this.viewPortSpan / this.props.defaultItemSpan
+            );
+            return bufferSize > 1 ? bufferSize : 1;
+        }
+
+        return 1;
+    };
+
+    /**
+     *  Handle scroll events
+     */
+    private onScrollCapture = (): void => {
+        this.lastRecordedScroll = this.getScrollPosition();
+        this.requestFrame();
+        if (isFunction(this.props.onScrollChange)) {
+            // TODO: store max scroll so we don't recalc
+            this.props.onScrollChange(
+                this.lastRecordedScroll,
+                this.getMaxScrollDistance()
+            );
+        }
+    };
+
+    /**
+     *  Handle viewport resize events
+     */
+    private handleResize = (entries: ResizeObserverEntry[]): void => {
+        this.viewPortSpan = this.getViewportSpan();
+        this.requestFrame();
+    };
+
+    /**
+     *  updates the direction in state if necessary
+     */
+    private updateDirection = (): void => {
+        const newDirection: Direction = this.getDirection();
+        if (newDirection !== this.state.direction) {
+            this.setState({
+                direction: newDirection,
+            });
+        }
+    };
+
+    /**
+     *  gets the current direction
+     */
+    private getDirection = (): Direction | null => {
+        if (this.rootElement.current === null) {
+            return Direction.ltr;
+        }
+
+        const closest: Element = this.rootElement.current.closest(
+            `[${StackPanel.DirectionAttributeName}]`
+        );
+
+        return closest === null ||
+            closest.getAttribute(StackPanel.DirectionAttributeName) === Direction.ltr
+            ? Direction.ltr
+            : Direction.rtl;
+    };
+
+    /**
+     *  Gets the scroll position and accounts for direction
+     */
+    private getScrollPosition = (): number => {
+        if (isNil(this.rootElement.current)) {
+            return 0;
+        }
+
+        let scrollPos: number = 0;
+
+        if (this.props.orientation === stackPanelOrientation.vertical) {
+            scrollPos = this.rootElement.current.scrollTop;
+        } else {
+            scrollPos = RtlScrollConverter.getScrollLeft(
+                this.rootElement.current,
+                this.state.direction
+            );
+            scrollPos = this.state.direction === Direction.rtl ? -scrollPos : scrollPos;
+        }
+
+        return scrollPos;
+    };
+
+    /**
+     *  Sets the scroll position and accounts for direction
+     */
+    private setScrollPosition = (scrollValue: number): void => {
+        if (isNil(this.rootElement.current)) {
+            return;
+        }
+
+        if (this.props.orientation === stackPanelOrientation.vertical) {
+            this.rootElement.current.scrollTop = scrollValue;
+        } else {
+            RtlScrollConverter.setScrollLeft(
+                this.rootElement.current,
+                this.state.direction === Direction.rtl ? -scrollValue : scrollValue,
+                this.state.direction
+            );
+        }
+    };
+
+    /**
+     *  Compares viewport, item and desired peek value to come up with
+     *  peek value to use. We don't want to clip focused item to get peek on next/previous item.
+     */
+    private getScrollPeek = (itemSpan: number): number => {
+        let maxPeek: number = this.viewPortSpan - itemSpan;
+        maxPeek = maxPeek < 0 ? 0 : maxPeek;
+
+        const peek: number =
+            this.props.nextItemPeek > maxPeek ? maxPeek : this.props.nextItemPeek;
+
+        return peek;
+    };
+
+    /**
+     * A child item got focus
+     */
+    private onItemFocus = (event: React.FocusEvent): void => {
+        if (!this.state.isScrolling || !this.props.enableSmoothScrolling) {
+            return;
+        }
+
+        // smooth scroll into view
+        const itemStart: number =
+            this.props.orientation === stackPanelOrientation.horizontal
+                ? (event.currentTarget as HTMLElement).offsetLeft
+                : (event.currentTarget as HTMLElement).offsetTop;
+
+        const itemSpan: number =
+            this.props.orientation === stackPanelOrientation.horizontal
+                ? (event.currentTarget as HTMLElement).clientWidth
+                : (event.currentTarget as HTMLElement).clientHeight;
+        const itemEnd: number = itemStart + itemSpan;
+
+        const peek: number = this.getScrollPeek(itemSpan);
+
+        let scrollStart: number = this.lastRecordedScroll;
+
+        if (this.isScrollAnimating) {
+            const duration: number = this.props.scrollDuration;
+            const currentDate: number = new Date().getTime();
+            const currentTime: number = currentDate - this.currentScrollAnimStartTime;
+
+            scrollStart = this.getScrollAnimationPosition(currentTime, duration);
+        }
+
+        if (itemStart - this.lastRecordedScroll < 0) {
+            this.scrollContent(scrollStart, itemStart - peek);
+        } else if (itemEnd - scrollStart > this.viewPortSpan) {
+            this.scrollContent(scrollStart, itemEnd - this.viewPortSpan + peek);
+        }
+    };
+
+    /**
+     * Scrolls the container for the items list
+     */
+    private scrollContent(
+        startScrollPosition: number,
+        targetScrollPosition: number
+    ): void {
+        const newScrollPosition: number = Math.max(
+            0,
+            Math.min(targetScrollPosition, this.getMaxScrollDistance())
+        );
+
+        if (this.props.enableSmoothScrolling) {
+            this.isScrollAnimating = true;
+            this.currentScrollAnimStartPosition = startScrollPosition;
+            this.currentScrollAnimEndPosition = newScrollPosition;
+            this.currentScrollAnimStartTime = new Date().getTime();
+            this.requestFrame();
+        } else {
+            this.isScrollAnimating = false;
+            this.setScrollPosition(newScrollPosition);
+        }
+    }
+
+    /**
+     * Easing animation
+     */
+    private easeInOutQuad(
+        currentTime: number,
+        startValue: number,
+        changeInValue: number,
+        duration: number
+    ): number {
+        currentTime /= duration / 2;
+
+        if (currentTime < 1) {
+            return (changeInValue / 2) * currentTime * currentTime + startValue;
+        }
+
+        currentTime--;
+
+        return (-changeInValue / 2) * (currentTime * (currentTime - 2) - 1) + startValue;
+    }
+
+    /**
+     * Gets the maximum distance that can be scrolled
+     */
+    private getMaxScrollDistance(): number {
+        if (this.itemPositions.length === 0) {
+            return 0;
+        }
+
+        const contentSpan: number = this.itemPositions[this.itemPositions.length - 1].end;
+        return contentSpan - this.viewPortSpan;
+    }
+
+    /**
+     *  get scroll animation position for the provided time
+     */
+    private getScrollAnimationPosition = (
+        currentTime: number,
+        duration: number
+    ): number => {
+        if (currentTime < duration) {
+            return this.easeInOutQuad(
+                currentTime,
+                this.currentScrollAnimStartPosition,
+                this.currentScrollAnimEndPosition - this.currentScrollAnimStartPosition,
+                duration
+            );
+        } else {
+            return this.currentScrollAnimEndPosition;
+        }
+    };
+
+    /**
+     * Gets the scroll position that brings the item at a particular index into the viewport
+     * (including peek)
+     */
+    private getScrollIntoViewPosition = (index: number): number => {
+        if (this.itemPositions.length < this.props.initiallyVisibleItemIndex) {
+            return 0;
+        }
+
+        const itemPosition: ItemPosition = this.itemPositions[
+            this.props.initiallyVisibleItemIndex
+        ];
+        const peek: number = this.getScrollPeek(itemPosition.span);
+        const newScrollPosition: number = Math.max(
+            0,
+            Math.min(itemPosition.start - peek, this.getMaxScrollDistance())
+        );
+        return newScrollPosition;
+    };
+}
+
+export default StackPanel;
+export * from "./stack-panel.props";
+export { StackPanelClassNameContract };

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -71,6 +71,8 @@ class StackPanel extends Foundation<
         scrollDuration: void 0,
         managedClasses: void 0,
         initiallyVisibleItemIndex: void 0,
+        onRenderedRangeChange: void 0,
+        onScrollChange: void 0,
     };
 
     private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
@@ -416,6 +418,11 @@ class StackPanel extends Foundation<
         if (renderEndIndex > lastIndex) {
             renderEndIndex = lastIndex;
         }
+
+        if (isFunction(this.props.onRenderedRangeChange)) {
+            this.props.onRenderedRangeChange(renderStartIndex, renderEndIndex);
+        }
+
         this.setState({
             renderedRangeStartIndex: renderStartIndex,
             renderedRangeEndIndex: renderEndIndex,

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -70,7 +70,6 @@ class StackPanel extends Foundation<
         scrollDuration: void 0,
         managedClasses: void 0,
         initiallyVisibleItemIndex: void 0,
-        onRenderedRangeChange: void 0,
         onScrollChange: void 0,
     };
 
@@ -421,10 +420,6 @@ class StackPanel extends Foundation<
             renderEndIndex = lastIndex;
         }
 
-        if (isFunction(this.props.onRenderedRangeChange)) {
-            this.props.onRenderedRangeChange(renderStartIndex, renderEndIndex);
-        }
-
         this.setState({
             renderedRangeStartIndex: renderStartIndex,
             renderedRangeEndIndex: renderEndIndex,
@@ -507,10 +502,11 @@ class StackPanel extends Foundation<
         this.lastRecordedScroll = this.getScrollPosition();
         this.requestFrame();
         if (isFunction(this.props.onScrollChange)) {
-            // TODO: store max scroll so we don't recalc
+            // TODO: store max scroll so we don't recalculate
             this.props.onScrollChange(
                 this.lastRecordedScroll,
-                this.getMaxScrollDistance()
+                this.getMaxScrollDistance(),
+                this.viewPortSpan
             );
         }
     };

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -86,7 +86,7 @@ class StackPanel extends Foundation<
     private openRequestAnimationFrame: number = null;
     private resizeDetector: ResizeObserverClassDefinition;
     private itemPositions: ItemPosition[];
-    private viewPortSpan: number = 0;
+    private viewportSpan: number = 0;
     private itemContainerSpan: number = 0;
     private maxScroll: number = 0;
 
@@ -188,7 +188,7 @@ class StackPanel extends Foundation<
             }
         }
 
-        this.viewPortSpan = this.getViewportSpan();
+        this.viewportSpan = this.getViewportSpan();
         this.updateLayout();
 
         if (
@@ -207,7 +207,7 @@ class StackPanel extends Foundation<
      */
     public componentDidUpdate(prevProps: StackPanelProps): void {
         if (prevProps.orientation !== this.props.orientation) {
-            this.viewPortSpan = this.getViewportSpan();
+            this.viewportSpan = this.getViewportSpan();
         }
 
         if (
@@ -359,7 +359,7 @@ class StackPanel extends Foundation<
         }
 
         const contentSpan: number = this.itemPositions[this.itemPositions.length - 1].end;
-        return contentSpan - this.viewPortSpan;
+        return contentSpan - this.viewportSpan;
     }
 
     /**
@@ -412,8 +412,8 @@ class StackPanel extends Foundation<
             this.itemPositions.length === 0 ? 0 : this.itemPositions.length - 1;
 
         const effectiveViewportSpan: number =
-            this.viewPortSpan >= this.props.defaultItemSpan
-                ? this.viewPortSpan
+            this.viewportSpan >= this.props.defaultItemSpan
+                ? this.viewportSpan
                 : this.props.defaultItemSpan;
 
         const visibleRangeStartIndex: number = this.getThresholdItemIndex(
@@ -444,7 +444,7 @@ class StackPanel extends Foundation<
         this.setState({
             renderedRangeStartIndex: renderStartIndex,
             renderedRangeEndIndex: renderEndIndex,
-            isScrollable: this.itemContainerSpan > this.viewPortSpan ? true : false,
+            isScrollable: this.itemContainerSpan > this.viewportSpan ? true : false,
         });
     };
 
@@ -508,7 +508,7 @@ class StackPanel extends Foundation<
         if (!isNil(this.rootElement) && !isNil(this.rootElement.current)) {
             // one page is default
             const bufferSize: number = Math.ceil(
-                this.viewPortSpan / this.props.defaultItemSpan
+                this.viewportSpan / this.props.defaultItemSpan
             );
             return bufferSize > 1 ? bufferSize : 1;
         }
@@ -538,7 +538,7 @@ class StackPanel extends Foundation<
             this.props.onScrollChange(
                 this.lastRecordedScroll,
                 this.maxScroll,
-                this.viewPortSpan
+                this.viewportSpan
             );
         }
     };
@@ -547,7 +547,7 @@ class StackPanel extends Foundation<
      *  Handle viewport resize events
      */
     private handleResize = (entries: ResizeObserverEntry[]): void => {
-        this.viewPortSpan = this.getViewportSpan();
+        this.viewportSpan = this.getViewportSpan();
         this.updateLayout();
     };
 
@@ -628,7 +628,7 @@ class StackPanel extends Foundation<
      *  peek value to use. We don't want to clip focused item to get peek on next/previous item.
      */
     private getScrollPeek = (itemSpan: number): number => {
-        let maxPeek: number = this.viewPortSpan - itemSpan;
+        let maxPeek: number = this.viewportSpan - itemSpan;
         maxPeek = maxPeek < 0 ? 0 : maxPeek;
 
         const peek: number =
@@ -671,8 +671,8 @@ class StackPanel extends Foundation<
 
         if (itemStart - this.lastRecordedScroll < 0) {
             this.scrollContent(scrollStart, itemStart - peek);
-        } else if (itemEnd - scrollStart > this.viewPortSpan) {
-            this.scrollContent(scrollStart, itemEnd - this.viewPortSpan + peek);
+        } else if (itemEnd - scrollStart > this.viewportSpan) {
+            this.scrollContent(scrollStart, itemEnd - this.viewportSpan + peek);
         }
     };
 

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -50,23 +50,17 @@ class StackPanel extends Foundation<
         itemSpan: 100,
         preloadBufferLength: 1,
         orientation: Orientation.vertical,
-        nextItemPeek: 50,
-        enableSmoothScrolling: true,
-        scrollDuration: 500,
         scrollLayoutUpdateDelay: 50,
     };
 
     private static DirectionAttributeName: string = "dir";
 
     protected handledProps: HandledProps<StackPanelHandledProps> = {
-        nextItemPeek: void 0,
         itemSpan: void 0,
         virtualize: void 0,
         neverVirtualizeIndexes: void 0,
         preloadBufferLength: void 0,
         orientation: void 0,
-        enableSmoothScrolling: void 0,
-        scrollDuration: void 0,
         managedClasses: void 0,
         initiallyVisibleItemIndex: void 0,
         onScrollChange: void 0,
@@ -86,7 +80,6 @@ class StackPanel extends Foundation<
         HTMLDivElement
     >();
 
-    private openRequestAnimationFrame: number = null;
     private resizeDetector: ResizeObserverClassDefinition;
     private itemPositions: ItemPosition[];
     private viewportSpan: number = 0;
@@ -153,6 +146,7 @@ class StackPanel extends Foundation<
                 ref={this.rootElement}
                 className={this.generateClassNames()}
                 onScrollCapture={this.onScrollCapture}
+                tabIndex={-1}
             >
                 <div
                     className={classNames(stackPanel_items)}
@@ -306,17 +300,12 @@ class StackPanel extends Foundation<
         if (this.isClonableElement(item)) {
             const styleProps: React.CSSProperties = get(item.props, "style");
             return React.cloneElement(item, {
-                onFocusCapture: this.onItemFocus,
                 style: merge({}, styleProps, newStyleProps),
             });
         }
 
         // it's a string, so wrap it in a div for positioning
-        return (
-            <div onFocusCapture={this.onItemFocus} style={newStyleProps}>
-                {item}
-            </div>
-        );
+        return <div style={newStyleProps}>{item}</div>;
     };
 
     /**
@@ -378,25 +367,6 @@ class StackPanel extends Foundation<
     };
 
     /**
-     * Request's an animation frame if there are currently no open animation frame requests
-     */
-    private requestFrame = (): void => {
-        if (this.openRequestAnimationFrame === null) {
-            this.openRequestAnimationFrame = window.requestAnimationFrame(
-                this.gotAnimationFrame
-            );
-        }
-    };
-
-    /**
-     * Got an animation frame
-     */
-    private gotAnimationFrame = (): void => {
-        this.openRequestAnimationFrame = null;
-        this.updateScrollAnimation();
-    };
-
-    /**
      * Recalculates the layout
      */
     private updateLayout = (): void => {
@@ -442,24 +412,6 @@ class StackPanel extends Foundation<
             renderedRangeEndIndex: renderEndIndex,
             isScrollable: this.itemContainerSpan > this.viewportSpan ? true : false,
         });
-    };
-
-    /**
-     *  Animate one frame of scrolling
-     */
-    private updateScrollAnimation = (): void => {
-        const currentDate: number = new Date().getTime();
-        const currentTime: number = currentDate - this.currentScrollAnimStartTime;
-
-        this.setScrollPosition(
-            this.getScrollAnimationPosition(currentTime, this.props.scrollDuration)
-        );
-
-        if (currentTime < this.props.scrollDuration) {
-            this.requestFrame();
-        } else {
-            this.isScrollAnimating = false;
-        }
     };
 
     /**
@@ -516,10 +468,6 @@ class StackPanel extends Foundation<
             }, this.props.scrollLayoutUpdateDelay);
         } else {
             this.updateLayout();
-        }
-
-        if (this.isScrollAnimating) {
-            this.requestFrame();
         }
 
         if (isFunction(this.props.onScrollChange)) {
@@ -612,59 +560,6 @@ class StackPanel extends Foundation<
     };
 
     /**
-     *  Compares viewport, item and desired peek value to come up with
-     *  peek value to use. We don't want to clip focused item to get peek on next/previous item.
-     */
-    private getScrollPeek = (itemSpan: number): number => {
-        let maxPeek: number = this.viewportSpan - itemSpan;
-        maxPeek = maxPeek < 0 ? 0 : maxPeek;
-
-        const peek: number =
-            this.props.nextItemPeek > maxPeek ? maxPeek : this.props.nextItemPeek;
-
-        return peek;
-    };
-
-    /**
-     * A child item got focus
-     */
-    private onItemFocus = (event: React.FocusEvent): void => {
-        if (!this.state.isScrollable || !this.props.enableSmoothScrolling) {
-            return;
-        }
-
-        // smooth scroll into view
-        const itemStart: number =
-            this.props.orientation === Orientation.horizontal
-                ? (event.currentTarget as HTMLElement).offsetLeft
-                : (event.currentTarget as HTMLElement).offsetTop;
-
-        const itemSpan: number =
-            this.props.orientation === Orientation.horizontal
-                ? (event.currentTarget as HTMLElement).clientWidth
-                : (event.currentTarget as HTMLElement).clientHeight;
-        const itemEnd: number = itemStart + itemSpan;
-
-        const peek: number = this.getScrollPeek(itemSpan);
-
-        let scrollStart: number = this.lastRecordedScroll;
-
-        if (this.isScrollAnimating) {
-            const duration: number = this.props.scrollDuration;
-            const currentDate: number = new Date().getTime();
-            const currentTime: number = currentDate - this.currentScrollAnimStartTime;
-            this.updateLayout();
-            scrollStart = this.getScrollAnimationPosition(currentTime, duration);
-        }
-
-        if (itemStart - this.lastRecordedScroll < 0) {
-            this.scrollContent(scrollStart, itemStart - peek);
-        } else if (itemEnd - scrollStart > this.viewportSpan) {
-            this.scrollContent(scrollStart, itemEnd - this.viewportSpan + peek);
-        }
-    };
-
-    /**
      * Scrolls the container for the items list
      */
     private scrollContent(
@@ -676,57 +571,9 @@ class StackPanel extends Foundation<
             Math.min(targetScrollPosition, this.maxScroll)
         );
 
-        if (this.props.enableSmoothScrolling) {
-            this.isScrollAnimating = true;
-            this.currentScrollAnimStartPosition = startScrollPosition;
-            this.currentScrollAnimEndPosition = newScrollPosition;
-            this.currentScrollAnimStartTime = new Date().getTime();
-            this.requestFrame();
-        } else {
-            this.isScrollAnimating = false;
-            this.updateLayout();
-            this.setScrollPosition(newScrollPosition);
-        }
+        this.setScrollPosition(newScrollPosition);
+        this.updateLayout();
     }
-
-    /**
-     * Easing animation
-     */
-    private easeInOutQuad(
-        currentTime: number,
-        startValue: number,
-        changeInValue: number,
-        duration: number
-    ): number {
-        currentTime /= duration / 2;
-
-        if (currentTime < 1) {
-            return (changeInValue / 2) * currentTime * currentTime + startValue;
-        }
-
-        currentTime--;
-
-        return (-changeInValue / 2) * (currentTime * (currentTime - 2) - 1) + startValue;
-    }
-
-    /**
-     *  get scroll animation position for the provided time
-     */
-    private getScrollAnimationPosition = (
-        currentTime: number,
-        duration: number
-    ): number => {
-        if (currentTime < duration) {
-            return this.easeInOutQuad(
-                currentTime,
-                this.currentScrollAnimStartPosition,
-                this.currentScrollAnimEndPosition - this.currentScrollAnimStartPosition,
-                duration
-            );
-        } else {
-            return this.currentScrollAnimEndPosition;
-        }
-    };
 
     /**
      * Gets the scroll position that brings the item at a particular index into the viewport
@@ -738,10 +585,9 @@ class StackPanel extends Foundation<
         }
 
         const itemPosition: ItemPosition = this.itemPositions[index];
-        const peek: number = this.getScrollPeek(itemPosition.span);
         const newScrollPosition: number = Math.max(
             0,
-            Math.min(itemPosition.start - peek, this.maxScroll)
+            Math.min(itemPosition.start, this.maxScroll)
         );
         return newScrollPosition;
     };

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -289,7 +289,9 @@ class StackPanel extends Foundation<
             ...(this.props.orientation === Orientation.horizontal
                 ? {
                       width: toPx(this.itemPositions[index].span),
-                      left: toPx(this.itemPositions[index].start),
+                      ...(this.state.direction === Direction.ltr
+                          ? { left: toPx(this.itemPositions[index].start) }
+                          : { right: toPx(this.itemPositions[index].start) }),
                   }
                 : {
                       height: toPx(this.itemPositions[index].span),

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -50,7 +50,7 @@ class StackPanel extends Foundation<
         itemSpan: 100,
         preloadBufferLength: 1,
         orientation: Orientation.vertical,
-        scrollLayoutUpdateDelay: 50,
+        scrollLayoutUpdateDelay: 0,
     };
 
     private static DirectionAttributeName: string = "dir";

--- a/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -73,10 +73,15 @@ class StackPanel extends Foundation<
         scrollLayoutUpdateDelay: void 0,
     };
 
+    // ref to the root element of the component
     private rootElement: React.RefObject<HTMLDivElement> = React.createRef<
         HTMLDivElement
     >();
 
+    /**
+     * ref to the element which is the container all children are rendered into
+     * It is sized accomodate all children and is the container that is being scrolled
+     */
     private itemContainerElement: React.RefObject<HTMLDivElement> = React.createRef<
         HTMLDivElement
     >();
@@ -177,6 +182,7 @@ class StackPanel extends Foundation<
      * React life-cycle method
      */
     public componentDidMount(): void {
+        // set up resize observer so we can update layout when component is resized
         if (!isNil(this.rootElement.current)) {
             if (((window as unknown) as WindowWithResizeObserver).ResizeObserver) {
                 this.resizeDetector = new ((window as unknown) as WindowWithResizeObserver).ResizeObserver(
@@ -189,6 +195,7 @@ class StackPanel extends Foundation<
         this.viewportSpan = this.getViewportSpan();
         this.updateLayout();
 
+        // if we need to have a particular child scrolled into view on mount do so
         if (
             !isNil(this.props.initiallyVisibleItemIndex) &&
             this.itemPositions.length > this.props.initiallyVisibleItemIndex
@@ -217,6 +224,8 @@ class StackPanel extends Foundation<
             this.updateLayout();
         }
 
+        // if the initiallyVisibleItemIndex prop is changed to a non-null value
+        // after initial mount we scroll to that position
         if (
             prevProps.initiallyVisibleItemIndex !==
                 this.props.initiallyVisibleItemIndex &&
@@ -249,14 +258,11 @@ class StackPanel extends Foundation<
     protected generateClassNames(): string {
         const {
             stackPanel,
-        }: // stackPanel__scrolling,
-        StackPanelClassNameContract = this.props.managedClasses;
+            stackPanel__scrollable,
+        }: StackPanelClassNameContract = this.props.managedClasses;
 
         return super.generateClassNames(
-            classNames(
-                stackPanel
-                // [stackPanel__scrolling, this.state.isScrolling]
-            )
+            classNames(stackPanel, [stackPanel__scrollable, this.state.isScrollable])
         );
     }
 


### PR DESCRIPTION
# Description
The stack panel component enables authors to create a horizontally or vertically scrolling list of child items that can be virtualized (ie. not rendered to the dom) when not within the viewport.  Authors provide the span (height or width depending on orientation) of each item, either a single value when all child items have identical spans, or as an array of values when children have variable spans. Because the stackpanel knows the space to allocate to each item it can create layouts without actually having to render each child which can be a significant performance gain.

The stack panel accepts children in the usual way for html markup.
`<StackPanel>`
`               <button/>`
`                <button/>`
`               <button/> `
`                etc...`
</StackPanel>`
The expectation is that the stackpanel's role is to manage virtualization at React node level and that other parent components, like a data grid or a feed for example, would handle more data driven inputs and handle converting those to nodes to be rendered  in an efficient manner.  

The prototype [data grid component](https://github.com/microsoft/fast-dna/tree/users/scomea/data-grid) takes in data and interacts with the stackpanel to only create nodes only for the rows that are in the region that is being rendered.  Browsing a large dataset in this scenario could end up with a stackpanel with children that look something like this:

`<StackPanel itemSpan={[500000, 100, ...more spans...100, 300000]}>`
`                <div>Filler child that represents first 5000 rows</div>`
`                <dataRow>Row index 5001</dataRow>`
`               ...more data rows...`
 `             <dataRow>Row index 6000</dataRow>`
 `           <div>Filler child that represents rows after 6000</div>`
`</StackPanel>`


As the user scrolls the data grid tracks the scroll position and updates the children as required.  The first and last child merely exist to take up virtual space and their spans change as the component is scrolled and which data rows are actually passed to the data grid changes accordingly.

## Motivation & context
https://github.com/microsoft/fast-dna/issues/2501

Consider a stackpanel with 200 child items rendered with virtualization turned off which takes about 5 seconds of churn on the main thread when first rendered:

![200NoVirt](https://user-images.githubusercontent.com/7649425/75366666-ef730f80-5873-11ea-8250-389f02af522b.png)


Turning on virtualization reduces that time to less than a second:

![200wVirt](https://user-images.githubusercontent.com/7649425/75366874-45e04e00-5874-11ea-8fac-74f372f9b4f2.png)


Further, upping the item count from 200 to 10000 does not have a significant impact:

![10kwVirt](https://user-images.githubusercontent.com/7649425/75367022-7e802780-5874-11ea-8ca7-177e4088fac9.png)


## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.