### PR TITLE
fix: select "aria-labelledby" should never be"undefined" string, remove "aria-live" tag

### DIFF
--- a/packages/fast-components-react-base/src/select/select.spec.tsx
+++ b/packages/fast-components-react-base/src/select/select.spec.tsx
@@ -85,7 +85,7 @@ describe("select", (): void => {
         expect(rendered.first().prop("tabIndex")).toEqual(-1);
     });
 
-    test("default trigger aria tags are set correctly", (): void => {
+    test("default trigger aria tags are set", (): void => {
         const rendered: any = mount(
             <Select selectedItems={["a"]} labelledBy="testLabellledBy">
                 {itemA}
@@ -99,7 +99,6 @@ describe("select", (): void => {
         const trigger: any = rendered.find("button");
         expect(trigger.prop("aria-expanded")).toEqual(false);
         expect(trigger.prop("aria-haspopup")).toEqual("listbox");
-        expect(trigger.prop("aria-live")).toEqual("polite");
         expect(trigger.prop("aria-labelledby").split(" ")).toEqual([
             "testLabellledBy",
             rendered.instance().triggerId,

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -465,10 +465,9 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         if (props.multiselectable) {
             return null;
         }
-        const labelledByFromProp: string = isNil(this.props.labelledBy)
-            ? ""
-            : `${this.props.labelledBy} `;
-        const labelledBy: string = `${labelledByFromProp}${triggerId}`;
+        const labelledBy: string = `${
+            isNil(this.props.labelledBy) ? "" : `${this.props.labelledBy} `
+        }${triggerId}`;
         return (
             <button
                 disabled={props.disabled}

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -476,7 +476,6 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
                 aria-haspopup="listbox"
                 aria-labelledby={labelledBy}
                 aria-expanded={state.isMenuOpen}
-                aria-live="polite"
             >
                 {state.displayString}
             </button>

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -13,7 +13,6 @@ import {
 import { canUseDOM } from "exenv-es6";
 import { get, isEqual, isNil, uniqueId } from "lodash-es";
 import React from "react";
-import Button from "../button";
 import Listbox from "../listbox";
 import { ListboxItemProps } from "../listbox-item";
 import { DisplayNamePrefix } from "../utilities";
@@ -466,7 +465,10 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         if (props.multiselectable) {
             return null;
         }
-        const labelledBy: string = `${this.props.labelledBy} ${triggerId}`;
+        const labelledByFromProp: string = isNil(this.props.labelledBy)
+            ? ""
+            : `${this.props.labelledBy} `;
+        const labelledBy: string = `${labelledByFromProp}${triggerId}`;
         return (
             <button
                 disabled={props.disabled}

--- a/packages/fast-components-react-msft/src/select/select.spec.tsx
+++ b/packages/fast-components-react-msft/src/select/select.spec.tsx
@@ -65,7 +65,6 @@ describe("select", (): void => {
         const trigger: any = rendered.find("button");
         expect(trigger.prop("aria-expanded")).toEqual(false);
         expect(trigger.prop("aria-haspopup")).toEqual("listbox");
-        expect(trigger.prop("aria-live")).toEqual("polite");
     });
 
     test("Custom menu render function is called", (): void => {

--- a/packages/fast-components-react-msft/src/select/select.tsx
+++ b/packages/fast-components-react-msft/src/select/select.tsx
@@ -7,6 +7,7 @@ import { DisplayNamePrefix } from "../utilities";
 import { SelectHandledProps, SelectProps, SelectUnhandledProps } from "./select.props";
 import { Background } from "../background";
 import { neutralLayerFloating } from "@microsoft/fast-components-styles-msft";
+import { isNil } from "lodash-es";
 
 class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, {}> {
     public static displayName: string = `${DisplayNamePrefix}Select`;
@@ -63,7 +64,11 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, {}> {
             select_buttonDisplayText,
         }: SelectClassNameContract = this.props.managedClasses;
 
-        const labelledBy: string = `${this.props.labelledBy} ${triggerId}`;
+        const labelledByFromProp: string = isNil(this.props.labelledBy)
+            ? ""
+            : `${this.props.labelledBy} `;
+
+        const labelledBy: string = `${labelledByFromProp}${triggerId}`;
 
         return (
             <button

--- a/packages/fast-components-react-msft/src/select/select.tsx
+++ b/packages/fast-components-react-msft/src/select/select.tsx
@@ -64,11 +64,9 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, {}> {
             select_buttonDisplayText,
         }: SelectClassNameContract = this.props.managedClasses;
 
-        const labelledByFromProp: string = isNil(this.props.labelledBy)
-            ? ""
-            : `${this.props.labelledBy} `;
-
-        const labelledBy: string = `${labelledByFromProp}${triggerId}`;
+        const labelledBy: string = `${
+            isNil(this.props.labelledBy) ? "" : `${this.props.labelledBy} `
+        }${triggerId}`;
 
         return (
             <button

--- a/packages/fast-components-react-msft/src/select/select.tsx
+++ b/packages/fast-components-react-msft/src/select/select.tsx
@@ -78,7 +78,6 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, {}> {
                 aria-haspopup="listbox"
                 aria-labelledby={labelledBy}
                 aria-expanded={state.isMenuOpen}
-                aria-live="polite"
             >
                 <span className={classNames(select_buttonContentRegion)}>
                     <div className={classNames(select_buttonDisplayText)}>


### PR DESCRIPTION
# Description
Avoid adding "undefined" to the aria tag rendered on the component when the labelledBy prop is not set.  Remove "aria-live" tag from trigger as it was incorrectly causing value to be read on page load.

## Motivation & context
- nothing good could come from an incorrect aria attribute
- narrator should not read values when select is not focused

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.