### PR TITLE
feat: add linked data control to update dictionary data

### DIFF
--- a/packages/fast-tooling-react/src/form/controls/control.linked-data.props.ts
+++ b/packages/fast-tooling-react/src/form/controls/control.linked-data.props.ts
@@ -1,0 +1,24 @@
+import { DragState, LinkedDataControlConfig } from "../templates";
+
+export interface ChildComponentDataMapping {
+    [T: string]: any;
+}
+
+/* tslint:disable-next-line */
+export interface LinkedDataControlProps extends LinkedDataControlConfig {}
+
+export enum Action {
+    add = "add",
+    edit = "edit",
+    delete = "delete",
+}
+
+/**
+ * State object for the LinkedDataControl component
+ */
+export interface LinkedDataControlState extends DragState {
+    /**
+     * The search term used to filter a list of linked data
+     */
+    searchTerm: string;
+}

--- a/packages/fast-tooling-react/src/form/controls/control.linked-data.spec.tsx
+++ b/packages/fast-tooling-react/src/form/controls/control.linked-data.spec.tsx
@@ -1,0 +1,267 @@
+import React from "react";
+import Adapter from "enzyme-adapter-react-16";
+import { configure, mount, ReactWrapper } from "enzyme";
+import HTML5Backend from "react-dnd-html5-backend";
+import { DndProvider } from "react-dnd";
+import {
+    keyCodeArrowDown,
+    keyCodeArrowUp,
+    keyCodeEnter,
+} from "@microsoft/fast-web-utilities";
+import { LinkedDataControl } from "./control.linked-data";
+import { LinkedDataControlProps } from "./control.linked-data.props";
+import { LinkedDataControlClassNameContract } from "./control.linked-data.style";
+import { ControlType } from "../templates";
+import { LinkedDataActionType } from "../templates/types";
+
+const LinkedDataFormControlWithDragAndDrop: React.FC<any> = (
+    props: React.PropsWithChildren<any>
+): React.ReactElement => {
+    return (
+        <DndProvider backend={HTML5Backend}>
+            <LinkedDataControl {...props} />
+        </DndProvider>
+    );
+};
+
+/*
+ * Configure Enzyme
+ */
+configure({ adapter: new Adapter() });
+
+const managedClasses: LinkedDataControlClassNameContract = {
+    linkedDataControl: "linkedDataFormControl-class",
+    linkedDataControl_linkedDataListControl:
+        "linkedDataFormControl_linkedDataListControl-class",
+    linkedDataControl_linkedDataListInput:
+        "linkedDataFormControl_linkedDataListInput-class",
+    linkedDataControl_delete: "linkedDataFormControl_delete-class",
+    linkedDataControl_deleteButton: "linkedDataFormControl_deleteButton-class",
+    linkedDataControl_existingLinkedData:
+        "linkedDataFormControl_existingLinkedData-class",
+    linkedDataControl_existingLinkedDataItem:
+        "linkedDataFormControl_existingLinkedDataItem-class",
+    linkedDataControl_existingLinkedDataItemContent:
+        "linkedDataFormControl_existingLinkedDataItemContent-class",
+    linkedDataControl_existingLinkedDataItemLink:
+        "linkedDataFormControl_existingLinkedDataItemLink-class",
+    linkedDataControl_existingLinkedDataItemName:
+        "linkedDataFormControl_existingLinkedDataItemName-class",
+};
+
+const linkedDataProps: LinkedDataControlProps = {
+    type: ControlType.linkedData,
+    schemaDictionary: {
+        alpha: {
+            title: "alpha",
+            id: "alpha",
+            type: "object",
+            properties: {},
+        },
+        beta: {
+            title: "beta",
+            id: "beta",
+            type: "object",
+            properties: {},
+        },
+        omega: {
+            title: "omega",
+            id: "omega",
+            type: "object",
+            properties: {},
+        },
+    },
+    required: false,
+    dataLocation: "locationOfLinkedData",
+    navigationConfigId: "",
+    dictionaryId: "",
+    dataDictionary: [
+        {
+            "": {
+                schemaId: "alpha",
+                data: {},
+            },
+            foo: {
+                schemaId: "beta",
+                data: {},
+            },
+        },
+        "",
+    ],
+    navigation: {},
+    value: undefined,
+    schema: {},
+    onChange: jest.fn(),
+    onUpdateSection: jest.fn(),
+    reportValidity: jest.fn(),
+    updateValidity: jest.fn(),
+    disabled: false,
+    elementRef: null,
+    validationErrors: [],
+};
+
+/* tslint:disable:no-string-literal */
+describe("LinkedDataControl", () => {
+    test("should not throw", () => {
+        expect(() => {
+            mount(
+                <LinkedDataFormControlWithDragAndDrop
+                    {...linkedDataProps}
+                    managedClasses={managedClasses}
+                />
+            );
+        }).not.toThrow();
+    });
+    test("should generate a text input", () => {
+        const rendered: any = mount(
+            <LinkedDataFormControlWithDragAndDrop
+                {...linkedDataProps}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(rendered.find("input")).toHaveLength(1);
+    });
+    test("should add a datalist", () => {
+        const rendered: any = mount(
+            <LinkedDataFormControlWithDragAndDrop
+                {...linkedDataProps}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(rendered.find("datalist")).toHaveLength(1);
+    });
+    test("should add an `aria-controls` on a text input with the same value as the id of the `listbox`", () => {
+        const rendered: any = mount(
+            <LinkedDataFormControlWithDragAndDrop
+                {...linkedDataProps}
+                managedClasses={managedClasses}
+            />
+        );
+        const inputAriaControls: string = rendered.find("input").props()["aria-controls"];
+        const datalist: string = rendered.find("datalist").props()["id"];
+
+        expect(inputAriaControls).toEqual(datalist);
+    });
+    test("should generate options based on the schema items in the schema dictionary", () => {
+        const rendered: any = mount(
+            <LinkedDataFormControlWithDragAndDrop
+                {...linkedDataProps}
+                managedClasses={managedClasses}
+            />
+        );
+        const listboxItems: any = rendered.find("datalist option");
+
+        expect(listboxItems).toHaveLength(3);
+    });
+    test("should show if linkedData are present in the data as a DragItem", () => {
+        const renderedWithOneChild: any = mount(
+            <LinkedDataFormControlWithDragAndDrop
+                {...linkedDataProps}
+                value={[{ id: "foo" }]}
+                managedClasses={managedClasses}
+            />
+        );
+
+        expect(renderedWithOneChild.find("DragItem")).toHaveLength(1);
+    });
+    test("should fire a callback to update the data when the value is changed", () => {
+        const callback: any = jest.fn();
+        const rendered: any = mount(
+            <LinkedDataFormControlWithDragAndDrop
+                {...linkedDataProps}
+                onChange={callback}
+                managedClasses={managedClasses}
+            />
+        );
+        const targetValue: any = { value: "omega" };
+        rendered
+            .find("input")
+            .simulate("change", { target: targetValue, currentTarget: targetValue });
+        rendered.find("input").simulate("keydown", { keyCode: keyCodeEnter });
+
+        expect(callback).toHaveBeenCalled();
+        expect(callback.mock.calls[0][0]).toEqual({
+            index: 0,
+            isLinkedData: true,
+            linkedDataAction: LinkedDataActionType.add,
+            value: [
+                {
+                    data: {},
+                    parent: {
+                        dataLocation: "locationOfLinkedData",
+                        id: "",
+                    },
+                    schemaId: "omega",
+                },
+            ],
+        });
+    });
+    test("should update active section to the linked data item clicked", () => {
+        const callback: any = jest.fn();
+        const rendered: ReactWrapper = mount(
+            <LinkedDataFormControlWithDragAndDrop
+                {...linkedDataProps}
+                value={[{ id: "foo" }]}
+                onUpdateSection={callback}
+                managedClasses={managedClasses}
+            />
+        );
+
+        rendered
+            .find(`li.${managedClasses.linkedDataControl_existingLinkedDataItem} > a`)
+            .simulate("click");
+
+        expect(callback).toHaveBeenCalled();
+        expect(callback.mock.calls[0][0]).toEqual("foo");
+    });
+    test("should not fire a callback to update the data when the value is changed but there is no match", () => {
+        const callback: any = jest.fn();
+        const rendered: any = mount(
+            <LinkedDataFormControlWithDragAndDrop
+                {...linkedDataProps}
+                onChange={callback}
+                managedClasses={managedClasses}
+            />
+        );
+        const targetValue: any = { value: "no match" };
+        rendered
+            .find("input")
+            .simulate("change", { target: targetValue, currentTarget: targetValue });
+        rendered.find("input").simulate("keydown", { keyCode: keyCodeEnter });
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+    test("should remove a child option from the data when the remove button has been clicked", () => {
+        const callback: any = jest.fn();
+        const renderedWithTwoLinkedData: any = mount(
+            <LinkedDataFormControlWithDragAndDrop
+                {...linkedDataProps}
+                managedClasses={managedClasses}
+                value={[
+                    {
+                        id: "foo",
+                    },
+                ]}
+                onChange={callback}
+            />
+        );
+
+        renderedWithTwoLinkedData
+            .find("DragItem")
+            .find("button")
+            .simulate("click");
+
+        expect(callback).toHaveBeenCalled();
+        expect(callback.mock.calls[0][0]).toEqual({
+            isLinkedData: true,
+            linkedDataAction: LinkedDataActionType.remove,
+            value: [
+                {
+                    id: "foo",
+                },
+            ],
+        });
+    });
+});

--- a/packages/fast-tooling-react/src/form/controls/control.linked-data.style.ts
+++ b/packages/fast-tooling-react/src/form/controls/control.linked-data.style.ts
@@ -1,0 +1,92 @@
+import { ellipsis } from "@microsoft/fast-jss-utilities";
+import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager-react";
+import {
+    accent,
+    ariaHiddenStyle,
+    background100,
+    cleanListStyle,
+    foreground300,
+    inputStyle,
+    removeItemStyle,
+    selectInputStyle,
+    selectSpanStyle,
+    softRemoveStyle,
+} from "../../style";
+
+/**
+ * LinkedData class name contract
+ */
+export interface LinkedDataControlClassNameContract {
+    linkedDataControl?: string;
+    linkedDataControl_existingLinkedData?: string;
+    linkedDataControl_existingLinkedDataItem?: string;
+    linkedDataControl_existingLinkedDataItemLink?: string;
+    linkedDataControl_existingLinkedDataItemContent?: string;
+    linkedDataControl_existingLinkedDataItemName?: string;
+    linkedDataControl_linkedDataListControl?: string;
+    linkedDataControl_linkedDataListInput?: string;
+    linkedDataControl_linkedDataListInputRegion?: string;
+    linkedDataControl_delete?: string;
+    linkedDataControl_deleteButton?: string;
+}
+
+const styles: ComponentStyles<LinkedDataControlClassNameContract, {}> = {
+    linkedDataControl: {},
+    linkedDataControl_existingLinkedData: {
+        ...cleanListStyle,
+    },
+    linkedDataControl_existingLinkedDataItem: {
+        position: "relative",
+        height: "30px",
+        marginLeft: "-10px",
+        paddingLeft: "10px",
+        fontSize: "12px",
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        "&:hover": {
+            backgroundColor: "rgba(255, 255, 255, 0.04)",
+        },
+    },
+    linkedDataControl_existingLinkedDataItemLink: {
+        width: "calc(100% - 36px)",
+        "&$linkedDataControl_existingLinkedDataItemName, &$linkedDataControl_existingLinkedDataItemContent": {
+            ...ellipsis(),
+            width: "100%",
+            display: "inline-block",
+            verticalAlign: "bottom",
+        },
+    },
+    linkedDataControl_existingLinkedDataItemName: {
+        ...ellipsis(),
+        display: "inline-block",
+        width: "100%",
+        whiteSpace: "nowrap",
+    },
+    linkedDataControl_existingLinkedDataItemContent: {},
+    linkedDataControl_linkedDataListControl: {
+        position: "relative",
+        width: "calc(100% - 30px)",
+    },
+    linkedDataControl_linkedDataListInput: {
+        ...selectInputStyle,
+        "&::-webkit-calendar-picker-indicator": {
+            display: "none",
+        },
+    },
+    linkedDataControl_linkedDataListInputRegion: {
+        ...selectSpanStyle,
+    },
+    linkedDataControl_delete: {
+        ...softRemoveStyle,
+        cursor: "pointer",
+        position: "relative",
+        verticalAlign: "middle",
+    },
+    linkedDataControl_deleteButton: {
+        ...removeItemStyle,
+        cursor: "pointer",
+    },
+};
+
+export default styles;

--- a/packages/fast-tooling-react/src/form/controls/control.linked-data.tsx
+++ b/packages/fast-tooling-react/src/form/controls/control.linked-data.tsx
@@ -1,0 +1,275 @@
+import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
+import React from "react";
+import { keyCodeEnter } from "@microsoft/fast-web-utilities";
+import { getDataFromSchema } from "../../data-utilities";
+import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
+import styles, { LinkedDataControlClassNameContract } from "./control.linked-data.style";
+import {
+    LinkedDataControlProps,
+    LinkedDataControlState,
+} from "./control.linked-data.props";
+import { DragItem } from "../templates";
+import { ArrayAction, LinkedDataActionType } from "../templates/types";
+
+/**
+ * Form control definition
+ */
+/* tslint:disable-next-line */
+class LinkedDataControl extends React.Component<
+    LinkedDataControlProps & ManagedClasses<LinkedDataControlClassNameContract>,
+    LinkedDataControlState
+> {
+    public static displayName: string = "LinkedDataControl";
+
+    public static defaultProps: Partial<
+        LinkedDataControlProps & ManagedClasses<LinkedDataControlClassNameContract>
+    > = {
+        managedClasses: {},
+    };
+
+    constructor(
+        props: LinkedDataControlProps & ManagedClasses<LinkedDataControlClassNameContract>
+    ) {
+        super(props);
+
+        this.state = {
+            searchTerm: "",
+            isDragging: false,
+            data: [].concat(props.value || []),
+        };
+    }
+
+    public render(): React.ReactNode {
+        // Convert to search component when #3006 has been completed
+        return (
+            <div className={this.props.managedClasses.linkedDataControl}>
+                {this.renderExistingLinkedData()}
+                {this.renderAddLinkedData()}
+            </div>
+        );
+    }
+
+    /**
+     * Render the UI for adding linked data
+     */
+    private renderAddLinkedData(): React.ReactNode {
+        return (
+            <div
+                className={
+                    this.props.managedClasses.linkedDataControl_linkedDataListControl
+                }
+            >
+                <span
+                    className={
+                        this.props.managedClasses
+                            .linkedDataControl_linkedDataListInputRegion
+                    }
+                >
+                    <input
+                        className={
+                            this.props.managedClasses
+                                .linkedDataControl_linkedDataListInput
+                        }
+                        type={"text"}
+                        aria-autocomplete={"list"}
+                        list={this.getLinkedDataInputId()}
+                        aria-controls={this.getLinkedDataInputId()}
+                        value={this.state.searchTerm}
+                        placeholder={"Add"}
+                        onChange={this.handleSearchTermUpdate}
+                        onKeyDown={this.handleLinkedDataKeydown}
+                    />
+                </span>
+                <datalist id={this.getLinkedDataInputId()} role={"listbox"}>
+                    {this.renderFilteredLinkedDataOptions()}
+                </datalist>
+            </div>
+        );
+    }
+
+    private renderFilteredLinkedDataOptions(): React.ReactNode {
+        return Object.keys(this.props.schemaDictionary).map(
+            (schemaDictionaryKey: string) => {
+                return (
+                    <option
+                        key={schemaDictionaryKey}
+                        value={this.props.schemaDictionary[schemaDictionaryKey].title}
+                    />
+                );
+            }
+        );
+    }
+
+    /**
+     * Render the list of existing linkedData for a component
+     */
+    private renderExistingLinkedData(): React.ReactNode {
+        const childItems: React.ReactNode = this.renderExistingLinkedDataItem();
+
+        if (childItems) {
+            return (
+                <ul
+                    className={
+                        this.props.managedClasses.linkedDataControl_existingLinkedData
+                    }
+                >
+                    {childItems}
+                </ul>
+            );
+        }
+    }
+
+    private renderExistingLinkedDataItem(): React.ReactNode {
+        if (Array.isArray(this.props.value)) {
+            const {
+                linkedDataControl_existingLinkedDataItem,
+                linkedDataControl_existingLinkedDataItemLink,
+                linkedDataControl_deleteButton,
+            }: LinkedDataControlClassNameContract = this.props.managedClasses;
+
+            return (this.state.isDragging ? this.state.data : this.props.value).map(
+                (value: any, index: number) => {
+                    return (
+                        <DragItem
+                            key={value + index}
+                            itemClassName={linkedDataControl_existingLinkedDataItem}
+                            itemLinkClassName={
+                                linkedDataControl_existingLinkedDataItemLink
+                            }
+                            itemRemoveClassName={linkedDataControl_deleteButton}
+                            minItems={0}
+                            itemLength={1}
+                            index={index}
+                            onClick={this.handleItemClick(value.id)}
+                            removeDragItem={this.handleRemoveItem}
+                            moveDragItem={this.handleMoveItem}
+                            dropDragItem={this.handleDropItem}
+                            dragStart={this.handleDragStart}
+                            dragEnd={this.handleDragEnd}
+                        >
+                            {
+                                this.props.schemaDictionary[
+                                    this.props.dataDictionary[0][value.id].schemaId
+                                ].title
+                            }
+                        </DragItem>
+                    );
+                }
+            );
+        }
+    }
+
+    private handleDragStart = (): void => {
+        this.setState({
+            isDragging: true,
+            data: [].concat(this.props.value || []),
+        });
+    };
+
+    private handleDragEnd = (): void => {
+        this.setState({
+            isDragging: false,
+        });
+    };
+
+    private handleItemClick = (
+        id: string
+    ): ((index: number) => (e: React.MouseEvent<HTMLAnchorElement>) => void) => {
+        return (index: number): ((e: React.MouseEvent<HTMLAnchorElement>) => void) => {
+            return (e: React.MouseEvent<HTMLAnchorElement>): void => {
+                this.props.onUpdateSection(id);
+            };
+        };
+    };
+
+    private handleRemoveItem = (
+        type: ArrayAction,
+        index: number
+    ): ((e: React.MouseEvent<HTMLButtonElement>) => void) => {
+        return (e: React.MouseEvent<HTMLButtonElement>): void => {
+            this.props.onChange({
+                value: this.props.value.splice(index, 1),
+                isLinkedData: true,
+                linkedDataAction: LinkedDataActionType.remove,
+            });
+        };
+    };
+
+    private handleMoveItem = (sourceIndex: number, targetIndex: number): void => {
+        const currentData: unknown[] = [].concat(this.props.value);
+
+        if (sourceIndex !== targetIndex) {
+            currentData.splice(targetIndex, 0, currentData.splice(sourceIndex, 1)[0]);
+        }
+
+        this.setState({
+            data: currentData,
+        });
+    };
+
+    private handleDropItem = (): void => {
+        this.props.onChange({
+            value: this.state.data,
+            isLinkedData: true,
+            linkedDataAction: LinkedDataActionType.reorder,
+        });
+    };
+
+    private handleLinkedDataKeydown = (
+        e: React.KeyboardEvent<HTMLInputElement>
+    ): void => {
+        if (e.keyCode === keyCodeEnter && e.target === e.currentTarget) {
+            e.preventDefault();
+
+            this.addLinkedData(e.currentTarget.value);
+        }
+    };
+
+    private matchValueWithSchema(value: string): string | void {
+        return Object.keys(this.props.schemaDictionary).find(
+            (schemaDictionaryKey: string) => {
+                return value === this.props.schemaDictionary[schemaDictionaryKey].title;
+            }
+        );
+    }
+
+    /**
+     * Change handler for editing the search term filter
+     */
+    private handleSearchTermUpdate = (e: React.ChangeEvent<HTMLInputElement>): void => {
+        this.setState({
+            searchTerm: e.target.value,
+        });
+
+        this.addLinkedData(e.currentTarget.value);
+    };
+
+    private addLinkedData(value: string): void {
+        const schemaId: string | void = this.matchValueWithSchema(value);
+
+        if (typeof schemaId !== "undefined") {
+            this.props.onChange({
+                value: [
+                    {
+                        schemaId,
+                        parent: {
+                            id: this.props.dictionaryId,
+                            dataLocation: this.props.dataLocation,
+                        },
+                        data: getDataFromSchema(this.props.schemaDictionary[schemaId]),
+                    },
+                ],
+                isLinkedData: true,
+                linkedDataAction: LinkedDataActionType.add,
+                index: Array.isArray(this.props.value) ? this.props.value.length : 0,
+            });
+        }
+    }
+
+    private getLinkedDataInputId(): string {
+        return `${this.props.dataLocation}-input`;
+    }
+}
+
+export { LinkedDataControl };
+export default manageJss(styles)(LinkedDataControl);

--- a/packages/fast-tooling-react/src/form/controls/control.linked-data.tsx
+++ b/packages/fast-tooling-react/src/form/controls/control.linked-data.tsx
@@ -88,14 +88,9 @@ class LinkedDataControl extends React.Component<
     }
 
     private renderFilteredLinkedDataOptions(): React.ReactNode {
-        return Object.keys(this.props.schemaDictionary).map(
-            (schemaDictionaryKey: string) => {
-                return (
-                    <option
-                        key={schemaDictionaryKey}
-                        value={this.props.schemaDictionary[schemaDictionaryKey].title}
-                    />
-                );
+        return Object.entries(this.props.schemaDictionary).map(
+            ([key, value]: [string, any]): React.ReactNode => {
+                return <option key={key} value={value.title} />;
             }
         );
     }

--- a/packages/fast-tooling-react/src/form/controls/index.ts
+++ b/packages/fast-tooling-react/src/form/controls/index.ts
@@ -7,12 +7,14 @@ import SectionControl from "./control.section";
 import SectionLinkControl from "./control.section-link";
 import SelectControl from "./control.select";
 import TextareaControl from "./control.textarea";
+import LinkedDataControl from "./control.linked-data";
 
 export {
     ArrayControl,
     ButtonControl,
     CheckboxControl,
     DisplayControl,
+    LinkedDataControl,
     NumberFieldControl,
     SectionControl,
     SectionLinkControl,

--- a/packages/fast-tooling-react/src/form/controls/utilities/control-switch.spec.tsx
+++ b/packages/fast-tooling-react/src/form/controls/utilities/control-switch.spec.tsx
@@ -32,6 +32,7 @@ import {
     ButtonControl,
     CheckboxControl,
     DisplayControl,
+    LinkedDataControl,
     NumberFieldControl,
     SectionControl,
     SectionLinkControl,
@@ -48,6 +49,12 @@ const arrayControl: StandardControlPlugin = new StandardControlPlugin({
     context: ControlContext.fill,
     control: (config: ArrayControlConfig): React.ReactNode => {
         return <ArrayControl {...config} />;
+    },
+});
+const linkedDataControl: StandardControlPlugin = new StandardControlPlugin({
+    context: ControlContext.default,
+    control: (config: LinkedDataControlConfig): React.ReactNode => {
+        return <LinkedDataControl {...config} />;
     },
 });
 const numberFieldControl: StandardControlPlugin = new StandardControlPlugin({
@@ -89,6 +96,7 @@ const buttonControl: StandardControlPlugin = new StandardControlPlugin({
 export const controls: Controls = {
     button: buttonControl,
     array: arrayControl,
+    linkedData: linkedDataControl,
     checkbox: checkboxControl,
     display: displayControl,
     textarea: textareaControl,

--- a/packages/fast-tooling-react/src/form/controls/utilities/control-switch.tsx
+++ b/packages/fast-tooling-react/src/form/controls/utilities/control-switch.tsx
@@ -45,6 +45,12 @@ class ControlSwitch extends React.Component<ControlSwitchProps, {}> {
             );
         }
 
+        if (this.props.schema[dictionaryLink]) {
+            return this.renderDataLink(
+                control !== undefined ? control : this.props.controls.linkedData
+            );
+        }
+
         const hasEnum: boolean = isSelect({ enum: this.props.schema.enum });
 
         if (

--- a/packages/fast-tooling-react/src/form/controls/utilities/types.ts
+++ b/packages/fast-tooling-react/src/form/controls/utilities/types.ts
@@ -13,6 +13,11 @@ export interface Controls {
     array: StandardControlPlugin;
 
     /**
+     * The linked data control
+     */
+    linkedData: StandardControlPlugin;
+
+    /**
      * The checkbox control
      */
     checkbox: SingleLineControlPlugin;

--- a/packages/fast-tooling-react/src/form/form.tsx
+++ b/packages/fast-tooling-react/src/form/form.tsx
@@ -3,6 +3,7 @@ import {
     ButtonControl,
     CheckboxControl,
     DisplayControl,
+    LinkedDataControl,
     NumberFieldControl,
     SectionControl,
     SectionLinkControl,
@@ -244,6 +245,12 @@ class Form extends React.Component<
                     component: ArrayControl,
                     context: ControlContext.fill,
                 };
+            case ControlType.linkedData:
+                return {
+                    plugin: StandardControlPlugin,
+                    component: LinkedDataControl,
+                    context: ControlContext.fill,
+                };
             case ControlType.numberField:
                 return {
                     plugin: StandardControlPlugin,
@@ -418,6 +425,7 @@ class Form extends React.Component<
             controls: {
                 button: this.buttonControl,
                 array: this.arrayControl,
+                linkedData: this.linkedDataControl,
                 checkbox: this.checkboxControl,
                 display: this.displayControl,
                 textarea: this.textareaControl,

--- a/packages/fast-tooling-react/src/form/templates/template.control.bare.spec.tsx
+++ b/packages/fast-tooling-react/src/form/templates/template.control.bare.spec.tsx
@@ -68,6 +68,7 @@ const props: BareControlTemplateProps = {
     },
     controls: {
         [ControlType.array]: null,
+        [ControlType.linkedData]: null,
         [ControlType.button]: null,
         [ControlType.checkbox]: null,
         [ControlType.display]: null,

--- a/packages/fast-tooling-react/src/form/templates/template.control.single-line.spec.tsx
+++ b/packages/fast-tooling-react/src/form/templates/template.control.single-line.spec.tsx
@@ -77,6 +77,7 @@ const props: SingleLineControlTemplateProps = {
     },
     controls: {
         [ControlType.array]: null,
+        [ControlType.linkedData]: null,
         [ControlType.button]: null,
         [ControlType.checkbox]: null,
         [ControlType.display]: null,

--- a/packages/fast-tooling-react/src/form/templates/template.control.standard.spec.tsx
+++ b/packages/fast-tooling-react/src/form/templates/template.control.standard.spec.tsx
@@ -83,6 +83,7 @@ const props: StandardControlTemplateProps = {
     },
     controls: {
         [ControlType.array]: null,
+        [ControlType.linkedData]: null,
         [ControlType.button]: null,
         [ControlType.checkbox]: null,
         [ControlType.display]: null,


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Add linked data control to the `Form`. This makes adding and removing linked data a default behavior.

Relies on #2710 and #2705, #2704 to pass the build

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->