### PR TITLE
fix(fast-element): ensure host attributes have a target name

### DIFF
--- a/packages/fast-element/src/template-compiler.ts
+++ b/packages/fast-element/src/template-compiler.ts
@@ -105,12 +105,12 @@ function compileAttributes(
 
     for (let i = 0, ii = attributes.length; i < ii; ++i) {
         const attr = attributes[i];
-        const attrName = attr.name;
         const attrValue = attr.value;
         let directive = tryParsePlaceholders(attrValue, directives);
 
         if (directive === null && includeBasicValues) {
             directive = new BindingDirective(x => attrValue);
+            directive.targetName = attr.name;
         }
 
         if (directive !== null) {


### PR DESCRIPTION
# Description

Host attributes that don't have a special directive associated with them are missing their attribute name.

## Motivation & context

This PR fixes a host attribute bug that was an oversight during the last revamp of how attribute and property binding works.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

## Next Steps

This particular bug and another one from earlier this week signals to me that we are far enough along where we need to get tests on the core library, so we can prevent regressions. Up until the last two weeks, various aspects of the library have been volatile enough that extensive tests would have slowed down the ability to revise and pivot quickly. I think we're past that point now and we need to get the infrastructure and some basic tests in place. Unless we have another urgent need, I plan to make that my next task.