### PR TITLE
fix(fast-element): prevent duplicate subscription and DOM update queuing

### DIFF
--- a/packages/fast-element/src/behaviors/binding-base.ts
+++ b/packages/fast-element/src/behaviors/binding-base.ts
@@ -29,6 +29,7 @@ export abstract class BindingBase
     implements IBehavior, IGetterInspector, IPropertyChangeListener {
     protected source: unknown;
     private record: ObservationRecord | null = null;
+    private needsQueue = true;
 
     constructor(protected directive: BindingDirective) {}
 
@@ -45,15 +46,15 @@ export abstract class BindingBase
         this.source = null;
     }
 
-    shouldQueueUpdate() {
-        return true;
-    }
-
     onPropertyChanged(source: any, propertyName: string): void {
-        this.shouldQueueUpdate() ? DOM.queueUpdate(this) : this.call();
+        if (this.needsQueue) {
+            this.needsQueue = false;
+            DOM.queueUpdate(this);
+        }
     }
 
     call() {
+        this.needsQueue = true;
         this.updateTarget(this.directive.evaluate(this.source));
     }
 

--- a/packages/fast-element/src/behaviors/property.ts
+++ b/packages/fast-element/src/behaviors/property.ts
@@ -2,15 +2,8 @@ import { BindingDirective } from "../directives/bind";
 import { BindingBase } from "./binding-base";
 
 export class PropertyBinding extends BindingBase {
-    private isElementTarget: boolean;
-
     constructor(directive: BindingDirective, private target: any) {
         super(directive);
-        this.isElementTarget = target instanceof HTMLElement;
-    }
-
-    shouldQueueUpdate() {
-        return this.isElementTarget;
     }
 
     updateTarget(value: unknown) {

--- a/packages/fast-element/src/observation/array-observer.ts
+++ b/packages/fast-element/src/observation/array-observer.ts
@@ -481,7 +481,11 @@ export class ArrayObserver implements INotifyPropertyChanged {
         propertyName: string,
         listener: IPropertyChangeListener
     ): void {
-        this.listeners.push(listener);
+        const index = this.listeners.indexOf(listener);
+
+        if (index === -1) {
+            this.listeners.push(listener);
+        }
     }
 
     public removePropertyChangeListener(

--- a/packages/fast-element/src/observation/observable.ts
+++ b/packages/fast-element/src/observation/observable.ts
@@ -34,7 +34,12 @@ export class PropertyChangeNotifier implements INotifyPropertyChanged {
     ) {
         const listeners =
             this.listeners[propertyName] || (this.listeners[propertyName] = []);
-        listeners.push(listener);
+
+        const index = listeners.indexOf(listener);
+
+        if (index === -1) {
+            listeners.push(listener);
+        }
     }
 
     public removePropertyChangeListener(


### PR DESCRIPTION
# Description

During the process of implementing the Krausest benchmarks, several bugs were discovered. The bugs fixed in this PR relate to duplicate collection subscriptions or duplicate entries being added into a DOM update batch.

## Motivation & context

Duplicate DOM batch entries causes unnecessary work to be done on an update, while duplicate collection subscriptions result in an n^2 increase in collection operations over time for certain scenarios.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.