### PR TITLE
fix(fast-element): ensure node exists when checking if it's a marker

### DIFF
--- a/packages/fast-element/src/dom.ts
+++ b/packages/fast-element/src/dom.ts
@@ -34,7 +34,9 @@ export const DOM = Object.freeze({
     },
 
     isMarker(node: Node): node is Comment {
-        return node.nodeType === 8 && (node as Comment).data.startsWith(markerClass);
+        return (
+            node && node.nodeType === 8 && (node as Comment).data.startsWith(markerClass)
+        );
     },
 
     extractDirectiveIndexFromMarker(node: Comment): number {


### PR DESCRIPTION
# Description

When checking if a node is a marker node, ensure that it is not null or undefined.

## Motivation & context

While working on the `fast-divider` component, @chrisdholt discovered an odd case where the compiler would throw on one of two nearly-identical templates. The only difference is that one template had no children, and the second had a single empty text node. As it turns out, the compiler was not accounting for the case where a template would have no child nodes. It seems an odd case, but is legitimate. This PR fixes the issue by checking before accessing properties on the node.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.