### PR TITLE
refactor(fast-element): improve types and remove unneeded code for views

### DIFF
--- a/packages/fast-element/src/controller.ts
+++ b/packages/fast-element/src/controller.ts
@@ -24,9 +24,11 @@ export class Controller extends PropertyChangeNotifier implements Container {
 
     public hydrateCustomElement() {
         const definition = this.definition;
-        const view = (this.view = definition.template.create(false));
+        const template = definition.template;
 
-        if (view !== null) {
+        if (template !== null) {
+            const view = (this.view = template.create());
+
             if (definition.shadowOptions === null) {
                 view.appendTo(this.element);
             } else {

--- a/packages/fast-element/src/custom-element.ts
+++ b/packages/fast-element/src/custom-element.ts
@@ -1,4 +1,4 @@
-import { Template, noopTemplate } from "./template";
+import { ElementViewTemplate } from "./template";
 import { BindableDefinition, Bindable } from "./bindable";
 import { Constructable } from "./interfaces";
 import { Registry } from "./di";
@@ -6,7 +6,7 @@ import { Observable } from "./observation/observable";
 
 export type PartialCustomElementDefinition = {
     readonly name: string;
-    readonly template?: Template;
+    readonly template?: ElementViewTemplate;
     readonly bindables?: Record<string, BindableDefinition>;
     readonly dependencies?: Registry[];
     readonly shadowOptions?: ShadowRootInit | null;
@@ -49,20 +49,12 @@ export const CustomElement = {
     },
 };
 
-function buildTemplate(def: PartialCustomElementDefinition): Template {
-    if (def.template === void 0) {
-        return noopTemplate;
-    }
-
-    return def.template;
-}
-
 export class CustomElementDefinition {
     public readonly attributes: Record<string, BindableDefinition>;
 
     public constructor(
         public readonly name: string,
-        public readonly template: Template,
+        public readonly template: ElementViewTemplate | null,
         public readonly bindables: Record<string, BindableDefinition>,
         public readonly dependencies: Registry[],
         public readonly shadowOptions: ShadowRootInit | null,
@@ -93,7 +85,7 @@ export class CustomElementDefinition {
 
         return new CustomElementDefinition(
             name,
-            buildTemplate(nameOrDef),
+            nameOrDef.template || null,
             bindables,
             dependencies,
             shadowOptions,

--- a/packages/fast-element/src/directives/repeat.ts
+++ b/packages/fast-element/src/directives/repeat.ts
@@ -1,5 +1,5 @@
 import { AccessScopeExpression, Expression, Getter } from "../expression";
-import { Template, CaptureType } from "../template";
+import { SyntheticViewTemplate, CaptureType } from "../template";
 import { Behavior } from "../behaviors/behavior";
 import { DOM } from "../dom";
 import { Observable, GetterInspector } from "../observation/observable";
@@ -12,7 +12,7 @@ import { Splice } from "../observation/array-change-records";
 export class RepeatDirective extends BindingDirective {
     behavior = RepeatBehavior;
 
-    constructor(public expression: Expression, public template: Template) {
+    constructor(public expression: Expression, public template: SyntheticViewTemplate) {
         super(expression);
         enableArrayObservation();
     }
@@ -115,9 +115,7 @@ export class RepeatBehavior implements Behavior, GetterInspector, Subscriber {
                 const neighbor = views[addIndex];
                 const location = neighbor ? neighbor.firstChild : this.location;
                 const view =
-                    totalRemoved.length > 0
-                        ? totalRemoved.shift()!
-                        : template.create(true);
+                    totalRemoved.length > 0 ? totalRemoved.shift()! : template.create();
 
                 views.splice(addIndex, 0, view);
                 view.bind(items[addIndex]);
@@ -145,7 +143,7 @@ export class RepeatBehavior implements Behavior, GetterInspector, Subscriber {
             if (i < viewsLength) {
                 views[i].bind(items[i]);
             } else {
-                const view = template.create(true);
+                const view = template.create();
                 view.bind(items[i]);
                 views.push(view);
                 view.insertBefore(this.location);
@@ -172,7 +170,7 @@ export class RepeatBehavior implements Behavior, GetterInspector, Subscriber {
 
 export function repeat<T = any, K = any>(
     expression: Getter<T, K[]> | keyof T,
-    template: Template
+    template: SyntheticViewTemplate
 ): CaptureType<T> {
     return new RepeatDirective(AccessScopeExpression.from(expression as any), template);
 }

--- a/packages/fast-element/src/directives/when.ts
+++ b/packages/fast-element/src/directives/when.ts
@@ -1,5 +1,5 @@
 import { DOM } from "../dom";
-import { Template, CaptureType } from "../template";
+import { SyntheticViewTemplate, CaptureType } from "../template";
 import { SyntheticView } from "../view";
 import { Expression, AccessScopeExpression, Getter } from "../expression";
 import { Behavior } from "../behaviors/behavior";
@@ -10,7 +10,7 @@ import { Subscriber } from "../observation/subscriber-collection";
 export class WhenDirective extends BindingDirective {
     behavior = WhenBehavior;
 
-    constructor(public expression: Expression, public template: Template) {
+    constructor(public expression: Expression, public template: SyntheticViewTemplate) {
         super(expression);
     }
 
@@ -57,8 +57,7 @@ export class WhenBehavior implements Behavior, GetterInspector, Subscriber {
     updateTarget(show: boolean) {
         if (show && this.view == null) {
             this.view =
-                this.cachedView ||
-                (this.cachedView = this.directive.template.create(true));
+                this.cachedView || (this.cachedView = this.directive.template.create());
             this.view.bind(this.source);
             this.view.insertBefore(this.location);
         } else if (!show && this.view !== null) {
@@ -71,7 +70,7 @@ export class WhenBehavior implements Behavior, GetterInspector, Subscriber {
 
 export function when<T = any, K = any>(
     expression: Getter<T, K> | keyof T,
-    template: Template
+    template: SyntheticViewTemplate
 ): CaptureType<T> {
     return new WhenDirective(AccessScopeExpression.from(expression as any), template);
 }

--- a/packages/fast-element/src/expression.ts
+++ b/packages/fast-element/src/expression.ts
@@ -46,8 +46,16 @@ export class InterpolationExpression implements Expression {
     constructor(private parts: (string | Getter)[]) {}
 
     public evaluate(scope: unknown, context?: ExpressionContext) {
-        return this.parts
-            .map(x => (typeof x === "string" ? x : x(scope, context!)))
-            .join("");
+        let output = "";
+        const parts = this.parts;
+
+        for (let i = 0, ii = parts.length; i < ii; ++i) {
+            const current = parts[i];
+            output =
+                output +
+                (typeof current === "string" ? current : current(scope, context!));
+        }
+
+        return output;
     }
 }

--- a/packages/fast-element/src/view.ts
+++ b/packages/fast-element/src/view.ts
@@ -3,7 +3,6 @@ import { Behavior } from "./behaviors/behavior";
 export interface View {
     bind(source: unknown): void;
     unbind(): void;
-    remove(): void;
 }
 
 export interface ElementView extends View {
@@ -14,27 +13,20 @@ export interface SyntheticView extends View {
     readonly firstChild: Node;
     readonly lastChild: Node;
     insertBefore(node: Node): void;
+    remove(): void;
 }
 
-export class HTMLView implements View, ElementView, SyntheticView {
-    private parent?: Node;
+export class HTMLView implements ElementView, SyntheticView {
     private source: any = void 0;
-    public firstChild!: Node;
-    public lastChild!: Node;
+    public firstChild: Node;
+    public lastChild: Node;
 
-    constructor(
-        private fragment: DocumentFragment,
-        private behaviors: Behavior[],
-        private isSynthetic: boolean = false
-    ) {
-        if (isSynthetic) {
-            this.firstChild = fragment.firstChild!;
-            this.lastChild = fragment.lastChild!;
-        }
+    constructor(private fragment: DocumentFragment, private behaviors: Behavior[]) {
+        this.firstChild = fragment.firstChild!;
+        this.lastChild = fragment.lastChild!;
     }
 
     public appendTo(node: Node) {
-        this.parent = node;
         node.appendChild(this.fragment);
     }
 
@@ -61,33 +53,24 @@ export class HTMLView implements View, ElementView, SyntheticView {
     }
 
     public remove() {
-        if (this.isSynthetic) {
-            const fragment = this.fragment;
-            let current: Node | null = this.firstChild!;
-            const end = this.lastChild!;
-            let next;
+        const fragment = this.fragment;
+        let current: Node | null = this.firstChild!;
+        const end = this.lastChild!;
+        let next;
 
-            while (current) {
-                next = current.nextSibling;
-                fragment.appendChild(current);
+        while (current) {
+            next = current.nextSibling;
+            fragment.appendChild(current);
 
-                if (current === end) {
-                    break;
-                }
-
-                current = next;
+            if (current === end) {
+                break;
             }
-        } else {
-            const parent = this.parent!;
-            const fragment = this.fragment;
 
-            while (parent.hasChildNodes()) {
-                fragment.appendChild(parent.firstChild!);
-            }
+            current = next;
         }
     }
 
-    bind(source: unknown) {
+    public bind(source: unknown) {
         if (this.source === source) {
             return;
         } else if (this.source !== void 0) {
@@ -101,7 +84,7 @@ export class HTMLView implements View, ElementView, SyntheticView {
         }
     }
 
-    unbind() {
+    public unbind() {
         if (this.source === void 0) {
             return;
         }


### PR DESCRIPTION
# Description

This PR improves the types related to templates/views and removes some unnecessary code.

## Motivation & context

The design of the `Template` interface was a bit awkward, requiring the consumer to call a method with a boolean that would return a different type based on the boolean value. This PR creates two new template interfaces instead (`ElementViewTemplate`, `SyntheticViewTemplate`), which each have a `create` method that returns the appropriate type (`ElementView`, `SyntheticView`). The actual underlying implementation is the same, but this allows the type system to ensure that the template and the view it creates is being used consistently, based on the intent. This can be seen in the updates to `when` and `repeat` which now take a dependency on a particular template type. With this in place, some additional updates were made to the view infrastructure to remove code that would never run under the new typings. Also, the controller was patched up to better handle custom elements with no view, so that a fake "no view" template was no longer needed. This also removes any form of polymorphism related to view construction.

Note: A couple micro-optimizations were squeezed into this PR, related to loops.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.
- [x] **Refactor**: A change to internal details that improves code.

**Is this a breaking change?**
- [x] This change causes current functionality to break.

While technically a breaking change, it is unlikely to affect anyone at this time since only the library itself depends on the template and view interfaces. In the future a change like this would affect others if they had created custom directives.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.