### PR TITLE
fix(fast-element): undefined/null should remove the html attribute

### DIFF
--- a/packages/fast-element/src/behaviors/attribute.ts
+++ b/packages/fast-element/src/behaviors/attribute.ts
@@ -7,6 +7,10 @@ export class AttributeBinding extends BindingBase {
     }
 
     updateTarget(value: unknown) {
-        this.target.setAttribute(this.directive.targetName!, value as string);
+        if (value === null || value === void 0) {
+            this.target.removeAttribute(this.directive.targetName!);
+        } else {
+            this.target.setAttribute(this.directive.targetName!, value as string);
+        }
     }
 }


### PR DESCRIPTION
# Description

Addresses the issue that occurs when properties with a null or undefined value are bound to an HTML attribute.

## Motivation & context

When binding something like `aria-label=${x => x.ariaLabel}`, if the `ariaLabel` property's value is `undefined` the the `aria-label` attribute gets set to the string "undefined", which is not desirable.

This PR fixes the above behavior such that if the value is either `null` or `undefined` the attribute is removed from the DOM all-together.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

## Next Steps

A follow-up feature is to allow our custom attributes to behave as boolean attributes and to also provide type conversion. For example, the string "true" often needs to be converted to the boolean value `true`. Boolean attributes and attribute type conversion are two separate features, but often a boolean attribute also wants to have its value be a real boolean.

I'm in the process of adjusting various internals of the element and template definition systems now. Once that settles down a bit (should be by tomorrow I hope) I can move on to implement these new attribute features.