### PR TITLE
fix: pivot onUpdate function should be called on update

### DIFF
--- a/packages/fast-components-react-msft/src/pivot/pivot.spec.tsx
+++ b/packages/fast-components-react-msft/src/pivot/pivot.spec.tsx
@@ -210,4 +210,26 @@ describe("pivot", (): void => {
                 .prop("className")
         ).toContain(`${managedClasses.pivot_tabPanel}`);
     });
+
+    test("should invoke an author-defined onUpdate callback when the Pivot changes the active tab", () => {
+        const onUpdate: jest.Mock<any, any> = jest.fn();
+        const rendered: any = mount(
+            <MSFTPivot
+                label={"foo"}
+                items={detailPivotItemData}
+                onUpdate={onUpdate as any}
+            />
+        );
+
+        expect(rendered.state("activeId")).toBe(id0);
+
+        rendered
+            .find('[role="tab"]')
+            .at(1)
+            .simulate("click");
+        expect(rendered.state("activeId")).toBe(id1);
+
+        expect(onUpdate).toHaveBeenCalledTimes(1);
+        expect(onUpdate).toHaveBeenCalledWith(id1);
+    });
 });

--- a/packages/fast-components-react-msft/src/pivot/pivot.tsx
+++ b/packages/fast-components-react-msft/src/pivot/pivot.tsx
@@ -149,6 +149,10 @@ class Pivot extends Foundation<PivotHandledProps, PivotUnhandledProps, PivotStat
         this.setState({
             activeId: activeTabId,
         });
+
+        if (typeof this.props.onUpdate === "function") {
+            this.props.onUpdate(activeTabId);
+        }
     };
 
     private isSelected(element: HTMLElement): boolean {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Author provided `onUpdate` callbacks were not getting invoked when the pivot updated the active slide. This change wires the callback.

<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->