### PR TITLE
fix: select focus on trigger on click selection in menu

### DIFF
--- a/packages/fast-components-react-base/src/select/select.spec.tsx
+++ b/packages/fast-components-react-base/src/select/select.spec.tsx
@@ -38,9 +38,6 @@ const managedClasses: SelectClassNameContract = {
     select__menuPositionVerticalInset: "select__menuPositionVerticalInset",
 };
 
-const container: HTMLDivElement = document.createElement("div");
-document.body.appendChild(container);
-
 describe("select", (): void => {
     test("should have a displayName that matches the component name", () => {
         expect(`${DisplayNamePrefix}${(Select as any).name}`).toBe(Select.displayName);
@@ -589,5 +586,51 @@ describe("select", (): void => {
         const preventDefault: jest.Mock = jest.fn();
         rendered.simulate("click", { preventDefault });
         expect(preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    test("trigger element is focused after menu selection via keyboard", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const rendered: any = mount(
+            <Select>
+                {itemA}
+                {itemB}
+                {itemC}
+            </Select>,
+            { attachTo: container }
+        );
+
+        rendered.simulate("click");
+        expect(rendered.state("isMenuOpen")).toBe(true);
+        rendered
+            .find('[displayString="a"]')
+            .simulate("keydown", { keyCode: keyCodeSpace });
+        expect(rendered.state("isMenuOpen")).toBe(false);
+        expect(document.activeElement.id.startsWith("selecttrigger")).toBe(true);
+
+        document.body.removeChild(container);
+    });
+
+    test("trigger element is focused after menu selection via click", (): void => {
+        const container: HTMLDivElement = document.createElement("div");
+        document.body.appendChild(container);
+
+        const rendered: any = mount(
+            <Select>
+                {itemA}
+                {itemB}
+                {itemC}
+            </Select>,
+            { attachTo: container }
+        );
+
+        rendered.simulate("click");
+        expect(rendered.state("isMenuOpen")).toBe(true);
+        rendered.find('[displayString="a"]').simulate("click");
+        expect(rendered.state("isMenuOpen")).toBe(false);
+        expect(document.activeElement.id.startsWith("selecttrigger")).toBe(true);
+
+        document.body.removeChild(container);
     });
 });

--- a/packages/fast-components-react-base/src/select/select.tsx
+++ b/packages/fast-components-react-base/src/select/select.tsx
@@ -509,6 +509,9 @@ class Select extends Foundation<SelectHandledProps, SelectUnhandledProps, Select
         }
         e.preventDefault();
         this.toggleMenu(!this.state.isMenuOpen);
+        if (this.validateMenuState(!this.state.isMenuOpen) === false) {
+            this.focusTriggerElement();
+        }
     };
 
     /**


### PR DESCRIPTION
# Description
When a menu item is selected via click we will force focus to the trigger element.  We previously did this only for keyboard selection but some accessiblity scenarios benefit from ensuring focus remains on the component with mouse/touch selection as well.

## Motivation & context
Partners raised issue.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.