### PR TITLE
feat: update description and metadata for L1 alt layer as no longer deprecated

### DIFF
--- a/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.ts
+++ b/packages/fast-components-styles-msft/src/utilities/color/neutral-layer.ts
@@ -174,9 +174,8 @@ export const neutralLayerL1: ColorRecipe<Swatch> = colorRecipeFactory(
 );
 
 /**
- * Previously used as the background color for card containers.
- *
- * @deprecated Use neutralLayerCardContainer instead.
+ * Alternate darker color for L1 surfaces. Currently the same as card container, but use
+ * the most applicable semantic named recipe.
  */
 export const neutralLayerL1Alt: ColorRecipe<Swatch> = neutralLayerCardContainer;
 


### PR DESCRIPTION
# Description

Updated description and metadata for L1 alt layer to no longer be deprecated. The most applicable semantic name should be used.

## Motivation & context

I originally deprecated this to better associate "card container" and "card" recipes. There are valid uses for an alternate L1 color that are not card containers, so using the card container recipe is somewhat misleading. Restoring this as a valid and recommended alternative.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->