### PR TITLE
feat: viewport positioner enable delayed instanciation

### DIFF
--- a/packages/fast-components-react-base/src/viewport-positioner/README.md
+++ b/packages/fast-components-react-base/src/viewport-positioner/README.md
@@ -42,9 +42,9 @@ The "AlwaysInView" props (i.e. "horizontalAlwaysInView" and "verticalAlwaysInVie
 
 The "fixedAfterInitialPlacement" prop is set the component will not adjust positioning after the initial render.
 
-Authors should be mindful that instanciating a flyout positioner can cause layout changes as it is actually inserted into the DOM and can cause parent containers to expand, move siblings down the page, etc.  It is up to authors to place the component such that it does not cause unwanted layout changes.  
+When the "delayContentInstanciation" prop is true the child of the positioner will not be rendered until the component has been positioned relative to its anchor.  This may be useful in cases where the browser auto scrolls to bring a focused child into view before it has been positioned, for example.  Default is false. This flag may be removed in a future version and become the default behavior.
 
-Authors should ensure that the positioner element has fixed dimensions. If these are dynamic this can cause incorrect positioning to be calculated.   
+Authors should be mindful that instanciating a flyout positioner can cause layout changes as it is actually inserted into the DOM and can cause parent containers to expand, move siblings down the page, etc.  It is up to authors to place the component such that it does not cause unwanted layout changes.    
 
 The not fully supported [ResizeObserver](https://developers.google.com/web/updates/2016/10/resizeobserver) and [IntersectionObserver](https://developers.google.com/web/updates/2016/04/intersectionobserver) are used (supported in Chrome), so it is necessary to apply a polyfill if more thorough browser support is needed (Safari and Firefox). Full adaptation is expected soon.
 

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
@@ -108,6 +108,14 @@ export interface ViewportPositionerHandledProps extends ViewportPositionerManage
      * The children of the viewport positioner
      */
     children?: React.ReactNode;
+
+    /**
+     * When true the children of the positioner will not be rendered until the component has been positioned
+     * relative to its anchor.  This may be useful in cases where the browser auto scrolls to bring a
+     * focused child into view before it has been positioned, for example.  Default is false.
+     * This flag may be removed in a future version and become the default behavior.
+     */
+    delayContentInstanciation?: boolean;
 }
 
 export type ViewportPositionerProps = ViewportPositionerHandledProps &

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.props.ts
@@ -110,7 +110,7 @@ export interface ViewportPositionerHandledProps extends ViewportPositionerManage
     children?: React.ReactNode;
 
     /**
-     * When true the children of the positioner will not be rendered until the component has been positioned
+     * When true the child of the positioner will not be rendered until the component has been positioned
      * relative to its anchor.  This may be useful in cases where the browser auto scrolls to bring a
      * focused child into view before it has been positioned, for example.  Default is false.
      * This flag may be removed in a future version and become the default behavior.

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -1341,7 +1341,7 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPositionLabel.bottom
         );
-        positioner.instance()["updatePositionerOffset"]();
+        positioner.instance()["updatePositionerOffset"](positionerRectX70Y70);
         expect(positioner.instance().baseHorizontalOffset).toBe(0);
         expect(positioner.instance().baseVerticalOffset).toBe(0);
 
@@ -1359,7 +1359,7 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPositionLabel.insetBottom
         );
-        positioner.instance()["updatePositionerOffset"]();
+        positioner.instance()["updatePositionerOffset"](positionerRectX70Y70);
         expect(positioner.instance().baseHorizontalOffset).toBe(-10);
         expect(positioner.instance().baseVerticalOffset).toBe(-10);
 
@@ -1376,7 +1376,7 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPositionLabel.top
         );
-        positioner.instance()["updatePositionerOffset"]();
+        positioner.instance()["updatePositionerOffset"](positionerRectX70Y70);
         expect(positioner.instance().baseHorizontalOffset).toBe(-20);
         expect(positioner.instance().baseVerticalOffset).toBe(-20);
 
@@ -1394,7 +1394,7 @@ describe("viewport positioner", (): void => {
         expect(positioner.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPositionLabel.insetTop
         );
-        positioner.instance()["updatePositionerOffset"]();
+        positioner.instance()["updatePositionerOffset"](positionerRectX70Y70);
         expect(positioner.instance().baseHorizontalOffset).toBe(-10);
         expect(positioner.instance().baseVerticalOffset).toBe(-10);
     });

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -1404,21 +1404,6 @@ describe("viewport positioner", (): void => {
         expect(positionerDimension.height).toBe(110);
     });
 
-    test("extractElementFromRef function returns element passed in directly", (): void => {
-        const rendered: any = mount(
-            <ViewportPositioner
-                viewport={document.firstElementChild as HTMLElement}
-                anchor={anchorElement}
-                managedClasses={managedClasses}
-            />
-        );
-
-        const testElement: Element = document.createElement("div");
-        expect(rendered.instance()["extractElementFromRef"](testElement)).toBe(
-            testElement
-        );
-    });
-
     test("should create a resize observer if it is available", (): void => {
         const container: HTMLDivElement = document.createElement("div");
         document.body.appendChild(container);

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.spec.tsx
@@ -4,35 +4,49 @@ import { configure, mount, shallow } from "enzyme";
 import ViewportPositioner, {
     Dimension,
     ViewportPositionerClassNameContract,
-    ViewportPositionerHandledProps,
     ViewportPositionerHorizontalPositionLabel,
-    ViewportPositionerProps,
     ViewportPositionerUnhandledProps,
     ViewportPositionerVerticalPositionLabel,
 } from "./viewport-positioner";
-import { DisplayNamePrefix } from "../utilities";
+import {
+    ConstructibleIntersectionObserver,
+    ConstructibleResizeObserver,
+    DisplayNamePrefix,
+} from "../utilities";
 import {
     AxisPositioningMode,
     ViewportPositionerHorizontalPosition,
     ViewportPositionerVerticalPosition,
 } from "./viewport-positioner.props";
-import Button from "../button";
 
 /*
  * Configure Enzyme
  */
 configure({ adapter: new Adapter() });
 
-// viewport rect is deliberately offset so we are testing that
-// calculations are correct when the viewport is not positioned at origin (i.e. x and y = 0)
-const viewportRect: ClientRect = {
-    top: 100,
-    right: 250,
-    bottom: 200,
-    left: 150,
-    height: 100,
-    width: 100,
-};
+// Mock observers
+// tslint:disable:max-classes-per-file
+class DefaultResizeObserver {
+    public observe: jest.Mock<any, any> = jest.fn();
+    public unobserve: jest.Mock<any, any> = jest.fn();
+    public disconnect: jest.Mock<any, any> = jest.fn();
+}
+
+// tslint:disable-next-line:max-classes-per-file
+class DefaultIntersectionObserver {
+    public observe: jest.Mock<any, any> = jest.fn();
+    public unobserve: jest.Mock<any, any> = jest.fn();
+    public disconnect: jest.Mock<any, any> = jest.fn();
+    public root: any = null;
+    public rootMargin: any = null;
+    public thresholds: any = null;
+    public takeRecords: any = null;
+}
+
+(window as WindowWithResizeObserver).ResizeObserver = DefaultResizeObserver;
+(window as WindowWithIntersectionObserver).IntersectionObserver = DefaultIntersectionObserver;
+
+const anchorElement: HTMLDivElement = document.createElement("div");
 
 // positioner rects are described by -x-y coordinates
 const positionerRectX20Y20: ClientRect = {
@@ -51,6 +65,17 @@ const positionerRectX70Y70: ClientRect = {
     left: 70,
     height: 10,
     width: 10,
+};
+
+// viewport rect is deliberately offset so we are testing that
+// calculations are correct when the viewport is not positioned at origin (i.e. x and y = 0)
+const viewportRect: ClientRect = {
+    top: 100,
+    right: 250,
+    bottom: 200,
+    left: 150,
+    height: 100,
+    width: 100,
 };
 
 const managedClasses: ViewportPositionerClassNameContract = {
@@ -115,78 +140,51 @@ describe("viewport positioner", (): void => {
 
     test("should be disabled without an anchor", (): void => {
         const rendered: any = mount(
-            <div>
-                <ViewportPositioner
-                    viewport={document.firstElementChild as HTMLElement}
-                    defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                viewport={document.firstElementChild as HTMLElement}
+                defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-        expect(positioner.instance().state.disabled).toBe(true);
+        expect(rendered.instance().state.disabled).toBe(true);
     });
 
     test("should be enabled with an anchor", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div>
-                <div ref={anchorElement} />
-                <ViewportPositioner
-                    viewport={document.firstElementChild as HTMLElement}
-                    anchor={anchorElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                viewport={document.firstElementChild as HTMLElement}
+                anchor={anchorElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-        expect(positioner.instance().state.disabled).toBe(false);
+        expect(rendered.instance().state.disabled).toBe(false);
     });
 
     test("should be disabled when disabled prop is set", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div>
-                <div ref={anchorElement} />
-                <ViewportPositioner
-                    viewport={document.firstElementChild as HTMLElement}
-                    disabled={true}
-                    anchor={anchorElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                viewport={document.firstElementChild as HTMLElement}
+                disabled={true}
+                anchor={anchorElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-        expect(positioner.instance().state.disabled).toBe(true);
+        expect(rendered.instance().state.disabled).toBe(true);
     });
 
     test("initial state function returns correct initial state", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div>
-                <div ref={anchorElement} />
-                <ViewportPositioner
-                    viewport={document.firstElementChild as HTMLElement}
-                    anchor={anchorElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                viewport={document.firstElementChild as HTMLElement}
+                anchor={anchorElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-        expect(positioner.instance()["generateInitialState"]()).toEqual({
+        expect(rendered.instance()["generateInitialState"]()).toEqual({
             disabled: true,
             noObserverMode: false,
             xTransformOrigin: "left",
@@ -209,350 +207,354 @@ describe("viewport positioner", (): void => {
     });
 
     test("positioning values applied correctly for specified default position - adjacent + top + left", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
 
         const rendered: any = mount(
-            <div>
-                <div ref={anchorElement} />
-                <ViewportPositioner
-                    viewport={document.firstElementChild as HTMLElement}
-                    horizontalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
-                    verticalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultVerticalPosition={ViewportPositionerVerticalPosition.top}
-                    anchor={anchorElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                viewport={container}
+                horizontalPositioningMode={AxisPositioningMode.adjacent}
+                defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
+                verticalPositioningMode={AxisPositioningMode.adjacent}
+                defaultVerticalPosition={ViewportPositionerVerticalPosition.top}
+                anchor={anchorElement}
+                verticalLockToDefault={true}
+                horizontalLockToDefault={true}
+                managedClasses={managedClasses}
+            />,
+            { attachTo: container }
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-        positioner.instance().updateLayout();
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 180;
+        rendered.instance().anchorRight = 240;
+        rendered.instance().anchorBottom = 190;
+        rendered.instance().anchorLeft = 230;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
+
+        rendered.instance().updateLayout();
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.left
         );
-        expect(positioner.instance().state.right).not.toBe(null);
-        expect(positioner.instance().state.left).toBe(null);
-        expect(positioner.instance().state.xTransformOrigin).toBe("right");
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().state.right).not.toBe(null);
+        expect(rendered.instance().state.left).toBe(null);
+        expect(rendered.instance().state.xTransformOrigin).toBe("right");
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__left
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__right
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__horizontalInset
         );
 
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.top
         );
-        expect(positioner.instance().state.bottom).not.toBe(null);
-        expect(positioner.instance().state.top).toBe(null);
-        expect(positioner.instance().state.yTransformOrigin).toBe("bottom");
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().state.bottom).not.toBe(null);
+        expect(rendered.instance().state.top).toBe(null);
+        expect(rendered.instance().state.yTransformOrigin).toBe("bottom");
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__top
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__bottom
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__verticalInset
         );
+
+        document.body.removeChild(container);
     });
 
     test("positioning values applied correctly for specified default position - adjacent + bottom + right", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
 
         const rendered: any = mount(
-            <div>
-                <div ref={anchorElement} />
-                <ViewportPositioner
-                    viewport={document.firstElementChild as HTMLElement}
-                    horizontalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultHorizontalPosition={ViewportPositionerHorizontalPosition.right}
-                    verticalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultVerticalPosition={ViewportPositionerVerticalPosition.bottom}
-                    anchor={anchorElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                viewport={document.firstElementChild as HTMLElement}
+                horizontalPositioningMode={AxisPositioningMode.adjacent}
+                defaultHorizontalPosition={ViewportPositionerHorizontalPosition.right}
+                verticalPositioningMode={AxisPositioningMode.adjacent}
+                defaultVerticalPosition={ViewportPositionerVerticalPosition.bottom}
+                anchor={anchorElement}
+                verticalLockToDefault={true}
+                horizontalLockToDefault={true}
+                managedClasses={managedClasses}
+            />,
+            { attachTo: container }
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-        positioner.instance().updateLayout();
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 180;
+        rendered.instance().anchorRight = 240;
+        rendered.instance().anchorBottom = 190;
+        rendered.instance().anchorLeft = 230;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
+
+        rendered.instance().updateLayout();
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.right
         );
-        expect(positioner.instance().state.right).toBe(null);
-        expect(positioner.instance().state.left).not.toBe(null);
-        expect(positioner.instance().state.xTransformOrigin).toBe("left");
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().state.right).toBe(null);
+        expect(rendered.instance().state.left).not.toBe(null);
+        expect(rendered.instance().state.xTransformOrigin).toBe("left");
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__right
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__left
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__horizontalInset
         );
 
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.bottom
         );
-        expect(positioner.instance().state.bottom).toBe(null);
-        expect(positioner.instance().state.top).not.toBe(null);
-        expect(positioner.instance().state.yTransformOrigin).toBe("top");
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().state.bottom).toBe(null);
+        expect(rendered.instance().state.top).not.toBe(null);
+        expect(rendered.instance().state.yTransformOrigin).toBe("top");
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__bottom
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__top
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__verticalInset
         );
+
+        document.body.removeChild(container);
     });
 
     test("positioning values applied correctly for specified default position - inset + top + left", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
 
         const rendered: any = mount(
-            <div>
-                <div ref={anchorElement} />
-                <ViewportPositioner
-                    viewport={document.firstElementChild as HTMLElement}
-                    horizontalPositioningMode={AxisPositioningMode.inset}
-                    defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
-                    verticalPositioningMode={AxisPositioningMode.inset}
-                    defaultVerticalPosition={ViewportPositionerVerticalPosition.top}
-                    anchor={anchorElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                viewport={document.firstElementChild as HTMLElement}
+                horizontalPositioningMode={AxisPositioningMode.inset}
+                defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
+                verticalPositioningMode={AxisPositioningMode.inset}
+                defaultVerticalPosition={ViewportPositionerVerticalPosition.top}
+                anchor={anchorElement}
+                verticalLockToDefault={true}
+                horizontalLockToDefault={true}
+                managedClasses={managedClasses}
+            />,
+            { attachTo: container }
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-        positioner.instance().updateLayout();
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 180;
+        rendered.instance().anchorRight = 240;
+        rendered.instance().anchorBottom = 190;
+        rendered.instance().anchorLeft = 230;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
+
+        rendered.instance().updateLayout();
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.insetLeft
         );
-        expect(positioner.instance().state.right).not.toBe(null);
-        expect(positioner.instance().state.left).toBe(null);
-        expect(positioner.instance().state.xTransformOrigin).toBe("right");
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().state.right).not.toBe(null);
+        expect(rendered.instance().state.left).toBe(null);
+        expect(rendered.instance().state.xTransformOrigin).toBe("right");
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__left
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__right
         );
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__horizontalInset
         );
 
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPositionLabel.insetTop
         );
-        expect(positioner.instance().state.bottom).not.toBe(null);
-        expect(positioner.instance().state.top).toBe(null);
-        expect(positioner.instance().state.yTransformOrigin).toBe("bottom");
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().state.bottom).not.toBe(null);
+        expect(rendered.instance().state.top).toBe(null);
+        expect(rendered.instance().state.yTransformOrigin).toBe("bottom");
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__top
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__bottom
         );
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__verticalInset
         );
+
+        document.body.removeChild(container);
     });
 
     test("positioning values applied correctly for specified default position - inset + bottom + right", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
 
         const rendered: any = mount(
-            <div>
-                <div ref={anchorElement} />
-                <ViewportPositioner
-                    viewport={document.firstElementChild as HTMLElement}
-                    horizontalPositioningMode={AxisPositioningMode.inset}
-                    defaultHorizontalPosition={ViewportPositionerHorizontalPosition.right}
-                    verticalPositioningMode={AxisPositioningMode.inset}
-                    defaultVerticalPosition={ViewportPositionerVerticalPosition.bottom}
-                    anchor={anchorElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                viewport={document.firstElementChild as HTMLElement}
+                horizontalPositioningMode={AxisPositioningMode.inset}
+                defaultHorizontalPosition={ViewportPositionerHorizontalPosition.right}
+                verticalPositioningMode={AxisPositioningMode.inset}
+                defaultVerticalPosition={ViewportPositionerVerticalPosition.bottom}
+                anchor={anchorElement}
+                verticalLockToDefault={true}
+                horizontalLockToDefault={true}
+                managedClasses={managedClasses}
+            />,
+            { attachTo: container }
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-        positioner.instance().updateLayout();
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 180;
+        rendered.instance().anchorRight = 240;
+        rendered.instance().anchorBottom = 190;
+        rendered.instance().anchorLeft = 230;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
+
+        rendered.instance().updateLayout();
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.insetRight
         );
-        expect(positioner.instance().state.right).toBe(null);
-        expect(positioner.instance().state.left).not.toBe(null);
-        expect(positioner.instance().state.xTransformOrigin).toBe("left");
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().state.right).toBe(null);
+        expect(rendered.instance().state.left).not.toBe(null);
+        expect(rendered.instance().state.xTransformOrigin).toBe("left");
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__right
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__left
         );
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__horizontalInset
         );
 
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPositionLabel.insetBottom
         );
-        expect(positioner.instance().state.bottom).toBe(null);
-        expect(positioner.instance().state.top).not.toBe(null);
-        expect(positioner.instance().state.yTransformOrigin).toBe("top");
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().state.bottom).toBe(null);
+        expect(rendered.instance().state.top).not.toBe(null);
+        expect(rendered.instance().state.yTransformOrigin).toBe("top");
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__bottom
         );
-        expect(positioner.instance().rootElement.current.className).not.toContain(
+        expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.viewportPositioner__top
         );
-        expect(positioner.instance().rootElement.current.className).toContain(
+        expect(rendered.instance().rootElement.current.className).toContain(
             managedClasses.viewportPositioner__verticalInset
         );
+
+        document.body.removeChild(container);
     });
 
     test("Option sizes calculated correctly - adjacent", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.adjacent}
-                    verticalPositioningMode={AxisPositioningMode.adjacent}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.adjacent}
+                verticalPositioningMode={AxisPositioningMode.adjacent}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 180;
-        positioner.instance().anchorRight = 240;
-        positioner.instance().anchorBottom = 190;
-        positioner.instance().anchorLeft = 230;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
-        positioner.instance().scrollTop = 0;
-        positioner.instance().scrollLeft = 0;
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 180;
+        rendered.instance().anchorRight = 240;
+        rendered.instance().anchorBottom = 190;
+        rendered.instance().anchorLeft = 230;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getAvailableWidth"](ViewportPositionerHorizontalPosition.left)
         ).toBe(80);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getAvailableWidth"](ViewportPositionerHorizontalPosition.right)
         ).toBe(10);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getAvailableHeight"](ViewportPositionerVerticalPosition.top)
         ).toBe(80);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getAvailableHeight"](ViewportPositionerVerticalPosition.bottom)
         ).toBe(10);
     });
 
     test("Option sizes calculated correctly - inset", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.inset}
-                    verticalPositioningMode={AxisPositioningMode.inset}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.inset}
+                verticalPositioningMode={AxisPositioningMode.inset}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 180;
-        positioner.instance().anchorRight = 240;
-        positioner.instance().anchorBottom = 190;
-        positioner.instance().anchorLeft = 230;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
-        positioner.instance().scrollTop = 0;
-        positioner.instance().scrollLeft = 0;
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 180;
+        rendered.instance().anchorRight = 240;
+        rendered.instance().anchorBottom = 190;
+        rendered.instance().anchorLeft = 230;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getAvailableWidth"](ViewportPositionerHorizontalPositionLabel.insetLeft)
         ).toBe(90);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getAvailableWidth"](
                     ViewportPositionerHorizontalPositionLabel.insetRight
                 )
         ).toBe(20);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getAvailableHeight"](ViewportPositionerVerticalPositionLabel.insetTop)
         ).toBe(90);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getAvailableHeight"](
                     ViewportPositionerVerticalPositionLabel.insetBottom
@@ -568,12 +570,10 @@ describe("viewport positioner", (): void => {
             />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-
-        const horizontalPositions: ViewportPositionerHorizontalPositionLabel[] = positioner
+        const horizontalPositions: ViewportPositionerHorizontalPositionLabel[] = rendered
             .instance()
             ["getHorizontalPositioningOptions"]();
-        const verticalPositions: ViewportPositionerVerticalPositionLabel[] = positioner
+        const verticalPositions: ViewportPositionerVerticalPositionLabel[] = rendered
             .instance()
             ["getVerticalPositioningOptions"]();
 
@@ -605,12 +605,10 @@ describe("viewport positioner", (): void => {
             />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-
-        const horizontalPositions: ViewportPositionerHorizontalPosition[] = positioner
+        const horizontalPositions: ViewportPositionerHorizontalPosition[] = rendered
             .instance()
             ["getHorizontalPositioningOptions"]();
-        const verticalPositions: ViewportPositionerVerticalPosition[] = positioner
+        const verticalPositions: ViewportPositionerVerticalPosition[] = rendered
             .instance()
             ["getVerticalPositioningOptions"]();
 
@@ -631,579 +629,417 @@ describe("viewport positioner", (): void => {
     });
 
     test("widest option chosen by default - pt1", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultHorizontalPosition={
-                        ViewportPositionerHorizontalPosition.uncontrolled
-                    }
-                    verticalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultVerticalPosition={
-                        ViewportPositionerVerticalPosition.uncontrolled
-                    }
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.adjacent}
+                defaultHorizontalPosition={
+                    ViewportPositionerHorizontalPosition.uncontrolled
+                }
+                verticalPositioningMode={AxisPositioningMode.adjacent}
+                defaultVerticalPosition={ViewportPositionerVerticalPosition.uncontrolled}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 180;
+        rendered.instance().anchorRight = 240;
+        rendered.instance().anchorBottom = 190;
+        rendered.instance().anchorLeft = 230;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
 
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 180;
-        positioner.instance().anchorRight = 240;
-        positioner.instance().anchorBottom = 190;
-        positioner.instance().anchorLeft = 230;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
-        positioner.instance().scrollTop = 0;
-        positioner.instance().scrollLeft = 0;
+        rendered.instance()["updateLayout"]();
 
-        positioner.instance()["updateLayout"]();
-
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.left
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.top
         );
     });
 
     test("widest option chosen by default - pt2", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.adjacent}
-                    verticalPositioningMode={AxisPositioningMode.adjacent}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.adjacent}
+                verticalPositioningMode={AxisPositioningMode.adjacent}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 20, width: 20 };
+        rendered.instance().anchorTop = 110;
+        rendered.instance().anchorRight = 170;
+        rendered.instance().anchorBottom = 120;
+        rendered.instance().anchorLeft = 160;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
 
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().positionerRect = positionerRectX20Y20;
-        positioner.instance().anchorTop = 110;
-        positioner.instance().anchorRight = 170;
-        positioner.instance().anchorBottom = 120;
-        positioner.instance().anchorLeft = 160;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
-        positioner.instance().scrollTop = 0;
-        positioner.instance().scrollLeft = 0;
+        rendered.instance()["updateLayout"]();
 
-        positioner.instance()["updateLayout"]();
-
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.right
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.bottom
         );
     });
 
     test("Translate transforms calculated correctly - top/left", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.inset}
-                    verticalPositioningMode={AxisPositioningMode.inset}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                    horizontalAlwaysInView={true}
-                    verticalAlwaysInView={true}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.inset}
+                verticalPositioningMode={AxisPositioningMode.inset}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+                horizontalAlwaysInView={true}
+                verticalAlwaysInView={true}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().anchorTop = 210;
-        positioner.instance().anchorRight = 270;
-        positioner.instance().anchorBottom = 220;
-        positioner.instance().anchorLeft = 260;
-        positioner.instance().setState({ noObserverMode: false });
-        expect(positioner.instance().state.noObserverMode).toBe(false);
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().anchorTop = 210;
+        rendered.instance().anchorRight = 270;
+        rendered.instance().anchorBottom = 220;
+        rendered.instance().anchorLeft = 260;
+        rendered.instance().setState({ noObserverMode: false });
+        expect(rendered.instance().state.noObserverMode).toBe(false);
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalTranslate"](
                     ViewportPositionerHorizontalPositionLabel.insetLeft
                 )
         ).toBe(-21);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalTranslate"](ViewportPositionerHorizontalPosition.left)
         ).toBe(-11);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalTranslate"](ViewportPositionerVerticalPositionLabel.insetTop)
         ).toBe(-21);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalTranslate"](ViewportPositionerVerticalPosition.top)
         ).toBe(-11);
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalTranslate"](
                     ViewportPositionerHorizontalPositionLabel.insetRight
                 )
         ).toBe(0);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalTranslate"](ViewportPositionerHorizontalPosition.right)
         ).toBe(0);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalTranslate"](
                     ViewportPositionerVerticalPositionLabel.insetBottom
                 )
         ).toBe(0);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalTranslate"](ViewportPositionerVerticalPosition.bottom)
         ).toBe(0);
     });
 
     test("Translate transforms calculated correctly - bottom/right", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.inset}
-                    verticalPositioningMode={AxisPositioningMode.inset}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                    horizontalAlwaysInView={true}
-                    verticalAlwaysInView={true}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.inset}
+                verticalPositioningMode={AxisPositioningMode.inset}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+                horizontalAlwaysInView={true}
+                verticalAlwaysInView={true}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().anchorTop = 80;
-        positioner.instance().anchorRight = 140;
-        positioner.instance().anchorBottom = 90;
-        positioner.instance().anchorLeft = 130;
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 80;
+        rendered.instance().anchorRight = 140;
+        rendered.instance().anchorBottom = 90;
+        rendered.instance().anchorLeft = 130;
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalTranslate"](
                     ViewportPositionerHorizontalPositionLabel.insetRight
                 )
         ).toBe(21);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalTranslate"](ViewportPositionerHorizontalPosition.right)
         ).toBe(11);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalTranslate"](
                     ViewportPositionerVerticalPositionLabel.insetBottom
                 )
         ).toBe(21);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalTranslate"](ViewportPositionerVerticalPosition.bottom)
         ).toBe(11);
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalTranslate"](
                     ViewportPositionerHorizontalPositionLabel.insetLeft
                 )
         ).toBe(0);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalTranslate"](ViewportPositionerHorizontalPosition.left)
         ).toBe(0);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalTranslate"](ViewportPositionerVerticalPositionLabel.insetTop)
         ).toBe(0);
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalTranslate"](ViewportPositionerVerticalPosition.top)
         ).toBe(0);
     });
 
     test("Positioner moves to biggest area on updateLayout() when spacing changes", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultHorizontalPosition={
-                        ViewportPositionerHorizontalPosition.uncontrolled
-                    }
-                    verticalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultVerticalPosition={
-                        ViewportPositionerVerticalPosition.uncontrolled
-                    }
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.adjacent}
+                defaultHorizontalPosition={
+                    ViewportPositionerHorizontalPosition.uncontrolled
+                }
+                verticalPositioningMode={AxisPositioningMode.adjacent}
+                defaultVerticalPosition={ViewportPositionerVerticalPosition.uncontrolled}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 180;
+        rendered.instance().anchorRight = 240;
+        rendered.instance().anchorBottom = 190;
+        rendered.instance().anchorLeft = 230;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
+        rendered.instance().setState({ noObserverMode: false });
 
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 180;
-        positioner.instance().anchorRight = 240;
-        positioner.instance().anchorBottom = 190;
-        positioner.instance().anchorLeft = 230;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
-        positioner.instance().scrollTop = 0;
-        positioner.instance().scrollLeft = 0;
-        positioner.instance().setState({ noObserverMode: false });
+        rendered.instance()["updateLayout"]();
 
-        positioner.instance()["updateLayout"]();
-
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.left
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.top
         );
 
-        positioner.instance().anchorTop = 110;
-        positioner.instance().anchorRight = 170;
-        positioner.instance().anchorBottom = 120;
-        positioner.instance().anchorLeft = 160;
+        rendered.instance().anchorTop = 110;
+        rendered.instance().anchorRight = 170;
+        rendered.instance().anchorBottom = 120;
+        rendered.instance().anchorLeft = 160;
 
-        positioner.instance()["updateLayout"]();
+        rendered.instance()["updateLayout"]();
 
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.right
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.bottom
         );
     });
 
     test("Positioner prefers default position until threshold is passed", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
-                    horizontalThreshold={20}
-                    verticalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultVerticalPosition={ViewportPositionerVerticalPosition.top}
-                    verticalThreshold={20}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.adjacent}
+                defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
+                horizontalThreshold={20}
+                verticalPositioningMode={AxisPositioningMode.adjacent}
+                defaultVerticalPosition={ViewportPositionerVerticalPosition.top}
+                verticalThreshold={20}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 180;
+        rendered.instance().anchorRight = 240;
+        rendered.instance().anchorBottom = 190;
+        rendered.instance().anchorLeft = 230;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
+        rendered.instance().setState({ noObserverMode: false });
 
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 180;
-        positioner.instance().anchorRight = 240;
-        positioner.instance().anchorBottom = 190;
-        positioner.instance().anchorLeft = 230;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
-        positioner.instance().scrollTop = 0;
-        positioner.instance().scrollLeft = 0;
-        positioner.instance().setState({ noObserverMode: false });
+        rendered.instance()["updateLayout"]();
 
-        positioner.instance()["updateLayout"]();
-
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.left
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.top
         );
 
-        positioner.instance().anchorTop = 120;
-        positioner.instance().anchorRight = 180;
-        positioner.instance().anchorBottom = 130;
-        positioner.instance().anchorLeft = 170;
+        rendered.instance().anchorTop = 120;
+        rendered.instance().anchorRight = 180;
+        rendered.instance().anchorBottom = 130;
+        rendered.instance().anchorLeft = 170;
 
-        positioner.instance()["updateLayout"]();
+        rendered.instance()["updateLayout"]();
 
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.left
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.top
         );
 
-        positioner.instance().anchorTop = 110;
-        positioner.instance().anchorRight = 170;
-        positioner.instance().anchorBottom = 120;
-        positioner.instance().anchorLeft = 160;
+        rendered.instance().anchorTop = 110;
+        rendered.instance().anchorRight = 170;
+        rendered.instance().anchorBottom = 120;
+        rendered.instance().anchorLeft = 160;
 
-        positioner.instance()["updateLayout"]();
+        rendered.instance()["updateLayout"]();
 
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.right
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.bottom
         );
     });
 
     test("Positioner stays fixed on default position when LocktoDefault set in props", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
-                    horizontalLockToDefault={true}
-                    horizontalThreshold={20}
-                    verticalPositioningMode={AxisPositioningMode.adjacent}
-                    defaultVerticalPosition={ViewportPositionerVerticalPosition.top}
-                    verticalLockToDefault={true}
-                    verticalThreshold={20}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.adjacent}
+                defaultHorizontalPosition={ViewportPositionerHorizontalPosition.left}
+                horizontalLockToDefault={true}
+                horizontalThreshold={20}
+                verticalPositioningMode={AxisPositioningMode.adjacent}
+                defaultVerticalPosition={ViewportPositionerVerticalPosition.top}
+                verticalLockToDefault={true}
+                verticalThreshold={20}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 80;
+        rendered.instance().anchorRight = 90;
+        rendered.instance().anchorBottom = 90;
+        rendered.instance().anchorLeft = 80;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
 
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 80;
-        positioner.instance().anchorRight = 90;
-        positioner.instance().anchorBottom = 90;
-        positioner.instance().anchorLeft = 80;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
-        positioner.instance().scrollTop = 0;
-        positioner.instance().scrollLeft = 0;
+        rendered.instance()["updateLayout"]();
 
-        positioner.instance()["updateLayout"]();
-
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.left
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.top
         );
 
-        positioner.instance().anchorTop = 20;
-        positioner.instance().anchorRight = 30;
-        positioner.instance().anchorBottom = 30;
-        positioner.instance().anchorLeft = 20;
+        rendered.instance().anchorTop = 20;
+        rendered.instance().anchorRight = 30;
+        rendered.instance().anchorBottom = 30;
+        rendered.instance().anchorLeft = 20;
 
-        positioner.instance()["updateLayout"]();
+        rendered.instance()["updateLayout"]();
 
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.left
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.top
         );
 
-        positioner.instance().anchorTop = 10;
-        positioner.instance().anchorRight = 20;
-        positioner.instance().anchorBottom = 20;
-        positioner.instance().anchorLeft = 10;
+        rendered.instance().anchorTop = 10;
+        rendered.instance().anchorRight = 20;
+        rendered.instance().anchorBottom = 20;
+        rendered.instance().anchorLeft = 10;
 
-        positioner.instance()["updateLayout"]();
+        rendered.instance()["updateLayout"]();
 
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPosition.left
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPosition.top
         );
     });
 
     test("Positioner base position offset from anchor is accounted for", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.adjacent}
-                    verticalPositioningMode={AxisPositioningMode.adjacent}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.adjacent}
+                verticalPositioningMode={AxisPositioningMode.adjacent}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 80;
-        positioner.instance().anchorRight = 90;
-        positioner.instance().anchorBottom = 90;
-        positioner.instance().anchorLeft = 80;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
-        positioner.instance().scrollTop = 0;
-        positioner.instance().scrollLeft = 0;
-        positioner.instance().baseHorizontalOffset = 10;
-        positioner.instance().baseVerticalOffset = 10;
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 80;
+        rendered.instance().anchorRight = 90;
+        rendered.instance().anchorBottom = 90;
+        rendered.instance().anchorLeft = 80;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
+        rendered.instance().baseHorizontalOffset = 10;
+        rendered.instance().baseVerticalOffset = 10;
 
         const positionerDimension: Dimension = {
             width: 10,
@@ -1211,7 +1047,7 @@ describe("viewport positioner", (): void => {
         };
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalPositioningState"](
                     ViewportPositionerHorizontalPositionLabel.right,
@@ -1220,7 +1056,7 @@ describe("viewport positioner", (): void => {
         ).toBe(20);
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalPositioningState"](
                     ViewportPositionerHorizontalPositionLabel.left,
@@ -1229,7 +1065,7 @@ describe("viewport positioner", (): void => {
         ).toBe(0);
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalPositioningState"](
                     ViewportPositionerHorizontalPositionLabel.insetRight,
@@ -1238,7 +1074,7 @@ describe("viewport positioner", (): void => {
         ).toBe(10);
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getHorizontalPositioningState"](
                     ViewportPositionerHorizontalPositionLabel.insetLeft,
@@ -1247,7 +1083,7 @@ describe("viewport positioner", (): void => {
         ).toBe(-10);
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalPositioningState"](
                     ViewportPositionerVerticalPositionLabel.top,
@@ -1256,7 +1092,7 @@ describe("viewport positioner", (): void => {
         ).toBe(10);
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalPositioningState"](
                     ViewportPositionerVerticalPositionLabel.bottom,
@@ -1265,7 +1101,7 @@ describe("viewport positioner", (): void => {
         ).toBe(10);
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalPositioningState"](
                     ViewportPositionerVerticalPositionLabel.insetTop,
@@ -1274,7 +1110,7 @@ describe("viewport positioner", (): void => {
         ).toBe(0);
 
         expect(
-            positioner
+            rendered
                 .instance()
                 ["getVerticalPositioningState"](
                     ViewportPositionerVerticalPositionLabel.insetBottom,
@@ -1284,164 +1120,122 @@ describe("viewport positioner", (): void => {
     });
 
     test("Positioner base position offset correctly calculated", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-        const viewportElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.adjacent}
-                    verticalPositioningMode={AxisPositioningMode.adjacent}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.adjacent}
+                verticalPositioningMode={AxisPositioningMode.adjacent}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().positionerRect = positionerRectX70Y70;
-        positioner.instance().anchorTop = 60;
-        positioner.instance().anchorRight = 70;
-        positioner.instance().anchorBottom = 70;
-        positioner.instance().anchorLeft = 60;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
-        positioner.instance().scrollTop = 0;
-        positioner.instance().scrollLeft = 0;
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 60;
+        rendered.instance().anchorRight = 70;
+        rendered.instance().anchorBottom = 70;
+        rendered.instance().anchorLeft = 60;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().scrollTop = 0;
+        rendered.instance().scrollLeft = 0;
 
         // test bottom right
-        positioner.instance().baseHorizontalOffset = 0;
-        positioner.instance().baseVerticalOffset = 0;
-        positioner.instance().setState({
+        rendered.instance().baseHorizontalOffset = 0;
+        rendered.instance().baseVerticalOffset = 0;
+        rendered.instance().setState({
             currentHorizontalPosition: ViewportPositionerHorizontalPositionLabel.right,
             currentVerticalPosition: ViewportPositionerVerticalPositionLabel.bottom,
         });
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.right
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPositionLabel.bottom
         );
-        positioner.instance()["updatePositionerOffset"](positionerRectX70Y70);
-        expect(positioner.instance().baseHorizontalOffset).toBe(0);
-        expect(positioner.instance().baseVerticalOffset).toBe(0);
+        rendered.instance()["updatePositionerOffset"](positionerRectX70Y70);
+        expect(rendered.instance().baseHorizontalOffset).toBe(0);
+        expect(rendered.instance().baseVerticalOffset).toBe(0);
 
         // test inset bottom right
-        positioner.instance().baseHorizontalOffset = 0;
-        positioner.instance().baseVerticalOffset = 0;
-        positioner.instance().setState({
+        rendered.instance().baseHorizontalOffset = 0;
+        rendered.instance().baseVerticalOffset = 0;
+        rendered.instance().setState({
             currentHorizontalPosition:
                 ViewportPositionerHorizontalPositionLabel.insetRight,
             currentVerticalPosition: ViewportPositionerVerticalPositionLabel.insetBottom,
         });
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.insetRight
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPositionLabel.insetBottom
         );
-        positioner.instance()["updatePositionerOffset"](positionerRectX70Y70);
-        expect(positioner.instance().baseHorizontalOffset).toBe(-10);
-        expect(positioner.instance().baseVerticalOffset).toBe(-10);
+        rendered.instance()["updatePositionerOffset"](positionerRectX70Y70);
+        expect(rendered.instance().baseHorizontalOffset).toBe(-10);
+        expect(rendered.instance().baseVerticalOffset).toBe(-10);
 
         // test top left
-        positioner.instance().baseHorizontalOffset = 0;
-        positioner.instance().baseVerticalOffset = 0;
-        positioner.instance().setState({
+        rendered.instance().baseHorizontalOffset = 0;
+        rendered.instance().baseVerticalOffset = 0;
+        rendered.instance().setState({
             currentHorizontalPosition: ViewportPositionerHorizontalPositionLabel.left,
             currentVerticalPosition: ViewportPositionerVerticalPositionLabel.top,
         });
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.left
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPositionLabel.top
         );
-        positioner.instance()["updatePositionerOffset"](positionerRectX70Y70);
-        expect(positioner.instance().baseHorizontalOffset).toBe(-20);
-        expect(positioner.instance().baseVerticalOffset).toBe(-20);
+        rendered.instance()["updatePositionerOffset"](positionerRectX70Y70);
+        expect(rendered.instance().baseHorizontalOffset).toBe(-20);
+        expect(rendered.instance().baseVerticalOffset).toBe(-20);
 
         // test inset top left
-        positioner.instance().baseHorizontalOffset = 0;
-        positioner.instance().baseVerticalOffset = 0;
-        positioner.instance().setState({
+        rendered.instance().baseHorizontalOffset = 0;
+        rendered.instance().baseVerticalOffset = 0;
+        rendered.instance().setState({
             currentHorizontalPosition:
                 ViewportPositionerHorizontalPositionLabel.insetLeft,
             currentVerticalPosition: ViewportPositionerVerticalPositionLabel.insetTop,
         });
-        expect(positioner.instance().state.currentHorizontalPosition).toBe(
+        expect(rendered.instance().state.currentHorizontalPosition).toBe(
             ViewportPositionerHorizontalPositionLabel.insetLeft
         );
-        expect(positioner.instance().state.currentVerticalPosition).toBe(
+        expect(rendered.instance().state.currentVerticalPosition).toBe(
             ViewportPositionerVerticalPositionLabel.insetTop
         );
-        positioner.instance()["updatePositionerOffset"](positionerRectX70Y70);
-        expect(positioner.instance().baseHorizontalOffset).toBe(-10);
-        expect(positioner.instance().baseVerticalOffset).toBe(-10);
+        rendered.instance()["updatePositionerOffset"](positionerRectX70Y70);
+        expect(rendered.instance().baseHorizontalOffset).toBe(-10);
+        expect(rendered.instance().baseVerticalOffset).toBe(-10);
     });
 
-    test("Should scale positioner dimenstions to match the viewports height when scaleTofit is set to true", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
+    test("Should scale positioner dimensions to match the viewport's height when scaleTofit is set to true", (): void => {
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.inset}
-                    verticalPositioningMode={AxisPositioningMode.inset}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                    scaleToFit={true}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.inset}
+                verticalPositioningMode={AxisPositioningMode.inset}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+                scaleToFit={true}
+            />
         );
 
-        const positioner: any = rendered.find("BaseViewportPositioner");
-
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().anchorTop = 100;
-        positioner.instance().anchorRight = 160;
-        positioner.instance().anchorBottom = 110;
-        positioner.instance().anchorLeft = 150;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().anchorTop = 100;
+        rendered.instance().anchorRight = 160;
+        rendered.instance().anchorBottom = 110;
+        rendered.instance().anchorLeft = 150;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
+        rendered.instance().updateLayout();
 
         let positionerDimension: Dimension;
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.insetRight,
@@ -1450,7 +1244,7 @@ describe("viewport positioner", (): void => {
         expect(positionerDimension.width).toBe(100);
         expect(positionerDimension.height).toBe(100);
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.right,
@@ -1459,7 +1253,7 @@ describe("viewport positioner", (): void => {
         expect(positionerDimension.width).toBe(90);
         expect(positionerDimension.height).toBe(90);
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.insetLeft,
@@ -1468,7 +1262,7 @@ describe("viewport positioner", (): void => {
         expect(positionerDimension.width).toBe(10);
         expect(positionerDimension.height).toBe(10);
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.left,
@@ -1479,47 +1273,29 @@ describe("viewport positioner", (): void => {
     });
 
     test("Positioner scaled sizes limited to viewport width", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.inset}
-                    verticalPositioningMode={AxisPositioningMode.inset}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                    scaleToFit={true}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.inset}
+                verticalPositioningMode={AxisPositioningMode.inset}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+                scaleToFit={true}
+            />
         );
 
         let positionerDimension: Dimension;
-        const positioner: any = rendered.find("BaseViewportPositioner");
 
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().anchorTop = 0;
-        positioner.instance().anchorRight = 60;
-        positioner.instance().anchorBottom = 10;
-        positioner.instance().anchorLeft = 50;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().anchorTop = 0;
+        rendered.instance().anchorRight = 60;
+        rendered.instance().anchorBottom = 10;
+        rendered.instance().anchorLeft = 50;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.insetRight,
@@ -1528,7 +1304,7 @@ describe("viewport positioner", (): void => {
         expect(positionerDimension.width).toBe(100);
         expect(positionerDimension.height).toBe(100);
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.right,
@@ -1537,12 +1313,12 @@ describe("viewport positioner", (): void => {
         expect(positionerDimension.width).toBe(100);
         expect(positionerDimension.height).toBe(100);
 
-        positioner.instance().anchorTop = 300;
-        positioner.instance().anchorRight = 360;
-        positioner.instance().anchorBottom = 310;
-        positioner.instance().anchorLeft = 3350;
+        rendered.instance().anchorTop = 300;
+        rendered.instance().anchorRight = 360;
+        rendered.instance().anchorBottom = 310;
+        rendered.instance().anchorLeft = 3350;
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.insetLeft,
@@ -1551,7 +1327,7 @@ describe("viewport positioner", (): void => {
         expect(positionerDimension.width).toBe(100);
         expect(positionerDimension.height).toBe(100);
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.left,
@@ -1562,49 +1338,31 @@ describe("viewport positioner", (): void => {
     });
 
     test("Positioner scaled sizes can't be smaller than threshold values", (): void => {
-        const anchorElement: React.RefObject<HTMLDivElement> = React.createRef<
-            HTMLDivElement
-        >();
-
         const rendered: any = mount(
-            <div
-                style={{
-                    height: "100px",
-                    width: "100px",
-                }}
-            >
-                <div
-                    style={{
-                        height: "10px",
-                        width: "10px",
-                    }}
-                    ref={anchorElement}
-                />
-                <ViewportPositioner
-                    horizontalPositioningMode={AxisPositioningMode.inset}
-                    verticalPositioningMode={AxisPositioningMode.inset}
-                    horizontalThreshold={110}
-                    verticalThreshold={110}
-                    anchor={anchorElement}
-                    viewport={document.firstElementChild as HTMLElement}
-                    managedClasses={managedClasses}
-                    scaleToFit={true}
-                />
-            </div>
+            <ViewportPositioner
+                horizontalPositioningMode={AxisPositioningMode.inset}
+                verticalPositioningMode={AxisPositioningMode.inset}
+                horizontalThreshold={110}
+                verticalThreshold={110}
+                anchor={anchorElement}
+                viewport={document.firstElementChild as HTMLElement}
+                managedClasses={managedClasses}
+                scaleToFit={true}
+            />
         );
 
         let positionerDimension: Dimension;
-        const positioner: any = rendered.find("BaseViewportPositioner");
 
-        positioner.instance().viewportRect = viewportRect;
-        positioner.instance().anchorTop = 0;
-        positioner.instance().anchorRight = 60;
-        positioner.instance().anchorBottom = 10;
-        positioner.instance().anchorLeft = 50;
-        positioner.instance().anchorWidth = 10;
-        positioner.instance().anchorHeight = 10;
+        rendered.instance().viewportRect = viewportRect;
+        rendered.instance().positionerDimension = { height: 70, width: 70 };
+        rendered.instance().anchorTop = 0;
+        rendered.instance().anchorRight = 60;
+        rendered.instance().anchorBottom = 10;
+        rendered.instance().anchorLeft = 50;
+        rendered.instance().anchorWidth = 10;
+        rendered.instance().anchorHeight = 10;
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.insetRight,
@@ -1613,7 +1371,7 @@ describe("viewport positioner", (): void => {
         expect(positionerDimension.width).toBe(110);
         expect(positionerDimension.height).toBe(110);
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.right,
@@ -1622,12 +1380,12 @@ describe("viewport positioner", (): void => {
         expect(positionerDimension.width).toBe(110);
         expect(positionerDimension.height).toBe(110);
 
-        positioner.instance().anchorTop = 300;
-        positioner.instance().anchorRight = 360;
-        positioner.instance().anchorBottom = 310;
-        positioner.instance().anchorLeft = 3350;
+        rendered.instance().anchorTop = 300;
+        rendered.instance().anchorRight = 360;
+        rendered.instance().anchorBottom = 310;
+        rendered.instance().anchorLeft = 3350;
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.insetLeft,
@@ -1636,7 +1394,7 @@ describe("viewport positioner", (): void => {
         expect(positionerDimension.width).toBe(110);
         expect(positionerDimension.height).toBe(110);
 
-        positionerDimension = positioner
+        positionerDimension = rendered
             .instance()
             ["getNextPositionerDimension"](
                 ViewportPositionerHorizontalPositionLabel.left,
@@ -1644,5 +1402,88 @@ describe("viewport positioner", (): void => {
             );
         expect(positionerDimension.width).toBe(110);
         expect(positionerDimension.height).toBe(110);
+    });
+
+    test("extractElementFromRef function returns element passed in directly", (): void => {
+        const rendered: any = mount(
+            <ViewportPositioner
+                viewport={document.firstElementChild as HTMLElement}
+                anchor={anchorElement}
+                managedClasses={managedClasses}
+            />
+        );
+
+        const testElement: Element = document.createElement("div");
+        expect(rendered.instance()["extractElementFromRef"](testElement)).toBe(
+            testElement
+        );
+    });
+
+    test("should create a resize observer if it is available", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const ActualObserver: ConstructibleResizeObserver = (window as WindowWithResizeObserver)
+            .ResizeObserver;
+        const construct: jest.Mock<any, any> = jest.fn();
+        // Mock the resize observer
+        class MockResizeObserver {
+            public observe: jest.Mock<any, any> = jest.fn();
+            public unobserve: jest.Mock<any, any> = jest.fn();
+            public disconnect: jest.Mock<any, any> = jest.fn();
+            constructor() {
+                construct();
+            }
+        }
+        (window as WindowWithResizeObserver).ResizeObserver = MockResizeObserver;
+
+        // Render the component
+        const rendered: any = mount(
+            <ViewportPositioner
+                viewport={container}
+                anchor={anchorElement}
+                managedClasses={managedClasses}
+            />,
+            { attachTo: container }
+        );
+
+        expect(construct).toBeCalledTimes(1);
+        // Replace the window to it's original state
+        (window as WindowWithResizeObserver).ResizeObserver = ActualObserver;
+
+        document.body.removeChild(container);
+    });
+
+    test("should disconnect the resize observer when unmounted", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const ActualObserver: ConstructibleResizeObserver = (window as WindowWithResizeObserver)
+            .ResizeObserver;
+        const disconnect: jest.Mock<any, any> = jest.fn();
+        // Mock the resize observer
+        class MockResizeObserver {
+            public observe: jest.Mock<any, any> = jest.fn();
+            public unobserve: jest.Mock<any, any> = jest.fn();
+            public disconnect: jest.Mock<any, any> = disconnect;
+        }
+        (window as WindowWithResizeObserver).ResizeObserver = MockResizeObserver;
+
+        // Render the component
+        const rendered: any = mount(
+            <ViewportPositioner
+                viewport={container}
+                anchor={anchorElement}
+                managedClasses={managedClasses}
+            />,
+            { attachTo: container }
+        );
+
+        rendered.unmount();
+        expect(disconnect).toBeCalledTimes(1);
+        // Replace the window to it's original state
+        (window as WindowWithResizeObserver).ResizeObserver = ActualObserver;
+
+        document.body.removeChild(container);
     });
 });

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -13,10 +13,12 @@ const anchorElement2: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivE
 
 interface TestViewportProps {
     positionerProps: ViewportPositionerProps[];
+    positionerContents: React.ReactNode[];
 }
 
 interface TestViewportState {
     currentDataSetIndex: number;
+    currentContentsIndex: number;
 }
 
 class TestViewport extends React.Component<TestViewportProps, TestViewportState> {
@@ -29,6 +31,7 @@ class TestViewport extends React.Component<TestViewportProps, TestViewportState>
 
         this.state = {
             currentDataSetIndex: 0,
+            currentContentsIndex: 0,
         };
     }
 
@@ -40,7 +43,8 @@ class TestViewport extends React.Component<TestViewportProps, TestViewportState>
                     width: "100%",
                 }}
             >
-                {this.renderSwitcherUi()}
+                {this.renderPropsSwitcherUi()}
+                {this.renderContentSwitcherUi()}
                 <ViewportContext.Provider
                     value={{
                         viewport: this.rootElement,
@@ -67,15 +71,11 @@ class TestViewport extends React.Component<TestViewportProps, TestViewportState>
                                     this.state.currentDataSetIndex
                                 ]}
                             >
-                                <div
-                                    style={{
-                                        height: "100%",
-                                        width: "100%",
-                                        background: "yellow",
-                                    }}
-                                >
-                                    Positioner
-                                </div>
+                                {
+                                    this.props.positionerContents[
+                                        this.state.currentContentsIndex
+                                    ]
+                                }
                             </ViewportPositioner>
                         </div>
                     </div>
@@ -84,18 +84,29 @@ class TestViewport extends React.Component<TestViewportProps, TestViewportState>
         );
     }
 
-    private renderSwitcherUi = (): ReactNode => {
+    private renderPropsSwitcherUi = (): ReactNode => {
         if (this.props.positionerProps.length < 2) {
             return null;
         }
         return (
             <div>
-                <button onClick={this.onClick}>Switch data</button>
+                <button onClick={this.onNextPropsClick}>Switch data</button>
             </div>
         );
     };
 
-    private onClick = (event: React.MouseEvent): void => {
+    private renderContentSwitcherUi = (): ReactNode => {
+        if (this.props.positionerContents.length < 2) {
+            return null;
+        }
+        return (
+            <div>
+                <button onClick={this.onNextContentsClick}>Switch Contents</button>
+            </div>
+        );
+    };
+
+    private onNextPropsClick = (event: React.MouseEvent): void => {
         const nextDataSetIndex: number = this.state.currentDataSetIndex + 1;
         this.setState({
             currentDataSetIndex:
@@ -104,16 +115,39 @@ class TestViewport extends React.Component<TestViewportProps, TestViewportState>
                     : 0,
         });
     };
+
+    private onNextContentsClick = (event: React.MouseEvent): void => {
+        const nextContentsIndex: number = this.state.currentContentsIndex + 1;
+        this.setState({
+            currentContentsIndex:
+                nextContentsIndex < this.props.positionerContents.length
+                    ? nextContentsIndex
+                    : 0,
+        });
+    };
 }
 
 storiesOf("Viewport Positioner", module)
     .add("Default", () => (
         <TestViewport
+            positionerContents={[
+                <div
+                    key="c1.1"
+                    style={{
+                        height: "100%",
+                        width: "100%",
+                        background: "yellow",
+                    }}
+                >
+                    Positioner
+                </div>,
+            ]}
             positionerProps={[
                 {
                     verticalPositioningMode: AxisPositioningMode.adjacent,
                     horizontalPositioningMode: AxisPositioningMode.adjacent,
                     anchor: anchorElement,
+                    delayContentInstanciation: true,
                     style: {
                         height: "100px",
                         width: "100px",
@@ -144,6 +178,18 @@ storiesOf("Viewport Positioner", module)
     ))
     .add("Squishy region", () => (
         <TestViewport
+            positionerContents={[
+                <div
+                    key="c2.1"
+                    style={{
+                        height: "100%",
+                        width: "100%",
+                        background: "yellow",
+                    }}
+                >
+                    Positioner
+                </div>,
+            ]}
             positionerProps={[
                 {
                     verticalPositioningMode: AxisPositioningMode.adjacent,
@@ -152,6 +198,7 @@ storiesOf("Viewport Positioner", module)
                         ViewportPositionerVerticalPosition.uncontrolled,
                     scaleToFit: true,
                     anchor: anchorElement,
+                    delayContentInstanciation: true,
                 },
             ]}
         >
@@ -178,6 +225,18 @@ storiesOf("Viewport Positioner", module)
     ))
     .add("Squishy region with thresholds", () => (
         <TestViewport
+            positionerContents={[
+                <div
+                    key="c3.1"
+                    style={{
+                        height: "100%",
+                        width: "100%",
+                        background: "yellow",
+                    }}
+                >
+                    Positioner
+                </div>,
+            ]}
             positionerProps={[
                 {
                     verticalPositioningMode: AxisPositioningMode.adjacent,
@@ -188,6 +247,7 @@ storiesOf("Viewport Positioner", module)
                         ViewportPositionerVerticalPosition.uncontrolled,
                     scaleToFit: true,
                     anchor: anchorElement,
+                    delayContentInstanciation: true,
                 },
             ]}
         >
@@ -214,6 +274,18 @@ storiesOf("Viewport Positioner", module)
     ))
     .add("Always in view - adjacent", () => (
         <TestViewport
+            positionerContents={[
+                <div
+                    key="c4.1"
+                    style={{
+                        height: "100%",
+                        width: "100%",
+                        background: "yellow",
+                    }}
+                >
+                    Positioner
+                </div>,
+            ]}
             positionerProps={[
                 {
                     verticalPositioningMode: AxisPositioningMode.adjacent,
@@ -221,6 +293,7 @@ storiesOf("Viewport Positioner", module)
                     verticalAlwaysInView: true,
                     horizontalAlwaysInView: true,
                     anchor: anchorElement,
+                    delayContentInstanciation: true,
                     style: {
                         height: "100px",
                         width: "100px",
@@ -251,6 +324,18 @@ storiesOf("Viewport Positioner", module)
     ))
     .add("Always in view - inset", () => (
         <TestViewport
+            positionerContents={[
+                <div
+                    key="c5.1"
+                    style={{
+                        height: "100%",
+                        width: "100%",
+                        background: "yellow",
+                    }}
+                >
+                    Positioner
+                </div>,
+            ]}
             positionerProps={[
                 {
                     verticalPositioningMode: AxisPositioningMode.inset,
@@ -258,6 +343,7 @@ storiesOf("Viewport Positioner", module)
                     verticalAlwaysInView: true,
                     horizontalAlwaysInView: true,
                     anchor: anchorElement,
+                    delayContentInstanciation: true,
                     style: {
                         height: "100px",
                         width: "100px",
@@ -288,11 +374,24 @@ storiesOf("Viewport Positioner", module)
     ))
     .add("Change anchors", () => (
         <TestViewport
+            positionerContents={[
+                <div
+                    key="c6.1"
+                    style={{
+                        height: "100%",
+                        width: "100%",
+                        background: "yellow",
+                    }}
+                >
+                    Positioner
+                </div>,
+            ]}
             positionerProps={[
                 {
                     verticalPositioningMode: AxisPositioningMode.adjacent,
                     horizontalPositioningMode: AxisPositioningMode.adjacent,
                     anchor: anchorElement,
+                    delayContentInstanciation: true,
                     style: {
                         height: "100px",
                         width: "100px",
@@ -302,6 +401,7 @@ storiesOf("Viewport Positioner", module)
                     verticalPositioningMode: AxisPositioningMode.adjacent,
                     horizontalPositioningMode: AxisPositioningMode.adjacent,
                     anchor: anchorElement2,
+                    delayContentInstanciation: true,
                     style: {
                         height: "100px",
                         width: "100px",
@@ -337,6 +437,63 @@ storiesOf("Viewport Positioner", module)
                     }}
                 >
                     Anchor2
+                </div>
+            </div>
+        </TestViewport>
+    ))
+    .add("resizing", () => (
+        <TestViewport
+            positionerContents={[
+                <div
+                    key="c7.1"
+                    style={{
+                        height: "100px",
+                        width: "100px",
+                        background: "yellow",
+                    }}
+                >
+                    Positioner
+                </div>,
+                <div
+                    key="c7.2"
+                    style={{
+                        height: "150px",
+                        width: "150px",
+                        background: "orange",
+                    }}
+                >
+                    Positioner
+                </div>,
+            ]}
+            positionerProps={[
+                {
+                    verticalPositioningMode: AxisPositioningMode.adjacent,
+                    horizontalPositioningMode: AxisPositioningMode.adjacent,
+                    anchor: anchorElement,
+                    delayContentInstanciation: true,
+                    style: {
+                        display: "inline-block",
+                    },
+                },
+            ]}
+        >
+            <div
+                style={{
+                    height: "1200px",
+                    width: "1200px",
+                    padding: "500px",
+                    background: "blue",
+                }}
+            >
+                <div
+                    ref={anchorElement}
+                    style={{
+                        height: "100px",
+                        width: "100px",
+                        background: "green",
+                    }}
+                >
+                    Anchor
                 </div>
             </div>
         </TestViewport>

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.stories.tsx
@@ -451,9 +451,7 @@ storiesOf("Viewport Positioner", module)
                         width: "100px",
                         background: "yellow",
                     }}
-                >
-                    Positioner
-                </div>,
+                />,
                 <div
                     key="c7.2"
                     style={{
@@ -461,9 +459,7 @@ storiesOf("Viewport Positioner", module)
                         width: "150px",
                         background: "orange",
                     }}
-                >
-                    Positioner
-                </div>,
+                />,
             ]}
             positionerProps={[
                 {
@@ -472,7 +468,8 @@ storiesOf("Viewport Positioner", module)
                     anchor: anchorElement,
                     delayContentInstanciation: true,
                     style: {
-                        display: "inline-block",
+                        height: "fit-content",
+                        width: "fit-content",
                     },
                 },
             ]}

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -166,8 +166,6 @@ class ViewportPositioner extends Foundation<
     private resizeDetector: ResizeObserverClassDefinition;
 
     private viewportRect: ClientRect | DOMRect;
-
-    // private positionerRect: ClientRect | DOMRect;
     private positionerDimension: Dimension;
 
     private anchorTop: number = 0;

--- a/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
+++ b/packages/fast-components-react-base/src/viewport-positioner/viewport-positioner.tsx
@@ -205,15 +205,19 @@ class ViewportPositioner extends Foundation<
     }
 
     public componentDidUpdate(prevProps: ViewportPositionerProps): void {
-        // if anchor or viewport changes the component needs to reset
-        if (
-            prevProps.anchor !== this.props.anchor ||
-            prevProps.viewport !== this.props.viewport
-        ) {
-            this.detachListeners(prevProps.viewport);
+        if (prevProps !== this.props) {
+            // if anchor or viewport changes the component needs to reset
+            if (
+                prevProps.anchor !== this.props.anchor ||
+                prevProps.viewport !== this.props.viewport
+            ) {
+                this.detachListeners(prevProps.viewport);
 
-            this.setState(this.generateInitialState());
-            return;
+                this.setState(this.generateInitialState());
+                return;
+            }
+
+            this.requestFrame();
         }
 
         if (
@@ -223,8 +227,6 @@ class ViewportPositioner extends Foundation<
             this.updateDisabledState();
             return;
         }
-
-        this.requestFrame();
     }
 
     /**

--- a/packages/fast-components-react-msft/src/flyout/flyout.props.ts
+++ b/packages/fast-components-react-msft/src/flyout/flyout.props.ts
@@ -70,6 +70,11 @@ export interface FlyoutHandledProps
     verticalPositioningMode?: FlyoutAxisPositioningMode;
 
     /**
+     * Sets the visibility of the flyout
+     */
+    delayContentInstanciation?: boolean;
+
+    /**
      *  The flyout height
      */
     height?: string;

--- a/packages/fast-components-react-msft/src/flyout/flyout.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.tsx
@@ -61,6 +61,7 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
         verticalThreshold: void 0,
         viewport: void 0,
         width: void 0,
+        delayContentInstanciation: void 0,
         scaleToFit: void 0,
     };
 

--- a/packages/fast-components-react-msft/src/flyout/flyout.tsx
+++ b/packages/fast-components-react-msft/src/flyout/flyout.tsx
@@ -117,6 +117,7 @@ class Flyout extends Foundation<FlyoutHandledProps, FlyoutUnhandledProps, {}> {
                 verticalThreshold={this.props.verticalThreshold}
                 verticalLockToDefault={this.props.verticalLockToDefault}
                 viewport={this.props.viewport}
+                delayContentInstanciation={this.props.delayContentInstanciation}
                 style={{
                     height: this.props.height,
                     width: this.props.width,


### PR DESCRIPTION
# Description
Adds a Boolean prop "delayContentInstanciation" to viewport positioner which defaults to false. When true the contents of the positioner are not instanciated until after an initial rendering pass where the empty component is placed in the layout.  The reason for this is that partners have encountered issues where the contents of a positioner get focus before the component gets placed and as a result the browser's scroll into view behavior is triggered as an undesirable side effect.

This change also required the component to support resizing of the positioner due to changing content size which it did not previously.

Tests have also been improved and coverage increased.

## Motivation & context
Addresses unwanted scroll into view behavior.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
