### PR TITLE
fix(view): ensure first/last child correct after removing view

### DIFF
--- a/packages/fast-element/src/template-compiler.ts
+++ b/packages/fast-element/src/template-compiler.ts
@@ -97,10 +97,6 @@ export function compileTemplate(
         }
     }
 
-    if (DOM.isMarker(fragment.firstChild!)) {
-        fragment.insertBefore(document.createComment(""), fragment.firstChild);
-    }
-
     return new HTMLTemplate(element, viewFactories, hostFactories);
 }
 

--- a/packages/fast-element/src/view.ts
+++ b/packages/fast-element/src/view.ts
@@ -117,6 +117,8 @@ export class HTMLView implements ElementView, SyntheticView {
         range.setStart(this.firstChild, 0);
         range.setEnd(this.lastChild, 0);
         this.fragment = range.extractContents();
+        this.firstChild = this.fragment.firstChild!;
+        this.lastChild = this.fragment.lastChild!;
     }
 
     /**


### PR DESCRIPTION
# Description

After removing a view from the DOM, its firsChild and lastChild node pointers were not refreshed, causing subsequent removals to fail.

## Motivation & context

This fixes issue #2816. Additionally, a second bug was fixed in template compilation, which only manifested when the first node of a view is a marker node.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.