### PR TITLE
perf(fast-element): improve subscribe/unsubscribe by reducing alloc

### DIFF
--- a/packages/fast-element/src/behaviors/binding-base.ts
+++ b/packages/fast-element/src/behaviors/binding-base.ts
@@ -2,7 +2,7 @@ import { IBehavior } from "./behavior";
 import { IGetterInspector, Observable } from "../observation/observable";
 import { BindingDirective } from "../directives/bind";
 import { DOM } from "../dom";
-import { ISubscriber } from "src/observation/subscriber-collection";
+import { ISubscriber } from "../observation/subscriber-collection";
 
 class ObservationRecord {
     constructor(private source: any, private propertyName: string) {}

--- a/packages/fast-element/src/behaviors/binding-base.ts
+++ b/packages/fast-element/src/behaviors/binding-base.ts
@@ -1,32 +1,22 @@
 import { IBehavior } from "./behavior";
-import {
-    IGetterInspector,
-    IPropertyChangeListener,
-    Observable,
-} from "../observation/observable";
+import { IGetterInspector, Observable } from "../observation/observable";
 import { BindingDirective } from "../directives/bind";
 import { DOM } from "../dom";
+import { ISubscriber } from "src/observation/subscriber-collection";
 
 class ObservationRecord {
     constructor(private source: any, private propertyName: string) {}
 
-    subscribe(listener: IPropertyChangeListener) {
-        Observable.getNotifier(this.source).addPropertyChangeListener(
-            this.propertyName,
-            listener
-        );
+    subscribe(subscriber: ISubscriber) {
+        Observable.getNotifier(this.source).subscribe(subscriber, this.propertyName);
     }
 
-    unsubscribe(listener: IPropertyChangeListener) {
-        Observable.getNotifier(this.source).removePropertyChangeListener(
-            this.propertyName,
-            listener
-        );
+    unsubscribe(subscriber: ISubscriber) {
+        Observable.getNotifier(this.source).unsubscribe(subscriber, this.propertyName);
     }
 }
 
-export abstract class BindingBase
-    implements IBehavior, IGetterInspector, IPropertyChangeListener {
+export abstract class BindingBase implements IBehavior, IGetterInspector, ISubscriber {
     protected source: unknown;
     private record: ObservationRecord | null = null;
     private needsQueue = true;
@@ -46,7 +36,7 @@ export abstract class BindingBase
         this.source = null;
     }
 
-    onPropertyChanged(source: any, propertyName: string): void {
+    handleChange(source: any, propertyName: string): void {
         if (this.needsQueue) {
             this.needsQueue = false;
             DOM.queueUpdate(this);

--- a/packages/fast-element/src/controller.ts
+++ b/packages/fast-element/src/controller.ts
@@ -3,17 +3,10 @@ import { Constructable } from "./interfaces";
 import { IContainer, IRegistry, Resolver, InterfaceSymbol } from "./di";
 import { IElementView } from "./view";
 import { IElementProjector, HostProjector, ShadowDOMProjector } from "./projectors";
-import {
-    INotifyPropertyChanged,
-    IPropertyChangeListener,
-    PropertyChangeNotifier,
-} from "./observation/observable";
+import { PropertyChangeNotifier } from "./observation/notifier";
 
-const controllerLookup: WeakMap<HTMLElement, Controller> = new WeakMap();
-
-export class Controller implements IContainer, INotifyPropertyChanged {
+export class Controller extends PropertyChangeNotifier implements IContainer {
     public view: IElementView | null = null;
-    private propertyChangeNotifier = new PropertyChangeNotifier();
     private resolvers = new Map<any, Resolver>();
 
     public constructor(
@@ -21,6 +14,7 @@ export class Controller implements IContainer, INotifyPropertyChanged {
         public readonly definition: CustomElementDefinition,
         public readonly projector: IElementProjector
     ) {
+        super();
         this.definition.dependencies.forEach(x => x.register(this));
     }
 
@@ -68,34 +62,18 @@ export class Controller implements IContainer, INotifyPropertyChanged {
         this.resolvers.set(key, resolver);
     }
 
-    public notifyPropertyChanged(source: any, propertyName: string) {
-        this.propertyChangeNotifier.notifyPropertyChanged(source, propertyName);
-    }
-
-    public addPropertyChangeListener(
-        propertyName: string,
-        listener: IPropertyChangeListener
-    ) {
-        this.propertyChangeNotifier.addPropertyChangeListener(propertyName, listener);
-    }
-
-    public removePropertyChangeListener(
-        propertyName: string,
-        listener: IPropertyChangeListener
-    ) {
-        this.propertyChangeNotifier.removePropertyChangeListener(propertyName, listener);
-    }
-
     public static forCustomElement(element: HTMLElement) {
-        if (controllerLookup.has(element)) {
-            return (controllerLookup.get(element) as unknown) as Controller;
+        let controller: Controller = (element as any).$controller;
+
+        if (controller !== void 0) {
+            return controller;
         }
 
         const definition = CustomElement.getDefinition(
             element.constructor as Constructable
         );
         if (definition === void 0) {
-            throw new Error(`Missing definition for custom element.`);
+            throw new Error("Missing custom element definition.");
         }
 
         const projector =
@@ -103,10 +81,11 @@ export class Controller implements IContainer, INotifyPropertyChanged {
                 ? new HostProjector(element)
                 : new ShadowDOMProjector(element, definition);
 
-        const controller = new Controller(element, definition, projector);
-
-        (element as any).$controller = controller;
-        controllerLookup.set(element, controller);
+        (element as any).$controller = controller = new Controller(
+            element,
+            definition,
+            projector
+        );
         controller.hydrateCustomElement();
 
         return controller;

--- a/packages/fast-element/src/directives/repeat.ts
+++ b/packages/fast-element/src/directives/repeat.ts
@@ -12,7 +12,7 @@ import {
     enableArrayObservation,
     IndexMap,
 } from "../observation/array-observer";
-import { ISubscriber } from "src/observation/subscriber-collection";
+import { ISubscriber } from "../observation/subscriber-collection";
 
 export class RepeatDirective extends BindingDirective {
     behavior = RepeatBehavior;

--- a/packages/fast-element/src/directives/repeat.ts
+++ b/packages/fast-element/src/directives/repeat.ts
@@ -2,11 +2,7 @@ import { AccessScopeExpression, IExpression, Getter } from "../expression";
 import { ITemplate, ICaptureType } from "../template";
 import { IBehavior } from "../behaviors/behavior";
 import { DOM } from "../dom";
-import {
-    IPropertyChangeListener,
-    Observable,
-    IGetterInspector,
-} from "../observation/observable";
+import { Observable, IGetterInspector } from "../observation/observable";
 import { BindingDirective } from "./bind";
 import { ISyntheticView } from "../view";
 import {
@@ -16,6 +12,7 @@ import {
     enableArrayObservation,
     IndexMap,
 } from "../observation/array-observer";
+import { ISubscriber } from "src/observation/subscriber-collection";
 
 export class RepeatDirective extends BindingDirective {
     behavior = RepeatBehavior;
@@ -30,8 +27,7 @@ export class RepeatDirective extends BindingDirective {
     }
 }
 
-export class RepeatBehavior
-    implements IBehavior, IGetterInspector, IPropertyChangeListener {
+export class RepeatBehavior implements IBehavior, IGetterInspector, ISubscriber {
     private location: Node;
     private source: unknown;
     private views: ISyntheticView[] = [];
@@ -68,14 +64,14 @@ export class RepeatBehavior
     }
 
     inspect(source: any, propertyName: string) {
-        Observable.getNotifier(source).addPropertyChangeListener(propertyName, this);
+        Observable.getNotifier(source).subscribe(this, propertyName);
     }
 
-    onPropertyChanged(source: any, propertyName: any): void {
-        if (typeof propertyName === "string") {
+    handleChange(source: any, args: string | IndexMap): void {
+        if (typeof args === "string") {
             this.source = source;
         } else {
-            this.indexMap = propertyName;
+            this.indexMap = args;
         }
 
         DOM.queueUpdate(this);
@@ -120,7 +116,7 @@ export class RepeatBehavior
         const oldObserver = this.observer;
         if (fromUnbind) {
             if (oldObserver !== void 0) {
-                oldObserver.removePropertyChangeListener("", this);
+                oldObserver.removeSubscriber(this);
             }
         } else {
             if (!this.items) {
@@ -132,11 +128,11 @@ export class RepeatBehavior
             ));
 
             if (oldObserver !== newObserver && oldObserver) {
-                oldObserver.removePropertyChangeListener("", this);
+                oldObserver.removeSubscriber(this);
             }
 
             if (newObserver) {
-                newObserver.addPropertyChangeListener("", this);
+                newObserver.addSubscriber(this);
             }
         }
     }

--- a/packages/fast-element/src/directives/when.ts
+++ b/packages/fast-element/src/directives/when.ts
@@ -5,7 +5,7 @@ import { IExpression, AccessScopeExpression, Getter } from "../expression";
 import { IBehavior } from "../behaviors/behavior";
 import { Observable, IGetterInspector } from "../observation/observable";
 import { BindingDirective } from "./bind";
-import { ISubscriber } from "src/observation/subscriber-collection";
+import { ISubscriber } from "../observation/subscriber-collection";
 
 export class WhenDirective extends BindingDirective {
     behavior = WhenBehavior;

--- a/packages/fast-element/src/directives/when.ts
+++ b/packages/fast-element/src/directives/when.ts
@@ -3,12 +3,9 @@ import { ITemplate, ICaptureType } from "../template";
 import { ISyntheticView } from "../view";
 import { IExpression, AccessScopeExpression, Getter } from "../expression";
 import { IBehavior } from "../behaviors/behavior";
-import {
-    IPropertyChangeListener,
-    Observable,
-    IGetterInspector,
-} from "../observation/observable";
+import { Observable, IGetterInspector } from "../observation/observable";
 import { BindingDirective } from "./bind";
+import { ISubscriber } from "src/observation/subscriber-collection";
 
 export class WhenDirective extends BindingDirective {
     behavior = WhenBehavior;
@@ -22,8 +19,7 @@ export class WhenDirective extends BindingDirective {
     }
 }
 
-export class WhenBehavior
-    implements IBehavior, IGetterInspector, IPropertyChangeListener {
+export class WhenBehavior implements IBehavior, IGetterInspector, ISubscriber {
     private location: Node;
     private view: ISyntheticView | null = null;
     private cachedView?: ISyntheticView;
@@ -47,10 +43,10 @@ export class WhenBehavior
     }
 
     inspect(source: any, propertyName: string) {
-        Observable.getNotifier(source).addPropertyChangeListener(propertyName, this);
+        Observable.getNotifier(source).subscribe(this, propertyName);
     }
 
-    onPropertyChanged(source: any, propertyName: string): void {
+    handleChange(source: any, propertyName: string): void {
         DOM.queueUpdate(this);
     }
 

--- a/packages/fast-element/src/observation/array-observer.ts
+++ b/packages/fast-element/src/observation/array-observer.ts
@@ -1,8 +1,6 @@
-import {
-    INotifyPropertyChanged,
-    IPropertyChangeListener,
-    Observable,
-} from "./observable";
+import { Observable } from "./observable";
+import { SubscriberCollection } from "./subscriber-collection";
+import { INotifier } from "./notifier";
 
 /**
  * An array of indices, where the index of an element represents the index to map FROM, and the numeric value of the element itself represents the index to map TO
@@ -236,7 +234,7 @@ const observe = {
         if ($this.$raw !== void 0) {
             $this = $this.$raw;
         }
-        const o = ($this as any).$controller;
+        const o = ($this as any).$controller as ArrayObserver;
         if (o === void 0) {
             return $push.apply($this, args);
         }
@@ -252,7 +250,7 @@ const observe = {
             o.indexMap[i] = -2;
             i++;
         }
-        o.notifyPropertyChanged();
+        o.notify();
         return $this.length;
     },
     // https://tc39.github.io/ecma262/#sec-array.prototype.unshift
@@ -264,7 +262,7 @@ const observe = {
         if ($this.$raw !== void 0) {
             $this = $this.$raw;
         }
-        const o = ($this as any).$controller;
+        const o = ($this as any).$controller as ArrayObserver;
         if (o === void 0) {
             return $unshift.apply($this, args);
         }
@@ -276,7 +274,7 @@ const observe = {
         }
         $unshift.apply(o.indexMap, inserts);
         const len = $unshift.apply($this, args);
-        o.notifyPropertyChanged();
+        o.notify();
         return len;
     },
     // https://tc39.github.io/ecma262/#sec-array.prototype.pop
@@ -285,7 +283,7 @@ const observe = {
         if ($this.$raw !== void 0) {
             $this = $this.$raw;
         }
-        const o = ($this as any).$controller;
+        const o = ($this as any).$controller as ArrayObserver;
         if (o === void 0) {
             return $pop.call($this);
         }
@@ -297,7 +295,7 @@ const observe = {
             indexMap.deletedItems.push(indexMap[index]);
         }
         $pop.call(indexMap);
-        o.notifyPropertyChanged();
+        o.notify();
         return element;
     },
     // https://tc39.github.io/ecma262/#sec-array.prototype.shift
@@ -306,7 +304,7 @@ const observe = {
         if ($this.$raw !== void 0) {
             $this = $this.$raw;
         }
-        const o = ($this as any).$controller;
+        const o = ($this as any).$controller as ArrayObserver;
         if (o === void 0) {
             return $shift.call($this);
         }
@@ -317,7 +315,7 @@ const observe = {
             indexMap.deletedItems.push(indexMap[0]);
         }
         $shift.call(indexMap);
-        o.notifyPropertyChanged();
+        o.notify();
         return element;
     },
     // https://tc39.github.io/ecma262/#sec-array.prototype.splice
@@ -331,7 +329,7 @@ const observe = {
         if ($this.$raw !== void 0) {
             $this = $this.$raw;
         }
-        const o = ($this as any).$controller;
+        const o = ($this as any).$controller as ArrayObserver;
         if (o === void 0) {
             return $splice.apply($this, args);
         }
@@ -367,7 +365,7 @@ const observe = {
             $splice.apply(indexMap, args);
         }
         const deleted = $splice.apply($this, args);
-        o.notifyPropertyChanged();
+        o.notify();
         return deleted;
     },
     // https://tc39.github.io/ecma262/#sec-array.prototype.reverse
@@ -376,7 +374,7 @@ const observe = {
         if ($this.$raw !== void 0) {
             $this = $this.$raw;
         }
-        const o = ($this as any).$controller;
+        const o = ($this as any).$controller as ArrayObserver;
         if (o === void 0) {
             $reverse.call($this);
             return this;
@@ -396,7 +394,7 @@ const observe = {
             o.indexMap[upper] = lowerIndex;
             lower++;
         }
-        o.notifyPropertyChanged();
+        o.notify();
         return this;
     },
     // https://tc39.github.io/ecma262/#sec-array.prototype.sort
@@ -409,7 +407,7 @@ const observe = {
         if ($this.$raw !== void 0) {
             $this = $this.$raw;
         }
-        const o = ($this as any).$controller;
+        const o = ($this as any).$controller as ArrayObserver;
         if (o === void 0) {
             $sort.call($this, compareFn);
             return this;
@@ -434,7 +432,7 @@ const observe = {
             compareFn = sortCompare;
         }
         quickSort($this, o.indexMap, 0, i, compareFn);
-        o.notifyPropertyChanged();
+        o.notify();
         return this;
     },
 };
@@ -460,12 +458,15 @@ export function enableArrayObservation(): void {
     arrayObservationEnabled = true;
 }
 
-export class ArrayObserver implements INotifyPropertyChanged {
+export class ArrayObserver extends SubscriberCollection implements INotifier {
     indexMap: IndexMap;
     collection: any[];
-    listeners: IPropertyChangeListener[] = [];
+    subscribe = this.addSubscriber;
+    unsubscribe = this.removeSubscriber;
 
     public constructor(array: IObservedArray) {
+        super();
+
         enableArrayObservation();
 
         for (const method of methods) {
@@ -477,41 +478,11 @@ export class ArrayObserver implements INotifyPropertyChanged {
         this.indexMap = createIndexMap(array.length);
     }
 
-    public addPropertyChangeListener(
-        propertyName: string,
-        listener: IPropertyChangeListener
-    ): void {
-        const index = this.listeners.indexOf(listener);
-
-        if (index === -1) {
-            this.listeners.push(listener);
-        }
-    }
-
-    public removePropertyChangeListener(
-        propertyName: string,
-        listener: IPropertyChangeListener
-    ): void {
-        const index = this.listeners.indexOf(listener);
-
-        if (index !== -1) {
-            this.listeners.splice(index, 1);
-        }
-    }
-
-    public notifyPropertyChanged(): void {
+    public notify(): void {
         const indexMap = this.indexMap;
         const length = this.collection.length;
         this.indexMap = createIndexMap(length);
-        const listeners = this.listeners;
-
-        if (listeners == void 0) {
-            return;
-        }
-
-        for (let i = 0, ii = listeners.length; i < ii; ++i) {
-            listeners[i].onPropertyChanged(this, indexMap as any);
-        }
+        this.notifySubscribers(this, indexMap);
     }
 }
 

--- a/packages/fast-element/src/observation/notifier.ts
+++ b/packages/fast-element/src/observation/notifier.ts
@@ -1,0 +1,37 @@
+import { ISubscriber, SubscriberCollection } from "./subscriber-collection";
+
+export interface INotifier {
+    notify(source: any, args: any): void;
+    subscribe(subscriber: ISubscriber, context?: any): void;
+    unsubscribe(subscriber: ISubscriber, context?: any): void;
+}
+
+export class PropertyChangeNotifier implements INotifier {
+    private subscribers: Record<string, SubscriberCollection> = {};
+
+    public notify(source: any, propertyName: string) {
+        const subscribers = this.subscribers[propertyName];
+
+        if (subscribers !== void 0) {
+            subscribers.notifySubscribers(source, propertyName);
+        }
+    }
+
+    public subscribe(subscriber: ISubscriber, propertyName: string) {
+        const subscribers =
+            this.subscribers[propertyName] ||
+            (this.subscribers[propertyName] = new SubscriberCollection());
+
+        subscribers.addSubscriber(subscriber);
+    }
+
+    public unsubscribe(subscriber: ISubscriber, propertyName: string): void {
+        const subscribers = this.subscribers[propertyName];
+
+        if (subscribers === void 0) {
+            return;
+        }
+
+        subscribers.removeSubscriber(subscriber);
+    }
+}

--- a/packages/fast-element/src/observation/observable.ts
+++ b/packages/fast-element/src/observation/observable.ts
@@ -1,71 +1,13 @@
 import { Controller } from "../controller";
 import { FastElement } from "../fast-element";
-
-export interface IPropertyChangeListener {
-    onPropertyChanged(source: any, propertyName: string): void;
-}
-
-export interface INotifyPropertyChanged {
-    notifyPropertyChanged(source: any, propertyName: string): void;
-    addPropertyChangeListener(
-        propertyName: string,
-        listener: IPropertyChangeListener
-    ): void;
-    removePropertyChangeListener(
-        propertyName: string,
-        listener: IPropertyChangeListener
-    ): void;
-}
-
-export class PropertyChangeNotifier implements INotifyPropertyChanged {
-    private listeners: Record<string, IPropertyChangeListener[]> = {};
-
-    public notifyPropertyChanged(source: any, propertyName: string) {
-        const listeners = this.listeners[propertyName];
-
-        if (listeners !== void 0) {
-            listeners.forEach(x => x.onPropertyChanged(source, propertyName));
-        }
-    }
-
-    public addPropertyChangeListener(
-        propertyName: string,
-        listener: IPropertyChangeListener
-    ) {
-        const listeners =
-            this.listeners[propertyName] || (this.listeners[propertyName] = []);
-
-        const index = listeners.indexOf(listener);
-
-        if (index === -1) {
-            listeners.push(listener);
-        }
-    }
-
-    public removePropertyChangeListener(
-        propertyName: string,
-        listener: IPropertyChangeListener
-    ) {
-        const listeners = this.listeners[propertyName];
-
-        if (listeners === void 0) {
-            return;
-        }
-
-        const index = listeners.indexOf(listener);
-
-        if (index !== -1) {
-            listeners.splice(index, 1);
-        }
-    }
-}
+import { INotifier, PropertyChangeNotifier } from "./notifier";
 
 export interface IGetterInspector {
     inspect(source: unknown, propertyName: string): void;
 }
 
-const notifierLookup = new WeakMap<any, PropertyChangeNotifier>();
-let currentInspector: IGetterInspector | null = null;
+const notifierLookup = new WeakMap<any, INotifier>();
+let currentInspector: IGetterInspector | undefined = void 0;
 
 export const Observable = {
     setInspector(watcher: IGetterInspector) {
@@ -73,16 +15,14 @@ export const Observable = {
     },
 
     clearInspector() {
-        currentInspector = null;
+        currentInspector = void 0;
     },
 
-    createArrayObserver(array: any[]): INotifyPropertyChanged {
+    createArrayObserver(array: any[]): INotifier {
         throw new Error("Must call enableArrayObservation before observing arrays.");
     },
 
-    getNotifier<T extends INotifyPropertyChanged = INotifyPropertyChanged>(
-        source: any
-    ): T {
+    getNotifier<T extends INotifier = INotifier>(source: any): T {
         let found = source.$controller || notifierLookup.get(source);
 
         if (found === void 0) {
@@ -90,7 +30,6 @@ export const Observable = {
                 found = Controller.forCustomElement(source);
             } else if (Array.isArray(source)) {
                 found = Observable.createArrayObserver(source);
-                notifierLookup.set(source, found);
             } else {
                 notifierLookup.set(source, (found = new PropertyChangeNotifier()));
             }
@@ -99,14 +38,14 @@ export const Observable = {
         return found;
     },
 
-    notifyPropertyAccessed(source: unknown, propertyName: string) {
-        if (currentInspector != null) {
+    track(source: unknown, propertyName: string) {
+        if (currentInspector !== void 0) {
             currentInspector.inspect(source, propertyName);
         }
     },
 
-    notifyPropertyChanged(source: unknown, propertyName: string) {
-        Observable.getNotifier(source).notifyPropertyChanged(source, propertyName);
+    notify(source: unknown, args: any) {
+        Observable.getNotifier(source).notify(source, args);
     },
 
     define(target: {}, propertyName: string) {
@@ -117,7 +56,7 @@ export const Observable = {
         Reflect.defineProperty(target, propertyName, {
             enumerable: true,
             get: function(this: any) {
-                Observable.notifyPropertyAccessed(this, propertyName);
+                Observable.track(this, propertyName);
                 return this[fieldName];
             },
             set: function(this: any, value) {
@@ -130,7 +69,7 @@ export const Observable = {
                         this[callbackName]();
                     }
 
-                    Observable.notifyPropertyChanged(this, propertyName);
+                    Observable.notify(this, propertyName);
                 }
             },
         });

--- a/packages/fast-element/src/observation/subscriber-collection.ts
+++ b/packages/fast-element/src/observation/subscriber-collection.ts
@@ -1,0 +1,94 @@
+export interface ISubscriber {
+    handleChange(source: any, args: any): void;
+}
+
+export class SubscriberCollection {
+    private sub1: ISubscriber | undefined = void 0;
+    private sub2: ISubscriber | undefined = void 0;
+    private sub3: ISubscriber | undefined = void 0;
+    private spillover: ISubscriber[] | undefined = void 0;
+
+    public hasSubscriber(subscriber: ISubscriber) {
+        if (this.sub1 === subscriber) return true;
+        if (this.sub2 === subscriber) return true;
+        if (this.sub3 === subscriber) return true;
+        return this.spillover !== void 0 && this.spillover.indexOf(subscriber) !== -1;
+    }
+
+    public addSubscriber(subscriber: ISubscriber) {
+        if (this.hasSubscriber(subscriber)) {
+            return;
+        }
+
+        if (this.sub1 === void 0) {
+            this.sub1 = subscriber;
+            return;
+        }
+
+        if (this.sub2 === void 0) {
+            this.sub2 = subscriber;
+            return;
+        }
+
+        if (this.sub3 === void 0) {
+            this.sub3 = subscriber;
+            return;
+        }
+
+        if (this.spillover === void 0) {
+            this.spillover = [];
+        }
+
+        this.spillover.push(subscriber);
+    }
+
+    public removeSubscriber(subscriber: ISubscriber) {
+        if (this.sub1 === subscriber) {
+            this.sub1 = void 0;
+            return;
+        }
+
+        if (this.sub2 === subscriber) {
+            this.sub2 = void 0;
+            return;
+        }
+
+        if (this.sub3 === subscriber) {
+            this.sub3 = void 0;
+            return;
+        }
+
+        if (this.spillover !== void 0) {
+            const index = this.spillover.indexOf(subscriber);
+
+            if (index !== -1) {
+                this.spillover.splice(index, 1);
+            }
+        }
+    }
+
+    public notifySubscribers(source: any, args: any) {
+        const sub1 = this.sub1;
+        const sub2 = this.sub2;
+        const sub3 = this.sub3;
+        const spillover = this.spillover;
+
+        if (sub1 !== void 0) {
+            sub1.handleChange(source, args);
+        }
+
+        if (sub2 !== void 0) {
+            sub2.handleChange(source, args);
+        }
+
+        if (sub3 !== void 0) {
+            sub3.handleChange(source, args);
+        }
+
+        if (spillover !== void 0) {
+            for (let i = 0, ii = spillover.length; i < ii; ++i) {
+                spillover[i].handleChange(source, args);
+            }
+        }
+    }
+}

--- a/packages/fast-element/src/observation/subscriber-collection.ts
+++ b/packages/fast-element/src/observation/subscriber-collection.ts
@@ -1,7 +1,18 @@
+/**
+ * Implemented by objects that are interested in change notifications.
+ */
 export interface ISubscriber {
     handleChange(source: any, args: any): void;
 }
 
+/**
+ * Efficiently keeps track of subscribers interested in change notifications.
+ *
+ * @remarks
+ * This collection is optimized for the most common scenario of 1 - 3 subscribers.
+ * With this in mind, it can store a subscriber in an internal field, allowing it to avoid Array#push operations.
+ * If the collection ever exceeds three subscribers, it will spill over into an array.
+ */
 export class SubscriberCollection {
     private sub1: ISubscriber | undefined = void 0;
     private sub2: ISubscriber | undefined = void 0;


### PR DESCRIPTION
# Description

This PR improves general performance, improves startup metrics, and reduces memory allocation.

## Motivation & context

Tracking observable subscribers previously involved creating a new array and pushing subscribers into that array for each source object. The constant creation of arrays along with the use of `Array#push` creates memory pressure, which has an affect on performance as well.

This PR takes an approach based on some techniques I've used previously in Aurelia. Instead of creating an `Array`, we create a `SubscriberCollection`. The subscriber collection is optimized for the most common scenario of 1 - 3 subscribers per observable property or array. With this in mind, it can store the subscriber in an internal field, allowing it to avoid `Array#push`. If the collection ever exceeds three subscribers, it will spill over into an array.

As part of this PR, I took the opportunity to refactor and improve the API design of all the notification-related classes and interfaces. The result is a clearer design that's more suitable for both property and array observation. Additionally, the amount of code needed to leverage the notification primitives has been reduced in some cases (e.g. `ArrayObserver` can now extend from `SubscriberCollection` and `Controller` can now extend from `PropertyChangeNotifier`).

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.
- [x] **Performance**: A change that improves performance or reduces memory usage.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.