### PR TITLE
fix: update breadcrumbs to have the proper sequence when nesting linked data

### DIFF
--- a/packages/fast-tooling-react/src/form/utilities/breadcrumb.spec.ts
+++ b/packages/fast-tooling-react/src/form/utilities/breadcrumb.spec.ts
@@ -89,24 +89,61 @@ describe("getDictionaryBreadcrumbs", () => {
                                 type: DataType.object,
                                 items: [],
                             },
+                            baz: {
+                                self: "baz",
+                                parent: "",
+                                relativeDataLocation: "baz",
+                                schemaLocation: "properties.baz",
+                                schema: {},
+                                disabled: false,
+                                data: {},
+                                text: "General example child 1",
+                                type: DataType.object,
+                                items: [],
+                            },
+                        },
+                        "",
+                    ],
+                    bat: [
+                        {
+                            "": {
+                                self: "",
+                                parent: null,
+                                parentDictionaryItem: {
+                                    id: "bar",
+                                    dataLocation: "baz",
+                                },
+                                relativeDataLocation: "",
+                                schemaLocation: "",
+                                schema: {},
+                                disabled: false,
+                                data: {},
+                                text: "General example child 1 child",
+                                type: DataType.object,
+                                items: [],
+                            },
                         },
                         "",
                     ],
                 },
                 "foo",
             ],
-            "bar",
+            "bat",
             "",
             jest.fn()
         );
 
-        expect(breadcrumbs.length).toBe(3);
+        expect(breadcrumbs.length).toBe(5);
         expect(breadcrumbs[0].href).toBe("");
         expect(breadcrumbs[0].text).toBe("General example root");
         expect(breadcrumbs[1].href).toBe("bat");
         expect(breadcrumbs[1].text).toBe("General example property");
         expect(breadcrumbs[2].href).toBe("");
         expect(breadcrumbs[2].text).toBe("General example child");
+        expect(breadcrumbs[3].href).toBe("baz");
+        expect(breadcrumbs[3].text).toBe("General example child 1");
+        expect(breadcrumbs[4].href).toBe("");
+        expect(breadcrumbs[4].text).toBe("General example child 1 child");
     });
 });
 
@@ -185,5 +222,8 @@ describe("getBreadcrumbs", () => {
         );
 
         expect(breadcrumbs.length).toBe(3);
+        expect(breadcrumbs[0].text).toBe("C");
+        expect(breadcrumbs[1].text).toBe("B");
+        expect(breadcrumbs[2].text).toBe("A");
     });
 });

--- a/packages/fast-tooling-react/src/form/utilities/breadcrumb.ts
+++ b/packages/fast-tooling-react/src/form/utilities/breadcrumb.ts
@@ -24,24 +24,41 @@ export function getDictionaryBreadcrumbs(
     navigationDictionary: NavigationConfigDictionary,
     dictionaryId: string,
     navigationConfigId: string,
+    handleClick: HandleBreadcrumbClick
+): BreadcrumbItem[] {
+    return resolveDictionaryBreadcrumbs(
+        navigationDictionary,
+        dictionaryId,
+        navigationConfigId,
+        handleClick
+    ).reverse();
+}
+
+/**
+ * Resolve breadcrumbs from navigation dictionary
+ */
+export function resolveDictionaryBreadcrumbs(
+    navigationDictionary: NavigationConfigDictionary,
+    dictionaryId: string,
+    navigationConfigId: string,
     handleClick: HandleBreadcrumbClick,
     breadcrumbItemList: BreadcrumbItem[][] = []
 ): BreadcrumbItem[] {
-    const breadcrumbItems: BreadcrumbItem[][] = [
+    const breadcrumbItems: BreadcrumbItem[][] = breadcrumbItemList.concat([
         getBreadcrumbs(
             navigationDictionary[0][dictionaryId][0],
             dictionaryId,
             navigationConfigId,
             handleClick
         ),
-    ].concat(breadcrumbItemList);
+    ]);
 
     const breadcrumbParent: Parent | undefined =
         navigationDictionary[0][dictionaryId][0][navigationDictionary[0][dictionaryId][1]]
             .parentDictionaryItem;
 
     if (typeof breadcrumbParent !== "undefined") {
-        return getDictionaryBreadcrumbs(
+        return resolveDictionaryBreadcrumbs(
             navigationDictionary,
             breadcrumbParent.id,
             breadcrumbParent.dataLocation, // unsafe replace with a search to find the dictionary id of this
@@ -91,5 +108,5 @@ export function getBreadcrumbs(
         );
     }
 
-    return navigationItems.reverse();
+    return navigationItems;
 }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Corrects an issue where there was incorrect sequence of the breadcrumbs displaying where sometimes the items were reversed. This now reverses all breadcrumb items at the end of the process.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->