### PR TITLE
fix: radio label color is being overwritten in high contrast 

### DIFF
--- a/packages/fast-components-styles-msft/src/radio/index.ts
+++ b/packages/fast-components-styles-msft/src/radio/index.ts
@@ -31,7 +31,6 @@ import { designUnit, outlineWidth } from "../utilities/design-system";
 import { applyCursorDisabled, applyCursorPointer } from "../utilities/cursor";
 import {
     HighContrastColor,
-    highContrastDisabledBorder,
     highContrastHighlightBackground,
     highContrastOptOutProperty,
     highContrastSelectedBackground,
@@ -53,9 +52,6 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         "flex-direction": "row",
         "align-items": "center",
         transition: "all 0.2s ease-in-out",
-        [highContrastSelector]: {
-            ...highContrastOptOutProperty,
-        },
     },
     radio_input: {
         position: "absolute",
@@ -104,6 +100,7 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
             },
         }),
         [highContrastSelector]: {
+            ...highContrastOptOutProperty,
             background: "transparent",
             border: format(
                 "{0} solid {1}",
@@ -131,6 +128,9 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
             right: indicatorMargin,
             background: "transparent",
         },
+        [highContrastSelector]: {
+            ...highContrastOptOutProperty,
+        },
     },
     radio_label: {
         ...applyCursorPointer(),
@@ -138,10 +138,6 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         ...applyScaledTypeRamp("t7"),
         "margin-left": directionSwitch(horizontalSpacing(2), ""),
         "margin-right": directionSwitch("", horizontalSpacing(2)),
-        [highContrastSelector]: {
-            background: "transparent",
-            color: important(HighContrastColor.text),
-        },
     },
     radio__checked: {
         "& $radio_stateIndicator": {
@@ -166,7 +162,13 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         ...applyDisabledState(),
         "& $radio_input, & $radio_label": {
             ...applyCursorDisabled(),
-            ...highContrastDisabledBorder,
+            [highContrastSelector]: {
+                ...highContrastOptOutProperty,
+                background: important(HighContrastColor.buttonBackground),
+                color: important(HighContrastColor.disabledText),
+                fill: important(HighContrastColor.disabledText),
+                "border-color": important(HighContrastColor.disabledText),
+            },
         },
     },
 };

--- a/packages/fast-components-styles-msft/src/radio/index.ts
+++ b/packages/fast-components-styles-msft/src/radio/index.ts
@@ -7,6 +7,7 @@ import {
     directionSwitch,
     divide,
     format,
+    important,
     toPx,
 } from "@microsoft/fast-jss-utilities";
 import {
@@ -139,7 +140,7 @@ const styles: ComponentStyles<RadioClassNameContract, DesignSystem> = {
         "margin-right": directionSwitch("", horizontalSpacing(2)),
         [highContrastSelector]: {
             background: "transparent",
-            color: HighContrastColor.text,
+            color: important(HighContrastColor.text),
         },
     },
     radio__checked: {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

The label's default color is overwriting the high contrast color, so as a result, the label is not showing the correct color value.
![image](https://user-images.githubusercontent.com/37851220/73197785-c6c9ef80-40e6-11ea-83d7-a3f55e42e641.png)

![image](https://user-images.githubusercontent.com/37851220/73197657-88343500-40e6-11ea-810a-e4c1f4790873.png)

Update:
Removed `-adjust: none` from the root of component, and only set it on input and indicator. By doing this we do not have to set any color value to the label.
 
## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->