### PR TITLE
refactor(all): remove I from interface names

### DIFF
--- a/packages/fast-element/src/behaviors/behavior.ts
+++ b/packages/fast-element/src/behaviors/behavior.ts
@@ -1,6 +1,6 @@
-export interface IBehavior {
+export interface Behavior {
     bind(source: unknown): void;
     unbind(): void;
 }
 
-export type BehaviorType<T = any> = new (directive: T, target: any) => IBehavior;
+export type BehaviorType<T = any> = new (directive: T, target: any) => Behavior;

--- a/packages/fast-element/src/behaviors/binding-base.ts
+++ b/packages/fast-element/src/behaviors/binding-base.ts
@@ -1,22 +1,22 @@
-import { IBehavior } from "./behavior";
-import { IGetterInspector, Observable } from "../observation/observable";
+import { Behavior } from "./behavior";
+import { GetterInspector, Observable } from "../observation/observable";
 import { BindingDirective } from "../directives/bind";
 import { DOM } from "../dom";
-import { ISubscriber } from "../observation/subscriber-collection";
+import { Subscriber } from "../observation/subscriber-collection";
 
 class ObservationRecord {
     constructor(private source: any, private propertyName: string) {}
 
-    subscribe(subscriber: ISubscriber) {
+    subscribe(subscriber: Subscriber) {
         Observable.getNotifier(this.source).subscribe(subscriber, this.propertyName);
     }
 
-    unsubscribe(subscriber: ISubscriber) {
+    unsubscribe(subscriber: Subscriber) {
         Observable.getNotifier(this.source).unsubscribe(subscriber, this.propertyName);
     }
 }
 
-export abstract class BindingBase implements IBehavior, IGetterInspector, ISubscriber {
+export abstract class BindingBase implements Behavior, GetterInspector, Subscriber {
     protected source: unknown;
     private record: ObservationRecord | null = null;
     private needsQueue = true;

--- a/packages/fast-element/src/behaviors/trigger.ts
+++ b/packages/fast-element/src/behaviors/trigger.ts
@@ -1,7 +1,7 @@
-import { IBehavior } from "./behavior";
+import { Behavior } from "./behavior";
 import { BindingDirective } from "../directives/bind";
 
-export class TriggerBinding implements IBehavior {
+export class TriggerBinding implements Behavior {
     private source: unknown = null;
 
     constructor(private directive: BindingDirective, private target: HTMLElement) {}

--- a/packages/fast-element/src/controller.ts
+++ b/packages/fast-element/src/controller.ts
@@ -1,18 +1,18 @@
 import { CustomElementDefinition, CustomElement } from "./custom-element";
 import { Constructable } from "./interfaces";
-import { IContainer, IRegistry, Resolver, InterfaceSymbol } from "./di";
-import { IElementView } from "./view";
-import { IElementProjector, HostProjector, ShadowDOMProjector } from "./projectors";
+import { Container, Registry, Resolver, InterfaceSymbol } from "./di";
+import { ElementView } from "./view";
+import { ElementProjector, HostProjector, ShadowDOMProjector } from "./projectors";
 import { PropertyChangeNotifier } from "./observation/notifier";
 
-export class Controller extends PropertyChangeNotifier implements IContainer {
-    public view: IElementView | null = null;
+export class Controller extends PropertyChangeNotifier implements Container {
+    public view: ElementView | null = null;
     private resolvers = new Map<any, Resolver>();
 
     public constructor(
         public readonly element: HTMLElement,
         public readonly definition: CustomElementDefinition,
-        public readonly projector: IElementProjector
+        public readonly projector: ElementProjector
     ) {
         super();
         this.definition.dependencies.forEach(x => x.register(this));
@@ -43,7 +43,7 @@ export class Controller extends PropertyChangeNotifier implements IContainer {
         (this.element as any)[bindable.property] = newValue;
     }
 
-    public register(registry: IRegistry) {
+    public register(registry: Registry) {
         registry.register(this);
     }
 

--- a/packages/fast-element/src/custom-element.ts
+++ b/packages/fast-element/src/custom-element.ts
@@ -14,7 +14,7 @@ export type PartialCustomElementDefinition = {
 };
 
 export function customElement(nameOrDef: string | PartialCustomElementDefinition) {
-    return function(type: Constructable<HTMLElement>) {
+    return function(type: Constructable) {
         CustomElement.define(nameOrDef, type);
     };
 }
@@ -22,7 +22,7 @@ export function customElement(nameOrDef: string | PartialCustomElementDefinition
 const elementDefinitions = new Map<Constructable, CustomElementDefinition>();
 
 export const CustomElement = {
-    define<T extends Constructable<HTMLElement>>(
+    define<T extends Constructable>(
         nameOrDef: string | PartialCustomElementDefinition,
         Type: T
     ): T {
@@ -40,7 +40,7 @@ export const CustomElement = {
         );
 
         elementDefinitions.set(Type, definition);
-        customElements.define(definition.name, Type, definition.elementOptions);
+        customElements.define(definition.name, Type as any, definition.elementOptions);
         return Type;
     },
 

--- a/packages/fast-element/src/custom-element.ts
+++ b/packages/fast-element/src/custom-element.ts
@@ -1,20 +1,20 @@
-import { ITemplate, noopTemplate } from "./template";
+import { Template, noopTemplate } from "./template";
 import { BindableDefinition, Bindable } from "./bindable";
 import { Constructable } from "./interfaces";
-import { IRegistry } from "./di";
+import { Registry } from "./di";
 import { Observable } from "./observation/observable";
 
 export type PartialCustomElementDefinition = {
     readonly name: string;
-    readonly template?: ITemplate;
+    readonly template?: Template;
     readonly bindables?: Record<string, BindableDefinition>;
-    readonly dependencies?: IRegistry[];
+    readonly dependencies?: Registry[];
     readonly shadowOptions?: ShadowRootInit | null;
     readonly elementOptions?: ElementDefinitionOptions;
 };
 
 export function customElement(nameOrDef: string | PartialCustomElementDefinition) {
-    return function(type: Constructable) {
+    return function(type: Constructable<HTMLElement>) {
         CustomElement.define(nameOrDef, type);
     };
 }
@@ -22,7 +22,7 @@ export function customElement(nameOrDef: string | PartialCustomElementDefinition
 const elementDefinitions = new Map<Constructable, CustomElementDefinition>();
 
 export const CustomElement = {
-    define<T extends Constructable>(
+    define<T extends Constructable<HTMLElement>>(
         nameOrDef: string | PartialCustomElementDefinition,
         Type: T
     ): T {
@@ -49,7 +49,7 @@ export const CustomElement = {
     },
 };
 
-function buildTemplate(def: PartialCustomElementDefinition): ITemplate {
+function buildTemplate(def: PartialCustomElementDefinition): Template {
     if (def.template === void 0) {
         return noopTemplate;
     }
@@ -62,9 +62,9 @@ export class CustomElementDefinition {
 
     public constructor(
         public readonly name: string,
-        public readonly template: ITemplate,
+        public readonly template: Template,
         public readonly bindables: Record<string, BindableDefinition>,
-        public readonly dependencies: IRegistry[],
+        public readonly dependencies: Registry[],
         public readonly shadowOptions: ShadowRootInit | null,
         public readonly elementOptions: ElementDefinitionOptions | undefined
     ) {

--- a/packages/fast-element/src/di.ts
+++ b/packages/fast-element/src/di.ts
@@ -1,16 +1,16 @@
-export type Resolver = (container: IContainer) => any;
+export type Resolver = (container: Container) => any;
 
-export interface IServiceLocator {
+export interface ServiceLocator {
     get<T>(key: InterfaceSymbol<T>): T | null;
     get<T = any>(key: any): T | null;
 }
 
-export interface IContainer extends IServiceLocator {
+export interface Container extends ServiceLocator {
     registerResolver(key: any, resolver: Resolver): void;
 }
 
-export interface IRegistry {
-    register(controller: IContainer): void;
+export interface Registry {
+    register(controller: Container): void;
 }
 
 export interface InterfaceSymbol<T> {}

--- a/packages/fast-element/src/directives/bind.ts
+++ b/packages/fast-element/src/directives/bind.ts
@@ -1,13 +1,13 @@
 import { Directive } from "./directive";
-import { IExpression } from "../expression";
-import { Observable, IGetterInspector } from "../observation/observable";
+import { Expression } from "../expression";
+import { Observable, GetterInspector } from "../observation/observable";
 import { BehaviorType } from "../behaviors/index";
 
 export class BindingDirective extends Directive {
     public targetName?: string;
     public behavior!: BehaviorType;
 
-    constructor(public expression: IExpression) {
+    constructor(public expression: Expression) {
         super();
     }
 
@@ -17,7 +17,7 @@ export class BindingDirective extends Directive {
 
     public inspectAndEvaluate<T = unknown>(
         scope: unknown,
-        inspector: IGetterInspector
+        inspector: GetterInspector
     ): T {
         Observable.setInspector(inspector);
         const value = this.expression.evaluate(scope);

--- a/packages/fast-element/src/directives/directive.ts
+++ b/packages/fast-element/src/directives/directive.ts
@@ -1,15 +1,15 @@
 import { DOM } from "../dom";
-import { IBehavior, BehaviorType } from "../behaviors/behavior";
-import { ITargetedInstruction } from "../instructions";
+import { Behavior, BehaviorType } from "../behaviors/behavior";
+import { TargetedInstruction } from "../instructions";
 
-export abstract class Directive implements ITargetedInstruction {
+export abstract class Directive implements TargetedInstruction {
     public abstract behavior: BehaviorType;
 
     public createPlaceholder(instructionIndex: number) {
         return DOM.createInterpolationPlaceholder(instructionIndex);
     }
 
-    public hydrate(target: any, behaviors: IBehavior[]): void {
+    public hydrate(target: any, behaviors: Behavior[]): void {
         behaviors.push(new this.behavior!(this, target));
     }
 }

--- a/packages/fast-element/src/directives/ref.ts
+++ b/packages/fast-element/src/directives/ref.ts
@@ -1,6 +1,6 @@
-import { IBehavior } from "../behaviors/behavior";
+import { Behavior } from "../behaviors/behavior";
 import { Directive } from "./directive";
-import { ICaptureType } from "../template";
+import { CaptureType } from "../template";
 
 export class RefDirective extends Directive {
     behavior = RefBinding;
@@ -14,7 +14,7 @@ export class RefDirective extends Directive {
     }
 }
 
-export class RefBinding implements IBehavior {
+export class RefBinding implements Behavior {
     constructor(private directive: RefDirective, private target: HTMLElement) {}
 
     bind(source: any) {
@@ -24,6 +24,6 @@ export class RefBinding implements IBehavior {
     unbind() {}
 }
 
-export function ref<T = any>(propertyName: keyof T & string): ICaptureType<T> {
+export function ref<T = any>(propertyName: keyof T & string): CaptureType<T> {
     return new RefDirective(propertyName);
 }

--- a/packages/fast-element/src/directives/repeat.ts
+++ b/packages/fast-element/src/directives/repeat.ts
@@ -1,18 +1,18 @@
-import { AccessScopeExpression, IExpression, Getter } from "../expression";
-import { ITemplate, ICaptureType } from "../template";
-import { IBehavior } from "../behaviors/behavior";
+import { AccessScopeExpression, Expression, Getter } from "../expression";
+import { Template, CaptureType } from "../template";
+import { Behavior } from "../behaviors/behavior";
 import { DOM } from "../dom";
-import { Observable, IGetterInspector } from "../observation/observable";
+import { Observable, GetterInspector } from "../observation/observable";
 import { BindingDirective } from "./bind";
-import { ISyntheticView } from "../view";
-import { ISubscriber } from "../observation/subscriber-collection";
+import { SyntheticView } from "../view";
+import { Subscriber } from "../observation/subscriber-collection";
 import { ArrayObserver, enableArrayObservation } from "../observation/array-observer";
 import { Splice } from "../observation/array-change-records";
 
 export class RepeatDirective extends BindingDirective {
     behavior = RepeatBehavior;
 
-    constructor(public expression: IExpression, public template: ITemplate) {
+    constructor(public expression: Expression, public template: Template) {
         super(expression);
         enableArrayObservation();
     }
@@ -22,10 +22,10 @@ export class RepeatDirective extends BindingDirective {
     }
 }
 
-export class RepeatBehavior implements IBehavior, IGetterInspector, ISubscriber {
+export class RepeatBehavior implements Behavior, GetterInspector, Subscriber {
     private location: Node;
     private source: unknown;
-    private views: ISyntheticView[] = [];
+    private views: SyntheticView[] = [];
     private items: any[] | null = null;
     private observer?: ArrayObserver;
 
@@ -89,7 +89,7 @@ export class RepeatBehavior implements IBehavior, IGetterInspector, ISubscriber 
 
     private updateViews(splices: Splice[]) {
         const views = this.views;
-        const totalRemoved: ISyntheticView[] = [];
+        const totalRemoved: SyntheticView[] = [];
         let removeDelta = 0;
 
         for (let i = 0, ii = splices.length; i < ii; ++i) {
@@ -172,7 +172,7 @@ export class RepeatBehavior implements IBehavior, IGetterInspector, ISubscriber 
 
 export function repeat<T = any, K = any>(
     expression: Getter<T, K[]> | keyof T,
-    template: ITemplate
-): ICaptureType<T> {
+    template: Template
+): CaptureType<T> {
     return new RepeatDirective(AccessScopeExpression.from(expression as any), template);
 }

--- a/packages/fast-element/src/directives/when.ts
+++ b/packages/fast-element/src/directives/when.ts
@@ -1,16 +1,16 @@
 import { DOM } from "../dom";
-import { ITemplate, ICaptureType } from "../template";
-import { ISyntheticView } from "../view";
-import { IExpression, AccessScopeExpression, Getter } from "../expression";
-import { IBehavior } from "../behaviors/behavior";
-import { Observable, IGetterInspector } from "../observation/observable";
+import { Template, CaptureType } from "../template";
+import { SyntheticView } from "../view";
+import { Expression, AccessScopeExpression, Getter } from "../expression";
+import { Behavior } from "../behaviors/behavior";
+import { Observable, GetterInspector } from "../observation/observable";
 import { BindingDirective } from "./bind";
-import { ISubscriber } from "../observation/subscriber-collection";
+import { Subscriber } from "../observation/subscriber-collection";
 
 export class WhenDirective extends BindingDirective {
     behavior = WhenBehavior;
 
-    constructor(public expression: IExpression, public template: ITemplate) {
+    constructor(public expression: Expression, public template: Template) {
         super(expression);
     }
 
@@ -19,10 +19,10 @@ export class WhenDirective extends BindingDirective {
     }
 }
 
-export class WhenBehavior implements IBehavior, IGetterInspector, ISubscriber {
+export class WhenBehavior implements Behavior, GetterInspector, Subscriber {
     private location: Node;
-    private view: ISyntheticView | null = null;
-    private cachedView?: ISyntheticView;
+    private view: SyntheticView | null = null;
+    private cachedView?: SyntheticView;
     private source: unknown;
 
     constructor(private directive: WhenDirective, marker: HTMLElement) {
@@ -71,7 +71,7 @@ export class WhenBehavior implements IBehavior, IGetterInspector, ISubscriber {
 
 export function when<T = any, K = any>(
     expression: Getter<T, K> | keyof T,
-    template: ITemplate
-): ICaptureType<T> {
+    template: Template
+): CaptureType<T> {
     return new WhenDirective(AccessScopeExpression.from(expression as any), template);
 }

--- a/packages/fast-element/src/expression.ts
+++ b/packages/fast-element/src/expression.ts
@@ -2,29 +2,27 @@
  * Provides additional contextual information available to arrow functions
  * evaluated in the context of a template update.
  */
-export interface IEvaluationContext<T = any> {
+export interface ExpressionContext {
     event: Event;
-    parent: T;
-    index: number;
 }
 
 /**
  * A simple abstraction of an expression which can be evaluated as part of
  * a template update.
  */
-export interface IExpression {
-    evaluate(scope: unknown, context?: IEvaluationContext): unknown;
+export interface Expression {
+    evaluate(scope: unknown, context?: ExpressionContext): unknown;
 }
 
 /**
  * The signature of an arrow function capable of being evluated as part of a template update.
  */
-export type Getter<T = any, K = any> = (model: T, context: IEvaluationContext) => K;
+export type Getter<T = any, K = any> = (model: T, context: ExpressionContext) => K;
 
 /**
- * A basic implementation of IExpression, which wraps a Getter function.
+ * A basic implementation of Expression, which wraps a Getter function.
  */
-export class AccessScopeExpression<T = any, K = any> implements IExpression {
+export class AccessScopeExpression<T = any, K = any> implements Expression {
     constructor(public getter: Getter<T, K>) {}
 
     public static from<T = any, K = any>(expression: Getter<T, K> | string) {
@@ -35,19 +33,19 @@ export class AccessScopeExpression<T = any, K = any> implements IExpression {
         return new AccessScopeExpression(expression);
     }
 
-    public evaluate(model: unknown, context?: IEvaluationContext) {
+    public evaluate(model: unknown, context?: ExpressionContext) {
         return this.getter(model as T, context!);
     }
 }
 
 /**
- * An implementation of IExpression which interpolates string literal values with
+ * An implementation of Expression which interpolates string literal values with
  * Getter functions to produce a final string.
  */
-export class InterpolationExpression implements IExpression {
+export class InterpolationExpression implements Expression {
     constructor(private parts: (string | Getter)[]) {}
 
-    public evaluate(scope: unknown, context?: IEvaluationContext) {
+    public evaluate(scope: unknown, context?: ExpressionContext) {
         return this.parts
             .map(x => (typeof x === "string" ? x : x(scope, context!)))
             .join("");

--- a/packages/fast-element/src/fast-element.ts
+++ b/packages/fast-element/src/fast-element.ts
@@ -1,6 +1,6 @@
 import { Controller } from "./controller";
 
-export function createFastElement(BaseType = HTMLElement) {
+export function createFastElement(BaseType: typeof HTMLElement) {
     return class FastElement extends BaseType {
         public $controller!: Controller;
 
@@ -27,4 +27,4 @@ export function createFastElement(BaseType = HTMLElement) {
     };
 }
 
-export const FastElement = createFastElement();
+export const FastElement = createFastElement(HTMLElement);

--- a/packages/fast-element/src/instructions.ts
+++ b/packages/fast-element/src/instructions.ts
@@ -1,17 +1,17 @@
-import { IBehavior } from "./behaviors/behavior";
+import { Behavior } from "./behaviors/behavior";
 
-export interface ITargetedInstruction {
-    hydrate(target: any, bindings: IBehavior[]): void;
+export interface TargetedInstruction {
+    hydrate(target: any, bindings: Behavior[]): void;
 }
 
-export class CompositeInstruction implements ITargetedInstruction {
-    public readonly instructions: ITargetedInstruction[];
+export class CompositeInstruction implements TargetedInstruction {
+    public readonly instructions: TargetedInstruction[];
 
-    constructor(...instructions: ITargetedInstruction[]) {
+    constructor(...instructions: TargetedInstruction[]) {
         this.instructions = instructions;
     }
 
-    public hydrate(target: any, bindings: IBehavior[]): void {
+    public hydrate(target: any, bindings: Behavior[]): void {
         const instructions = this.instructions;
 
         for (let i = 0, ii = instructions.length; i < ii; ++i) {

--- a/packages/fast-element/src/observation/array-observer.ts
+++ b/packages/fast-element/src/observation/array-observer.ts
@@ -1,6 +1,6 @@
 import { Observable } from "./observable";
 import { SubscriberCollection } from "./subscriber-collection";
-import { INotifier } from "./notifier";
+import { Notifier } from "./notifier";
 import { DOM } from "../dom";
 import {
     projectArraySplices,
@@ -158,7 +158,7 @@ function adjustIndex(changeRecord: Splice, array: any[]) {
     return changeRecord;
 }
 
-export class ArrayObserver extends SubscriberCollection implements INotifier {
+export class ArrayObserver extends SubscriberCollection implements Notifier {
     private collection: any[];
     private oldCollection: any[] | undefined = void 0;
     private splices: any[] | undefined = void 0;

--- a/packages/fast-element/src/observation/notifier.ts
+++ b/packages/fast-element/src/observation/notifier.ts
@@ -1,12 +1,12 @@
-import { ISubscriber, SubscriberCollection } from "./subscriber-collection";
+import { Subscriber, SubscriberCollection } from "./subscriber-collection";
 
-export interface INotifier {
+export interface Notifier {
     notify(source: any, args: any): void;
-    subscribe(subscriber: ISubscriber, context?: any): void;
-    unsubscribe(subscriber: ISubscriber, context?: any): void;
+    subscribe(subscriber: Subscriber, context?: any): void;
+    unsubscribe(subscriber: Subscriber, context?: any): void;
 }
 
-export class PropertyChangeNotifier implements INotifier {
+export class PropertyChangeNotifier implements Notifier {
     private subscribers: Record<string, SubscriberCollection> = {};
 
     public notify(source: any, propertyName: string) {
@@ -17,7 +17,7 @@ export class PropertyChangeNotifier implements INotifier {
         }
     }
 
-    public subscribe(subscriber: ISubscriber, propertyName: string) {
+    public subscribe(subscriber: Subscriber, propertyName: string) {
         const subscribers =
             this.subscribers[propertyName] ||
             (this.subscribers[propertyName] = new SubscriberCollection());
@@ -25,7 +25,7 @@ export class PropertyChangeNotifier implements INotifier {
         subscribers.addSubscriber(subscriber);
     }
 
-    public unsubscribe(subscriber: ISubscriber, propertyName: string): void {
+    public unsubscribe(subscriber: Subscriber, propertyName: string): void {
         const subscribers = this.subscribers[propertyName];
 
         if (subscribers === void 0) {

--- a/packages/fast-element/src/observation/observable.ts
+++ b/packages/fast-element/src/observation/observable.ts
@@ -1,28 +1,28 @@
 import { Controller } from "../controller";
 import { FastElement } from "../fast-element";
-import { INotifier, PropertyChangeNotifier } from "./notifier";
+import { Notifier, PropertyChangeNotifier } from "./notifier";
 
-export interface IGetterInspector {
+export interface GetterInspector {
     inspect(source: unknown, propertyName: string): void;
 }
 
-const notifierLookup = new WeakMap<any, INotifier>();
-let currentInspector: IGetterInspector | undefined = void 0;
+const notifierLookup = new WeakMap<any, Notifier>();
+let currentInspector: GetterInspector | undefined = void 0;
 
 export const Observable = {
-    setInspector(watcher: IGetterInspector) {
-        currentInspector = watcher;
+    setInspector(inspector: GetterInspector) {
+        currentInspector = inspector;
     },
 
     clearInspector() {
         currentInspector = void 0;
     },
 
-    createArrayObserver(array: any[]): INotifier {
+    createArrayObserver(array: any[]): Notifier {
         throw new Error("Must call enableArrayObservation before observing arrays.");
     },
 
-    getNotifier<T extends INotifier = INotifier>(source: any): T {
+    getNotifier<T extends Notifier = Notifier>(source: any): T {
         let found = source.$controller || notifierLookup.get(source);
 
         if (found === void 0) {

--- a/packages/fast-element/src/observation/subscriber-collection.ts
+++ b/packages/fast-element/src/observation/subscriber-collection.ts
@@ -1,7 +1,7 @@
 /**
  * Implemented by objects that are interested in change notifications.
  */
-export interface ISubscriber {
+export interface Subscriber {
     handleChange(source: any, args: any): void;
 }
 
@@ -14,10 +14,10 @@ export interface ISubscriber {
  * If the collection ever exceeds three subscribers, it will spill over into an array.
  */
 export class SubscriberCollection {
-    private sub1: ISubscriber | undefined = void 0;
-    private sub2: ISubscriber | undefined = void 0;
-    private sub3: ISubscriber | undefined = void 0;
-    private spillover: ISubscriber[] | undefined = void 0;
+    private sub1: Subscriber | undefined = void 0;
+    private sub2: Subscriber | undefined = void 0;
+    private sub3: Subscriber | undefined = void 0;
+    private spillover: Subscriber[] | undefined = void 0;
 
     public hasSubscribers() {
         return (
@@ -28,14 +28,14 @@ export class SubscriberCollection {
         );
     }
 
-    public hasSubscriber(subscriber: ISubscriber) {
+    public hasSubscriber(subscriber: Subscriber) {
         if (this.sub1 === subscriber) return true;
         if (this.sub2 === subscriber) return true;
         if (this.sub3 === subscriber) return true;
         return this.spillover !== void 0 && this.spillover.indexOf(subscriber) !== -1;
     }
 
-    public addSubscriber(subscriber: ISubscriber) {
+    public addSubscriber(subscriber: Subscriber) {
         if (this.hasSubscriber(subscriber)) {
             return;
         }
@@ -62,7 +62,7 @@ export class SubscriberCollection {
         this.spillover.push(subscriber);
     }
 
-    public removeSubscriber(subscriber: ISubscriber) {
+    public removeSubscriber(subscriber: Subscriber) {
         if (this.sub1 === subscriber) {
             this.sub1 = void 0;
             return;

--- a/packages/fast-element/src/projectors.ts
+++ b/packages/fast-element/src/projectors.ts
@@ -1,34 +1,34 @@
-import { IElementView } from "./view";
+import { ElementView } from "./view";
 import { Controller } from "./controller";
 import { CustomElementDefinition } from "./custom-element";
-import { IShadowDOMStyles } from "./styles";
+import { ShadowDOMStyles } from "./styles";
 
-export interface IElementProjector {
+export interface ElementProjector {
     readonly host: HTMLElement;
-    project(view: IElementView, controller: Controller): void;
+    project(view: ElementView, controller: Controller): void;
 }
 
-export class ShadowDOMProjector implements IElementProjector {
+export class ShadowDOMProjector implements ElementProjector {
     public readonly shadowRoot: ShadowRoot;
 
     constructor(public readonly host: HTMLElement, definition: CustomElementDefinition) {
         this.shadowRoot = host.attachShadow(definition.shadowOptions!);
     }
 
-    public project(view: IElementView, controller: Controller) {
+    public project(view: ElementView, controller: Controller) {
         view.appendTo(this.shadowRoot);
 
-        const styles = controller.get(IShadowDOMStyles);
+        const styles = controller.get(ShadowDOMStyles);
         if (styles !== null) {
             styles.applyTo(this.shadowRoot);
         }
     }
 }
 
-export class HostProjector implements IElementProjector {
+export class HostProjector implements ElementProjector {
     constructor(public readonly host: HTMLElement) {}
 
-    public project(view: IElementView, controller: Controller) {
+    public project(view: ElementView, controller: Controller) {
         view.appendTo(this.host);
     }
 }

--- a/packages/fast-element/src/styles.ts
+++ b/packages/fast-element/src/styles.ts
@@ -1,14 +1,13 @@
-import { IContainer, IRegistry, DI } from "./di";
-import { Constructable } from "./interfaces";
+import { Container, Registry, DI } from "./di";
 
-export interface IShadowDOMStyles {
+export interface ShadowDOMStyles {
     applyTo(shadowRoot: ShadowRoot): void;
 }
 
-export const IShadowDOMStyles = DI.createInterface<IShadowDOMStyles>("IShadowDOMStyles");
+export const ShadowDOMStyles = DI.createInterface<ShadowDOMStyles>("ShadowDOMStyles");
 
 type InjectableStyles = string | ShadowDOMRegistry;
-type ShadowDOMStyleFactory = (styles: InjectableStyles[]) => IShadowDOMStyles;
+type ShadowDOMStyleFactory = (styles: InjectableStyles[]) => ShadowDOMStyles;
 type HasAdoptedStyleSheets = ShadowRoot & {
     adoptedStyleSheets: CSSStyleSheet[];
 };
@@ -19,7 +18,7 @@ function reduceStyles(styles: InjectableStyles[]): string[] {
         .reduce((prev, curr) => prev.concat(curr), []);
 }
 
-export class ShadowDOMRegistry implements IRegistry {
+export class ShadowDOMRegistry implements Registry {
     private static _createStyles: ShadowDOMStyleFactory;
     private get createStyles(): ShadowDOMStyleFactory {
         return (
@@ -30,10 +29,8 @@ export class ShadowDOMRegistry implements IRegistry {
 
     public constructor(public styles: InjectableStyles[]) {}
 
-    public register(container: IContainer) {
-        container.registerResolver(IShadowDOMStyles, () =>
-            this.createStyles(this.styles)
-        );
+    public register(container: Container) {
+        container.registerResolver(ShadowDOMStyles, () => this.createStyles(this.styles));
     }
 
     public static createStyleFactory(): ShadowDOMStyleFactory {
@@ -50,7 +47,7 @@ export class ShadowDOMRegistry implements IRegistry {
     }
 }
 
-export class AdoptedStyleSheetsStyles implements IShadowDOMStyles {
+export class AdoptedStyleSheetsStyles implements ShadowDOMStyles {
     private readonly styleSheets: CSSStyleSheet[];
 
     public constructor(
@@ -84,7 +81,7 @@ export class AdoptedStyleSheetsStyles implements IShadowDOMStyles {
     }
 }
 
-export class StyleElementStyles implements IShadowDOMStyles {
+export class StyleElementStyles implements ShadowDOMStyles {
     public constructor(private styles: (string | ShadowDOMRegistry)[]) {}
 
     public applyTo(shadowRoot: ShadowRoot) {

--- a/packages/fast-element/src/template-compiler.ts
+++ b/packages/fast-element/src/template-compiler.ts
@@ -1,6 +1,6 @@
-import { InterpolationExpression, AccessScopeExpression, Getter } from "./expression";
+import { InterpolationExpression, AccessScopeExpression } from "./expression";
 import { HTMLTemplate } from "./template";
-import { ITargetedInstruction, CompositeInstruction } from "./instructions";
+import { TargetedInstruction, CompositeInstruction } from "./instructions";
 import { DOM } from "./dom";
 import {
     TextBinding,
@@ -37,7 +37,7 @@ export class TemplateCompiler {
             element = html;
         }
 
-        const instructions: ITargetedInstruction[] = [];
+        const instructions: TargetedInstruction[] = [];
         this.compileNode(element.content, element, directives, instructions);
 
         return new HTMLTemplate(element, instructions);
@@ -47,7 +47,7 @@ export class TemplateCompiler {
         node: Node,
         parentNode: Node,
         directives: Directive[],
-        instructions: ITargetedInstruction[]
+        instructions: TargetedInstruction[]
     ): MaybeNode {
         switch (node.nodeType) {
             case 1: //element node
@@ -112,10 +112,10 @@ export class TemplateCompiler {
     private compileElement(
         node: HTMLElement,
         directives: Directive[],
-        instructions: ITargetedInstruction[]
+        instructions: TargetedInstruction[]
     ): MaybeNode {
         const attributes = node.attributes;
-        let elementInstruction: ITargetedInstruction | null = null;
+        let elementInstruction: TargetedInstruction | null = null;
 
         for (let i = 0, ii = attributes.length; i < ii; ++i) {
             const attr = attributes[i];
@@ -154,7 +154,7 @@ export class TemplateCompiler {
     private compileBlock(
         node: HTMLElement,
         directives: Directive[],
-        instructions: ITargetedInstruction[]
+        instructions: TargetedInstruction[]
     ): MaybeNode {
         const instructionIndex = parseInt(node.getAttribute("i")!);
         const directive = directives[instructionIndex];

--- a/packages/fast-element/src/template.ts
+++ b/packages/fast-element/src/template.ts
@@ -1,23 +1,23 @@
 import { TemplateCompiler } from "./template-compiler";
-import { ITargetedInstruction } from "./instructions";
-import { HTMLView, IElementView, ISyntheticView } from "./view";
+import { TargetedInstruction } from "./instructions";
+import { HTMLView, ElementView, SyntheticView } from "./view";
 import { DOM } from "./dom";
-import { IBehavior } from "./behaviors/behavior";
+import { Behavior } from "./behaviors/behavior";
 import { Getter, AccessScopeExpression } from "./expression";
 import { Directive } from "./directives/directive";
 import { BindingDirective } from "./directives/bind";
 
-export interface ITemplate {
-    create(synthetic: false): IElementView | null;
-    create(synthetic: true): ISyntheticView;
+export interface Template {
+    create(synthetic: false): ElementView | null;
+    create(synthetic: true): SyntheticView;
 }
 
-export class HTMLTemplate extends Directive implements ITemplate {
+export class HTMLTemplate extends Directive implements Template {
     public behavior = HTMLTemplateBehavior;
 
     constructor(
         private templateElement: HTMLTemplateElement,
-        private instructions: ITargetedInstruction[]
+        private instructions: TargetedInstruction[]
     ) {
         super();
 
@@ -31,7 +31,7 @@ export class HTMLTemplate extends Directive implements ITemplate {
     public create(synthetic: boolean) {
         const fragment = this.templateElement.content.cloneNode(true) as DocumentFragment;
         const targets = fragment.querySelectorAll(".fm");
-        const behaviors: IBehavior[] = [];
+        const behaviors: Behavior[] = [];
 
         for (let i = 0, ii = targets.length; i < ii; ++i) {
             this.instructions[i].hydrate(targets[i], behaviors);
@@ -45,11 +45,11 @@ export class HTMLTemplate extends Directive implements ITemplate {
     }
 }
 
-export class HTMLTemplateBehavior implements IBehavior {
+export class HTMLTemplateBehavior implements Behavior {
     private location: Node;
-    private view: ISyntheticView;
+    private view: SyntheticView;
 
-    constructor(directive: ITemplate, marker: HTMLElement) {
+    constructor(directive: Template, marker: HTMLElement) {
         this.location = DOM.convertMarkerToLocation(marker);
         this.view = directive.create(true);
         this.view.insertBefore(this.location);
@@ -64,14 +64,14 @@ export class HTMLTemplateBehavior implements IBehavior {
     }
 }
 
-export const noopTemplate: ITemplate = {
+export const noopTemplate: Template = {
     create() {
         return null as any;
     },
 };
 
-export interface ICaptureType<T> {}
-type TemplateValue<T> = Getter<T> | string | number | Directive | ICaptureType<T>;
+export interface CaptureType<T> {}
+type TemplateValue<T> = Getter<T> | string | number | Directive | CaptureType<T>;
 
 export function html<T = any>(
     strings: TemplateStringsArray,

--- a/packages/fast-element/src/view.ts
+++ b/packages/fast-element/src/view.ts
@@ -1,22 +1,22 @@
-import { IBehavior } from "./behaviors/behavior";
+import { Behavior } from "./behaviors/behavior";
 
-export interface IView {
+export interface View {
     bind(source: unknown): void;
     unbind(): void;
     remove(): void;
 }
 
-export interface IElementView extends IView {
+export interface ElementView extends View {
     appendTo(node: Node): void;
 }
 
-export interface ISyntheticView extends IView {
+export interface SyntheticView extends View {
     readonly firstChild: Node;
     readonly lastChild: Node;
     insertBefore(node: Node): void;
 }
 
-export class HTMLView implements IView, IElementView, ISyntheticView {
+export class HTMLView implements View, ElementView, SyntheticView {
     private parent?: Node;
     private source: any = void 0;
     public firstChild!: Node;
@@ -24,7 +24,7 @@ export class HTMLView implements IView, IElementView, ISyntheticView {
 
     constructor(
         private fragment: DocumentFragment,
-        private behaviors: IBehavior[],
+        private behaviors: Behavior[],
         private isSynthetic: boolean = false
     ) {
         if (isSynthetic) {


### PR DESCRIPTION
# Description

A refactor PR that renames all interfaces to remove the "I" prefix.

## Motivation & context

According to the team's code style guidelines, interfaces should not start with an "I".

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [x] This change causes current functionality to break.

No functionality has changed. However, the type names for most interface types changed as part of this PR, so anyone dependent on those types would need to update. It's unlikely that anyone is dependent on that. Even if so, the fix is a very simple find/replace chore.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.