### PR TITLE
feat: add aria-modal attribute to modal dialogs

### DIFF
--- a/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.spec.tsx
@@ -119,6 +119,34 @@ describe("dialog", (): void => {
         );
     });
 
+    test('should have an attribute of `aria-modal="true"` when the `modal` prop is true', () => {
+        const rendered: any = shallow(
+            <Dialog managedClasses={managedClasses} modal={true} />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.dialog_contentRegion}`).prop("aria-modal")
+        ).toEqual(true);
+    });
+
+    test('should NOT have an attribute of `aria-modal="false"` when the `modal` prop is false', () => {
+        const rendered: any = shallow(
+            <Dialog managedClasses={managedClasses} modal={false} />
+        );
+
+        expect(
+            rendered.find(`.${managedClasses.dialog_contentRegion}`).prop("aria-modal")
+        ).toEqual(false);
+    });
+
+    test("should NOT have an attribute of `aria-modal` when the `modal` prop is not provided", () => {
+        const rendered: any = shallow(<Dialog managedClasses={managedClasses} />);
+
+        expect(
+            rendered.find(`.${managedClasses.dialog_contentRegion}`).prop("aria-modal")
+        ).toEqual(undefined);
+    });
+
     test("should call the `onDismiss` callback after a click event on the modal overlay when `visible` prop is true", () => {
         const onDismiss: any = jest.fn();
         const rendered: any = shallow(

--- a/packages/fast-components-react-base/src/dialog/dialog.tsx
+++ b/packages/fast-components-react-base/src/dialog/dialog.tsx
@@ -54,6 +54,7 @@ class Dialog extends Foundation<DialogHandledProps, DialogUnhandledProps, {}> {
                     {this.renderModalOverlay()}
                     <div
                         role="dialog"
+                        aria-modal={this.props.modal}
                         tabIndex={-1}
                         className={classNames(dialog_contentRegion)}
                         style={{


### PR DESCRIPTION
# Description
Support for aria-modal has increased and we're now a full revision beyond its inclusion in the WAI-ARIA specification. This PR adds the attribute to the dialog component.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->