### PR TITLE
feat(fast-element): boolean attributes and type conversion

### DIFF
--- a/packages/fast-element/src/attributes.ts
+++ b/packages/fast-element/src/attributes.ts
@@ -1,20 +1,138 @@
+import { Observable } from "./observation/observable";
+
+export interface ValueConverter {
+    toView(value: any): string;
+    fromView(value: string): any;
+}
+
+export type AttributeMode = "reflect" | "boolean" | "none";
+
 export type AttributeConfiguration = {
     property: string;
     attribute?: string;
+    mode?: AttributeMode;
+    converter?: ValueConverter;
 };
 
 export type DecoratorAttributeConfiguration = Omit<AttributeConfiguration, "property">;
 
+export const booleanConverter: ValueConverter = {
+    toView(value: any): string {
+        return value ? "true" : "false";
+    },
+
+    fromView(value: any): any {
+        if (
+            value === null ||
+            value === void 0 ||
+            value === "" ||
+            value === "false" ||
+            value === false ||
+            value === 0
+        ) {
+            return false;
+        }
+
+        return true;
+    },
+};
+
 export class AttributeDefinition {
+    private readonly fieldName: string;
+    private readonly callbackName: string;
+    private readonly hasCallback: boolean;
+    private readonly guards = new Set();
+
     public constructor(
+        public readonly Owner: Function,
         public readonly property: string,
-        public readonly attribute: string = property.toLowerCase()
-    ) {}
+        public readonly attribute: string = property.toLowerCase(),
+        public readonly mode: AttributeMode = "reflect",
+        public readonly converter?: ValueConverter
+    ) {
+        this.fieldName = `_${property}`;
+        this.callbackName = `${property}Changed`;
+        this.hasCallback = this.callbackName in Owner.prototype;
+
+        if (mode === "boolean" && converter === void 0) {
+            this.converter = booleanConverter;
+        }
+    }
+
+    public setValue(object: any, newValue: any) {
+        const oldValue = object[this.fieldName];
+        const converter = this.converter;
+
+        if (converter !== void 0) {
+            newValue = converter.fromView(newValue);
+        }
+
+        if (oldValue !== newValue) {
+            object[this.fieldName] = newValue;
+
+            this.tryReflectToAttribute(object, newValue, converter);
+
+            if (this.hasCallback) {
+                object[this.callbackName](oldValue, newValue);
+            }
+
+            Observable.notify(object, this.property);
+        }
+    }
+
+    public getValue(object: any): any {
+        Observable.track(object, this.property);
+        return object[this.fieldName];
+    }
+
+    public onAttributeChangedCallback(object: any, value: any) {
+        if (this.guards.has(object)) {
+            return;
+        }
+
+        this.guards.add(object);
+        this.setValue(object, value);
+        this.guards.delete(object);
+    }
+
+    private tryReflectToAttribute(
+        object: any,
+        newValue: any,
+        converter?: ValueConverter
+    ) {
+        const mode = this.mode;
+
+        if (this.guards.has(object) || mode === "none") {
+            return;
+        }
+
+        this.guards.add(object);
+
+        switch (mode) {
+            case "reflect":
+                if (converter !== void 0) {
+                    newValue = converter.toView(newValue);
+                }
+
+                (object as HTMLElement).setAttribute(this.attribute, newValue);
+                break;
+            case "boolean":
+                newValue
+                    ? (object as HTMLElement).setAttribute(this.attribute, "")
+                    : (object as HTMLElement).removeAttribute(this.attribute);
+                break;
+        }
+
+        this.guards.delete(object);
+    }
 
     public static collect(
+        Owner: Function,
         ...attributeLists: (ReadonlyArray<string | AttributeConfiguration> | undefined)[]
     ): ReadonlyArray<AttributeDefinition> {
         const attributes: AttributeDefinition[] = [];
+
+        attributeLists.push((Owner as any).attributes);
 
         for (let i = 0, ii = attributeLists.length; i < ii; ++i) {
             const list = attributeLists[i];
@@ -27,10 +145,16 @@ export class AttributeDefinition {
                 const config = list[j];
 
                 if (typeof config === "string") {
-                    attributes.push(new AttributeDefinition(config));
+                    attributes.push(new AttributeDefinition(Owner, config));
                 } else {
                     attributes.push(
-                        new AttributeDefinition(config.property, config.attribute)
+                        new AttributeDefinition(
+                            Owner,
+                            config.property,
+                            config.attribute,
+                            config.mode,
+                            config.converter
+                        )
                     );
                 }
             }

--- a/packages/fast-element/src/controller.ts
+++ b/packages/fast-element/src/controller.ts
@@ -68,7 +68,11 @@ export class Controller extends PropertyChangeNotifier implements Container {
     }
 
     public onAttributeChangedCallback(name: string, oldValue: string, newValue: string) {
-        (this.element as any)[this.definition.attributeLookup[name].property] = newValue;
+        const attrDef = this.definition.attributeLookup[name];
+
+        if (attrDef !== void 0) {
+            attrDef.onAttributeChangedCallback(this.element, newValue);
+        }
     }
 
     public emit(type: string, detail?: any, options?: Omit<CustomEventInit, "detail">) {

--- a/packages/fast-element/src/fast-element.ts
+++ b/packages/fast-element/src/fast-element.ts
@@ -60,10 +60,7 @@ export const FastElement = Object.assign(createFastElement(HTMLElement), {
         }
 
         const name = nameOrDef.name;
-        const attributes = AttributeDefinition.collect(
-            (Type as any).attributes,
-            nameOrDef.attributes
-        );
+        const attributes = AttributeDefinition.collect(Type, nameOrDef.attributes);
         const shadowOptions =
             nameOrDef.shadowOptions === void 0
                 ? defaultShadowOptions
@@ -83,10 +80,19 @@ export const FastElement = Object.assign(createFastElement(HTMLElement), {
 
         for (let i = 0, ii = attributes.length; i < ii; ++i) {
             const current = attributes[i];
-            Observable.define(proto, current.property);
             observedAttributes[i] = current.attribute;
             propertyLookup[current.property] = current;
             attributeLookup[current.attribute] = current;
+
+            Reflect.defineProperty(proto, current.property, {
+                enumerable: true,
+                get: function(this: any) {
+                    return current.getValue(this);
+                },
+                set: function(this: any, value) {
+                    return current.setValue(this, value);
+                },
+            });
         }
 
         Reflect.defineProperty(Type, "observedAttributes", {

--- a/packages/fast-element/src/observation/observable.ts
+++ b/packages/fast-element/src/observation/observable.ts
@@ -60,14 +60,14 @@ export const Observable = {
                 Observable.track(this, propertyName);
                 return this[fieldName];
             },
-            set: function(this: any, value) {
+            set: function(this: any, newValue) {
                 const oldValue = this[fieldName];
 
-                if (oldValue !== value) {
-                    this[fieldName] = value;
+                if (oldValue !== newValue) {
+                    this[fieldName] = newValue;
 
                     if (hasCallback) {
-                        this[callbackName]();
+                        this[callbackName](oldValue, newValue);
                     }
 
                     Observable.notify(this, propertyName);


### PR DESCRIPTION
# Description

This PR adds support for type conversion of attribute values as well as boolean attribute behavior.

## Motivation & context

Specifically, this PR implements #2742 by adding new APIs to the AttributeDefinition class, which is now used by attribute getters and setters to change values. The APIs are also used to respond to the onAttributeChangedCallback.

The feature enables three modes (`reflect`, `boolean`, `none`) per the above issue, and also enables a custom converter, per the above issue. A `booleanConverter` is provided out of the box and is automatically set when in `boolean` mode.

Here's how one would create a custom element with a boolean attribute behavior:

```TypeScript
@customElement(...)
export class Switch extends FastElement {
  @attr({ mode: 'boolean' }) disabled = false;
}
```

This PR also updates change handlers for attr and observable to pass the old and new values.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

> **NOTE:** I'll be updating the documentation on attributes to explain these new capabilities. I'll add it as an additional commit to this PR and update the checklist above, but have not done this work yet. That should not block review of the code in this PR.