### PR TITLE
feat: add fixed height to horizontal overflow

### DIFF
--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.props.ts
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.props.ts
@@ -68,6 +68,12 @@ export interface HorizontalOverflowHandledProps extends HorizontalOverflowManage
      * view and skipping the scroll animation
      */
     nextItemPeek?: number;
+
+    /**
+     * Set the horizontal overflow to a fixed height instead of sizing to the largest child item.
+     * Useful when server side rendering to ensure server and client DOM matching.
+     */
+    fixedHeight?: number;
 }
 
 export type HorizontalOverflowProps = HorizontalOverflowHandledProps &

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.props.ts
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.props.ts
@@ -73,7 +73,7 @@ export interface HorizontalOverflowHandledProps extends HorizontalOverflowManage
      * Set the horizontal overflow to a fixed height instead of sizing to the largest child item.
      * Useful when server side rendering to ensure server and client DOM matching.
      */
-    fixedHeight?: number;
+    fixedHeight?: number | null;
 }
 
 export type HorizontalOverflowProps = HorizontalOverflowHandledProps &

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -207,7 +207,7 @@ describe("horizontal overflow", (): void => {
         expect(rendered.state("itemsHeight")).toBe(100);
     });
     test("should set `itemHeight` to the fixedHeight if children have been passed but a fixedHeight has been set", () => {
-        const rendered = mount(
+        const rendered: any = mount(
             <HorizontalOverflow managedClasses={managedClasses} fixedHeight={100}>
                 <img key="image1" src="https://placehold.it/200x200?text=1" />
             </HorizontalOverflow>

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -206,7 +206,7 @@ describe("horizontal overflow", (): void => {
 
         expect(rendered.state("itemsHeight")).toBe(100);
     });
-    test("should set `itemHeight` to the fixedHeight if children have been passed but a fixedHeight has been set", () => {
+    test("should set `itemHeight` to the fixedHeight if children have been passed and a fixedHeight has been set", () => {
         const rendered: any = mount(
             <HorizontalOverflow managedClasses={managedClasses} fixedHeight={100}>
                 <img key="image1" src="https://placehold.it/200x200?text=1" />

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.spec.tsx
@@ -192,12 +192,28 @@ describe("horizontal overflow", (): void => {
 
         expect(renderedWithImages.find("img").length).toBe(6);
     });
-    test("should not set `itemHeight` if no children have been passed", () => {
+    test("should not set `itemHeight` if no children have been passed or fixedHeight set", () => {
         const rendered: any = mount(
             <HorizontalOverflow managedClasses={managedClasses} />
         );
 
         expect(rendered.state("itemsHeight")).toBe(null);
+    });
+    test("should set `itemHeight` to the fixedHeight if no children have been passed but a fixedHeight has been set", () => {
+        const rendered: any = mount(
+            <HorizontalOverflow managedClasses={managedClasses} fixedHeight={100} />
+        );
+
+        expect(rendered.state("itemsHeight")).toBe(100);
+    });
+    test("should set `itemHeight` to the fixedHeight if children have been passed but a fixedHeight has been set", () => {
+        const rendered = mount(
+            <HorizontalOverflow managedClasses={managedClasses} fixedHeight={100}>
+                <img key="image1" src="https://placehold.it/200x200?text=1" />
+            </HorizontalOverflow>
+        );
+
+        expect(rendered.state("itemsHeight")).toBe(100);
     });
     test("should update the rendering of a series of items if they are modified", () => {
         const renderedWithImages: any = mount(

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -42,6 +42,7 @@ class HorizontalOverflow extends Foundation<
     public static defaultProps: Partial<HorizontalOverflowProps> = {
         managedClasses: {},
         nextItemPeek: 50,
+        fixedHeight: null,
     };
     private static DirectionAttributeName: string = "dir";
     private static defaultScrollAnimationDuration: number = 500;
@@ -52,6 +53,7 @@ class HorizontalOverflow extends Foundation<
         onScrollChange: void 0,
         onOverflowChange: void 0,
         nextItemPeek: void 0,
+        fixedHeight: void 0,
     };
 
     private horizontalOverflowItemsRef: React.RefObject<HTMLUListElement>;
@@ -129,7 +131,7 @@ class HorizontalOverflow extends Foundation<
 
         this.state = {
             direction: Direction.ltr,
-            itemsHeight: null,
+            itemsHeight: props.fixedHeight,
         };
     }
 
@@ -192,7 +194,9 @@ class HorizontalOverflow extends Foundation<
             return;
         }
 
-        const itemsHeight: number = this.getItemMaxHeight();
+        const itemsHeight: number = this.props.fixedHeight
+            ? this.props.fixedHeight
+            : this.getItemMaxHeight();
 
         this.setState({
             itemsHeight,
@@ -404,7 +408,9 @@ class HorizontalOverflow extends Foundation<
      * onLoad handler to make sure any children affecting height are accounted for
      */
     private itemsOnLoad = (): void => {
-        const itemsHeight: number = this.getItemMaxHeight();
+        const itemsHeight: number = this.props.fixedHeight
+            ? this.props.fixedHeight
+            : this.getItemMaxHeight();
 
         if (itemsHeight !== this.state.itemsHeight) {
             this.setState({

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -194,9 +194,10 @@ class HorizontalOverflow extends Foundation<
             return;
         }
 
-        const itemsHeight: number = this.props.fixedHeight
-            ? this.props.fixedHeight
-            : this.getItemMaxHeight();
+        const itemsHeight: number =
+            this.props.fixedHeight !== null
+                ? this.props.fixedHeight
+                : this.getItemMaxHeight();
 
         if (itemsHeight !== this.state.itemsHeight) {
             this.setState({
@@ -410,9 +411,10 @@ class HorizontalOverflow extends Foundation<
      * onLoad handler to make sure any children affecting height are accounted for
      */
     private itemsOnLoad = (): void => {
-        const itemsHeight: number = this.props.fixedHeight
-            ? this.props.fixedHeight
-            : this.getItemMaxHeight();
+        const itemsHeight: number =
+            this.props.fixedHeight !== null
+                ? this.props.fixedHeight
+                : this.getItemMaxHeight();
 
         if (itemsHeight !== this.state.itemsHeight) {
             this.setState({

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -198,9 +198,11 @@ class HorizontalOverflow extends Foundation<
             ? this.props.fixedHeight
             : this.getItemMaxHeight();
 
-        this.setState({
-            itemsHeight,
-        });
+        if (itemsHeight !== this.state.itemsHeight) {
+            this.setState({
+                itemsHeight,
+            });
+        }
 
         if (canUseDOM() && this.horizontalOverflowItemsRef.current) {
             this.updateDirection();

--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -194,10 +194,7 @@ class HorizontalOverflow extends Foundation<
             return;
         }
 
-        const itemsHeight: number =
-            this.props.fixedHeight !== null
-                ? this.props.fixedHeight
-                : this.getItemMaxHeight();
+        const itemsHeight: number = this.getItemHeight();
 
         if (itemsHeight !== this.state.itemsHeight) {
             this.setState({
@@ -411,10 +408,7 @@ class HorizontalOverflow extends Foundation<
      * onLoad handler to make sure any children affecting height are accounted for
      */
     private itemsOnLoad = (): void => {
-        const itemsHeight: number =
-            this.props.fixedHeight !== null
-                ? this.props.fixedHeight
-                : this.getItemMaxHeight();
+        const itemsHeight: number = this.getItemHeight();
 
         if (itemsHeight !== this.state.itemsHeight) {
             this.setState({
@@ -469,6 +463,15 @@ class HorizontalOverflow extends Foundation<
             });
         }
     };
+
+    /**
+     * Returns the fixed height if set or identifies and returns the tallest child height
+     */
+    private getItemHeight(): number {
+        return this.props.fixedHeight !== null
+            ? this.props.fixedHeight
+            : this.getItemMaxHeight();
+    }
 
     /**
      * Identifies and returns the tallest child height


### PR DESCRIPTION
# Description
Add fixedHeight property to HorizontalOverflow.

## Motivation & context
https://github.com/microsoft/fast-dna/issues/2687
When server side rendering - the children heights are not calculated meaning height is always "auto". This feature allows a known fixed height to be used instead.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [x] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.