### PR TITLE
perf(fast-element): new strategy for array observation and repeat

### DIFF
--- a/packages/fast-element/src/directives/repeat.ts
+++ b/packages/fast-element/src/directives/repeat.ts
@@ -5,14 +5,9 @@ import { DOM } from "../dom";
 import { Observable, IGetterInspector } from "../observation/observable";
 import { BindingDirective } from "./bind";
 import { ISyntheticView } from "../view";
-import {
-    synchronizeIndices,
-    applyMutationsToIndices,
-    ArrayObserver,
-    enableArrayObservation,
-    IndexMap,
-} from "../observation/array-observer";
 import { ISubscriber } from "../observation/subscriber-collection";
+import { ArrayObserver, enableArrayObservation } from "../observation/array-observer";
+import { Splice } from "../observation/array-change-records";
 
 export class RepeatDirective extends BindingDirective {
     behavior = RepeatBehavior;
@@ -33,7 +28,6 @@ export class RepeatBehavior implements IBehavior, IGetterInspector, ISubscriber 
     private views: ISyntheticView[] = [];
     private items: any[] | null = null;
     private observer?: ArrayObserver;
-    private indexMap?: IndexMap;
 
     constructor(private directive: RepeatDirective, marker: HTMLElement) {
         this.location = DOM.convertMarkerToLocation(marker);
@@ -42,73 +36,29 @@ export class RepeatBehavior implements IBehavior, IGetterInspector, ISubscriber 
     bind(source: unknown) {
         this.source = source;
         this.items = this.directive.inspectAndEvaluate(source, this);
-
-        // bind
         this.checkCollectionObserver(false);
-        this.processViewsKeyed(void 0);
-
-        // attach
-        this.attachViews(void 0);
+        this.refreshAllViews();
     }
 
     unbind() {
         this.source = null;
         this.items = null;
-
-        // detach
-        this.detachViewsByRange(0, this.views.length);
-
-        // unbind
+        this.unbindAllViews();
         this.checkCollectionObserver(true);
-        this.unbindAndRemoveViewsByRange(0, this.views.length, false);
     }
 
     inspect(source: any, propertyName: string) {
         Observable.getNotifier(source).subscribe(this, propertyName);
     }
 
-    handleChange(source: any, args: string | IndexMap): void {
+    handleChange(source: any, args: string | Splice[]): void {
         if (typeof args === "string") {
             this.source = source;
-        } else {
-            this.indexMap = args;
-        }
-
-        DOM.queueUpdate(this);
-    }
-
-    public call() {
-        if (this.indexMap === void 0) {
             this.items = this.directive.inspectAndEvaluate(this.source, this);
             this.checkCollectionObserver(false);
-            this.processViewsKeyed(void 0);
+            this.refreshAllViews();
         } else {
-            const indexMap = this.indexMap;
-            this.indexMap = void 0;
-            this.processViewsKeyed(indexMap);
-        }
-    }
-
-    private processViewsKeyed(indexMap: IndexMap | undefined): void {
-        const oldLength = this.views.length;
-        if (indexMap === void 0) {
-            this.detachViewsByRange(0, oldLength);
-            this.unbindAndRemoveViewsByRange(0, oldLength, false);
-            this.createAndBindAllViews();
-            this.attachViewsKeyed();
-        } else {
-            applyMutationsToIndices(indexMap);
-
-            // first detach+unbind+(remove from array) the deleted view indices
-            if (indexMap.deletedItems.length > 0) {
-                indexMap.deletedItems.sort(compareNumber);
-                this.detachViewsByKey(indexMap);
-                this.unbindAndRemoveViewsByKey(indexMap);
-            }
-
-            // then insert new views at the "added" indices to bring the views array in aligment with indexMap size
-            this.createAndBindNewViewsByKey(indexMap);
-            this.sortViewsByKey(oldLength, indexMap);
+            this.updateViews(args);
         }
     }
 
@@ -137,233 +87,87 @@ export class RepeatBehavior implements IBehavior, IGetterInspector, ISubscriber 
         }
     }
 
-    private detachViewsByRange(iStart: number, iEnd: number): void {
+    private updateViews(splices: Splice[]) {
         const views = this.views;
-        let view: ISyntheticView;
-        for (let i = iStart; i < iEnd; ++i) {
-            view = views[i];
-            view.remove();
-        }
-    }
+        const totalRemoved: ISyntheticView[] = [];
+        let removeDelta = 0;
 
-    private unbindAndRemoveViewsByRange(
-        iStart: number,
-        iEnd: number,
-        adjustLength: boolean
-    ): void {
-        const views = this.views;
-        let view: ISyntheticView;
-        for (let i = iStart; i < iEnd; ++i) {
-            view = views[i];
+        for (let i = 0, ii = splices.length; i < ii; ++i) {
+            const splice = splices[i];
+            const removed = splice.removed;
+
+            totalRemoved.push(
+                ...views.splice(splice.index + removeDelta, removed.length)
+            );
+
+            removeDelta -= splice.addedCount;
+        }
+
+        const items = this.items!;
+        const template = this.directive.template;
+
+        for (let i = 0, ii = splices.length; i < ii; ++i) {
+            const splice = splices[i];
+            let addIndex = splice.index;
+            const end = addIndex + splice.addedCount;
+
+            for (; addIndex < end; ++addIndex) {
+                const neighbor = views[addIndex];
+                const location = neighbor ? neighbor.firstChild : this.location;
+                const view =
+                    totalRemoved.length > 0
+                        ? totalRemoved.shift()!
+                        : template.create(true);
+
+                views.splice(addIndex, 0, view);
+                view.bind(items[addIndex]);
+                view.insertBefore(location);
+            }
+        }
+
+        for (let i = 0, ii = totalRemoved.length; i < ii; ++i) {
+            const view = totalRemoved[i];
+            view.remove();
             view.unbind();
         }
-
-        if (adjustLength) {
-            this.views.length = iStart;
-        }
     }
 
-    private detachViewsByKey(indexMap: IndexMap): void {
+    private refreshAllViews() {
+        const items = this.items!;
         const views = this.views;
-        const deleted = indexMap.deletedItems;
-        const deletedLen = deleted.length;
-        let view: ISyntheticView;
-        for (let i = 0; i < deletedLen; ++i) {
-            view = views[deleted[i]];
-            view.remove();
-        }
-    }
+        const viewsLength = views.length;
+        const template = this.directive.template;
 
-    private unbindAndRemoveViewsByKey(indexMap: IndexMap): void {
-        const views = this.views;
-        const deleted = indexMap.deletedItems;
-        const deletedLen = deleted.length;
-        let view: ISyntheticView;
+        let itemsLength = items.length;
         let i = 0;
-        for (; i < deletedLen; ++i) {
-            view = views[deleted[i]];
+
+        for (; i < itemsLength; ++i) {
+            if (i < viewsLength) {
+                views[i].bind(items[i]);
+            } else {
+                const view = template.create(true);
+                view.bind(items[i]);
+                views.push(view);
+                view.insertBefore(this.location);
+            }
+        }
+
+        const removed = views.splice(i, viewsLength - i);
+
+        for (i = 0, itemsLength = removed.length; i < itemsLength; ++i) {
+            const view = removed[i];
+            view.remove();
             view.unbind();
         }
-
-        i = 0;
-        let j = 0;
-        for (; i < deletedLen; ++i) {
-            j = deleted[i] - i;
-            this.views.splice(j, 1);
-        }
     }
 
-    private createAndBindAllViews(): void {
-        let view: ISyntheticView;
-        const factory = this.directive.template;
-        const items = this.items;
-        const newLen = this.items!.length;
-        const views = (this.views = Array(newLen));
-
-        for (let i = 0; i < newLen; ++i) {
-            view = views[i] = factory.create(true)!;
-            view.bind(items![i]);
-        }
-    }
-
-    private createAndBindNewViewsByKey(indexMap: IndexMap): void {
-        let view: ISyntheticView;
-        const factory = this.directive.template;
+    private unbindAllViews() {
         const views = this.views;
-        const mapLen = indexMap.length;
-        const items = this.items;
 
-        for (let i = 0; i < mapLen; ++i) {
-            if (indexMap[i] === -2) {
-                view = factory.create(true)!;
-                view.bind(items![i]);
-                views.splice(i, 0, view);
-            }
-        }
-
-        if (views.length !== mapLen) {
-            throw new Error(`viewsLen=${views.length}, mapLen=${mapLen}`);
-        }
-    }
-
-    private attachViews(indexMap: IndexMap | undefined): void {
-        let view: ISyntheticView;
-
-        const views = this.views;
-        const location = this.location;
-
-        if (indexMap === void 0) {
-            for (let i = 0, ii = views.length; i < ii; ++i) {
-                view = views[i];
-                view.insertBefore(location);
-            }
-        } else {
-            for (let i = 0, ii = views.length; i < ii; ++i) {
-                if (indexMap[i] !== i) {
-                    view = views[i];
-                    view.insertBefore(location);
-                }
-            }
-        }
-    }
-
-    private attachViewsKeyed(): void {
-        let view: ISyntheticView;
-        const { views, location } = this;
         for (let i = 0, ii = views.length; i < ii; ++i) {
-            view = views[i];
-            view.insertBefore(location);
+            views[i].unbind();
         }
     }
-
-    private sortViewsByKey(oldLength: number, indexMap: IndexMap): void {
-        // TODO: integrate with tasks
-        const location = this.location;
-        const views = this.views;
-        const newLen = indexMap.length;
-        synchronizeIndices(views, indexMap);
-
-        // this algorithm retrieves the indices of the longest increasing subsequence of items in the repeater
-        // the items on those indices are not moved; this minimizes the number of DOM operations that need to be performed
-        const seq = longestIncreasingSubsequence(indexMap);
-        const seqLen = seq.length;
-
-        let next: ISyntheticView;
-        let j = seqLen - 1;
-        let i = newLen - 1;
-        let view: ISyntheticView;
-        for (; i >= 0; --i) {
-            view = views[i];
-            if (indexMap[i] === -2) {
-                view.insertBefore(location);
-            } else if (j < 0 || seqLen === 1 || i !== seq[j]) {
-                // view.attach();
-            } else {
-                --j;
-            }
-
-            next = views[i + 1];
-            if (next !== void 0) {
-                // view.nodes!.link(next.nodes);
-            } else {
-                // view.nodes!.link(location);
-            }
-        }
-    }
-}
-
-let maxLen = 16;
-let prevIndices = new Int32Array(maxLen);
-let tailIndices = new Int32Array(maxLen);
-
-// Based on inferno's lis_algorithm @ https://github.com/infernojs/inferno/blob/master/packages/inferno/src/DOM/patching.ts#L732
-// with some tweaks to make it just a bit faster + account for IndexMap (and some names changes for readability)
-function longestIncreasingSubsequence(indexMap: IndexMap): Int32Array {
-    const len = indexMap.length;
-
-    if (len > maxLen) {
-        maxLen = len;
-        prevIndices = new Int32Array(len);
-        tailIndices = new Int32Array(len);
-    }
-
-    let cursor = 0;
-    let cur = 0;
-    let prev = 0;
-    let i = 0;
-    let j = 0;
-    let low = 0;
-    let high = 0;
-    let mid = 0;
-
-    for (; i < len; i++) {
-        cur = indexMap[i];
-        if (cur !== -2) {
-            j = prevIndices[cursor];
-
-            prev = indexMap[j];
-            if (prev !== -2 && prev < cur) {
-                tailIndices[i] = j;
-                prevIndices[++cursor] = i;
-                continue;
-            }
-
-            low = 0;
-            high = cursor;
-
-            while (low < high) {
-                mid = (low + high) >> 1;
-                prev = indexMap[prevIndices[mid]];
-                if (prev !== -2 && prev < cur) {
-                    low = mid + 1;
-                } else {
-                    high = mid;
-                }
-            }
-
-            prev = indexMap[prevIndices[low]];
-            if (cur < prev || prev === -2) {
-                if (low > 0) {
-                    tailIndices[i] = prevIndices[low - 1];
-                }
-                prevIndices[low] = i;
-            }
-        }
-    }
-    i = ++cursor;
-    const result = new Int32Array(i);
-    cur = prevIndices[cursor - 1];
-
-    while (cursor-- > 0) {
-        result[cursor] = cur;
-        cur = tailIndices[cur];
-    }
-    while (i-- > 0) prevIndices[i] = 0;
-    return result;
-}
-
-function compareNumber(a: number, b: number): number {
-    return a - b;
 }
 
 export function repeat<T = any, K = any>(

--- a/packages/fast-element/src/observation/array-change-records.ts
+++ b/packages/fast-element/src/observation/array-change-records.ts
@@ -1,0 +1,428 @@
+export interface Splice {
+    index: number;
+    removed: any[];
+    addedCount: number;
+}
+
+export function newSplice(index: number, removed: any[], addedCount: number): Splice {
+    return {
+        index: index,
+        removed: removed,
+        addedCount: addedCount,
+    };
+}
+
+const EDIT_LEAVE = 0;
+const EDIT_UPDATE = 1;
+const EDIT_ADD = 2;
+const EDIT_DELETE = 3;
+
+// Note: This function is *based* on the computation of the Levenshtein
+// "edit" distance. The one change is that "updates" are treated as two
+// edits - not one. With Array splices, an update is really a delete
+// followed by an add. By retaining this, we optimize for "keeping" the
+// maximum array items in the original array. For example:
+//
+//   'xxxx123' -> '123yyyy'
+//
+// With 1-edit updates, the shortest path would be just to update all seven
+// characters. With 2-edit updates, we delete 4, leave 3, and add 4. This
+// leaves the substring '123' intact.
+function calcEditDistances(
+    current: any[],
+    currentStart: number,
+    currentEnd: number,
+    old: any[],
+    oldStart: number,
+    oldEnd: number
+) {
+    // "Deletion" columns
+    const rowCount = oldEnd - oldStart + 1;
+    const columnCount = currentEnd - currentStart + 1;
+    const distances = new Array(rowCount);
+    let north;
+    let west;
+
+    // "Addition" rows. Initialize null column.
+    for (let i = 0; i < rowCount; ++i) {
+        distances[i] = new Array(columnCount);
+        distances[i][0] = i;
+    }
+
+    // Initialize null row
+    for (let j = 0; j < columnCount; ++j) {
+        distances[0][j] = j;
+    }
+
+    for (let i = 1; i < rowCount; ++i) {
+        for (let j = 1; j < columnCount; ++j) {
+            if (current[currentStart + j - 1] === old[oldStart + i - 1]) {
+                distances[i][j] = distances[i - 1][j - 1];
+            } else {
+                north = distances[i - 1][j] + 1;
+                west = distances[i][j - 1] + 1;
+                distances[i][j] = north < west ? north : west;
+            }
+        }
+    }
+
+    return distances;
+}
+
+// This starts at the final weight, and walks "backward" by finding
+// the minimum previous weight recursively until the origin of the weight
+// matrix.
+function spliceOperationsFromEditDistances(distances: number[][]) {
+    let i = distances.length - 1;
+    let j = distances[0].length - 1;
+    let current = distances[i][j];
+    const edits = [];
+
+    while (i > 0 || j > 0) {
+        if (i === 0) {
+            edits.push(EDIT_ADD);
+            j--;
+            continue;
+        }
+        if (j === 0) {
+            edits.push(EDIT_DELETE);
+            i--;
+            continue;
+        }
+
+        const northWest = distances[i - 1][j - 1];
+        const west = distances[i - 1][j];
+        const north = distances[i][j - 1];
+
+        let min;
+        if (west < north) {
+            min = west < northWest ? west : northWest;
+        } else {
+            min = north < northWest ? north : northWest;
+        }
+
+        if (min === northWest) {
+            if (northWest === current) {
+                edits.push(EDIT_LEAVE);
+            } else {
+                edits.push(EDIT_UPDATE);
+                current = northWest;
+            }
+            i--;
+            j--;
+        } else if (min === west) {
+            edits.push(EDIT_DELETE);
+            i--;
+            current = west;
+        } else {
+            edits.push(EDIT_ADD);
+            j--;
+            current = north;
+        }
+    }
+
+    edits.reverse();
+    return edits;
+}
+
+/**
+ * Splice Projection functions:
+ *
+ * A splice map is a representation of how a previous array of items
+ * was transformed into a new array of items. Conceptually it is a list of
+ * tuples of
+ *
+ *   <index, removed, addedCount>
+ *
+ * which are kept in ascending index order of. The tuple represents that at
+ * the |index|, |removed| sequence of items were removed, and counting forward
+ * from |index|, |addedCount| items were added.
+ */
+
+/**
+ * Lacking individual splice mutation information, the minimal set of
+ * splices can be synthesized given the previous state and final state of an
+ * array. The basic approach is to calculate the edit distance matrix and
+ * choose the shortest path through it.
+ *
+ * Complexity: O(l * p)
+ *   l: The length of the current array
+ *   p: The length of the old array
+ */
+export function calcSplices(
+    current: any[],
+    currentStart: number,
+    currentEnd: number,
+    old: any[],
+    oldStart: number,
+    oldEnd: number
+) {
+    let prefixCount = 0;
+    let suffixCount = 0;
+
+    const minLength = Math.min(currentEnd - currentStart, oldEnd - oldStart);
+    if (currentStart === 0 && oldStart === 0) {
+        prefixCount = sharedPrefix(current, old, minLength);
+    }
+
+    if (currentEnd === current.length && oldEnd === old.length) {
+        suffixCount = sharedSuffix(current, old, minLength - prefixCount);
+    }
+
+    currentStart += prefixCount;
+    oldStart += prefixCount;
+    currentEnd -= suffixCount;
+    oldEnd -= suffixCount;
+
+    if (currentEnd - currentStart === 0 && oldEnd - oldStart === 0) {
+        return [];
+    }
+
+    if (currentStart === currentEnd) {
+        const splice = newSplice(currentStart, [], 0);
+
+        while (oldStart < oldEnd) {
+            splice.removed.push(old[oldStart++]);
+        }
+
+        return [splice];
+    } else if (oldStart === oldEnd) {
+        return [newSplice(currentStart, [], currentEnd - currentStart)];
+    }
+
+    const ops = spliceOperationsFromEditDistances(
+        calcEditDistances(current, currentStart, currentEnd, old, oldStart, oldEnd)
+    );
+
+    const splices = [];
+    let splice: Splice | undefined = void 0;
+    let index = currentStart;
+    let oldIndex = oldStart;
+
+    for (let i = 0; i < ops.length; ++i) {
+        switch (ops[i]) {
+            case EDIT_LEAVE:
+                if (splice !== void 0) {
+                    splices.push(splice);
+                    splice = void 0;
+                }
+
+                index++;
+                oldIndex++;
+                break;
+            case EDIT_UPDATE:
+                if (splice === void 0) {
+                    splice = newSplice(index, [], 0);
+                }
+
+                splice.addedCount++;
+                index++;
+
+                splice.removed.push(old[oldIndex]);
+                oldIndex++;
+                break;
+            case EDIT_ADD:
+                if (splice === void 0) {
+                    splice = newSplice(index, [], 0);
+                }
+
+                splice.addedCount++;
+                index++;
+                break;
+            case EDIT_DELETE:
+                if (splice === void 0) {
+                    splice = newSplice(index, [], 0);
+                }
+
+                splice.removed.push(old[oldIndex]);
+                oldIndex++;
+                break;
+            // no default
+        }
+    }
+
+    if (splice !== void 0) {
+        splices.push(splice);
+    }
+
+    return splices;
+}
+
+function sharedPrefix(current: any[], old: any[], searchLength: number) {
+    for (let i = 0; i < searchLength; ++i) {
+        if (current[i] !== old[i]) {
+            return i;
+        }
+    }
+
+    return searchLength;
+}
+
+function sharedSuffix(current: any[], old: any[], searchLength: number) {
+    let index1 = current.length;
+    let index2 = old.length;
+    let count = 0;
+
+    while (count < searchLength && current[--index1] === old[--index2]) {
+        count++;
+    }
+
+    return count;
+}
+
+function intersect(start1: number, end1: number, start2: number, end2: number) {
+    // Disjoint
+    if (end1 < start2 || end2 < start1) {
+        return -1;
+    }
+
+    // Adjacent
+    if (end1 === start2 || end2 === start1) {
+        return 0;
+    }
+
+    // Non-zero intersect, span1 first
+    if (start1 < start2) {
+        if (end1 < end2) {
+            return end1 - start2; // Overlap
+        }
+
+        return end2 - start2; // Contained
+    }
+
+    // Non-zero intersect, span2 first
+    if (end2 < end1) {
+        return end2 - start1; // Overlap
+    }
+
+    return end1 - start1; // Contained
+}
+
+const $push = Array.prototype.push;
+
+function mergeSplice(
+    splices: Splice[],
+    index: number,
+    removed: any[],
+    addedCount: number
+) {
+    const splice = newSplice(index, removed, addedCount);
+    let inserted = false;
+    let insertionOffset = 0;
+
+    for (let i = 0, ii = splices.length; i < ii; i++) {
+        const current = splices[i];
+        current.index += insertionOffset;
+
+        if (inserted) {
+            continue;
+        }
+
+        const intersectCount = intersect(
+            splice.index,
+            splice.index + splice.removed.length,
+            current.index,
+            current.index + current.addedCount
+        );
+
+        if (intersectCount >= 0) {
+            // Merge the two splices
+
+            splices.splice(i, 1);
+            i--;
+
+            insertionOffset -= current.addedCount - current.removed.length;
+
+            splice.addedCount += current.addedCount - intersectCount;
+            const deleteCount =
+                splice.removed.length + current.removed.length - intersectCount;
+
+            if (!splice.addedCount && !deleteCount) {
+                // merged splice is a noop. discard.
+                inserted = true;
+            } else {
+                let currentRemoved = current.removed;
+
+                if (splice.index < current.index) {
+                    // some prefix of splice.removed is prepended to current.removed.
+                    const prepend = splice.removed.slice(0, current.index - splice.index);
+                    $push.apply(prepend, currentRemoved);
+                    currentRemoved = prepend;
+                }
+
+                if (
+                    splice.index + splice.removed.length >
+                    current.index + current.addedCount
+                ) {
+                    // some suffix of splice.removed is appended to current.removed.
+                    const append = splice.removed.slice(
+                        current.index + current.addedCount - splice.index
+                    );
+                    $push.apply(currentRemoved, append);
+                }
+
+                splice.removed = currentRemoved;
+
+                if (current.index < splice.index) {
+                    splice.index = current.index;
+                }
+            }
+        } else if (splice.index < current.index) {
+            // Insert splice here.
+
+            inserted = true;
+
+            splices.splice(i, 0, splice);
+            i++;
+
+            const offset = splice.addedCount - splice.removed.length;
+            current.index += offset;
+            insertionOffset += offset;
+        }
+    }
+
+    if (!inserted) {
+        splices.push(splice);
+    }
+}
+
+function createInitialSplices(changeRecords: Splice[]) {
+    const splices: Splice[] = [];
+
+    for (let i = 0, ii = changeRecords.length; i < ii; i++) {
+        const record = changeRecords[i];
+        mergeSplice(splices, record.index, record.removed, record.addedCount);
+    }
+
+    return splices;
+}
+
+export function projectArraySplices(array: any[], changeRecords: any[]) {
+    let splices: Splice[] = [];
+    const initialSplices = createInitialSplices(changeRecords);
+
+    for (let i = 0, ii = initialSplices.length; i < ii; ++i) {
+        const splice = initialSplices[i];
+
+        if (splice.addedCount === 1 && splice.removed.length === 1) {
+            if (splice.removed[0] !== array[splice.index]) {
+                splices.push(splice);
+            }
+
+            continue;
+        }
+
+        splices = splices.concat(
+            calcSplices(
+                array,
+                splice.index,
+                splice.index + splice.addedCount,
+                splice.removed,
+                0,
+                splice.removed.length
+            )
+        );
+    }
+
+    return splices;
+}

--- a/packages/fast-element/src/observation/array-change-records.ts
+++ b/packages/fast-element/src/observation/array-change-records.ts
@@ -76,7 +76,7 @@ function spliceOperationsFromEditDistances(distances: number[][]) {
     let i = distances.length - 1;
     let j = distances[0].length - 1;
     let current = distances[i][j];
-    const edits = [];
+    const edits: number[] = [];
 
     while (i > 0 || j > 0) {
         if (i === 0) {
@@ -194,7 +194,7 @@ export function calcSplices(
         calcEditDistances(current, currentStart, currentEnd, old, oldStart, oldEnd)
     );
 
-    const splices = [];
+    const splices: Splice[] = [];
     let splice: Splice | undefined = void 0;
     let index = currentStart;
     let oldIndex = oldStart;

--- a/packages/fast-element/src/observation/array-observer.ts
+++ b/packages/fast-element/src/observation/array-observer.ts
@@ -1,530 +1,230 @@
 import { Observable } from "./observable";
 import { SubscriberCollection } from "./subscriber-collection";
 import { INotifier } from "./notifier";
+import { DOM } from "../dom";
+import {
+    projectArraySplices,
+    calcSplices,
+    Splice,
+    newSplice,
+} from "./array-change-records";
 
-/**
- * An array of indices, where the index of an element represents the index to map FROM, and the numeric value of the element itself represents the index to map TO
- *
- * The deletedItems property contains the items (in case of an array) or keys (in case of map or set) that have been deleted.
- */
-export type IndexMap = number[] & {
-    deletedItems: number[];
-    isIndexMap: true;
-};
-
-export function createIndexMap(length: number = 0): IndexMap {
-    const arr = Array(length) as IndexMap;
-    let i = 0;
-    while (i < length) {
-        arr[i] = i++;
-    }
-    arr.deletedItems = [];
-    arr.isIndexMap = true;
-    return arr;
-}
-
-interface IObservedCollection {
-    $raw?: this;
-}
-
-/**
- * An array that is being observed for mutations
- */
-export interface IObservedArray<T = unknown> extends IObservedCollection, Array<T> {}
-
-// https://tc39.github.io/ecma262/#sec-sortcompare
-function sortCompare(x: unknown, y: unknown): number {
-    if (x === y) {
-        return 0;
-    }
-    x = x === null ? "null" : (x as {}).toString();
-    y = y === null ? "null" : (y as {}).toString();
-    return (x as {}) < (y as {}) ? -1 : 1;
-}
-
-function preSortCompare(x: unknown, y: unknown): number {
-    if (x === void 0) {
-        if (y === void 0) {
-            return 0;
-        } else {
-            return 1;
-        }
-    }
-    if (y === void 0) {
-        return -1;
-    }
-    return 0;
-}
-
-function insertionSort(
-    arr: IObservedArray,
-    indexMap: IndexMap,
-    from: number,
-    to: number,
-    compareFn: (a: unknown, b: unknown) => number
-): void {
-    let velement, ielement, vtmp, itmp, order;
-    let i, j;
-    for (i = from + 1; i < to; i++) {
-        velement = arr[i];
-        ielement = indexMap[i];
-        for (j = i - 1; j >= from; j--) {
-            vtmp = arr[j];
-            itmp = indexMap[j];
-            order = compareFn(vtmp, velement);
-            if (order > 0) {
-                arr[j + 1] = vtmp;
-                indexMap[j + 1] = itmp;
-            } else {
-                break;
-            }
-        }
-        arr[j + 1] = velement;
-        indexMap[j + 1] = ielement;
-    }
-}
-
-function quickSort(
-    arr: IObservedArray,
-    indexMap: IndexMap,
-    from: number,
-    to: number,
-    compareFn: (a: unknown, b: unknown) => number
-): void {
-    let thirdIndex = 0,
-        i = 0;
-    let v0, v1, v2;
-    let i0, i1, i2;
-    let c01, c02, c12;
-    let vtmp, itmp;
-    let vpivot, ipivot, lowEnd, highStart;
-    let velement, ielement, order, vtopElement;
-
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-        if (to - from <= 10) {
-            insertionSort(arr, indexMap, from, to, compareFn);
-            return;
-        }
-
-        thirdIndex = from + ((to - from) >> 1);
-        v0 = arr[from];
-        i0 = indexMap[from];
-        v1 = arr[to - 1];
-        i1 = indexMap[to - 1];
-        v2 = arr[thirdIndex];
-        i2 = indexMap[thirdIndex];
-        c01 = compareFn(v0, v1);
-        if (c01 > 0) {
-            vtmp = v0;
-            itmp = i0;
-            v0 = v1;
-            i0 = i1;
-            v1 = vtmp;
-            i1 = itmp;
-        }
-        c02 = compareFn(v0, v2);
-        if (c02 >= 0) {
-            vtmp = v0;
-            itmp = i0;
-            v0 = v2;
-            i0 = i2;
-            v2 = v1;
-            i2 = i1;
-            v1 = vtmp;
-            i1 = itmp;
-        } else {
-            c12 = compareFn(v1, v2);
-            if (c12 > 0) {
-                vtmp = v1;
-                itmp = i1;
-                v1 = v2;
-                i1 = i2;
-                v2 = vtmp;
-                i2 = itmp;
-            }
-        }
-        arr[from] = v0;
-        indexMap[from] = i0;
-        arr[to - 1] = v2;
-        indexMap[to - 1] = i2;
-        vpivot = v1;
-        ipivot = i1;
-        lowEnd = from + 1;
-        highStart = to - 1;
-        arr[thirdIndex] = arr[lowEnd];
-        indexMap[thirdIndex] = indexMap[lowEnd];
-        arr[lowEnd] = vpivot;
-        indexMap[lowEnd] = ipivot;
-
-        partition: for (i = lowEnd + 1; i < highStart; i++) {
-            velement = arr[i];
-            ielement = indexMap[i];
-            order = compareFn(velement, vpivot);
-            if (order < 0) {
-                arr[i] = arr[lowEnd];
-                indexMap[i] = indexMap[lowEnd];
-                arr[lowEnd] = velement;
-                indexMap[lowEnd] = ielement;
-                lowEnd++;
-            } else if (order > 0) {
-                do {
-                    highStart--;
-                    // eslint-disable-next-line eqeqeq
-                    if (highStart == i) {
-                        break partition;
-                    }
-                    vtopElement = arr[highStart];
-                    order = compareFn(vtopElement, vpivot);
-                } while (order > 0);
-                arr[i] = arr[highStart];
-                indexMap[i] = indexMap[highStart];
-                arr[highStart] = velement;
-                indexMap[highStart] = ielement;
-                if (order < 0) {
-                    velement = arr[i];
-                    ielement = indexMap[i];
-                    arr[i] = arr[lowEnd];
-                    indexMap[i] = indexMap[lowEnd];
-                    arr[lowEnd] = velement;
-                    indexMap[lowEnd] = ielement;
-                    lowEnd++;
-                }
-            }
-        }
-
-        if (to - highStart < lowEnd - from) {
-            quickSort(arr, indexMap, highStart, to, compareFn);
-            to = lowEnd;
-        } else {
-            quickSort(arr, indexMap, from, lowEnd, compareFn);
-            from = highStart;
-        }
-    }
-}
-
-const proto = Array.prototype as {
-    [K in keyof any[]]: any[][K] & { observing?: boolean }
-};
-
-const $push = proto.push;
-const $unshift = proto.unshift;
-const $pop = proto.pop;
-const $shift = proto.shift;
-const $splice = proto.splice;
-const $reverse = proto.reverse;
-const $sort = proto.sort;
-const methods: ["push", "unshift", "pop", "shift", "splice", "reverse", "sort"] = [
-    "push",
-    "unshift",
-    "pop",
-    "shift",
-    "splice",
-    "reverse",
-    "sort",
-];
-
-const observe = {
-    // https://tc39.github.io/ecma262/#sec-array.prototype.push
-    push: function(
-        this: IObservedArray,
-        ...args: unknown[]
-    ): ReturnType<typeof Array.prototype.push> {
-        let $this = this;
-        if ($this.$raw !== void 0) {
-            $this = $this.$raw;
-        }
-        const o = ($this as any).$controller as ArrayObserver;
-        if (o === void 0) {
-            return $push.apply($this, args);
-        }
-        const len = $this.length;
-        const argCount = args.length;
-        if (argCount === 0) {
-            return len;
-        }
-        $this.length = o.indexMap.length = len + argCount;
-        let i = len;
-        while (i < $this.length) {
-            $this[i] = args[i - len];
-            o.indexMap[i] = -2;
-            i++;
-        }
-        o.notify();
-        return $this.length;
-    },
-    // https://tc39.github.io/ecma262/#sec-array.prototype.unshift
-    unshift: function(
-        this: IObservedArray,
-        ...args: unknown[]
-    ): ReturnType<typeof Array.prototype.unshift> {
-        let $this = this;
-        if ($this.$raw !== void 0) {
-            $this = $this.$raw;
-        }
-        const o = ($this as any).$controller as ArrayObserver;
-        if (o === void 0) {
-            return $unshift.apply($this, args);
-        }
-        const argCount = args.length;
-        const inserts = new Array(argCount);
-        let i = 0;
-        while (i < argCount) {
-            inserts[i++] = -2;
-        }
-        $unshift.apply(o.indexMap, inserts);
-        const len = $unshift.apply($this, args);
-        o.notify();
-        return len;
-    },
-    // https://tc39.github.io/ecma262/#sec-array.prototype.pop
-    pop: function(this: IObservedArray): ReturnType<typeof Array.prototype.pop> {
-        let $this = this;
-        if ($this.$raw !== void 0) {
-            $this = $this.$raw;
-        }
-        const o = ($this as any).$controller as ArrayObserver;
-        if (o === void 0) {
-            return $pop.call($this);
-        }
-        const indexMap = o.indexMap;
-        const element = $pop.call($this);
-        // only mark indices as deleted if they actually existed in the original array
-        const index = indexMap.length - 1;
-        if (indexMap[index] > -1) {
-            indexMap.deletedItems.push(indexMap[index]);
-        }
-        $pop.call(indexMap);
-        o.notify();
-        return element;
-    },
-    // https://tc39.github.io/ecma262/#sec-array.prototype.shift
-    shift: function(this: IObservedArray): ReturnType<typeof Array.prototype.shift> {
-        let $this = this;
-        if ($this.$raw !== void 0) {
-            $this = $this.$raw;
-        }
-        const o = ($this as any).$controller as ArrayObserver;
-        if (o === void 0) {
-            return $shift.call($this);
-        }
-        const indexMap = o.indexMap;
-        const element = $shift.call($this);
-        // only mark indices as deleted if they actually existed in the original array
-        if (indexMap[0] > -1) {
-            indexMap.deletedItems.push(indexMap[0]);
-        }
-        $shift.call(indexMap);
-        o.notify();
-        return element;
-    },
-    // https://tc39.github.io/ecma262/#sec-array.prototype.splice
-    splice: function(
-        this: IObservedArray,
-        ...args: [number, number, ...unknown[]]
-    ): ReturnType<typeof Array.prototype.splice> {
-        const start: number = args[0];
-        const deleteCount: number | undefined = args[1];
-        let $this = this;
-        if ($this.$raw !== void 0) {
-            $this = $this.$raw;
-        }
-        const o = ($this as any).$controller as ArrayObserver;
-        if (o === void 0) {
-            return $splice.apply($this, args);
-        }
-        const len = this.length;
-        const relativeStart = start | 0;
-        const actualStart =
-            relativeStart < 0
-                ? Math.max(len + relativeStart, 0)
-                : Math.min(relativeStart, len);
-        const indexMap = o.indexMap;
-        const argCount = args.length;
-        const actualDeleteCount =
-            argCount === 0 ? 0 : argCount === 1 ? len - actualStart : deleteCount;
-        if (actualDeleteCount > 0) {
-            let i = actualStart;
-            const to = i + actualDeleteCount;
-            while (i < to) {
-                if (indexMap[i] > -1) {
-                    indexMap.deletedItems.push(indexMap[i]);
-                }
-                i++;
-            }
-        }
-        if (argCount > 2) {
-            const itemCount = argCount - 2;
-            const inserts = new Array(itemCount);
-            let i = 0;
-            while (i < itemCount) {
-                inserts[i++] = -2;
-            }
-            $splice.call(indexMap, start, deleteCount, ...inserts);
-        } else {
-            $splice.apply(indexMap, args);
-        }
-        const deleted = $splice.apply($this, args);
-        o.notify();
-        return deleted;
-    },
-    // https://tc39.github.io/ecma262/#sec-array.prototype.reverse
-    reverse: function(this: IObservedArray): ReturnType<typeof Array.prototype.reverse> {
-        let $this = this;
-        if ($this.$raw !== void 0) {
-            $this = $this.$raw;
-        }
-        const o = ($this as any).$controller as ArrayObserver;
-        if (o === void 0) {
-            $reverse.call($this);
-            return this;
-        }
-        const len = $this.length;
-        const middle = (len / 2) | 0;
-        let lower = 0;
-        while (lower !== middle) {
-            const upper = len - lower - 1;
-            const lowerValue = $this[lower];
-            const lowerIndex = o.indexMap[lower];
-            const upperValue = $this[upper];
-            const upperIndex = o.indexMap[upper];
-            $this[lower] = upperValue;
-            o.indexMap[lower] = upperIndex;
-            $this[upper] = lowerValue;
-            o.indexMap[upper] = lowerIndex;
-            lower++;
-        }
-        o.notify();
-        return this;
-    },
-    // https://tc39.github.io/ecma262/#sec-array.prototype.sort
-    // https://github.com/v8/v8/blob/master/src/js/array
-    sort: function(
-        this: IObservedArray,
-        compareFn?: (a: unknown, b: unknown) => number
-    ): IObservedArray {
-        let $this = this;
-        if ($this.$raw !== void 0) {
-            $this = $this.$raw;
-        }
-        const o = ($this as any).$controller as ArrayObserver;
-        if (o === void 0) {
-            $sort.call($this, compareFn);
-            return this;
-        }
-        const len = $this.length;
-        if (len < 2) {
-            return this;
-        }
-        quickSort($this, o.indexMap, 0, len, preSortCompare);
-        let i = 0;
-        while (i < len) {
-            if ($this[i] === void 0) {
-                break;
-            }
-            i++;
-        }
-        if (
-            compareFn === void 0 ||
-            typeof compareFn !==
-                "function" /* spec says throw a TypeError, should we do that too? */
-        ) {
-            compareFn = sortCompare;
-        }
-        quickSort($this, o.indexMap, 0, i, compareFn);
-        o.notify();
-        return this;
-    },
-};
-
-const descriptorProps = {
-    writable: true,
-    enumerable: false,
-    configurable: true,
-};
-
-const def = Reflect.defineProperty;
 let arrayObservationEnabled = false;
 
-export function enableArrayObservation(): void {
+export function enableArrayObservation() {
     if (arrayObservationEnabled) {
         return;
     }
 
-    Observable.createArrayObserver = (arr: any[]) => {
-        return new ArrayObserver(arr);
+    arrayObservationEnabled = true;
+
+    Observable.createArrayObserver = (collection: any[]) => {
+        return new ArrayObserver(collection);
     };
 
-    arrayObservationEnabled = true;
+    const arrayProto = Array.prototype;
+    const pop = arrayProto.pop;
+    const push = arrayProto.push;
+    const reverse = arrayProto.reverse;
+    const shift = arrayProto.shift;
+    const sort = arrayProto.sort;
+    const splice = arrayProto.splice;
+    const unshift = arrayProto.unshift;
+
+    arrayProto.pop = function() {
+        const notEmpty = this.length > 0;
+        const methodCallResult = pop.apply(this, arguments as any);
+        const o = (this as any).$controller as ArrayObserver;
+
+        if (o !== void 0 && notEmpty) {
+            o.addSplice(newSplice(this.length, [methodCallResult], 0));
+        }
+
+        return methodCallResult;
+    };
+
+    arrayProto.push = function() {
+        const methodCallResult = push.apply(this, arguments as any);
+        const o = (this as any).$controller as ArrayObserver;
+
+        if (o !== void 0) {
+            o.addSplice(
+                adjustIndex(
+                    newSplice(this.length - arguments.length, [], arguments.length),
+                    this
+                )
+            );
+        }
+
+        return methodCallResult;
+    };
+
+    arrayProto.reverse = function() {
+        let oldArray;
+        const o = (this as any).$controller as ArrayObserver;
+
+        if (o !== void 0) {
+            o.notify();
+            oldArray = this.slice();
+        }
+
+        const methodCallResult = reverse.apply(this, arguments as any);
+
+        if (o !== void 0) {
+            o.reset(oldArray);
+        }
+
+        return methodCallResult;
+    };
+
+    arrayProto.shift = function() {
+        const notEmpty = this.length > 0;
+        const methodCallResult = shift.apply(this, arguments as any);
+        const o = (this as any).$controller as ArrayObserver;
+
+        if (o !== void 0 && notEmpty) {
+            o.addSplice(newSplice(0, [methodCallResult], 0));
+        }
+
+        return methodCallResult;
+    };
+
+    arrayProto.sort = function() {
+        let oldArray;
+        const o = (this as any).$controller as ArrayObserver;
+
+        if (o !== void 0) {
+            o.notify();
+            oldArray = this.slice();
+        }
+
+        const methodCallResult = sort.apply(this, arguments as any);
+
+        if (o !== void 0) {
+            o.reset(oldArray);
+        }
+
+        return methodCallResult;
+    };
+
+    arrayProto.splice = function() {
+        const methodCallResult = splice.apply(this, arguments as any);
+        const o = (this as any).$controller as ArrayObserver;
+
+        if (o !== void 0) {
+            o.addSplice(
+                adjustIndex(
+                    newSplice(
+                        +arguments[0],
+                        methodCallResult,
+                        arguments.length > 2 ? arguments.length - 2 : 0
+                    ),
+                    this
+                )
+            );
+        }
+
+        return methodCallResult;
+    };
+
+    arrayProto.unshift = function() {
+        const methodCallResult = unshift.apply(this, arguments as any);
+        const o = (this as any).$controller as ArrayObserver;
+
+        if (o !== void 0) {
+            o.addSplice(adjustIndex(newSplice(0, [], arguments.length), this));
+        }
+
+        return methodCallResult;
+    };
+}
+
+function adjustIndex(changeRecord: Splice, array: any[]) {
+    let index = changeRecord.index;
+    const arrayLength = array.length;
+
+    if (index > arrayLength) {
+        index = arrayLength - changeRecord.addedCount;
+    } else if (index < 0) {
+        index =
+            arrayLength + changeRecord.removed.length + index - changeRecord.addedCount;
+    }
+
+    if (index < 0) {
+        index = 0;
+    }
+
+    changeRecord.index = index;
+    return changeRecord;
 }
 
 export class ArrayObserver extends SubscriberCollection implements INotifier {
-    indexMap: IndexMap;
-    collection: any[];
+    private collection: any[];
+    private oldCollection: any[] | undefined = void 0;
+    private splices: any[] | undefined = void 0;
+    private needsQueue = true;
+
     subscribe = this.addSubscriber;
     unsubscribe = this.removeSubscriber;
 
-    public constructor(array: IObservedArray) {
+    constructor(collection: any[]) {
         super();
-
-        enableArrayObservation();
-
-        for (const method of methods) {
-            def(array, method, { ...descriptorProps, value: observe[method] });
-        }
-
-        (array as any).$controller = this;
-        this.collection = array;
-        this.indexMap = createIndexMap(array.length);
+        (collection as any).$controller = this;
+        this.collection = collection;
     }
 
-    public notify(): void {
-        const indexMap = this.indexMap;
-        const length = this.collection.length;
-        this.indexMap = createIndexMap(length);
-        this.notifySubscribers(this, indexMap);
-    }
-}
+    addSplice(splice: Splice) {
+        if (this.hasSubscribers()) {
+            if (this.splices === void 0) {
+                this.splices = [splice];
+            } else {
+                this.splices.push(splice);
+            }
 
-/**
- * Applies offsets to the non-negative indices in the IndexMap
- * based on added and deleted items relative to those indices.
- *
- * e.g. turn `[-2, 0, 1]` into `[-2, 1, 2]`, allowing the values at the indices to be
- * used for sorting/reordering items if needed
- */
-export function applyMutationsToIndices(indexMap: IndexMap): void {
-    let offset = 0;
-    let j = 0;
-    const len = indexMap.length;
-    for (let i = 0; i < len; ++i) {
-        while (indexMap.deletedItems[j] <= i - offset) {
-            ++j;
-            --offset;
-        }
-        if (indexMap[i] === -2) {
-            ++offset;
-        } else {
-            indexMap[i] += offset;
+            if (this.needsQueue) {
+                this.needsQueue = false;
+                DOM.queueUpdate(this);
+            }
         }
     }
-}
 
-/**
- * After `applyMutationsToIndices`, this function can be used to reorder items in a derived
- * array (e.g.  the items in the `views` in the repeater are derived from the `items` property)
- */
-export function synchronizeIndices<T>(items: T[], indexMap: IndexMap): void {
-    const copy = items.slice();
+    reset(oldCollection: any[] | undefined) {
+        this.oldCollection = oldCollection;
 
-    const len = indexMap.length;
-    let to = 0;
-    let from = 0;
-    while (to < len) {
-        from = indexMap[to];
-        if (from !== -2) {
-            items[to] = copy[from];
+        if (this.hasSubscribers() && this.needsQueue) {
+            this.needsQueue = false;
+            DOM.queueUpdate(this);
         }
-        ++to;
+    }
+
+    notify() {
+        if (this.splices !== void 0 || this.oldCollection !== void 0) {
+            this.call();
+        }
+    }
+
+    call() {
+        const splices = this.splices;
+        const oldCollection = this.oldCollection;
+
+        this.needsQueue = true;
+        this.splices = void 0;
+        this.oldCollection = void 0;
+
+        if (this.hasSubscribers()) {
+            const finalSplices =
+                oldCollection === void 0
+                    ? projectArraySplices(this.collection, splices!)
+                    : calcSplices(
+                          this.collection,
+                          0,
+                          this.collection.length,
+                          oldCollection,
+                          0,
+                          oldCollection.length
+                      );
+
+            this.notifySubscribers(this, finalSplices);
+        }
     }
 }

--- a/packages/fast-element/src/observation/subscriber-collection.ts
+++ b/packages/fast-element/src/observation/subscriber-collection.ts
@@ -19,6 +19,15 @@ export class SubscriberCollection {
     private sub3: ISubscriber | undefined = void 0;
     private spillover: ISubscriber[] | undefined = void 0;
 
+    public hasSubscribers() {
+        return (
+            this.sub1 !== void 0 ||
+            this.sub2 !== void 0 ||
+            this.sub3 !== void 0 ||
+            (this.spillover !== void 0 && this.spillover!.length > 0)
+        );
+    }
+
     public hasSubscriber(subscriber: ISubscriber) {
         if (this.sub1 === subscriber) return true;
         if (this.sub2 === subscriber) return true;


### PR DESCRIPTION
# Description

This PR re-writes the internal mechanism for array change observation and how the repeat directive works in conjunction with that.

## Motivation & context

When benchmarking the library, most benchmarks looked pretty solid, but a few were way out of range. Here is a snapshot of the perf before this PR:

<img width="306" alt="3 - perf" src="https://user-images.githubusercontent.com/131485/74881902-002aff00-5323-11ea-88c1-cf4103a703c9.png">

Notice "swap rows" and "append rows to large table". After this PR, here's what the perf metrics look like:

<img width="411" alt="5 - perf" src="https://user-images.githubusercontent.com/131485/74882010-36687e80-5323-11ea-8312-8efa11d0a926.png">

"swap rows" is close to 10x faster and "append rows to large table" is almost 2x faster. Additionally, "create rows", "replace all rows", and "clear rows" also improved, enabling fast-element to now beat lit-html by a noticeable amount, being only .03 off from hand-optimized vanilla JS.

Additionally, memory allocation was improved. Here's the before:

<img width="619" alt="3 - memory" src="https://user-images.githubusercontent.com/131485/74882263-a24ae700-5323-11ea-8c39-2b533ceeaa1d.png">

And the after:

<img width="412" alt="5 - memory" src="https://user-images.githubusercontent.com/131485/74882282-abd44f00-5323-11ea-9f80-fbe4bdb938ca.png">

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.
- [x] **Performance**: Improvements to performance or memory consumption.

This is not a breaking change for element authors. It does change how array observation works internally and the data structures related to that. If someone were manually observing an array, they would now receive a collection of splices as opposed to the previous IndexMap.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

## Next Steps

This is the last perf PR for a bit. Now that we're moving out of the prototyping phase, I'll be focusing on documentation, testing, and fixing bugs as they come up.