### PR TITLE
fix: update to avoid null ref error on horizontal overflow mount

### DIFF
--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -676,7 +676,7 @@ class HorizontalOverflow extends Foundation<
      */
     private getItemWidths(): number[] {
         if (isNil(this.horizontalOverflowItemsRef.current)) {
-            return null;
+            return [];
         }
         const items: HTMLElement[] = Array.prototype.slice.call(
             this.horizontalOverflowItemsRef.current.childNodes


### PR DESCRIPTION
# Description
A recent change to horizontal overflow added an isOverflow() check on mount which could result in a null ref error when the item container ref was null.    Straightforward fix was to have getItemWidths() return an empty array rather than null when the ref is nil.

## Motivation & context
Manifested in partner tests.  Not sure how to replicate this in our test environment - ie. trigger componentDidMount without having a valid container ref.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.