### PR TITLE
feat: move extractElementFromRef function to utilities

### DIFF
--- a/packages/fast-components-react-base/src/utilities/extract-element.spec.tsx
+++ b/packages/fast-components-react-base/src/utilities/extract-element.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
 import { configure, mount, shallow } from "enzyme";
-import { extractElementFromRef } from "./extract-element";
+import { extractHtmlElement } from "./extract-element";
 
 /*
  * Configure Enzyme
@@ -23,13 +23,13 @@ class TestClass extends React.Component<{}, {}> {
 describe("extract-element", (): void => {
     test("extractElementFromRef function returns element passed in directly", (): void => {
         const testElement: HTMLDivElement = document.createElement("div");
-        expect(extractElementFromRef(testElement)).toBe(testElement);
+        expect(extractHtmlElement(testElement)).toBe(testElement);
     });
 
     test("extractElementFromRef function returns element passed in as a ref", (): void => {
         const rendered: any = shallow(<TestClass />);
 
-        const extracted: HTMLElement = extractElementFromRef(rendered.instance().testRef);
+        const extracted: HTMLElement = extractHtmlElement(rendered.instance().testRef);
         expect(extracted).toEqual(rendered.instance().testRef.current);
     });
 
@@ -38,6 +38,6 @@ describe("extract-element", (): void => {
             HTMLDivElement
         >();
 
-        expect(extractElementFromRef(testRef)).toBe(null);
+        expect(extractHtmlElement(testRef)).toBe(null);
     });
 });

--- a/packages/fast-components-react-base/src/utilities/extract-element.spec.tsx
+++ b/packages/fast-components-react-base/src/utilities/extract-element.spec.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
+import { configure, mount, shallow } from "enzyme";
+import { extractElementFromRef } from "./extract-element";
+
+/*
+ * Configure Enzyme
+ */
+configure({ adapter: new Adapter() });
+
+class TestClass extends React.Component<{}, {}> {
+    private testRef: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
+
+    constructor(props: {}) {
+        super(props);
+    }
+
+    public render(): JSX.Element {
+        return <div ref={this.testRef} />;
+    }
+}
+
+describe("extract-element", (): void => {
+    test("extractElementFromRef function returns element passed in directly", (): void => {
+        const testElement: HTMLDivElement = document.createElement("div");
+        expect(extractElementFromRef(testElement)).toBe(testElement);
+    });
+
+    test("extractElementFromRef function returns element passed in as a ref", (): void => {
+        const rendered: any = shallow(<TestClass />);
+
+        const extracted: HTMLElement = extractElementFromRef(rendered.instance().testRef);
+        expect(extracted).toEqual(rendered.instance().testRef.current);
+    });
+
+    test("extractElementFromRef function returns null from uninitialized ref object", (): void => {
+        const testRef: React.RefObject<HTMLDivElement> = React.createRef<
+            HTMLDivElement
+        >();
+
+        expect(extractElementFromRef(testRef)).toBe(null);
+    });
+});

--- a/packages/fast-components-react-base/src/utilities/extract-element.spec.tsx
+++ b/packages/fast-components-react-base/src/utilities/extract-element.spec.tsx
@@ -21,19 +21,19 @@ class TestClass extends React.Component<{}, {}> {
 }
 
 describe("extract-element", (): void => {
-    test("extractElementFromRef function returns element passed in directly", (): void => {
+    test("extractHtmlElement function returns element passed in directly", (): void => {
         const testElement: HTMLDivElement = document.createElement("div");
         expect(extractHtmlElement(testElement)).toBe(testElement);
     });
 
-    test("extractElementFromRef function returns element passed in as a ref", (): void => {
+    test("extractHtmlElement function returns element passed in as a ref", (): void => {
         const rendered: any = shallow(<TestClass />);
 
         const extracted: HTMLElement = extractHtmlElement(rendered.instance().testRef);
         expect(extracted).toEqual(rendered.instance().testRef.current);
     });
 
-    test("extractElementFromRef function returns null from uninitialized ref object", (): void => {
+    test("extractHtmlElement function returns null from uninitialized ref object", (): void => {
         const testRef: React.RefObject<HTMLDivElement> = React.createRef<
             HTMLDivElement
         >();

--- a/packages/fast-components-react-base/src/utilities/extract-element.ts
+++ b/packages/fast-components-react-base/src/utilities/extract-element.ts
@@ -1,0 +1,26 @@
+import ReactDOM from "react-dom";
+import { isNil } from "lodash-es";
+
+/**
+ * extracts the html element from React ref or simply returns html element passed in
+ */
+export function extractElementFromRef(
+    sourceRef: React.RefObject<HTMLElement> | HTMLElement
+): HTMLElement | null {
+    if (sourceRef instanceof HTMLElement) {
+        return sourceRef;
+    }
+    if (!isNil(sourceRef.current)) {
+        if (sourceRef.current instanceof HTMLElement) {
+            return sourceRef.current;
+        }
+
+        const foundNode: Element | Text | null = ReactDOM.findDOMNode(sourceRef.current);
+
+        if (foundNode instanceof HTMLElement) {
+            return foundNode;
+        }
+    }
+
+    return null;
+}

--- a/packages/fast-components-react-base/src/utilities/extract-element.ts
+++ b/packages/fast-components-react-base/src/utilities/extract-element.ts
@@ -4,7 +4,7 @@ import { isNil } from "lodash-es";
 /**
  * extracts the html element from React ref or simply returns html element passed in
  */
-export function extractElementFromRef(
+export function extractHtmlElement(
     sourceRef: React.RefObject<HTMLElement> | HTMLElement
 ): HTMLElement | null {
     if (sourceRef instanceof HTMLElement) {

--- a/packages/fast-components-react-base/src/utilities/index.ts
+++ b/packages/fast-components-react-base/src/utilities/index.ts
@@ -19,3 +19,4 @@ export * from "./resize-observer";
 export * from "./resize-observer-entry";
 export * from "./intersection-observer";
 export * from "./intersection-observer-entry";
+export * from "./extract-element";

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -1645,49 +1645,4 @@ describe("viewport positioner", (): void => {
         expect(positionerDimension.width).toBe(110);
         expect(positionerDimension.height).toBe(110);
     });
-
-    test("extractElementFromRef function returns element passed in directly", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
-        const rendered: any = mount(
-            <div>
-                <div ref={anchorElement} />
-                <ViewportPositioner
-                    viewport={document.firstElementChild as HTMLElement}
-                    anchor={anchorElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
-        );
-
-        const positioner: any = rendered.find("BaseViewportPositioner");
-        const testElement: Element = document.createElement("div");
-        expect(positioner.instance()["extractElementFromRef"](testElement)).toBe(
-            testElement
-        );
-    });
-
-    test("extractElementFromRef function returns element passed in as a ref", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
-        const rendered: any = mount(
-            <div>
-                <div ref={anchorElement} />
-                <ViewportPositioner
-                    viewport={document.firstElementChild as HTMLElement}
-                    anchor={anchorElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
-        );
-
-        const positioner: any = rendered.find("BaseViewportPositioner");
-        expect(positioner.instance()["extractElementFromRef"](anchorElement)).toBe(
-            anchorElement.current
-        );
-    });
 });

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import {
     DisplayNamePrefix,
+    extractElementFromRef,
     IntersectionObserverEntry,
     ResizeObserverClassDefinition,
     ResizeObserverEntry,
@@ -1137,7 +1138,7 @@ class ViewportPositioner extends Foundation<
         if (isNil(this.props.anchor)) {
             return null;
         }
-        return this.extractElementFromRef(this.props.anchor);
+        return extractElementFromRef(this.props.anchor);
     };
 
     /**
@@ -1147,42 +1148,16 @@ class ViewportPositioner extends Foundation<
         viewportRef: React.RefObject<any> | HTMLElement
     ): HTMLElement | null => {
         if (!isNil(viewportRef)) {
-            return this.extractElementFromRef(viewportRef);
+            return extractElementFromRef(viewportRef);
         }
 
         if (!isNil(this.context.viewport)) {
-            return this.extractElementFromRef(this.context.viewport);
+            return extractElementFromRef(this.context.viewport);
         }
 
         if (document.scrollingElement instanceof HTMLElement) {
             return document.scrollingElement as HTMLElement;
         }
-        return null;
-    };
-
-    /**
-     * returns an html element from a ref
-     */
-    private extractElementFromRef = (
-        sourceRef: React.RefObject<any> | HTMLElement
-    ): HTMLElement | null => {
-        if (sourceRef instanceof HTMLElement) {
-            return sourceRef;
-        }
-        if (!isNil(sourceRef.current)) {
-            if (sourceRef.current instanceof HTMLElement) {
-                return sourceRef.current;
-            }
-
-            const foundNode: Element | Text | null = ReactDOM.findDOMNode(
-                sourceRef.current
-            );
-
-            if (foundNode instanceof HTMLElement) {
-                return foundNode;
-            }
-        }
-
         return null;
     };
 

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import {
     DisplayNamePrefix,
-    extractElementFromRef,
+    extractHtmlElement,
     IntersectionObserverEntry,
     ResizeObserverClassDefinition,
     ResizeObserverEntry,
@@ -1138,7 +1138,7 @@ class ViewportPositioner extends Foundation<
         if (isNil(this.props.anchor)) {
             return null;
         }
-        return extractElementFromRef(this.props.anchor);
+        return extractHtmlElement(this.props.anchor);
     };
 
     /**
@@ -1148,11 +1148,11 @@ class ViewportPositioner extends Foundation<
         viewportRef: React.RefObject<any> | HTMLElement
     ): HTMLElement | null => {
         if (!isNil(viewportRef)) {
-            return extractElementFromRef(viewportRef);
+            return extractHtmlElement(viewportRef);
         }
 
         if (!isNil(this.context.viewport)) {
-            return extractElementFromRef(this.context.viewport);
+            return extractHtmlElement(this.context.viewport);
         }
 
         if (document.scrollingElement instanceof HTMLElement) {


### PR DESCRIPTION
# Description
Moving the extractElementFromRef function from Viewport Positioner to base component utilities as it will be used by other components.

## Motivation & context
Code reuse, reduce duplication.

## Issue type checklist
- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
