### PR TITLE
fix(fast-element): type fixes, api docs, and one op order correction

### DIFF
--- a/packages/fast-element/src/directives/when.ts
+++ b/packages/fast-element/src/directives/when.ts
@@ -67,8 +67,9 @@ export class WhenBehavior implements Behavior, GetterInspector, Subscriber {
             this.view.bind(this.source);
             this.view.insertBefore(this.location);
         } else if (!show && this.view !== null) {
-            this.view.unbind();
+            // do not dispose, since we may want to use the view again
             this.view.remove();
+            this.view.unbind();
             this.view = null;
         }
     }

--- a/packages/fast-element/src/fast-element.ts
+++ b/packages/fast-element/src/fast-element.ts
@@ -1,5 +1,5 @@
 import { Controller } from "./controller";
-import { CustomElementConstructor, emptyArray } from "./interfaces";
+import { emptyArray } from "./interfaces";
 import { Observable } from "./observation/observable";
 import { ElementViewTemplate } from "./template";
 import { ElementStyles } from "./styles";
@@ -44,14 +44,14 @@ function createFastElement(BaseType: typeof HTMLElement) {
     };
 }
 
-const fastDefinitions = new Map<CustomElementConstructor, FastElementDefinition>();
+const fastDefinitions = new Map<Function, FastElementDefinition>();
 
 export const FastElement = Object.assign(createFastElement(HTMLElement), {
     from(BaseType: typeof HTMLElement) {
         return createFastElement(BaseType);
     },
 
-    define<T extends CustomElementConstructor>(
+    define<T extends Function>(
         Type: T,
         nameOrDef: string | PartialFastElementDefinition = (Type as any).definition
     ): T {
@@ -107,13 +107,11 @@ export const FastElement = Object.assign(createFastElement(HTMLElement), {
         );
 
         fastDefinitions.set(Type, definition);
-        customElements.define(name, Type, definition.elementOptions);
+        customElements.define(name, Type as any, definition.elementOptions);
         return Type;
     },
 
-    getDefinition<T extends CustomElementConstructor>(
-        Type: T
-    ): FastElementDefinition | undefined {
+    getDefinition<T extends Function>(Type: T): FastElementDefinition | undefined {
         return fastDefinitions.get(Type);
     },
 });
@@ -143,7 +141,7 @@ export class FastElementDefinition {
 }
 
 export function customElement(nameOrDef: string | PartialFastElementDefinition) {
-    return function(type: CustomElementConstructor) {
+    return function(type: Function) {
         FastElement.define(type, nameOrDef);
     };
 }

--- a/packages/fast-element/src/interfaces.ts
+++ b/packages/fast-element/src/interfaces.ts
@@ -2,10 +2,6 @@ export type Callable = typeof Function.prototype.call | { call(): void };
 
 export const emptyArray = Object.freeze([]);
 
-export type CustomElementConstructor = {
-    new (): HTMLElement;
-};
-
 /**
  * Provides additional contextual information available to arrow functions
  * evaluated in the context of a template update.

--- a/packages/fast-element/src/view.ts
+++ b/packages/fast-element/src/view.ts
@@ -1,24 +1,73 @@
 import { Behavior } from "./directives/behavior";
 
+/**
+ * Represents a collection of DOM nodes which can be bound to a data source.
+ */
 export interface View {
+    /**
+     * Binds a view's behaviors to its binding source.
+     * @param source The binding source for the view's binding behaviors.
+     */
     bind(source: unknown): void;
+
+    /**
+     * Unbinds a view's behaviors from its binding source.
+     */
     unbind(): void;
 }
 
+/**
+ * A View representing DOM nodes specifically for rendering the view of a custom element.
+ */
 export interface ElementView extends View {
+    /**
+     * Appends the view's DOM nodes to the referenced node.
+     * @param node The parent node to append the view's DOM nodes to.
+     */
     appendTo(node: Node): void;
 }
 
+/**
+ * A view representing a range of DOM nodes which can be added/removed adhoc.
+ */
 export interface SyntheticView extends View {
+    /**
+     * The first DOM node in the range of nodes that make up the view.
+     */
+
     readonly firstChild: Node;
+
+    /**
+     * The last DOM node in the range of nodes that make up the view.
+     */
     readonly lastChild: Node;
+
+    /**
+     * Inserts the view's DOM nodes before the referenced node.
+     * @param node The node to insert the view's DOM before.
+     */
     insertBefore(node: Node): void;
+
+    /**
+     * Removes the view's DOM nodes.
+     * The nodes are not disposed and the view can later be re-inserted.
+     */
     remove(): void;
+
+    /**
+     * Removes the view and unbinds its behaviors, disposing of DOM nodes afterward.
+     * Once a view has been disposed, it cannot be inserted or bound again.
+     */
     dispose(): void;
 }
 
+// A singleton Range instance used to efficiently remove ranges of DOM nodes.
+// See the implementation of HTMLView below for further details.
 const range = document.createRange();
 
+/**
+ * The standard View implementation, which also implements ElementView and SyntheticView.
+ */
 export class HTMLView implements ElementView, SyntheticView {
     private source: any = void 0;
     public firstChild: Node;
@@ -29,10 +78,18 @@ export class HTMLView implements ElementView, SyntheticView {
         this.lastChild = fragment.lastChild!;
     }
 
+    /**
+     * Appends the view's DOM nodes to the referenced node.
+     * @param node The parent node to append the view's DOM nodes to.
+     */
     public appendTo(node: Node) {
         node.appendChild(this.fragment);
     }
 
+    /**
+     * Inserts the view's DOM nodes before the referenced node.
+     * @param node The node to insert the view's DOM before.
+     */
     public insertBefore(node: Node) {
         if (this.fragment.hasChildNodes()) {
             node.parentNode!.insertBefore(this.fragment, node);
@@ -52,12 +109,20 @@ export class HTMLView implements ElementView, SyntheticView {
         }
     }
 
+    /**
+     * Removes the view's DOM nodes.
+     * The nodes are not disposed and the view can later be re-inserted.
+     */
     public remove() {
         range.setStart(this.firstChild, 0);
         range.setEnd(this.lastChild, 0);
         this.fragment = range.extractContents();
     }
 
+    /**
+     * Removes the view and unbinds its behaviors, disposing of DOM nodes afterward.
+     * Once a view has been disposed, it cannot be inserted or bound again.
+     */
     public dispose() {
         range.setStart(this.firstChild, 0);
         range.setEnd(this.lastChild, 0);
@@ -70,6 +135,10 @@ export class HTMLView implements ElementView, SyntheticView {
         }
     }
 
+    /**
+     * Binds a view's behaviors to its binding source.
+     * @param source The binding source for the view's binding behaviors.
+     */
     public bind(source: unknown) {
         if (this.source === source) {
             return;
@@ -84,6 +153,9 @@ export class HTMLView implements ElementView, SyntheticView {
         }
     }
 
+    /**
+     * Unbinds a view's behaviors from its binding source.
+     */
     public unbind() {
         if (this.source === void 0) {
             return;
@@ -98,6 +170,10 @@ export class HTMLView implements ElementView, SyntheticView {
         this.source = void 0;
     }
 
+    /**
+     * Efficiently disposes of a contiguous range of synthetic view instances.
+     * @param views A contiguous range of views to be disposed.
+     */
     public static disposeContiguousBatch(views: SyntheticView[]) {
         if (views.length === 0) {
             return;


### PR DESCRIPTION
# Description

A small PR that adds some API docs for clarity and fixes a couple small bugs.

## Motivation & context

A typing fix was needed in order to prevent decorator errors. Types were relaxed in order to address the issue. While doing this work, I noticed a small issue with `when` and the order of view removal, so I fixed that. I also wanted to start the process of documenting APIs, so I added some comments to the recent API changes to make them clearer (when I was working on fixing `when` I realized they needed some explanation.)

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.
- [x] **Documentation**: A fix or additional of documentation.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.