### PR TITLE
fix: update sequence indicators to have visual focus styling

### DIFF
--- a/packages/fast-components-react-msft/src/carousel/carousel.stories.tsx
+++ b/packages/fast-components-react-msft/src/carousel/carousel.stories.tsx
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/react";
-import React from "react";
+import React, { useState } from "react";
 import {
     Carousel,
     CarouselClassNameContract,
@@ -23,7 +23,7 @@ function itemsFiller(
         const theme: CarouselSlideTheme =
             x > 0 ? CarouselSlideTheme.light : CarouselSlideTheme.dark;
         fillerArray.push({
-            id: uniqueId(),
+            id: `slide${i}`,
             theme,
             content: (className?: string): React.ReactNode => (
                 <CarouselHero
@@ -64,10 +64,49 @@ const carouselSequenceStylesOverrides: ComponentStyles<
     },
 };
 
+function CarouselSateHandler(props: {
+    autoPlay: boolean;
+    children: (
+        autoPlay: boolean,
+        onFocus: (event: React.FocusEvent) => void,
+        onBlur: (event: React.FocusEvent) => void
+    ) => JSX.Element;
+}): JSX.Element {
+    const [autoPlay, setAutoPlay]: [
+        boolean,
+        React.Dispatch<React.SetStateAction<boolean>>
+    ] = useState(props.autoPlay);
+
+    function handleOnFocus(event: React.FocusEvent): void {
+        setAutoPlay(false);
+    }
+
+    function handleOnBlur(event: React.FocusEvent): void {
+        setAutoPlay(props.autoPlay);
+    }
+
+    return props.children(autoPlay, handleOnFocus, handleOnBlur);
+}
+
 storiesOf("Carousel", module)
-    .add("Default", () => (
-        <Carousel label="A carousel of items" autoplay={true} items={itemsFiller(6)} />
-    ))
+    .add("Default", () => {
+        function render(
+            autoPlay: boolean,
+            onFocus: (event: React.FocusEvent) => void,
+            onBlur: (event: React.FocusEvent) => void
+        ): JSX.Element {
+            return (
+                <Carousel
+                    label="A carousel of items"
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                    autoplay={autoPlay}
+                    items={itemsFiller(6)}
+                />
+            );
+        }
+        return <CarouselSateHandler autoPlay={true}>{render}</CarouselSateHandler>;
+    })
     .add("No Looping and No Autoplay", () => (
         <Carousel
             label="A carousel of items"
@@ -76,25 +115,47 @@ storiesOf("Carousel", module)
             items={itemsFiller(8)}
         />
     ))
-    .add("Looping and Autoplay", () => (
-        <Carousel
-            label="A carousel of items"
-            autoplay={true}
-            loop={true}
-            items={itemsFiller(4)}
-        />
-    ))
-    .add("Sequence Indicator Test with Many Items", () => (
-        <Carousel
-            label="A carousel of items"
-            autoplay={true}
-            loop={true}
-            items={itemsFiller(
-                30,
-                "Sequence Indicator Test",
-                "The Sequence Indicators Container should not be full width and not cover up any actions that are in the content corners. If the individual Indicator's widths are not reduced, as they are here, the container will be too wide and cover up the buttons in the lower corners.",
-                true
-            )}
-            jssStyleSheet={carouselSequenceStylesOverrides}
-        />
-    ));
+    .add("Looping and Autoplay", () => {
+        function render(
+            autoPlay: boolean,
+            onFocus: (event: React.FocusEvent) => void,
+            onBlur: (event: React.FocusEvent) => void
+        ): JSX.Element {
+            return (
+                <Carousel
+                    label="A carousel of items"
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                    autoplay={autoPlay}
+                    loop={true}
+                    items={itemsFiller(4)}
+                />
+            );
+        }
+        return <CarouselSateHandler autoPlay={true}>{render}</CarouselSateHandler>;
+    })
+    .add("Sequence Indicator Test with Many Items", () => {
+        function render(
+            autoPlay: boolean,
+            onFocus: (event: React.FocusEvent) => void,
+            onBlur: (event: React.FocusEvent) => void
+        ): JSX.Element {
+            return (
+                <Carousel
+                    label="A carousel of items"
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                    autoplay={autoPlay}
+                    loop={true}
+                    items={itemsFiller(
+                        30,
+                        "Sequence Indicator Test",
+                        "The Sequence Indicators Container should not be full width and not cover up any actions that are in the content corners. If the individual Indicator's widths are not reduced, as they are here, the container will be too wide and cover up the buttons in the lower corners.",
+                        true
+                    )}
+                    jssStyleSheet={carouselSequenceStylesOverrides}
+                />
+            );
+        }
+        return <CarouselSateHandler autoPlay={true}>{render}</CarouselSateHandler>;
+    });

--- a/packages/fast-components-styles-msft/src/carousel/index.ts
+++ b/packages/fast-components-styles-msft/src/carousel/index.ts
@@ -1,11 +1,17 @@
 import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
-import { directionSwitch, format, toPx } from "@microsoft/fast-jss-utilities";
+import {
+    directionSwitch,
+    format,
+    toPx,
+    applyFocusVisible,
+} from "@microsoft/fast-jss-utilities";
 import {
     neutralFillStealthHover,
     neutralFillStealthRest,
     neutralForegroundRest,
     neutralOutlineRest,
+    neutralFocus,
 } from "../utilities/color";
 import { CarouselClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { designUnit, outlineWidth } from "../utilities/design-system";
@@ -41,6 +47,13 @@ const lightModeNeutralOutlineRest: DesignSystemResolver<string> = neutralOutline
     (): string => white
 );
 
+const darkModeNneutralFocus: DesignSystemResolver<string> = neutralFocus(
+    (): string => black
+);
+const lightModeNneutralFocus: DesignSystemResolver<string> = neutralFocus(
+    (): string => white
+);
+
 function flipperStyles(): CSSRules<{}> {
     return {
         position: "absolute",
@@ -66,7 +79,7 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
     carousel_slides: {},
     carousel_sequenceIndicators: {
         position: "absolute",
-        bottom: "8px",
+        bottom: "4px",
         display: "inline-flex",
         padding: "0",
         "text-align": "center",
@@ -80,10 +93,26 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
     },
     carousel_sequenceIndicator: {
         display: "inline-block",
-        padding: "0 2px",
+        padding: "4px",
+        position: "relative",
         "&:focus": {
             outline: "none",
         },
+        ...applyFocusVisible<DesignSystem>({
+            "&::after": {
+                opacity: "1",
+                position: "absolute",
+                border: "2px solid transparent",
+                "border-radius": "40px",
+                top: "0",
+                right: "0",
+                left: "0",
+                bottom: "0",
+                content: "''",
+                display: "block",
+                transition: "all 0.05s ease-in-out",
+            },
+        }),
         "&::before": {
             opacity: "0.45",
             border: "1px solid transparent",
@@ -172,10 +201,16 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                 "border-color": darkModeNeutralOutlineRest,
                 ...highContrastButtonColorIndicator,
             },
+            "&::after": {
+                "border-color": darkModeNneutralFocus,
+            },
             "&$carousel_sequenceIndicator__active": {
                 "&::before": {
                     background: darkModeNeutralFillStealthRest,
                     ...highContrastHighlightColorIndicator,
+                },
+                "&::after": {
+                    "border-color": darkModeNneutralFocus,
                 },
             },
         },
@@ -226,10 +261,16 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                 "border-color": lightModeNeutralOutlineRest,
                 ...highContrastButtonColorIndicator,
             },
+            "&::after": {
+                "border-color": lightModeNneutralFocus,
+            },
             "&$carousel_sequenceIndicator__active": {
                 "&::before": {
                     background: lightModeNeutralFillStealthRest,
                     ...highContrastHighlightColorIndicator,
+                },
+                "&::after": {
+                    "border-color": lightModeNneutralFocus,
                 },
             },
         },

--- a/packages/fast-components-styles-msft/src/carousel/index.ts
+++ b/packages/fast-components-styles-msft/src/carousel/index.ts
@@ -27,30 +27,30 @@ import {
 
 const white: string = "#FFF";
 const black: string = "#101010";
-const darkModeNeutralForegroundRest: DesignSystemResolver<string> = neutralForegroundRest(
-    (): string => black
-);
-const lightModeNeutralForegroundRest: DesignSystemResolver<
+const themeDarkNeutralForegroundRest: DesignSystemResolver<
+    string
+> = neutralForegroundRest((): string => black);
+const themeLightNeutralForegroundRest: DesignSystemResolver<
     string
 > = neutralForegroundRest((): string => white);
-const darkModeNeutralFillStealthRest: DesignSystemResolver<
+const themeDarkNeutralFillStealthRest: DesignSystemResolver<
     string
 > = neutralFillStealthRest((): string => black);
-const lightModeNeutralFillStealthRest: DesignSystemResolver<
+const themeLightNeutralFillStealthRest: DesignSystemResolver<
     string
 > = neutralFillStealthRest((): string => white);
 
-const darkModeNeutralOutlineRest: DesignSystemResolver<string> = neutralOutlineRest(
+const themeDarkNeutralOutlineRest: DesignSystemResolver<string> = neutralOutlineRest(
     (): string => black
 );
-const lightModeNeutralOutlineRest: DesignSystemResolver<string> = neutralOutlineRest(
+const themeLightNeutralOutlineRest: DesignSystemResolver<string> = neutralOutlineRest(
     (): string => white
 );
 
-const darkModeNneutralFocus: DesignSystemResolver<string> = neutralFocus(
+const themeDarkNeutralFocus: DesignSystemResolver<string> = neutralFocus(
     (): string => black
 );
-const lightModeNneutralFocus: DesignSystemResolver<string> = neutralFocus(
+const themeLightNeutralFocus: DesignSystemResolver<string> = neutralFocus(
     (): string => white
 );
 
@@ -157,18 +157,18 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
     carousel__themeDark: {
         "& $carousel_flipperPrevious, & $carousel_flipperNext": {
             "&::before": {
-                color: darkModeNeutralForegroundRest,
-                fill: darkModeNeutralForegroundRest,
-                background: darkModeNeutralFillStealthRest,
+                color: themeDarkNeutralForegroundRest,
+                fill: themeDarkNeutralForegroundRest,
+                background: themeDarkNeutralFillStealthRest,
                 border: format(
                     "{0} solid {1}",
                     toPx<DesignSystem>(outlineWidth),
-                    darkModeNeutralOutlineRest
+                    themeDarkNeutralOutlineRest
                 ),
                 ...highContrastColorBackground,
             },
             "& span::before": {
-                "border-color": darkModeNeutralForegroundRest,
+                "border-color": themeDarkNeutralForegroundRest,
             },
             "&:hover": {
                 "&::before": {
@@ -183,11 +183,11 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                     },
                 },
                 "& span::before": {
-                    "border-color": darkModeNeutralForegroundRest,
+                    "border-color": themeDarkNeutralForegroundRest,
                 },
             },
             "& > svg": {
-                fill: darkModeNeutralForegroundRest,
+                fill: themeDarkNeutralForegroundRest,
                 ...highContrastForeground,
             },
             [highContrastSelector]: {
@@ -196,20 +196,17 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
         },
         "& $carousel_sequenceIndicator": {
             "&::before": {
-                background: darkModeNeutralFillStealthRest,
-                "border-color": darkModeNeutralOutlineRest,
+                background: themeDarkNeutralFillStealthRest,
+                "border-color": themeDarkNeutralOutlineRest,
                 ...highContrastButtonColorIndicator,
             },
             "&::after": {
-                "border-color": darkModeNneutralFocus,
+                "border-color": themeDarkNeutralFocus,
             },
             "&$carousel_sequenceIndicator__active": {
                 "&::before": {
-                    background: darkModeNeutralFillStealthRest,
+                    background: themeDarkNeutralFillStealthRest,
                     ...highContrastHighlightColorIndicator,
-                },
-                "&::after": {
-                    "border-color": darkModeNneutralFocus,
                 },
             },
         },
@@ -217,18 +214,18 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
     carousel__themeLight: {
         "& $carousel_flipperPrevious, & $carousel_flipperNext": {
             "&::before": {
-                color: lightModeNeutralForegroundRest,
-                fill: lightModeNeutralForegroundRest,
-                background: lightModeNeutralFillStealthRest,
+                color: themeLightNeutralForegroundRest,
+                fill: themeLightNeutralForegroundRest,
+                background: themeLightNeutralFillStealthRest,
                 border: format(
                     "{0} solid {1}",
                     toPx<DesignSystem>(outlineWidth),
-                    lightModeNeutralOutlineRest
+                    themeLightNeutralOutlineRest
                 ),
                 ...highContrastColorBackground,
             },
             "& span::before": {
-                "border-color": lightModeNeutralForegroundRest,
+                "border-color": themeLightNeutralForegroundRest,
             },
             "&:hover": {
                 "&::before": {
@@ -243,11 +240,11 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
                     },
                 },
                 "& span::before": {
-                    "border-color": lightModeNeutralForegroundRest,
+                    "border-color": themeLightNeutralForegroundRest,
                 },
             },
             "& > svg": {
-                fill: lightModeNeutralForegroundRest,
+                fill: themeLightNeutralForegroundRest,
                 ...highContrastForeground,
             },
             [highContrastSelector]: {
@@ -256,20 +253,17 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
         },
         "& $carousel_sequenceIndicator": {
             "&::before": {
-                background: lightModeNeutralFillStealthRest,
-                "border-color": lightModeNeutralOutlineRest,
+                background: themeLightNeutralFillStealthRest,
+                "border-color": themeLightNeutralOutlineRest,
                 ...highContrastButtonColorIndicator,
             },
             "&::after": {
-                "border-color": lightModeNneutralFocus,
+                "border-color": themeLightNeutralFocus,
             },
             "&$carousel_sequenceIndicator__active": {
                 "&::before": {
-                    background: lightModeNeutralFillStealthRest,
+                    background: themeLightNeutralFillStealthRest,
                     ...highContrastHighlightColorIndicator,
-                },
-                "&::after": {
-                    "border-color": lightModeNneutralFocus,
                 },
             },
         },

--- a/packages/fast-components-styles-msft/src/carousel/index.ts
+++ b/packages/fast-components-styles-msft/src/carousel/index.ts
@@ -1,17 +1,17 @@
 import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager";
 import {
+    applyFocusVisible,
     directionSwitch,
     format,
     toPx,
-    applyFocusVisible,
 } from "@microsoft/fast-jss-utilities";
 import {
     neutralFillStealthHover,
     neutralFillStealthRest,
+    neutralFocus,
     neutralForegroundRest,
     neutralOutlineRest,
-    neutralFocus,
 } from "../utilities/color";
 import { CarouselClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { designUnit, outlineWidth } from "../utilities/design-system";

--- a/packages/fast-components-styles-msft/src/carousel/index.ts
+++ b/packages/fast-components-styles-msft/src/carousel/index.ts
@@ -14,7 +14,7 @@ import {
     neutralOutlineRest,
 } from "../utilities/color";
 import { CarouselClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
-import { designUnit, outlineWidth } from "../utilities/design-system";
+import { designUnit, focusOutlineWidth, outlineWidth } from "../utilities/design-system";
 import {
     highContrastButtonColorIndicator,
     HighContrastColor,
@@ -100,9 +100,8 @@ const styles: ComponentStyles<CarouselClassNameContract, DesignSystem> = {
         },
         ...applyFocusVisible<DesignSystem>({
             "&::after": {
-                opacity: "1",
                 position: "absolute",
-                border: "2px solid transparent",
+                border: format("{0} solid transparent", toPx(focusOutlineWidth)),
                 "border-radius": "40px",
                 top: "0",
                 right: "0",


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
closes: #2682 

Added an `after` pseudo element to handle focus visual. Updated stories to use simple state handler to prevent autoplay when carousel is focued.

Before:
<img width="779" alt="Screen Shot 2020-02-20 at 12 18 44 PM" src="https://user-images.githubusercontent.com/37851214/74975449-eac5db80-53db-11ea-8902-126bc1337d14.png">

After:
![image](https://user-images.githubusercontent.com/37851214/74975604-295b9600-53dc-11ea-9e29-6a507e14d008.png)

<img width="778" alt="Screen Shot 2020-02-20 at 12 18 25 PM" src="https://user-images.githubusercontent.com/37851214/74975452-eb5e7200-53db-11ea-96a6-a9b5297372d1.png">

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->