### PR TITLE
chore: adds form-associated-custom-element spec

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -5,5 +5,6 @@ Here you'll find specifications for custom elements and other library features.
 > **Note:** When authoring a new spec, please use [our standard spec template](./template.md). Specs can be submitted in the form of a PR. Prior to creating a PR, be sure to remove any boilerplate from the spec template which was not used. The PR that introduces your spec should also add a link to this readme in the specs section below.
 
 ## Specs
+[Form associated custom elements]("./form-associated-custom-element.md")
 [Switch](./switch.md)
 [Tree View](./tree-view/tree-view.md)

--- a/specs/form-associated-custom-element.md
+++ b/specs/form-associated-custom-element.md
@@ -1,0 +1,115 @@
+# Form Associated Custom Elements
+
+## Overview
+This spec regards a general implementation to facilitate form communication and connection for components that should be form-associated, including checkboxes,
+radios, text inputs, and other components which store user input and should be captured during form submission.
+
+### Background
+Components that replace or behave like native form elements (input, textarea, select) should generally behave like native like their native counterpart. One key aspect to this is associating the element with the parent form. To do this, we will expose a mechanism to expose form-association to custom elements that can be shared across implementations with maximum re-use.
+
+### Use Cases
+Any custom element that should associate a value to a form.
+
+## Design
+The implementation will be an *abstract class* that will extend `FastElement`. The class will expose implementations for all of the common form element capabilities. It will also expose and manage an implementation for when the form-associated custom element APIs are not available.
+
+Another option I looked at is using a decorator, but there are a few challenges with that approach:
+  1. decorators cannot augment the class type, so we would need to use a pattern similar to https://www.typescriptlang.org/docs/handbook/mixins.html to gain accurate type definitions
+  2. Decorators cannot provide a *default* implementation that can be overridden by the extending class. Using an abstract class allows straight overrides of implementation or merging of implementation with super
+
+The implementation will standardize an interface between two common cases: browsers with form-associated-custom-element support and browsers without.
+
+### Browsers with FACE support
+For browsers *with* support, methods and properties will generally proxy to the `ElementInternals` implementation.
+
+### Browsers with FACE support
+The implementation will manage a "proxy" element that will be appended to the light-dom. This proxy element will server as the custom-element's association to the form. All relevant properties will be forwarded to this element, and certain API calls will retrieve data from it.
+
+### API
+#### IDL attributes
+- `public static formAssociated: boolean`
+  - Required for form-associated custom element API. This will feature-detect the API and resolve a value corresponding to feature-support
+- `public readonly validity: ValidityState`
+  - Returns the [validity](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) of the component
+- `public readonly form: HTMLFormElement | null`
+  - The associated form element
+- `public readonly validationMessage: string`
+  - The current validation message of the element
+- `public readonly labels: Node[]`
+  - Labels associated to the element. See [risks and challenges](#retrieving-labels)
+- `protected abstract proxy: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement`
+  - A proxy element that will be appended to the DOM when form-association APIs are unavailable. It will server as the custom-elements connection to the form.
+- `protected elementInternals: ElementInternals`
+  - Provides form-association through dedicated APIs.
+- `protected setFormValue(value: File | string | FormData | null, state?: File | string | FormData): void`
+  - When using `elementInternals`, this will set the value in the form. With no form-association support, this will noop because the value will automatically be associated by the proxy element. This can be overridden as necessary by components with more advanced behavior.
+- `protected onLabelClick(): void`: **Discussion**
+  - see [risks and challenges](#clicking-labels)
+- `protected handleKeyPress(): void`
+  - Will submit the form when `enter` key is pressed to match standard input behavior. Can be overridden or extended.
+- `protected setValidity(flags: ValidityStateFlags, message?: string, anchor?: HTMLElement): void;`
+  - With form association support, will set the validity of the component. With no form association, this will noop unless a message is passed. If a message is passed, the proxy element's `setCustomValidity` method will be invoked with the value of the message.
+
+#### Content attributes
+- `id: string`
+  - The id attribute of the component. Used for label association.
+- `value: string | File | FormData`
+  - When provided as a content attribute, value must be a string. When provided as an IDL property, value can be a `string`, `File`, or `FormData`
+- `autofocus: boolean`
+  - Boolean attribute. Will auto-focus the element on page load.
+- `disabled: boolean`
+  - Boolean attribute. Disables the form control, ensuring it doesn't participate in form submission
+- `name: string`
+  - The name of the element. Allows access by name from the associated form.
+- `required: boolean`
+  - Boolean attribute.
+
+### Risks and Challenges
+
+#### Retrieving labels
+Accessing the [`labels`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/labels) property of a native input returns a `NodeList`. In cases where the form-association APIs are available, the implementation from `ElementInternals.labels` works as expected. In cases where we implement a proxy element though, we need to construct the label set from the following:
+  1. any parent `<label>`element. Can be retrieved from the proxy element's `labels` property
+  2. any `<label>` element with `[for="$id"]`, where $id is the `id` attribute *of the custom element*. Because the custom element does not reflect it's `id` attribute to the proxy element (that would result in two elements with the same ID in the DOM), the labels are not automatically associated to the `labels` property of the proxy.
+
+`NodeList`s are not constructable in JavaScript, and because we need to construct the label set in cases where we're using a proxy element, I'm purposing standardizing this property to `Node[]` , which AFAIK is as close to `NodeList` as we can get.
+
+#### Clicking labels
+Clicking a label of a native input element can have several side effects. First (and in general) it will focus the element. In cases like radio and checkbox, it changes the value of the input. There are likely other side-effects.
+
+How this works under the hood seems to be that clicking the label *also* invokes a click event on the element the label *labels*.
+
+However, because (in proxy element cases) the label's aren't *actually* associated to the element, the click event on the custom element isn't ever fired. This is the case for all label's using the `for` attribute to make the association. *Wrapping* labels (`<label><custom-element></label>`) *do* seem to fire the click event on the custom element.
+
+In order to *truly* support this scenario, we need to attach click event handlers to all labels for the elements. It *also* means that we need to attach new listeners when *new* labels get added to the DOM. This is the tricky part. We could use mutation observer, but my fear is that is heavy-handed for an edge-case scenario. 
+
+Another options would be to document the gap and not support this scenario, instead only attaching listeners to elements that are in the DOM when the component connects. Any other thoughts here?
+
+### Accessibility
+
+No accessibility concerns for this utility. Accessibility will be the concern of the implementing class.
+
+### Globalization
+
+No globalization concerns.
+
+### Security
+
+No new security concerns. Form data sanitation will be the responsibility of the consuming application.
+
+### Performance
+
+Potentially using a MutationObserver to attach new click handlers to label elements. TBD on if we want to do this.
+
+### Dependencies
+
+No Dependencies
+
+### Test Plan
+
+TBD. Form association APIs are very new so JSDOM is not likely to expose the feature. It might make sense to do in-browser tests against browsers both with and without support to ensure parity.
+
+
+## Resources
+- https://docs.google.com/document/d/1JO8puctCSpW-ZYGU8lF-h4FWRIDQNDVexzHoOQ2iQmY/edit?pli=1
+- https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-face-example
+- https://web.dev/more-capable-form-controls/

--- a/specs/form-associated-custom-element.md
+++ b/specs/form-associated-custom-element.md
@@ -73,7 +73,7 @@ Accessing the [`labels`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIn
   1. any parent `<label>`element. Can be retrieved from the proxy element's `labels` property
   2. any `<label>` element with `[for="$id"]`, where $id is the `id` attribute *of the custom element*. Because the custom element does not reflect it's `id` attribute to the proxy element (that would result in two elements with the same ID in the DOM), the labels are not automatically associated to the `labels` property of the proxy.
 
-`NodeList`s are not constructable in JavaScript, and because we need to construct the label set in cases where we're using a proxy element, I'm purposing standardizing this property to `Node[]` , which AFAIK is as close to `NodeList` as we can get.
+`NodeList`s are not constructable in JavaScript, thus this property is standardized to `Node[]` due to the need to construct the label when implementing with a proxy element. The use of Node[] is intended to map as close to `NodeList` as possible.
 
 #### Clicking labels
 Clicking a label of a native input element can have several side effects. First (and in general) it will focus the element. In cases like radio and checkbox, it changes the value of the input. There are likely other side-effects.
@@ -82,7 +82,7 @@ How this works under the hood seems to be that clicking the label *also* invokes
 
 However, because (in proxy element cases) the label's aren't *actually* associated to the element, the click event on the custom element isn't ever fired. This is the case for all label's using the `for` attribute to make the association. *Wrapping* labels (`<label><custom-element></label>`) *do* seem to fire the click event on the custom element.
 
-In order to *truly* support this scenario, we need to attach click event handlers to all labels for the elements. It *also* means that new listeners must be attached when *new* labels get added to the DOM. This is the tricky part. A mutation observer could be used, but this could be heavy-handed for this edge case. 
+To *truly* support this scenario, click event handlers must be attached to all labels for the elements. It *also* means that new listeners must be attached when *new* labels get added to the DOM. This is the tricky part. A mutation observer could be used, but this could be heavy-handed for this edge case. 
 
 Another options would be to document the gap and not support this scenario, instead only attaching listeners to elements that are in the DOM when the component connects. Any other thoughts here?
 
@@ -112,6 +112,6 @@ TBD. Form association APIs are very new so JSDOM is not likely to expose the fea
 
 
 ## Resources
-- https://docs.google.com/document/d/1JO8puctCSpW-ZYGU8lF-h4FWRIDQNDVexzHoOQ2iQmY/edit?pli=1
-- https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-face-example
-- https://web.dev/more-capable-form-controls/
+- [Form Participation API Explained](https://docs.google.com/document/d/1JO8puctCSpW-ZYGU8lF-h4FWRIDQNDVexzHoOQ2iQmY/edit?pli=1)
+- [Creating a form-associated custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-face-example)
+- [More capable form controls](https://web.dev/more-capable-form-controls/)

--- a/specs/form-associated-custom-element.md
+++ b/specs/form-associated-custom-element.md
@@ -45,8 +45,6 @@ The implementation will manage a "proxy" element that will be appended to the li
   - Provides form-association through dedicated APIs.
 - `protected setFormValue(value: File | string | FormData | null, state?: File | string | FormData): void`
   - When using `elementInternals`, this will set the value in the form. With no FACE support, this will do nothing because the value will automatically be associated by the proxy element. This can be overridden as necessary by components with more advanced behavior.
-- `protected onLabelClick(): void`: **Discussion**
-  - see [risks and challenges](#clicking-labels)
 - `protected handleKeyPress(): void`
   - Will submit the form when `enter` key is pressed to match standard input behavior. Can be overridden or extended.
 - `protected setValidity(flags: ValidityStateFlags, message?: string, anchor?: HTMLElement): void;`
@@ -82,9 +80,7 @@ How this works under the hood seems to be that clicking the label *also* invokes
 
 However, because (in proxy element cases) the label's aren't *actually* associated to the element, the click event on the custom element isn't ever fired. This is the case for all label's using the `for` attribute to make the association. *Wrapping* labels (`<label><custom-element></label>`) *do* seem to fire the click event on the custom element.
 
-To *truly* support this scenario, click event handlers must be attached to all labels for the elements. It *also* means that new listeners must be attached when *new* labels get added to the DOM. This is the tricky part. A mutation observer could be used, but this could be heavy-handed for this edge case. 
-
-Another options would be to document the gap and not support this scenario, instead only attaching listeners to elements that are in the DOM when the component connects. Any other thoughts here?
+See (next steps)[#next-steps].
 
 ### Accessibility
 

--- a/specs/form-associated-custom-element.md
+++ b/specs/form-associated-custom-element.md
@@ -1,7 +1,7 @@
 # Form Associated Custom Elements
 
 ## Overview
-This spec regards a general implementation to facilitate form communication and connection for components that should be form-associated, including checkboxes,radios, text inputs, and other components which store user input and should be captured during form submission.
+This spec regards a general implementation to facilitate form communication and connection for components that should be form-associated, including checkboxes, radios, text inputs, and other components which store user input and should be captured during form submission.
 
 ### Background
 Components that replace or behave like native form elements (input, textarea, select) should generally behave like native like their native counterpart. One key aspect to this is associating the element with the parent form. To do this, we will expose a mechanism to expose form-association to custom elements that can be shared across implementations with maximum re-use.

--- a/specs/form-associated-custom-element.md
+++ b/specs/form-associated-custom-element.md
@@ -1,8 +1,7 @@
 # Form Associated Custom Elements
 
 ## Overview
-This spec regards a general implementation to facilitate form communication and connection for components that should be form-associated, including checkboxes,
-radios, text inputs, and other components which store user input and should be captured during form submission.
+This spec regards a general implementation to facilitate form communication and connection for components that should be form-associated, including checkboxes,radios, text inputs, and other components which store user input and should be captured during form submission.
 
 ### Background
 Components that replace or behave like native form elements (input, textarea, select) should generally behave like native like their native counterpart. One key aspect to this is associating the element with the parent form. To do this, we will expose a mechanism to expose form-association to custom elements that can be shared across implementations with maximum re-use.

--- a/specs/form-associated-custom-element.md
+++ b/specs/form-associated-custom-element.md
@@ -110,8 +110,10 @@ No Dependencies
 
 TBD. Form association APIs are very new so JSDOM is not likely to expose the feature. It might make sense to do in-browser tests against browsers both with and without support to ensure parity.
 
-
 ## Resources
 - [Form Participation API Explained](https://docs.google.com/document/d/1JO8puctCSpW-ZYGU8lF-h4FWRIDQNDVexzHoOQ2iQmY/edit?pli=1)
 - [Creating a form-associated custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-face-example)
 - [More capable form controls](https://web.dev/more-capable-form-controls/)
+
+### Next Steps
+We will solve label-clicking for browsers with no FACE support in the future. A promising approach would be to catch click events on the parent form and delegate focus from there. The edge-case this does not address is elements that are not a descendent of the form element but are still associated using the [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefform) content attributes.

--- a/specs/form-associated-custom-element.md
+++ b/specs/form-associated-custom-element.md
@@ -14,8 +14,8 @@ Any custom element that should associate a value to a form.
 The implementation will be an *abstract class* that will extend `FastElement`. The class will expose implementations for all of the common form element capabilities. It will also expose and manage an implementation for when the form-associated custom element APIs are not available.
 
 Another option I looked at is using a decorator, but there are a few challenges with that approach:
-  1. decorators cannot augment the class type, so we would need to use a pattern similar to https://www.typescriptlang.org/docs/handbook/mixins.html to gain accurate type definitions
-  2. Decorators cannot provide a *default* implementation that can be overridden by the extending class. Using an abstract class allows straight overrides of implementation or merging of implementation with super
+  1. decorators cannot augment the class type directly, so we would need to use a pattern similar to https://www.typescriptlang.org/docs/handbook/mixins.html to gain accurate type definitions
+  2. Decorators cannot (easily?) provide a *default* implementation that can be overridden by the extending class. Using an abstract class allows straight overrides of implementation or merging of implementation with super
 
 The implementation will standardize an interface between two common cases: browsers with form-associated-custom-element support and browsers without.
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
This specification is designed to outline a base class for implementing custom form elements in web components.

(living) prototype implementation of this spec exists here: https://github.com/microsoft/fast-dna/blob/users/nirice/wc-checkbox-prototype/packages/fast-components/src/checkbox/checkbox.ts
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->