### PR TITLE
fix: select - add css class for scaleToFit mode

### DIFF
--- a/packages/fast-components-class-name-contracts-base/src/select/index.ts
+++ b/packages/fast-components-class-name-contracts-base/src/select/index.ts
@@ -13,6 +13,11 @@ export interface SelectClassNameContract {
     select__disabled?: string;
 
     /**
+     * If the component is in "scale to fit" mode
+     */
+    select__scaleToFit?: string;
+
+    /**
      * The menu of the select component
      */
     select_menu?: string;

--- a/packages/fast-components-react-base/src/select/select.spec.tsx
+++ b/packages/fast-components-react-base/src/select/select.spec.tsx
@@ -9,10 +9,7 @@ import {
     keyCodeSpace,
 } from "@microsoft/fast-web-utilities";
 import { DisplayNamePrefix } from "../utilities";
-import {
-    AxisPositioningMode,
-    ViewportPositionerVerticalPosition,
-} from "../viewport-positioner";
+import { AxisPositioningMode } from "../viewport-positioner";
 
 /*
  * Configure Enzyme
@@ -28,6 +25,7 @@ const itemC: JSX.Element = <ListboxItem id="c" value="c" displayString="abc" />;
 
 const managedClasses: SelectClassNameContract = {
     select: "select",
+    select__scaleToFit: "select__scaleToFit",
     select__disabled: "select__disabled",
     select_menu: "select_menu",
     select_menu__open: "select_menu__open",
@@ -494,6 +492,89 @@ describe("select", (): void => {
         );
         expect(positioner.prop("verticalPositioningMode")).toBe(
             AxisPositioningMode.inset
+        );
+    });
+
+    test("Default classname applied", (): void => {
+        const rendered: any = mount(
+            <Select managedClasses={managedClasses}>
+                {itemA}
+                {itemB}
+                {itemC}
+            </Select>
+        );
+
+        expect(rendered.instance().rootElement.current.className).toContain(
+            managedClasses.select
+        );
+        expect(rendered.instance().rootElement.current.className).not.toContain(
+            managedClasses.select__disabled
+        );
+        expect(rendered.instance().rootElement.current.className).not.toContain(
+            managedClasses.select__scaleToFit
+        );
+        expect(rendered.instance().rootElement.current.className).not.toContain(
+            managedClasses.select__multiSelectable
+        );
+        expect(rendered.instance().rootElement.current.className).not.toContain(
+            managedClasses.select_menu__open
+        );
+    });
+
+    test("Classname applied when disabled", (): void => {
+        const rendered: any = mount(
+            <Select managedClasses={managedClasses} disabled={true}>
+                {itemA}
+                {itemB}
+                {itemC}
+            </Select>
+        );
+        expect(rendered.instance().rootElement.current.className).toContain(
+            managedClasses.select__disabled
+        );
+    });
+
+    test("Classname applied when scaleToFit enabled", (): void => {
+        const rendered: any = mount(
+            <Select
+                managedClasses={managedClasses}
+                menuFlyoutConfig={{
+                    scaleToFit: true,
+                }}
+            >
+                {itemA}
+                {itemB}
+                {itemC}
+            </Select>
+        );
+        expect(rendered.instance().rootElement.current.className).toContain(
+            managedClasses.select__scaleToFit
+        );
+    });
+
+    test("Classname applied when multi-selectable", (): void => {
+        const rendered: any = mount(
+            <Select managedClasses={managedClasses} multiselectable={true}>
+                {itemA}
+                {itemB}
+                {itemC}
+            </Select>
+        );
+        expect(rendered.instance().rootElement.current.className).toContain(
+            managedClasses.select__multiSelectable
+        );
+    });
+
+    test("Classname applied when menu open", (): void => {
+        const rendered: any = mount(
+            <Select managedClasses={managedClasses} isMenuOpen={true}>
+                {itemA}
+                {itemB}
+                {itemC}
+            </Select>
+        );
+        expect(rendered.instance().rootElement.current.className).toContain(
+            managedClasses.select_menu__open
         );
     });
 });

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -179,6 +179,7 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
     protected generateClassNames(): string {
         const {
             select,
+            select__scaleToFit,
             select__disabled,
             select_menu__open,
             select__multiSelectable,
@@ -187,6 +188,11 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         return super.generateClassNames(
             classNames(
                 select,
+                [
+                    select__scaleToFit,
+                    !isNil(this.props.menuFlyoutConfig) &&
+                        this.props.menuFlyoutConfig.scaleToFit,
+                ],
                 [select__disabled, this.props.disabled],
                 [select_menu__open, this.state.isMenuOpen],
                 [select__multiSelectable, this.props.multiselectable]

--- a/packages/fast-components-react-msft/src/select/select.spec.tsx
+++ b/packages/fast-components-react-msft/src/select/select.spec.tsx
@@ -15,7 +15,7 @@ const itemA: JSX.Element = <SelectOption id="a" value="a" displayString="a" />;
 const itemB: JSX.Element = <SelectOption id="b" value="b" displayString="ab" />;
 const itemC: JSX.Element = <SelectOption id="c" value="c" displayString="abc" />;
 
-describe("button", (): void => {
+describe("select", (): void => {
     const href: string = "https://www.microsoft.com";
 
     test("should have a displayName that matches the component name", () => {

--- a/packages/fast-components-react-msft/src/select/select.stories.tsx
+++ b/packages/fast-components-react-msft/src/select/select.stories.tsx
@@ -5,7 +5,11 @@ import { Heading, HeadingSize } from "../heading";
 import { Select } from "./";
 import { uniqueId } from "lodash-es";
 import { action } from "@storybook/addon-actions";
-import { AxisPositioningMode } from "@microsoft/fast-components-react-base";
+import {
+    AxisPositioningMode,
+    ViewportPositionerVerticalPosition,
+    ViewportPositionerHorizontalPosition,
+} from "@microsoft/fast-components-react-base";
 import { Dialog } from "../dialog";
 
 const rootElement: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
@@ -154,12 +158,14 @@ storiesOf("Select", module)
             />
         </Select>
     ))
-    .add("Adjacent", () => (
+    .add("Right", () => (
         <Select
             placeholder="Select an option"
             onValueChange={action("onValueChange")}
             menuFlyoutConfig={{
                 horizontalPositioningMode: AxisPositioningMode.adjacent,
+                defaultHorizontalPosition: ViewportPositionerHorizontalPosition.right,
+                horizontalLockToDefault: true,
                 verticalPositioningMode: AxisPositioningMode.inset,
             }}
         >
@@ -185,7 +191,78 @@ storiesOf("Select", module)
             />
         </Select>
     ))
-    .add("Scaling in dialog", () => (
+    .add("left", () => (
+        <Select
+            style={{
+                marginLeft: "200px",
+            }}
+            placeholder="Select an option"
+            onValueChange={action("onValueChange")}
+            menuFlyoutConfig={{
+                horizontalPositioningMode: AxisPositioningMode.adjacent,
+                defaultHorizontalPosition: ViewportPositionerHorizontalPosition.left,
+                horizontalLockToDefault: true,
+                verticalPositioningMode: AxisPositioningMode.inset,
+            }}
+        >
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 1"
+                displayString="Select option 1"
+            />
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 2"
+                displayString="Select option 2"
+            />
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 3"
+                displayString="Select option 3"
+            />
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 4"
+                displayString="Select option 4"
+            />
+        </Select>
+    ))
+    .add("Above", () => (
+        <Select
+            style={{
+                marginTop: "200px",
+            }}
+            placeholder="Select an option"
+            onValueChange={action("onValueChange")}
+            menuFlyoutConfig={{
+                verticalPositioningMode: AxisPositioningMode.adjacent,
+                verticalLockToDefault: true,
+                defaultVerticalPosition: ViewportPositionerVerticalPosition.top,
+            }}
+        >
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 1"
+                displayString="Select option 1"
+            />
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 2"
+                displayString="Select option 2"
+            />
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 3"
+                displayString="Select option 3"
+            />
+            <SelectOption
+                id={uniqueId()}
+                value="Select option 4"
+                displayString="Select option 4"
+            />
+        </Select>
+    ))
+    .add("Scaling", () => (
         <Dialog modal={true} visible={true}>
             <div
                 ref={rootElement}
@@ -193,24 +270,24 @@ storiesOf("Select", module)
                     height: "100%",
                     width: "100%",
                     overflowY: "scroll",
-                    overflowX: "hidden",
+                    overflowX: "scroll",
                 }}
             >
                 <div
                     style={{
                         height: "1000px",
+                        width: "1000px",
                     }}
                 >
                     <Select
                         style={{
-                            margin: "350px 0 0 20px",
+                            margin: "350px 0 0 300px",
                             width: "180px",
                         }}
                         placeholder="Select an option"
                         onValueChange={action("onValueChange")}
                         menuFlyoutConfig={{
                             viewport: rootElement,
-                            horizontalPositioningMode: AxisPositioningMode.uncontrolled,
                             verticalPositioningMode: AxisPositioningMode.adjacent,
                             scaleToFit: true,
                         }}

--- a/packages/fast-components-react-msft/src/select/select.stories.tsx
+++ b/packages/fast-components-react-msft/src/select/select.stories.tsx
@@ -7,8 +7,8 @@ import { uniqueId } from "lodash-es";
 import { action } from "@storybook/addon-actions";
 import {
     AxisPositioningMode,
-    ViewportPositionerVerticalPosition,
     ViewportPositionerHorizontalPosition,
+    ViewportPositionerVerticalPosition,
 } from "@microsoft/fast-components-react-base";
 import { Dialog } from "../dialog";
 

--- a/packages/fast-components-styles-msft/src/select/index.ts
+++ b/packages/fast-components-styles-msft/src/select/index.ts
@@ -113,17 +113,22 @@ const styles: ComponentStyles<SelectClassNameContract, DesignSystem> = {
     },
     select__menuPositionTop: {
         "grid-template-rows": "1fr auto",
-
         "& $select_menu": {
             "grid-row": "2",
-            "margin-top": "12px",
         },
     },
     select__menuPositionBottom: {
         "grid-template-rows": "auto 1fr",
         "& $select_menu": {
             "grid-row": "1",
+        },
+    },
+    select__scaleToFit: {
+        "& $select_menu, & $select__menuPositionBottom": {
             "margin-bottom": "12px",
+        },
+        "& $select_menu, & $select__menuPositionTop": {
+            "margin-top": "12px",
         },
     },
 };


### PR DESCRIPTION
# Description
Found that styling for menu needed to be able to differentiate styling for "scaleToFit" mode, so added a class for that and tweaked our styles.

## Motivation & context
Styles that worked for scale to fit mode needed adjustments for when that is disabled (bad margins).  

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
