### PR TITLE
doc(specs): introduce spec template

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -1,9 +1,7 @@
 # Specs
 
-Here you'll find specifications for fast-dna custom elements and other library features.
+Here you'll find specifications for custom elements and other library features.
 
 > **Note:** When authoring a new spec, please use [our standard spec template](./template.md). The PR that introduces your spec should also add a link to this readme in the specs section below.
 
 ## Specs
-
-Coming soon...

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,9 @@
+# Specs
+
+Here you'll find specifications for fast-dna custom elements and other library features.
+
+> **Note:** When authoring a new spec, please use [our standard spec template](./template.md). The PR that introduces your spec should also add a link to this readme in the specs section below.
+
+## Specs
+
+Coming soon...

--- a/specs/template.md
+++ b/specs/template.md
@@ -78,7 +78,7 @@
 
 - *Special RTL handling*
 - *Swapping of internal icons/visuals*
-- *Localization of text*
+- *Localization*
 
 ### Security
 

--- a/specs/template.md
+++ b/specs/template.md
@@ -22,7 +22,7 @@
 
 ### Prior Art/Examples
 
-*Screenshots and/or links to existing, canonical or exemplary implementations of the component.*
+*Screenshots and/or links to existing, canonical, or exemplary implementations of the component.*
 
 ---
 

--- a/specs/template.md
+++ b/specs/template.md
@@ -18,7 +18,7 @@
 
 ### Risks and Challenges
 
-*Notable risks or challenges associated with implementing the component. Would we need to make any breaking changes to other parts of fast-dna in order to achieve this component's goals?*
+*Notable risks or challenges associated with implementing the component. Would we need to make any breaking changes in order to achieve this component's goals?*
 
 ### Prior Art/Examples
 
@@ -31,7 +31,7 @@
 *Describe the design of the component, thinking through several perspectives:*
 
 - *A customer using the component on a web page.*
-- *A developer building an app with the component and interacting through HTML/CSS/JS.*
+- *A developer building an app with the component and interacting through HTML/CSS/JavaScript.*
 - *A designer customizing the component.*
 
 ### API
@@ -43,7 +43,7 @@
 - *Methods*
 - *Events*
 
-*Consider high and low-level APIs. Attempt to design a powerful and extensible low-level API with a higher-level API for developer/designer ergonomics and simplicity.*
+*Consider high and low-level APIs. Attempt to design a powerful and extensible low-level API with a high-level API for developer/designer ergonomics and simplicity.*
 
 ### Anatomy and Appearance
 
@@ -58,7 +58,7 @@
 
 ## Implementation
 
-*Important aspects of the planned implementation, with careful consideration of web standards and integration.*
+*Important aspects of the planned implementation with careful consideration of web standards and integration.*
 
 ### States
 
@@ -109,7 +109,7 @@
 
 ### Documentation
 
-*What additions or changes would need to be made to our user documentation and demos? Are there any architectural/engineering docs we should create as well, perhaps due to some interesting technical challenge or design decisions related to this component?*
+*What additions or changes are needed for user documentation and demos? Are there any architectural/engineering docs we should create as well, perhaps due to some interesting technical challenge or design decisions related to this component?*
 
 ---
 

--- a/specs/template.md
+++ b/specs/template.md
@@ -1,0 +1,117 @@
+# Spec Title
+
+## Overview
+
+*The name of the component, along with a high-level description.*
+
+### Background
+
+*Relevant historical or background information, related existing issues, etc.*
+
+### Use Cases
+
+*Primary use cases for this component.*
+  
+### Features
+
+*A list of the key features unique to this component.*
+
+### Risks and Challenges
+
+*Notable risks or challenges associated with implementing the component. Would we need to make any breaking changes to other parts of fast-dna in order to achieve this component's goals?*
+
+### Prior Art/Examples
+
+*Screenshots and/or links to existing, canonical or exemplary implementations of the component.*
+
+---
+
+## Design
+
+*Describe the design of the component, thinking through several perspectives:*
+
+- *A customer using the component on a web page.*
+- *A developer building an app with the component and interacting through HTML/CSS/JS.*
+- *A designer customizing the component.*
+
+### API
+
+*The key elements of the component's public API surface:*
+
+- *Component Name*
+- *Props/Attrs*
+- *Methods*
+- *Events*
+
+*Consider high and low-level APIs. Attempt to design a powerful and extensible low-level API with a higher-level API for developer/designer ergonomics and simplicity.*
+
+### Anatomy and Appearance
+
+*Screenshots and/or description of the basic appearance of the component. Outline its structure with a diagram of its visual tree (shadow dom). Enumerate key areas of visual customization, such as:*
+
+- *Slot Names*
+- *Host Classes*
+- *Slotted Content/Slotted Classes*
+- *CSS Parts*
+
+---
+
+## Implementation
+
+*Important aspects of the planned implementation, with careful consideration of web standards and integration.*
+
+### States
+
+*Key component states, valid state transitions, and how interactions trigger a state transition.*
+
+### Accessibility
+
+*Consider the accessibility of the component, including:*
+
+- *Use with Assistive Technology*
+- *Keyboard Navigation and Focus*
+- *Form Input*
+
+### Globalization
+
+*Consider whether the component has any special globalization needs such as:*
+
+- *Special RTL handling*
+- *Swapping of internal icons/visuals*
+- *Localization of text*
+
+### Security
+
+*Are there any security implications surrounding the component?*
+
+### Performance
+
+*Are there any performance pitfalls or challenges with implementing the component?*
+
+### Dependencies
+
+*Will implementing the component require taking on any dependencies?*
+
+- *3rd party libraries*
+- *Upcoming standards we need to polyfill*
+- *Dependencies on other fast components or utilities*
+
+*Do any of these dependencies bring along an associated timeline?*
+
+### Test Plan
+
+*What is the plan for testing the component, if different from the normal path?*
+
+### Tooling
+
+*Are there any special considerations for tooling? Will tooling changes need to be made? Is there a special way to light up this component in our tooling that would be compelling for developers/designers?*
+
+### Documentation
+
+*What additions or changes would need to be made to our user documentation and demos? Are there any architectural/engineering docs we should create as well, perhaps due to some interesting technical challenge or design decisions related to this component?*
+
+---
+
+## Resources
+
+*Any related resource links such as web standards, discussion threads, diagrams, etc.*

--- a/specs/template.md
+++ b/specs/template.md
@@ -68,9 +68,10 @@
 
 *Consider the accessibility of the component, including:*
 
-- *Use with Assistive Technology*
 - *Keyboard Navigation and Focus*
 - *Form Input*
+- *Use with Assistive Technology*
+  - e.g. The implications shadow dom might have on how roles are presented to the AT.
 
 ### Globalization
 


### PR DESCRIPTION
# Description

This PR adds a new top-level `specs` folder for storing team specs. A spec template is provided as well as a readme to serve as an index of specs.

## Motivation & context

We'd like to increase transparency over the component design and implementation process, both inside and outside of our team. We'd also like to enable richer design discussions and greater consistency in our components. We believe spending some time writing specs for new components will enable these goals and result in higher-quality components in the end.

A secondary goal is to enable upstreaming our component specs to the open-ui project, helping to improve the open-ui process and content.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.
- [x] **Documentation** A change that adds/fixes user docs or engineering notes.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.