### PR TITLE
fix: update opacity so that it no longer applies to objects and prevents users from modifying the value via const, soft remove and default buttons

### DIFF
--- a/packages/fast-tooling-react/app/pages/form/index.ts
+++ b/packages/fast-tooling-react/app/pages/form/index.ts
@@ -14,6 +14,7 @@ import {
     controlPluginSchema as customControlSchema,
     defaultsSchema,
     dictionarySchema,
+    disabledSchema,
     generalSchema,
     invalidDataSchema,
     mergedOneOfSchema,
@@ -120,4 +121,8 @@ export const customControl: ExampleComponent = {
 
 export const tooltip: ExampleComponent = {
     schema: tooltipSchema,
+};
+
+export const disabled: ExampleComponent = {
+    schema: disabledSchema,
 };

--- a/packages/fast-tooling-react/src/__tests__/schemas/disabled.schema.ts
+++ b/packages/fast-tooling-react/src/__tests__/schemas/disabled.schema.ts
@@ -1,0 +1,61 @@
+import { linkedDataSchema } from "@microsoft/fast-tooling";
+
+export default {
+    $schema: "http://json-schema.org/schema#",
+    title: "Component with all disabled types",
+    description: "A test component's schema definition.",
+    type: "object",
+    id: "disabled",
+    disabled: true,
+    properties: {
+        textarea: {
+            title: "textarea",
+            type: "string",
+            disabled: true,
+        },
+        "section-link": {
+            title: "section-link",
+            type: "object",
+            disabled: true,
+        },
+        display: {
+            title: "display",
+            const: "foobar",
+            disabled: true,
+        },
+        checkbox: {
+            title: "checkbox",
+            type: "boolean",
+            disabled: true,
+        },
+        button: {
+            title: "button",
+            type: "null",
+            disabled: true,
+        },
+        array: {
+            title: "array",
+            items: {
+                title: "array item",
+                type: "string",
+                disabled: true,
+            },
+            disabled: true,
+        },
+        "number-field": {
+            title: "number-field",
+            type: "number",
+            disabled: true,
+        },
+        select: {
+            title: "select",
+            type: "string",
+            enum: ["foo", "bar", "bat"],
+            disabled: true,
+        },
+        children: {
+            ...linkedDataSchema,
+            disabled: true,
+        },
+    },
+};

--- a/packages/fast-tooling-react/src/__tests__/schemas/index.ts
+++ b/packages/fast-tooling-react/src/__tests__/schemas/index.ts
@@ -11,6 +11,7 @@ import constSchema from "./const.schema";
 import controlPluginSchema from "./control-plugin.schema";
 import defaultsSchema from "./defaults.schema";
 import dictionarySchema from "./dictionary.schema";
+import disabledSchema from "./disabled.schema";
 import generalExampleSchema from "./general-example.schema";
 import generalSchema from "./general.schema";
 import invalidDataSchema from "./invalid-data.schema";
@@ -40,6 +41,7 @@ export {
     controlPluginSchema,
     defaultsSchema,
     dictionarySchema,
+    disabledSchema,
     generalExampleSchema,
     generalSchema,
     invalidDataSchema,

--- a/packages/fast-tooling-react/src/form/controls/control.section.style.ts
+++ b/packages/fast-tooling-react/src/form/controls/control.section.style.ts
@@ -8,7 +8,9 @@ const styles: ComponentStyles<SectionControlClassNameContract, {}> = {
         border: "none",
         "min-inline-size": "unset", // override for fieldsets inherited style
     },
-    sectionControl__disabled: {},
+    sectionControl__disabled: {
+        opacity: "1", // override the fieldset disabled inherited style
+    },
 };
 
 export default styles;

--- a/packages/fast-tooling-react/src/form/templates/const-value.props.ts
+++ b/packages/fast-tooling-react/src/form/templates/const-value.props.ts
@@ -1,4 +1,17 @@
 export interface ConstValueProps {
+    /**
+     * The class name
+     */
     className: string;
+
+    /**
+     * The onChange callback to set
+     * the value to the const
+     */
     onChange: () => void;
+
+    /**
+     * The disabled state
+     */
+    disabled: boolean;
 }

--- a/packages/fast-tooling-react/src/form/templates/const-value.tsx
+++ b/packages/fast-tooling-react/src/form/templates/const-value.tsx
@@ -4,7 +4,11 @@ import { ConstValueProps } from "./const-value.props";
 class ConstValue extends React.Component<ConstValueProps, {}> {
     public render(): React.ReactNode {
         return (
-            <button className={this.props.className} onClick={this.props.onChange}>
+            <button
+                className={this.props.className}
+                onClick={this.props.onChange}
+                disabled={this.props.disabled}
+            >
                 <svg
                     width={"13"}
                     height={"13"}

--- a/packages/fast-tooling-react/src/form/templates/default-value.props.ts
+++ b/packages/fast-tooling-react/src/form/templates/default-value.props.ts
@@ -1,4 +1,17 @@
 export interface DefaultValueProps {
+    /**
+     * The class name
+     */
     className: string;
+
+    /**
+     * The onChange callback to set
+     * the value to the default
+     */
     onChange: () => void;
+
+    /**
+     * The disabled state
+     */
+    disabled: boolean;
 }

--- a/packages/fast-tooling-react/src/form/templates/default-value.tsx
+++ b/packages/fast-tooling-react/src/form/templates/default-value.tsx
@@ -4,7 +4,11 @@ import { DefaultValueProps } from "./default-value.props";
 class DefaultValue extends React.Component<DefaultValueProps, {}> {
     public render(): React.ReactNode {
         return (
-            <button className={this.props.className} onClick={this.props.onChange}>
+            <button
+                className={this.props.className}
+                onClick={this.props.onChange}
+                disabled={this.props.disabled}
+            >
                 <svg
                     viewBox={"0 0 16 16"}
                     height={"14"}

--- a/packages/fast-tooling-react/src/form/templates/template.control.bare.style.ts
+++ b/packages/fast-tooling-react/src/form/templates/template.control.bare.style.ts
@@ -1,5 +1,4 @@
 import { ComponentStyles } from "@microsoft/fast-jss-manager-react";
-import { formControlDisabledStyle } from "../../style";
 
 export interface BareControlTemplateClassNameContract {
     bareControlTemplate?: string;
@@ -8,9 +7,7 @@ export interface BareControlTemplateClassNameContract {
 
 const style: ComponentStyles<BareControlTemplateClassNameContract, {}> = {
     bareControlTemplate: {},
-    bareControlTemplate__disabled: {
-        ...formControlDisabledStyle,
-    },
+    bareControlTemplate__disabled: {},
 };
 
 export default style;

--- a/packages/fast-tooling-react/src/form/templates/template.control.utilities.tsx
+++ b/packages/fast-tooling-react/src/form/templates/template.control.utilities.tsx
@@ -41,7 +41,11 @@ abstract class ControlTemplateUtilities<P, S> extends React.Component<
                     className={className}
                     checked={this.props.data !== undefined}
                     onChange={this.handleSoftRemove}
-                    disabled={this.props.data === undefined && this.cache === undefined}
+                    disabled={
+                        this.props.disabled &&
+                        this.props.data === undefined &&
+                        this.cache === undefined
+                    }
                 />
             );
         }
@@ -62,7 +66,11 @@ abstract class ControlTemplateUtilities<P, S> extends React.Component<
     public renderConstValueIndicator(className: string): React.ReactNode {
         if (this.props.const !== undefined && this.props.data !== this.props.const) {
             return (
-                <ConstValue className={className} onChange={this.handleSetConstValue} />
+                <ConstValue
+                    className={className}
+                    disabled={this.props.disabled}
+                    onChange={this.handleSetConstValue}
+                />
             );
         }
     }
@@ -79,6 +87,7 @@ abstract class ControlTemplateUtilities<P, S> extends React.Component<
             return (
                 <DefaultValue
                     className={className}
+                    disabled={this.props.disabled}
                     onChange={this.handleSetDefaultValue}
                 />
             );


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Does the following:
- Removes disabled styling from the `<fieldset>` which represents objects. This was causing a multiplication effect on contained types on opacity.
- Adds a disabled prop to the components which now prevents a user from modifying the value via the generated UI for setting const, default and soft remove.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Resolves #2796

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->