### PR TITLE
fix: checkbox control is visually represented with a checkmark when used outside of the SingleLineControlPlugin

### DIFF
--- a/packages/fast-tooling-react/src/form/controls/control.checkbox.spec.tsx
+++ b/packages/fast-tooling-react/src/form/controls/control.checkbox.spec.tsx
@@ -82,13 +82,14 @@ describe("CheckboxControl", () => {
             />
         );
 
+        const wrapper: any = rendered.find("div");
         const input: any = rendered.find("input");
 
         expect(input).toHaveLength(1);
         expect(input.prop("disabled")).toBeTruthy();
-        expect(
-            rendered.find(`.${managedClasses.checkboxControl__disabled}`)
-        ).toHaveLength(1);
+        expect(wrapper.find(`.${managedClasses.checkboxControl__disabled}`)).toHaveLength(
+            1
+        );
     });
     test("should show default values if they exist and no data is available", () => {
         const rendered: any = mount(

--- a/packages/fast-tooling-react/src/form/controls/control.checkbox.style.ts
+++ b/packages/fast-tooling-react/src/form/controls/control.checkbox.style.ts
@@ -8,10 +8,18 @@ import { error, foreground300, foreground800, insetStrongBoxShadow } from "../..
 export interface CheckboxControlClassNameContract {
     checkboxControl?: string;
     checkboxControl__disabled?: string;
+    checkboxControl_input?: string;
+    checkboxControl_checkmark?: string;
 }
 
 const styles: ComponentStyles<CheckboxControlClassNameContract, {}> = {
     checkboxControl: {
+        position: "relative",
+        height: "14px",
+        width: "14px",
+    },
+    checkboxControl_input: {
+        position: "absolute",
         appearance: "none",
         minWidth: "14px",
         height: "14px",
@@ -30,21 +38,8 @@ const styles: ComponentStyles<CheckboxControlClassNameContract, {}> = {
             outline: "none",
             ...insetStrongBoxShadow(foreground300),
         }),
-        "& + span": {
-            position: "absolute",
-            left: "0",
-            width: "14px",
-            height: "14px",
-            "&::after, &::before": {
-                position: "absolute",
-                display: "block",
-                content: "''",
-                width: "1px",
-                background: foreground300,
-            },
-        },
         "&:checked": {
-            "& + span": {
+            "& + $checkboxControl_checkmark": {
                 "&::before": {
                     height: "3px",
                     left: "4px",
@@ -61,6 +56,19 @@ const styles: ComponentStyles<CheckboxControlClassNameContract, {}> = {
         },
         "&:invalid": {
             borderColor: error,
+        },
+    },
+    checkboxControl_checkmark: {
+        position: "absolute",
+        left: "0",
+        width: "14px",
+        height: "14px",
+        "&::after, &::before": {
+            position: "absolute",
+            display: "block",
+            content: "''",
+            width: "1px",
+            background: foreground300,
         },
     },
     checkboxControl__disabled: {},

--- a/packages/fast-tooling-react/src/form/controls/control.checkbox.tsx
+++ b/packages/fast-tooling-react/src/form/controls/control.checkbox.tsx
@@ -30,21 +30,26 @@ class CheckboxControl extends React.Component<
                     : false;
 
         return (
-            <input
+            <div
                 className={classNames(this.props.managedClasses.checkboxControl, [
                     this.props.managedClasses.checkboxControl__disabled,
                     this.props.disabled,
                 ])}
-                id={this.props.dataLocation}
-                type={"checkbox"}
-                value={value.toString()}
-                onChange={this.handleChange()}
-                checked={value}
-                disabled={this.props.disabled}
-                ref={this.props.elementRef as React.Ref<HTMLInputElement>}
-                onFocus={this.props.reportValidity}
-                onBlur={this.props.updateValidity}
-            />
+            >
+                <input
+                    className={this.props.managedClasses.checkboxControl_input}
+                    id={this.props.dataLocation}
+                    type={"checkbox"}
+                    value={value.toString()}
+                    onChange={this.handleChange()}
+                    checked={value}
+                    disabled={this.props.disabled}
+                    ref={this.props.elementRef as React.Ref<HTMLInputElement>}
+                    onFocus={this.props.reportValidity}
+                    onBlur={this.props.updateValidity}
+                />
+                <span className={this.props.managedClasses.checkboxControl_checkmark} />
+            </div>
         );
     }
 

--- a/packages/fast-tooling-react/src/form/templates/template.control.single-line.tsx
+++ b/packages/fast-tooling-react/src/form/templates/template.control.single-line.tsx
@@ -46,7 +46,6 @@ class SingleLineControlTemplate extends ControlTemplateUtilities<
             >
                 <div className={singleLineControlTemplate_control}>
                     {this.props.control(this.getConfig())}
-                    <span />
                     <label
                         className={singleLineControlTemplate_label}
                         htmlFor={this.props.dataLocation}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
The checkbox does not visually show the checkmark when the checkbox control is used inside the `StandardControlPlugin`.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
When using a control the means of indicating it's value should always be self contained, this was not the case for the checkbox control. This change rectifies this issue.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->