### PR TITLE
fix: correct tabs interaction model to map to the w3c specification and add default orientation

### DIFF
--- a/packages/fast-components-react-base/src/tabs/tabs.spec.tsx
+++ b/packages/fast-components-react-base/src/tabs/tabs.spec.tsx
@@ -206,7 +206,7 @@ describe("tabs", (): void => {
         );
     });
 
-    test("should have an aria-orientation if the orientation prop is passed", () => {
+    test("should set an aria-orientation value equal to the value of the orientation prop when passed", () => {
         const renderedWithChildren: any = mount(
             <Tabs managedClasses={tabsManagedClasses} label={"items"}>
                 {children}
@@ -231,7 +231,6 @@ describe("tabs", (): void => {
             </Tabs>
         );
 
-        expect(renderedWithChildren.find("[aria-orientation]")).toHaveLength(0);
         expect(
             renderedWithChildrenHorizontal.find("[aria-orientation]").props()[
                 "aria-orientation"
@@ -242,6 +241,16 @@ describe("tabs", (): void => {
                 "aria-orientation"
             ]
         ).toBe(Orientation.vertical);
+    });
+
+    test("should set a default orientation of `horizontal`", () => {
+        const renderedWithChildren: any = mount(
+            <Tabs managedClasses={tabsManagedClasses} label={"items"}>
+                {children}
+            </Tabs>
+        );
+
+        expect(renderedWithChildren.prop("orientation")).toBe(Orientation.horizontal);
     });
 
     test("should use an id prop passed to a TabItem as aria-controls on the Tab and aria-labelledby on the TabPanel", () => {
@@ -360,9 +369,33 @@ describe("tabs", (): void => {
         expect(renderedWithChildren.prop("children")).not.toBe(undefined);
     });
 
-    test("should prevent default behavior on arrow down to prevent scroll events", (): void => {
+    test("should NOT prevent default behavior on arrow down to prevent scroll events when horizontally oriented", (): void => {
         const rendered: any = mount(
-            <Tabs managedClasses={tabsManagedClasses} label={"items"}>
+            <Tabs
+                managedClasses={tabsManagedClasses}
+                label={"items"}
+                orientation={Orientation.horizontal}
+            >
+                {children}
+            </Tabs>
+        );
+
+        const preventDefault: any = jest.fn();
+        const tab1: any = rendered.find(Tab.displayName).at(0);
+        tab1.simulate("keydown", { keyCode: keyCodeArrowDown, preventDefault });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+
+        rendered.unmount();
+    });
+
+    test("should prevent default behavior on arrow down to prevent scroll events when vertically oriented", (): void => {
+        const rendered: any = mount(
+            <Tabs
+                managedClasses={tabsManagedClasses}
+                label={"items"}
+                orientation={Orientation.vertical}
+            >
                 {children}
             </Tabs>
         );
@@ -372,11 +405,38 @@ describe("tabs", (): void => {
         tab1.simulate("keydown", { keyCode: keyCodeArrowDown, preventDefault });
 
         expect(preventDefault).toHaveBeenCalled();
+
+        rendered.unmount();
     });
 
-    test("should prevent default behavior on arrow up to prevent scroll events", (): void => {
+    test("should NOT prevent default behavior on arrow up to prevent scroll events when horizontally oriented", (): void => {
         const rendered: any = mount(
-            <Tabs managedClasses={tabsManagedClasses} label={"items"}>
+            <Tabs
+                managedClasses={tabsManagedClasses}
+                label={"items"}
+                orientation={Orientation.horizontal}
+            >
+                {children}
+            </Tabs>
+        );
+
+        const preventDefault: any = jest.fn();
+        const tab2: any = rendered.find(Tab.displayName).at(1);
+
+        tab2.simulate("keydown", { keyCode: keyCodeArrowUp, preventDefault });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+
+        rendered.unmount();
+    });
+
+    test("should prevent default behavior on arrow up to prevent scroll events when vertically oriented", (): void => {
+        const rendered: any = mount(
+            <Tabs
+                managedClasses={tabsManagedClasses}
+                label={"items"}
+                orientation={Orientation.vertical}
+            >
                 {children}
             </Tabs>
         );
@@ -387,6 +447,89 @@ describe("tabs", (): void => {
         tab2.simulate("keydown", { keyCode: keyCodeArrowUp, preventDefault });
 
         expect(preventDefault).toHaveBeenCalled();
+
+        rendered.unmount();
+    });
+
+    test("should NOT prevent default behavior on arrow left to prevent scroll events when vertically oriented", (): void => {
+        const rendered: any = mount(
+            <Tabs
+                managedClasses={tabsManagedClasses}
+                label={"items"}
+                orientation={Orientation.vertical}
+            >
+                {children}
+            </Tabs>
+        );
+
+        const preventDefault: any = jest.fn();
+        const tab1: any = rendered.find(Tab.displayName).at(0);
+        tab1.simulate("keydown", { keyCode: keyCodeArrowLeft, preventDefault });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+
+        rendered.unmount();
+    });
+
+    test("should prevent default behavior on arrow left to prevent scroll events when horizontally oriented", (): void => {
+        const rendered: any = mount(
+            <Tabs
+                managedClasses={tabsManagedClasses}
+                label={"items"}
+                orientation={Orientation.horizontal}
+            >
+                {children}
+            </Tabs>
+        );
+
+        const preventDefault: any = jest.fn();
+        const tab1: any = rendered.find(Tab.displayName).at(0);
+        tab1.simulate("keydown", { keyCode: keyCodeArrowLeft, preventDefault });
+
+        expect(preventDefault).toHaveBeenCalled();
+
+        rendered.unmount();
+    });
+
+    test("should NOT prevent default behavior on arrow right to prevent scroll events when vertically oriented", (): void => {
+        const rendered: any = mount(
+            <Tabs
+                managedClasses={tabsManagedClasses}
+                label={"items"}
+                orientation={Orientation.vertical}
+            >
+                {children}
+            </Tabs>
+        );
+
+        const preventDefault: any = jest.fn();
+        const tab1: any = rendered.find(Tab.displayName).at(0);
+        tab1.simulate("keydown", { keyCode: keyCodeArrowRight, preventDefault });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+
+        rendered.unmount();
+    });
+
+    test("should prevent default behavior on arrow right to prevent scroll events when horizontally oriented", (): void => {
+        const rendered: any = mount(
+            <Tabs
+                managedClasses={tabsManagedClasses}
+                label={"items"}
+                orientation={Orientation.horizontal}
+            >
+                {children}
+            </Tabs>
+        );
+
+        const preventDefault: any = jest.fn();
+        const tab2: any = rendered.find(Tab.displayName).at(1);
+
+        tab2.simulate("keydown", { keyCode: keyCodeArrowRight, preventDefault });
+
+        expect(preventDefault).toHaveBeenCalled();
+
+        rendered.unmount();
     });
 
     test("should allow a user to control the component from a callback", () => {
@@ -525,89 +668,7 @@ describe("tabs", (): void => {
                 .prop("active")
         ).toBe(false);
 
-        tab1.simulate("keydown", { keyCode: keyCodeArrowUp });
-
-        expect(onUpdate).toBeCalledWith(id2);
-
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(0)
-                .prop("tabIndex")
-        ).toEqual(0);
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(1)
-                .prop("tabIndex")
-        ).toEqual(-1);
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(2)
-                .prop("tabIndex")
-        ).toEqual(-1);
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(0)
-                .prop("active")
-        ).toBe(true);
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(1)
-                .prop("active")
-        ).toBe(false);
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(2)
-                .prop("active")
-        ).toBe(false);
-
         tab1.simulate("keydown", { keyCode: keyCodeArrowRight });
-
-        expect(onUpdate).toBeCalledWith(id1);
-
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(0)
-                .prop("tabIndex")
-        ).toEqual(0);
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(1)
-                .prop("tabIndex")
-        ).toEqual(-1);
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(2)
-                .prop("tabIndex")
-        ).toEqual(-1);
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(0)
-                .prop("active")
-        ).toBe(true);
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(1)
-                .prop("active")
-        ).toBe(false);
-        expect(
-            rendered
-                .find(Tab.displayName)
-                .at(2)
-                .prop("active")
-        ).toBe(false);
-
-        tab1.simulate("keydown", { keyCode: keyCodeArrowDown });
 
         expect(onUpdate).toBeCalledWith(id1);
 
@@ -810,6 +871,7 @@ describe("tabs", (): void => {
         const rendered: any = mount(
             <Tabs
                 managedClasses={tabsManagedClasses}
+                orientation={Orientation.vertical}
                 children={children}
                 label={"items"}
             />
@@ -856,7 +918,7 @@ describe("tabs", (): void => {
                 .prop("active")
         ).toBe(false);
 
-        tab1.simulate("keydown", { keyCode: keyCodeArrowLeft });
+        tab1.simulate("keydown", { keyCode: keyCodeArrowUp });
 
         expect(
             rendered
@@ -934,7 +996,7 @@ describe("tabs", (): void => {
                 .prop("active")
         ).toBe(false);
 
-        tab2.simulate("keydown", { keyCode: keyCodeArrowLeft });
+        tab2.simulate("keydown", { keyCode: keyCodeArrowUp });
 
         expect(
             rendered
@@ -973,7 +1035,7 @@ describe("tabs", (): void => {
                 .prop("active")
         ).toBe(false);
 
-        tab1.simulate("keydown", { keyCode: keyCodeArrowRight });
+        tab1.simulate("keydown", { keyCode: keyCodeArrowDown });
 
         expect(
             rendered
@@ -1051,7 +1113,7 @@ describe("tabs", (): void => {
                 .prop("active")
         ).toBe(true);
 
-        tab3.simulate("keydown", { keyCode: keyCodeArrowRight });
+        tab3.simulate("keydown", { keyCode: keyCodeArrowDown });
 
         expect(
             rendered

--- a/packages/fast-components-react-base/src/tabs/tabs.tsx
+++ b/packages/fast-components-react-base/src/tabs/tabs.tsx
@@ -8,6 +8,7 @@ import {
     keyCodeArrowUp,
     keyCodeEnd,
     keyCodeHome,
+    Orientation,
 } from "@microsoft/fast-web-utilities";
 import { get } from "lodash-es";
 import React from "react";
@@ -37,6 +38,7 @@ export interface TabsState {
 
 class Tabs extends Foundation<TabsHandledProps, TabsUnhandledProps, TabsState> {
     public static defaultProps: Partial<TabsProps> = {
+        orientation: Orientation.horizontal,
         disableTabFocus: false,
         managedClasses: {},
     };
@@ -316,18 +318,33 @@ class Tabs extends Foundation<TabsHandledProps, TabsUnhandledProps, TabsState> {
      * Handles the keydown event on the tab element
      */
     private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
-        switch (e.keyCode) {
-            case keyCodeArrowLeft:
-            case keyCodeArrowUp:
-                e.preventDefault();
-                this.activateTab(TabLocation.previous);
-                break;
-            case keyCodeArrowRight:
-            case keyCodeArrowDown:
-                e.preventDefault();
+        const keyCode: number = e.keyCode;
 
-                this.activateTab(TabLocation.next);
-                break;
+        if (this.props.orientation === Orientation.horizontal) {
+            switch (keyCode) {
+                case keyCodeArrowLeft:
+                    e.preventDefault();
+                    this.activateTab(TabLocation.previous);
+                    break;
+                case keyCodeArrowRight:
+                    e.preventDefault();
+                    this.activateTab(TabLocation.next);
+                    break;
+            }
+        } else {
+            switch (e.keyCode) {
+                case keyCodeArrowUp:
+                    e.preventDefault();
+                    this.activateTab(TabLocation.previous);
+                    break;
+                case keyCodeArrowDown:
+                    e.preventDefault();
+                    this.activateTab(TabLocation.next);
+                    break;
+            }
+        }
+
+        switch (keyCode) {
             case keyCodeHome:
                 this.activateTab(TabLocation.first);
                 break;

--- a/packages/fast-components-react-msft/src/carousel/carousel.tsx
+++ b/packages/fast-components-react-msft/src/carousel/carousel.tsx
@@ -2,7 +2,7 @@ import { TabsClassNameContract } from "@microsoft/fast-components-class-name-con
 import { CarouselClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { Tabs, TabsItem } from "@microsoft/fast-components-react-base";
-import { classNames } from "@microsoft/fast-web-utilities";
+import { classNames, Orientation } from "@microsoft/fast-web-utilities";
 import { canUseDOM } from "exenv-es6";
 import { get, isNil } from "lodash-es";
 import React from "react";
@@ -113,6 +113,7 @@ class Carousel extends Foundation<
                     onUpdate={this.handleUpdate}
                     items={this.slides as TabsItem[]}
                     managedClasses={this.generateTabsClassNames()}
+                    orientation={Orientation.horizontal}
                     disableTabFocus={this.props.autoplay}
                 />
                 {this.generateNextFlipper()}

--- a/packages/fast-components-react-msft/src/pivot/pivot.tsx
+++ b/packages/fast-components-react-msft/src/pivot/pivot.tsx
@@ -3,7 +3,7 @@ import { PivotClassNameContract } from "@microsoft/fast-components-class-name-co
 import Foundation, { HandledProps } from "@microsoft/fast-components-foundation-react";
 import { Tabs as BaseTabs } from "@microsoft/fast-components-react-base";
 import { toPx } from "@microsoft/fast-jss-utilities";
-import { classNames, Direction } from "@microsoft/fast-web-utilities";
+import { classNames, Direction, Orientation } from "@microsoft/fast-web-utilities";
 import { canUseDOM } from "exenv-es6";
 import { get } from "lodash-es";
 import React from "react";
@@ -104,6 +104,7 @@ class Pivot extends Foundation<PivotHandledProps, PivotUnhandledProps, PivotStat
                 managedClasses={this.generatePivotClassNames()}
                 activeId={this.state.activeId}
                 onUpdate={this.handleTabsUpdate}
+                orientation={this.props.orientation}
                 items={this.props.items}
                 label={this.props.label}
             >


### PR DESCRIPTION
# Description
This change fixes the interaction model to align with the W3C specification.

## Motivation & context
It was recently brought to my attention that the MSFT carousel and pivot components both prevent page scroll behavior on arrow up/down events. While that behavior is expected for vertically oriented tabs, it is unexpected for horizontally oriented tabs. The [W3C specification](https://w3c.github.io/aria-practices/#keyboard-interaction-20) specifically details that horizontal tabs do not listen for up/down events to enable the default browser behavior:
> If the tab list is horizontal, it does not listen for Down Arrow or Up Arrow so those keys can provide their normal browser scrolling functions even when focus is inside the tab list.

With this in mind, I've updated the control to behave as expected. In addition, this change reveals a need to align to a single orientation by default. Given that the spec reads as though the default is horizontal and our two first class "styled" implementations are horizontal, this PR proposes a default value of "horizontal". 

While this change technically breaks existing behavior, that behavior is incorrect. I believe this should be classified as a fix without the designation of a "breaking change".

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->