### PR TITLE
feat(fast-element): base shadow and element options on defaults

### DIFF
--- a/packages/fast-element/docs/building-components.md
+++ b/packages/fast-element/docs/building-components.md
@@ -772,7 +772,7 @@ export class NameTag extends FastElement {
 
 > **IMPORTANT:** If you choose to render to the Light DOM, you will not be able to compose content, use slots, or leverage encapsulated styles. Light DOM rendering is not recommended for re-usable components. It may have some limited use as the root component of a small app.
 
-In addition to the Shadow DOM mode, `shadowOptions` exposes all the options that can be set through the standard `attachShadow` API. This means that you can also use it to specify new options such as `delegatesFocus: true`.
+In addition to the Shadow DOM mode, `shadowOptions` exposes all the options that can be set through the standard `attachShadow` API. This means that you can also use it to specify new options such as `delegatesFocus: true`. You only need to specify options that are different from the defaults mentioned above.
 
 ## Defining CSS
 

--- a/packages/fast-element/src/fast-element.ts
+++ b/packages/fast-element/src/fast-element.ts
@@ -6,6 +6,9 @@ import { ElementStyles } from "./styles";
 import { AttributeDefinition, AttributeConfiguration } from "./attributes";
 import { Registry } from "./di";
 
+const defaultShadowOptions: ShadowRootInit = { mode: "open" };
+const defaultElementOptions: ElementDefinitionOptions = {};
+
 function createFastElement(BaseType: typeof HTMLElement) {
     return class FastElement extends BaseType {
         public $controller!: Controller;
@@ -63,8 +66,15 @@ export const FastElement = Object.assign(createFastElement(HTMLElement), {
         );
         const shadowOptions =
             nameOrDef.shadowOptions === void 0
-                ? ({ mode: "open" } as ShadowRootInit)
-                : nameOrDef.shadowOptions || void 0;
+                ? defaultShadowOptions
+                : nameOrDef.shadowOptions === null
+                    ? void 0
+                    : { ...defaultShadowOptions, ...nameOrDef.shadowOptions };
+
+        const elementOptions =
+            nameOrDef.elementOptions === void 0
+                ? defaultElementOptions
+                : { ...defaultElementOptions, ...nameOrDef.shadowOptions };
 
         const observedAttributes = new Array(attributes.length);
         const proto = Type.prototype;
@@ -92,7 +102,7 @@ export const FastElement = Object.assign(createFastElement(HTMLElement), {
             nameOrDef.template,
             nameOrDef.styles,
             shadowOptions,
-            nameOrDef.elementOptions,
+            elementOptions,
             nameOrDef.dependencies
         );
 
@@ -114,7 +124,7 @@ export type PartialFastElementDefinition = {
     readonly styles?: ElementStyles;
     readonly attributes?: (AttributeConfiguration | string)[];
     readonly dependencies?: Registry[];
-    readonly shadowOptions?: ShadowRootInit | null;
+    readonly shadowOptions?: Partial<ShadowRootInit> | null;
     readonly elementOptions?: ElementDefinitionOptions;
 };
 


### PR DESCRIPTION
# Description

Allow element authors to provide shadow and element options as overrides of defaults.

## Motivation & context

Prior to this change, if an element author wanted to configure their shadow root with `delegatesFocus: true`, they would also have to specify the `mode`, even though they didn't want to change this behavior. As of this PR, the shadow and element options config objects allow the element author to only specify what is different from the defaults. When the final element definition is built up, the overrides are merged with our library defaults to produce the final options object used by the underlying platform APIs.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.