### PR TITLE
fix: button anchors have no hover or active states

### DIFF
--- a/packages/fast-components-react-msft/src/action-trigger/action-trigger.stories.tsx
+++ b/packages/fast-components-react-msft/src/action-trigger/action-trigger.stories.tsx
@@ -28,11 +28,31 @@ storiesOf("Action trigger", module)
             Download
         </ActionTrigger>
     ))
+    .add("Justified Anchor", () => (
+        <ActionTrigger
+            glyph={glyphFactory(SVGGlyph.download)}
+            appearance={ActionTriggerAppearance.justified}
+            onClick={action("onClick")}
+            href="#"
+        >
+            Download
+        </ActionTrigger>
+    ))
     .add("Lightweight", () => (
         <ActionTrigger
             glyph={glyphFactory(SVGGlyph.download)}
             appearance={ActionTriggerAppearance.lightweight}
             onClick={action("onClick")}
+        >
+            Download
+        </ActionTrigger>
+    ))
+    .add("Lightweight Anchor", () => (
+        <ActionTrigger
+            glyph={glyphFactory(SVGGlyph.download)}
+            appearance={ActionTriggerAppearance.lightweight}
+            onClick={action("onClick")}
+            href="#"
         >
             Download
         </ActionTrigger>
@@ -46,6 +66,16 @@ storiesOf("Action trigger", module)
             Download
         </ActionTrigger>
     ))
+    .add("Outline Anchor", () => (
+        <ActionTrigger
+            glyph={glyphFactory(SVGGlyph.download)}
+            appearance={ActionTriggerAppearance.outline}
+            onClick={action("onClick")}
+            href="#"
+        >
+            Download
+        </ActionTrigger>
+    ))
     .add("Primary", () => (
         <ActionTrigger
             glyph={glyphFactory(SVGGlyph.download)}
@@ -55,11 +85,42 @@ storiesOf("Action trigger", module)
             Download
         </ActionTrigger>
     ))
+    .add("Primary Anchor", () => (
+        <ActionTrigger
+            glyph={glyphFactory(SVGGlyph.download)}
+            appearance={ActionTriggerAppearance.primary}
+            onClick={action("onClick")}
+            href="#"
+        >
+            Download
+        </ActionTrigger>
+    ))
+    .add("Primary Anchor Disabled", () => (
+        <ActionTrigger
+            glyph={glyphFactory(SVGGlyph.download)}
+            appearance={ActionTriggerAppearance.primary}
+            onClick={action("onClick")}
+            disabled={true}
+            href="#"
+        >
+            Download
+        </ActionTrigger>
+    ))
     .add("Stealth", () => (
         <ActionTrigger
             glyph={glyphFactory(SVGGlyph.download)}
             appearance={ActionTriggerAppearance.stealth}
             onClick={action("onClick")}
+        >
+            Download
+        </ActionTrigger>
+    ))
+    .add("Stealth Anchor", () => (
+        <ActionTrigger
+            glyph={glyphFactory(SVGGlyph.download)}
+            appearance={ActionTriggerAppearance.stealth}
+            onClick={action("onClick")}
+            href="#"
         >
             Download
         </ActionTrigger>

--- a/packages/fast-components-react-msft/src/button/button.stories.tsx
+++ b/packages/fast-components-react-msft/src/button/button.stories.tsx
@@ -37,6 +37,17 @@ storiesOf("Button", module)
             Primary Button
         </Button>
     ))
+    .add("Primary Anchor - disabled", () => (
+        <Button
+            appearance={ButtonAppearance.primary}
+            href="#"
+            beforeContent={glyphFactory(SVGGlyph.user)}
+            afterContent={glyphFactory(SVGGlyph.download)}
+            disabled={true}
+        >
+            Primary Anchor
+        </Button>
+    ))
     .add("Outline", () => (
         <Button appearance={ButtonAppearance.outline}>Outline Button</Button>
     ))

--- a/packages/fast-components-react-msft/src/call-to-action/call-to-action.stories.tsx
+++ b/packages/fast-components-react-msft/src/call-to-action/call-to-action.stories.tsx
@@ -12,6 +12,15 @@ storiesOf("Call to action", module)
             Buy now
         </CallToAction>
     ))
+    .add("Primary Anchor - disabled", () => (
+        <CallToAction
+            appearance={CallToActionAppearance.primary}
+            href="#"
+            disabled={true}
+        >
+            Buy now
+        </CallToAction>
+    ))
     .add("Justified", () => (
         <CallToAction appearance={CallToActionAppearance.justified}>Buy now</CallToAction>
     ))
@@ -33,9 +42,19 @@ storiesOf("Call to action", module)
     .add("Outline", () => (
         <CallToAction appearance={CallToActionAppearance.outline}>Buy now</CallToAction>
     ))
+    .add("Outline Anchor", () => (
+        <CallToAction appearance={CallToActionAppearance.outline} href="#">
+            Buy now
+        </CallToAction>
+    ))
     .add("Primary", () => (
         <CallToAction appearance={CallToActionAppearance.primary}>Buy now</CallToAction>
     ))
     .add("Stealth", () => (
         <CallToAction appearance={CallToActionAppearance.stealth}>Buy now</CallToAction>
+    ))
+    .add("Stealth Anchor", () => (
+        <CallToAction appearance={CallToActionAppearance.stealth} href="#">
+            Buy now
+        </CallToAction>
     ));

--- a/packages/fast-components-styles-msft/src/accent-button/index.ts
+++ b/packages/fast-components-styles-msft/src/accent-button/index.ts
@@ -32,14 +32,14 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
         color: accentForegroundCut,
         fill: accentForegroundCut,
         background: accentFillRest,
-        "&:hover:enabled": {
+        "&:hover:enabled, a&:not($button__disabled):hover": {
             background: accentFillHover,
             ...highContrastSelectedOutline,
             "& $button_beforeContent, & $button_afterContent": {
                 ...highContrastHighlightForeground,
             },
         },
-        "&:active:enabled": {
+        "&:active:enabled, a&:not($button__disabled):active": {
             background: accentFillActive,
         },
         ...applyFocusVisible<DesignSystem>({
@@ -66,7 +66,7 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
             "& $button_beforeContent, & $button_afterContent": {
                 ...highContrastLinkForeground,
             },
-            "&:hover": {
+            "&:not($button__disabled):hover": {
                 ...highContrastLinkBorder,
                 "& $button_beforeContent, & $button_afterContent": {
                     ...highContrastLinkForeground,

--- a/packages/fast-components-styles-msft/src/accent-button/index.ts
+++ b/packages/fast-components-styles-msft/src/accent-button/index.ts
@@ -61,7 +61,7 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
             ...highContrastSelectedForeground,
         },
         ...highContrastAccent,
-        "a&": {
+        "a&:not($button__disabled)": {
             ...highContrastLinkOutline,
             "& $button_beforeContent, & $button_afterContent": {
                 ...highContrastLinkForeground,

--- a/packages/fast-components-styles-msft/src/action-trigger/index.ts
+++ b/packages/fast-components-styles-msft/src/action-trigger/index.ts
@@ -41,7 +41,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = {
         "& $actionTrigger_glyph": {
             ...highContrastForeground,
         },
-        "&:hover:enabled": {
+        "&:hover:enabled, a&:not($actionTrigger__disabled):hover": {
             "& $actionTrigger_glyph": {
                 [highContrastSelector]: {
                     ...highContrastSelectedForeground,
@@ -49,7 +49,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = {
             },
         },
         [`&$actionTrigger__justified, &$actionTrigger__lightweight`]: {
-            "&:hover:enabled": {
+            "&:hover:enabled, a&:not($actionTrigger__disabled):hover": {
                 "& $actionTrigger_glyph": {
                     [highContrastSelector]: {
                         fill: "Highlight !important",
@@ -72,7 +72,7 @@ const styles: ComponentStyles<ActionTriggerClassNameContract, DesignSystem> = {
                 ...highContrastSelectedForeground,
             },
         },
-        "&:hover:enabled": {
+        "&:hover:enabled, a&:not($actionTrigger__disabled):hover": {
             "& $actionTrigger_glyph": {
                 [highContrastSelector]: {
                     fill: "Highlight !important",

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -99,7 +99,7 @@ const applyTransparentBackplateStyles: CSSRules<DesignSystem> = {
     "&$button__disabled, &$button__disabled $button_contentRegion::before": {
         ...transparentBackground,
     },
-    "&:hover:enabled": {
+    "&:hover:enabled, a&:not($button__disabled):hover": {
         color: accentForegroundHover,
         ...transparentBackground,
         ...highContrastHighlightForeground,
@@ -108,7 +108,7 @@ const applyTransparentBackplateStyles: CSSRules<DesignSystem> = {
             ...highContrastHighlightForeground,
         },
     },
-    "&:active:enabled": {
+    "&:active:enabled, a&:not($button__disabled):active": {
         color: accentForegroundActive,
         fill: accentForegroundActive,
         ...transparentBackground,
@@ -140,14 +140,14 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         color: neutralForegroundRest,
         fill: neutralForegroundRest,
         background: neutralFillRest,
-        "&:hover:enabled": {
+        "&:hover:enabled, a&:not($button__disabled):hover": {
             background: neutralFillHover,
             ...highContrastSelected,
             "& $button_beforeContent, & $button_afterContent": {
                 ...highContrastSelectedForeground,
             },
         },
-        "&:active:enabled": {
+        "&:active:enabled, a&:not($button__disabled):active": {
             background: neutralFillActive,
         },
         ...applyFocusVisible<DesignSystem>({
@@ -163,8 +163,11 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         ...highContrastOutline,
         "a&": {
             ...highContrastLinkOutline,
-            "&:hover": {
+            "&:not($button__disabled):hover": {
                 ...highContrastLinkBorder,
+                "& $button_beforeContent, & $button_afterContent": {
+                    ...highContrastLinkForeground,
+                },
             },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
@@ -180,11 +183,11 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         color: accentForegroundCut,
         fill: accentForegroundCut,
         background: accentFillRest,
-        "&:hover:enabled": {
+        "&:hover:enabled, a&:not($button__disabled):hover": {
             background: accentFillHover,
             ...highContrastSelectedOutline,
         },
-        "&:active:enabled": {
+        "&:active:enabled, a&:not($button__disabled):active": {
             background: accentFillActive,
         },
         ...applyFocusVisible<DesignSystem>({
@@ -214,7 +217,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             neutralOutlineRest
         ),
         padding: format("0 {0}", horizontalSpacing(outlineWidth)),
-        "&:hover:enabled": {
+        "&:hover:enabled, a&:not($button__disabled):hover": {
             background: "transparent",
             border: format(
                 "{0} solid {1}",
@@ -223,7 +226,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             ),
             ...highContrastSelected,
         },
-        "&:active:enabled": {
+        "&:active:enabled, a&:not($button__disabled):active": {
             background: "transparent",
             border: format(
                 "{0} solid {1}",
@@ -245,9 +248,11 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
     button__lightweight: {
         ...applyTransparentBackplateStyles,
         "a&": {
-            "&:hover": {
+            "&:not($button__disabled):hover": {
                 [highContrastSelector]: {
                     "box-shadow": "none !important",
+                    color: highContrastLinkValue,
+                    fill: highContrastLinkValue,
                 },
                 "& $button_contentRegion::before": {
                     [highContrastSelector]: {
@@ -273,9 +278,11 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         "border-width": "0",
         "justify-content": "flex-start",
         "a&": {
-            "&:hover": {
+            "&:not($button__disabled):hover": {
                 [highContrastSelector]: {
                     "box-shadow": "none !important",
+                    color: highContrastLinkValue,
+                    fill: highContrastLinkValue,
                 },
                 "& $button_contentRegion::before": {
                     [highContrastSelector]: {
@@ -290,11 +297,11 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
     },
     button__stealth: {
         background: neutralFillStealthRest,
-        "&:hover:enabled": {
+        "&:hover:enabled, a&:not($button__disabled):hover": {
             "background-color": neutralFillStealthHover,
             ...highContrastSelected,
         },
-        "&:active:enabled": {
+        "&:active:enabled, a&:not($button__disabled):active": {
             "background-color": neutralFillStealthActive,
         },
         ...applyFocusVisible<DesignSystem>({

--- a/packages/fast-components-styles-msft/src/button/index.ts
+++ b/packages/fast-components-styles-msft/src/button/index.ts
@@ -161,7 +161,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             border: "0",
         },
         ...highContrastOutline,
-        "a&": {
+        "a&:not($button__disabled)": {
             ...highContrastLinkOutline,
             "&:not($button__disabled):hover": {
                 ...highContrastLinkBorder,
@@ -203,7 +203,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
             fill: accentForegroundCut,
         },
         ...highContrastAccent,
-        "a&": {
+        "a&:not($button__disabled)": {
             "& $button_beforeContent, & $button_afterContent": {
                 ...highContrastLinkForeground,
             },
@@ -247,7 +247,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
     },
     button__lightweight: {
         ...applyTransparentBackplateStyles,
-        "a&": {
+        "a&:not($button__disabled)": {
             "&:not($button__disabled):hover": {
                 [highContrastSelector]: {
                     "box-shadow": "none !important",
@@ -277,7 +277,7 @@ const styles: ComponentStyles<ButtonClassNameContract, DesignSystem> = {
         "padding-right": "0",
         "border-width": "0",
         "justify-content": "flex-start",
-        "a&": {
+        "a&:not($button__disabled)": {
             "&:not($button__disabled):hover": {
                 [highContrastSelector]: {
                     "box-shadow": "none !important",

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -15,6 +15,7 @@ import {
     highContrastDisabledForeground,
     highContrastHighlightBackground,
     highContrastHighlightForeground,
+    highContrastLinkForeground,
     highContrastLinkValue,
     highContrastSelector,
     highContrastStealth,
@@ -62,13 +63,13 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             "background-color": "transparent",
             ...highContrastDisabledForeground,
         },
-        "&:hover:enabled": {
+        "&:hover:enabled, a&:not($button__disabled):hover": {
             color: accentForegroundHover,
             fill: accentForegroundHover,
             "background-color": "transparent",
             ...highContrastHighlightForeground,
         },
-        "&:active:enabled": {
+        "&:active:enabled, a&:not($button__disabled):active": {
             color: accentForegroundActive,
             fill: accentForegroundActive,
             "background-color": "transparent",
@@ -79,6 +80,9 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
                 background: HighContrastColor.background,
                 color: highContrastLinkValue,
                 fill: highContrastLinkValue,
+            },
+            "&:not($button__disabled):hover": {
+                ...highContrastLinkForeground,
             },
             // Underline
             "&:hover $button_contentRegion::before": {

--- a/packages/fast-components-styles-msft/src/lightweight-button/index.ts
+++ b/packages/fast-components-styles-msft/src/lightweight-button/index.ts
@@ -75,7 +75,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             "background-color": "transparent",
         },
         ...highContrastStealth,
-        "a&": {
+        "a&:not($button__disabled)": {
             [highContrastSelector]: {
                 background: HighContrastColor.background,
                 color: highContrastLinkValue,

--- a/packages/fast-components-styles-msft/src/neutral-button/index.ts
+++ b/packages/fast-components-styles-msft/src/neutral-button/index.ts
@@ -27,11 +27,11 @@ const styles: ComponentStyles<NeutralButtonClassNameContract, DesignSystem> = {
         color: neutralForegroundRest,
         fill: neutralForegroundRest,
         background: neutralFillRest,
-        "&:hover:enabled": {
+        "&:hover:enabled, a&:not($button__disabled):hover": {
             background: neutralFillHover,
             ...highContrastSelected,
         },
-        "&:active:enabled": {
+        "&:active:enabled, a&:not($button__disabled):active": {
             background: neutralFillActive,
         },
         ...applyFocusVisible<DesignSystem>({
@@ -47,16 +47,11 @@ const styles: ComponentStyles<NeutralButtonClassNameContract, DesignSystem> = {
         ...highContrastOutline,
         "a&": {
             ...highContrastLinkOutline,
-            "&:hover": {
+            "&:not($button__disabled):hover": {
                 ...highContrastLinkBorder,
             },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
-                "&:hover": {
-                    [highContrastSelector]: {
-                        "box-shadow": "none !important",
-                    },
-                },
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/neutral-button/index.ts
+++ b/packages/fast-components-styles-msft/src/neutral-button/index.ts
@@ -17,7 +17,6 @@ import {
     highContrastOutline,
     highContrastOutlineFocus,
     highContrastSelected,
-    highContrastSelector,
 } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<NeutralButtonClassNameContract, DesignSystem> = {
@@ -45,7 +44,7 @@ const styles: ComponentStyles<NeutralButtonClassNameContract, DesignSystem> = {
             border: "0",
         },
         ...highContrastOutline,
-        "a&": {
+        "a&:not($button__disabled)": {
             ...highContrastLinkOutline,
             "&:not($button__disabled):hover": {
                 ...highContrastLinkBorder,

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -19,7 +19,6 @@ import {
     highContrastOutline,
     highContrastOutlineFocus,
     highContrastSelected,
-    highContrastSelector,
 } from "../utilities/high-contrast";
 
 const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> = {
@@ -65,7 +64,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             ...highContrastDisabledBorder,
         },
         ...highContrastOutline,
-        "a&": {
+        "a&:not($button__disabled)": {
             ...highContrastLinkOutline,
             "&:not($button__disabled):hover": {
                 ...highContrastLinkBorder,

--- a/packages/fast-components-styles-msft/src/outline-button/index.ts
+++ b/packages/fast-components-styles-msft/src/outline-button/index.ts
@@ -35,7 +35,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             neutralOutlineRest
         ),
         padding: format("0 {0}", horizontalSpacing(outlineWidth)),
-        "&:hover:enabled": {
+        "&:hover:enabled, a&:not($button__disabled):hover": {
             background: "transparent",
             border: format(
                 "{0} solid {1}",
@@ -44,7 +44,7 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
             ),
             ...highContrastSelected,
         },
-        "&:active:enabled": {
+        "&:active:enabled, a&:not($button__disabled):active": {
             background: "transparent",
             border: format(
                 "{0} solid {1}",
@@ -67,16 +67,11 @@ const styles: ComponentStyles<LightweightButtonClassNameContract, DesignSystem> 
         ...highContrastOutline,
         "a&": {
             ...highContrastLinkOutline,
-            "&:hover": {
+            "&:not($button__disabled):hover": {
                 ...highContrastLinkBorder,
             },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
-                "&:hover": {
-                    [highContrastSelector]: {
-                        "box-shadow": "none !important",
-                    },
-                },
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/stealth-button/index.ts
+++ b/packages/fast-components-styles-msft/src/stealth-button/index.ts
@@ -27,11 +27,11 @@ const styles: ComponentStyles<StealthButtonClassNameContract, DesignSystem> = {
         color: neutralForegroundRest,
         fill: neutralForegroundRest,
         background: neutralFillStealthRest,
-        "&:hover:enabled": {
+        "&:hover:enabled, a&:not($button__disabled):hover": {
             "background-color": neutralFillStealthHover,
             ...highContrastSelected,
         },
-        "&:active:enabled": {
+        "&:active:enabled, a&:not($button__disabled):active": {
             "background-color": neutralFillStealthActive,
         },
         ...applyFocusVisible<DesignSystem>({
@@ -44,16 +44,11 @@ const styles: ComponentStyles<StealthButtonClassNameContract, DesignSystem> = {
         ...highContrastStealth,
         "a&": {
             ...highContrastLinkOutline,
-            "&:hover": {
+            "&:not($button__disabled):hover": {
                 ...highContrastLinkBorder,
             },
             "&$button__disabled": {
                 ...highContrastDisabledBorder,
-                "&:hover": {
-                    [highContrastSelector]: {
-                        "box-shadow": "none !important",
-                    },
-                },
             },
         },
     },

--- a/packages/fast-components-styles-msft/src/stealth-button/index.ts
+++ b/packages/fast-components-styles-msft/src/stealth-button/index.ts
@@ -16,7 +16,6 @@ import {
     highContrastLinkOutline,
     highContrastOutlineFocus,
     highContrastSelected,
-    highContrastSelector,
     highContrastStealth,
 } from "../utilities/high-contrast";
 
@@ -42,7 +41,7 @@ const styles: ComponentStyles<StealthButtonClassNameContract, DesignSystem> = {
             ...highContrastDisabledBorder,
         },
         ...highContrastStealth,
-        "a&": {
+        "a&:not($button__disabled)": {
             ...highContrastLinkOutline,
             "&:not($button__disabled):hover": {
                 ...highContrastLinkBorder,

--- a/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
+++ b/packages/fast-components-styles-msft/src/utilities/high-contrast.ts
@@ -223,6 +223,7 @@ export const highContrastBorderColor: CSSRules<DesignSystem> = {
 // Used to set box-shadow border color to be 'link' color
 export const highContrastLinkBorder: CSSRules<DesignSystem> = {
     [highContrastSelector]: {
+        background: HighContrastColor.buttonBackground,
         "box-shadow": format(
             "0 0 0 {0} inset {1}",
             toPx(outlineWidth),


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
closes: #2696 

This change makes sure that when a `<Button/>` is passed a `href` and renders an `<a/>` that the hover and active states remain the same. Since `:enabled` selectors don't apply to `<a/>` we need to specify and `hover` and `active` state for `<a/>`.

this change applies to all appearance variations of `<Button/>`, `<AccentButton/>`, `<LightweightButton/>`, `<NeutralButton/>`, `<OutlineButton/>`, `<StealthButton/>`, all appearance variations of `<ActionTrigger/>`, and all appearance variations of `<CallToAction/>` so please test accordingly.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->