### PR TITLE
fix: horizontal overflow - add initial value to reduce fn to avoid throw

### DIFF
--- a/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
+++ b/packages/fast-components-react-base/src/horizontal-overflow/horizontal-overflow.tsx
@@ -440,7 +440,10 @@ class HorizontalOverflow extends Foundation<
     private isOverflow(): boolean {
         const availableWidth: number = this.getAvailableWidth();
         const itemWidths: number[] = this.getItemWidths();
-        const totalItemWidth: number = itemWidths.reduce((a: number, b: number) => a + b);
+        const totalItemWidth: number = itemWidths.reduce(
+            (a: number, b: number) => a + b,
+            0
+        );
 
         return totalItemWidth > availableWidth;
     }


### PR DESCRIPTION
# Description
We were using a reduce function without an inial value so it could throw on an empty array.  Added an initial value of 0.

## Motivation & context
Avoid throwing error

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
