### PR TITLE
fix: ensure the horizontalLockFromDefault property from ViewportPositioner is passed to Flyout

### DIFF
--- a/packages/fast-components-react-msft/src/flyout/flyout.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.tsx
@@ -105,6 +105,7 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
                     ]
                 }
                 horizontalThreshold={this.props.horizontalThreshold}
+                horizontalLockToDefault={this.props.horizontalLockToDefault}
                 managedClasses={this.generateManagedClassNames()}
                 verticalAlwaysInView={this.props.verticalAlwaysInView}
                 verticalPositioningMode={
@@ -113,6 +114,7 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
                     ]
                 }
                 verticalThreshold={this.props.verticalThreshold}
+                verticalLockToDefault={this.props.verticalLockToDefault}
                 viewport={this.props.viewport}
                 style={{
                     height: this.props.height,


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

The component *Flyout* uses *ViewportPositioner* for placement of the flyout. It handles the lock properties *horizontalLockToDefault* and *verticalLockToDefault* which were added later. But these properties were not forwarded to the *ViewportPositioner* thus leading to anyone using flyout component and using these properties to have no effect on the,

## Motivation & context

The pdf in Edge has a new feature, which uses the Flyout Component to show the feature. At some of the system configuration it was behaving weirdly where the flyout was going above the toolbar. To fix this we tried using this property to always make it come at bottom. But the property was not respected. Upon debugging and with the FAST team we figured that it was this mistake where the lock properties were not respected. By changing this locally, we could see the property being respected and our bug getting fixed. 

Please help land it, so that our feature gets unblocked for this release. For more details please contact at prchan@microsoft.com

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist


<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes. (The documentation should already have that)
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->