### PR TITLE
fix: applying the cssGridPropertyName correctly in Page.tsx

### DIFF
--- a/packages/fast-layouts-react/src/page/page.no-css-grid.spec.tsx
+++ b/packages/fast-layouts-react/src/page/page.no-css-grid.spec.tsx
@@ -22,6 +22,18 @@ describe("Page - without CSS grid support", (): void => {
         expect(rendered.props().style.display).toEqual("-ms-grid");
     });
 
+    test("should set an inline style of `display: -ms-grid` when -ms-grid is specified and CSS grid is NOT supported", () => {
+        const rendered: any = shallow(<Page cssGridPropertyName="-ms-grid" />);
+
+        expect(rendered.props().style.display).toEqual("-ms-grid");
+    });
+
+    test("should set an inline style of `display: grid` when grid is specified and CSS grid is NOT supported", () => {
+        const rendered: any = shallow(<Page cssGridPropertyName="grid" />);
+
+        expect(rendered.props().style.display).toEqual("grid");
+    });
+
     test("should set an inline style of `msGridColumns` when CSS grid is supported", () => {
         const expectedMargin: string = "0";
         const expectedMaxWidth: string = "1200px";

--- a/packages/fast-layouts-react/src/page/page.spec.tsx
+++ b/packages/fast-layouts-react/src/page/page.spec.tsx
@@ -61,6 +61,18 @@ describe("Page", (): void => {
         expect(rendered.props().style.display).toEqual("grid");
     });
 
+    test("should set an inline style of `display: -ms-grid` when -ms-grid is specified and CSS grid is supported", () => {
+        const rendered: any = shallow(<Page cssGridPropertyName="-ms-grid" />);
+
+        expect(rendered.props().style.display).toEqual("-ms-grid");
+    });
+
+    test("should set an inline style of `display: grid` when grid is specified and CSS grid is supported", () => {
+        const rendered: any = shallow(<Page cssGridPropertyName="grid" />);
+
+        expect(rendered.props().style.display).toEqual("grid");
+    });
+
     test("should set a default maxWidth value if no `maxWidth` prop is passed", () => {
         const rendered: any = mount(<Page managedClasses={managedClasses} />);
 
@@ -104,13 +116,5 @@ describe("Page", (): void => {
         expect(rendered.props().style.gridTemplateColumns).toEqual(
             gridTemplateColumnsFormatter(expectedMargin, expectedMaxWidth)
         );
-    });
-});
-
-describe("Page - without CSS grid support but `cssGridPropertyName` prop is `grid`", (): void => {
-    test("should set an inline style of `display: grid` when CSS grid is NOT supported but the `cssGridPropertyName` prop passed is `grid`", () => {
-        const rendered: any = shallow(<Page cssGridPropertyName={"grid"} />);
-
-        expect(rendered.props().style.display).toEqual("grid");
     });
 });

--- a/packages/fast-layouts-react/src/page/page.tsx
+++ b/packages/fast-layouts-react/src/page/page.tsx
@@ -46,9 +46,13 @@ export class Page extends Foundation<PageHandledProps, PageUnhandledProps, {}> {
             ...attributes,
             style: {
                 display:
-                    this.props.cssGridPropertyName || canUseCssGrid()
+                    this.props.cssGridPropertyName === "grid"
                         ? "grid"
-                        : "-ms-grid",
+                        : this.props.cssGridPropertyName === "-ms-grid"
+                            ? "-ms-grid"
+                            : canUseCssGrid()
+                                ? "grid"
+                                : "-ms-grid",
                 gridTemplateColumns: columns,
                 msGridColumns: columns,
                 // attributes.style has to be spread here again in order to


### PR DESCRIPTION
# Description
Fix logic in application of cssGridPropertyName in Page.tsx.

## Motivation & context
https://github.com/microsoft/fast-dna/issues/2689

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.