### PR TITLE
feat(fast-element): add multi property binding support

### DIFF
--- a/packages/fast-element/src/attributes.ts
+++ b/packages/fast-element/src/attributes.ts
@@ -1,5 +1,6 @@
 import { Observable } from "./observation/observable";
 import { DOM } from "./dom";
+import { Notifier } from "./observation/notifier";
 
 export interface ValueConverter {
     toView(value: any): string | null;
@@ -94,7 +95,7 @@ export class AttributeDefinition {
                 element[this.callbackName](oldValue, newValue);
             }
 
-            Observable.notify(element, this.property);
+            ((element as any).$fastController as Notifier).notify(element, this.property);
         }
     }
 

--- a/packages/fast-element/src/controller.ts
+++ b/packages/fast-element/src/controller.ts
@@ -142,7 +142,7 @@ export class Controller extends PropertyChangeNotifier implements Container {
     }
 
     public static forCustomElement(element: HTMLElement) {
-        const controller: Controller = (element as any).$controller;
+        const controller: Controller = (element as any).$fastController;
 
         if (controller !== void 0) {
             return controller;
@@ -154,6 +154,6 @@ export class Controller extends PropertyChangeNotifier implements Container {
             throw new Error("Missing fast element definition.");
         }
 
-        return ((element as any).$controller = new Controller(element, definition));
+        return ((element as any).$fastController = new Controller(element, definition));
     }
 }

--- a/packages/fast-element/src/fast-element.ts
+++ b/packages/fast-element/src/fast-element.ts
@@ -10,7 +10,7 @@ const defaultElementOptions: ElementDefinitionOptions = {};
 
 function createFastElement(BaseType: typeof HTMLElement) {
     return class FastElement extends BaseType {
-        public $controller!: Controller;
+        public $fastController!: Controller;
 
         public constructor() {
             super();
@@ -22,15 +22,15 @@ function createFastElement(BaseType: typeof HTMLElement) {
             detail?: any,
             options?: Omit<CustomEventInit, "detail">
         ) {
-            return this.$controller.emit(type, detail, options);
+            return this.$fastController.emit(type, detail, options);
         }
 
         public connectedCallback() {
-            this.$controller.onConnectedCallback();
+            this.$fastController.onConnectedCallback();
         }
 
         public disconnectedCallback() {
-            this.$controller.onDisconnectedCallback();
+            this.$fastController.onDisconnectedCallback();
         }
 
         public attributeChangedCallback(
@@ -38,7 +38,7 @@ function createFastElement(BaseType: typeof HTMLElement) {
             oldValue: string,
             newValue: string
         ) {
-            this.$controller.onAttributeChangedCallback(name, oldValue, newValue);
+            this.$fastController.onAttributeChangedCallback(name, oldValue, newValue);
         }
     };
 }

--- a/packages/fast-element/src/observation/array-observer.ts
+++ b/packages/fast-element/src/observation/array-observer.ts
@@ -34,7 +34,7 @@ export function enableArrayObservation() {
     arrayProto.pop = function() {
         const notEmpty = this.length > 0;
         const methodCallResult = pop.apply(this, arguments as any);
-        const o = (this as any).$controller as ArrayObserver;
+        const o = (this as any).$fastController as ArrayObserver;
 
         if (o !== void 0 && notEmpty) {
             o.addSplice(newSplice(this.length, [methodCallResult], 0));
@@ -45,7 +45,7 @@ export function enableArrayObservation() {
 
     arrayProto.push = function() {
         const methodCallResult = push.apply(this, arguments as any);
-        const o = (this as any).$controller as ArrayObserver;
+        const o = (this as any).$fastController as ArrayObserver;
 
         if (o !== void 0) {
             o.addSplice(
@@ -61,7 +61,7 @@ export function enableArrayObservation() {
 
     arrayProto.reverse = function() {
         let oldArray;
-        const o = (this as any).$controller as ArrayObserver;
+        const o = (this as any).$fastController as ArrayObserver;
 
         if (o !== void 0) {
             o.notify();
@@ -80,7 +80,7 @@ export function enableArrayObservation() {
     arrayProto.shift = function() {
         const notEmpty = this.length > 0;
         const methodCallResult = shift.apply(this, arguments as any);
-        const o = (this as any).$controller as ArrayObserver;
+        const o = (this as any).$fastController as ArrayObserver;
 
         if (o !== void 0 && notEmpty) {
             o.addSplice(newSplice(0, [methodCallResult], 0));
@@ -91,7 +91,7 @@ export function enableArrayObservation() {
 
     arrayProto.sort = function() {
         let oldArray;
-        const o = (this as any).$controller as ArrayObserver;
+        const o = (this as any).$fastController as ArrayObserver;
 
         if (o !== void 0) {
             o.notify();
@@ -109,7 +109,7 @@ export function enableArrayObservation() {
 
     arrayProto.splice = function() {
         const methodCallResult = splice.apply(this, arguments as any);
-        const o = (this as any).$controller as ArrayObserver;
+        const o = (this as any).$fastController as ArrayObserver;
 
         if (o !== void 0) {
             o.addSplice(
@@ -129,7 +129,7 @@ export function enableArrayObservation() {
 
     arrayProto.unshift = function() {
         const methodCallResult = unshift.apply(this, arguments as any);
-        const o = (this as any).$controller as ArrayObserver;
+        const o = (this as any).$fastController as ArrayObserver;
 
         if (o !== void 0) {
             o.addSplice(adjustIndex(newSplice(0, [], arguments.length), this));
@@ -169,7 +169,7 @@ export class ArrayObserver extends SubscriberCollection implements Notifier {
 
     constructor(collection: any[]) {
         super();
-        (collection as any).$controller = this;
+        (collection as any).$fastController = this;
         this.collection = collection;
     }
 

--- a/packages/fast-element/src/observation/observable.ts
+++ b/packages/fast-element/src/observation/observable.ts
@@ -2,29 +2,18 @@ import { Controller } from "../controller";
 import { FastElement } from "../fast-element";
 import { Notifier, PropertyChangeNotifier } from "./notifier";
 import { Expression, ExpressionContext, emptyArray } from "../interfaces";
-
-export interface GetterInspector {
-    inspect(source: unknown, propertyName: string): void;
-}
+import { DOM } from "../dom";
 
 const notifierLookup = new WeakMap<any, Notifier>();
-let currentInspector: GetterInspector | undefined = void 0;
+let watcher: ObservableExpression | undefined = void 0;
 
 export const Observable = {
-    setInspector(inspector: GetterInspector) {
-        currentInspector = inspector;
-    },
-
-    clearInspector() {
-        currentInspector = void 0;
-    },
-
     createArrayObserver(array: any[]): Notifier {
         throw new Error("Must call enableArrayObservation before observing arrays.");
     },
 
     getNotifier<T extends Notifier = Notifier>(source: any): T {
-        let found = source.$controller || notifierLookup.get(source);
+        let found = source.$fastController || notifierLookup.get(source);
 
         if (found === void 0) {
             if (source instanceof FastElement) {
@@ -40,13 +29,13 @@ export const Observable = {
     },
 
     track(source: unknown, propertyName: string) {
-        if (currentInspector !== void 0) {
-            currentInspector.inspect(source, propertyName);
+        if (watcher !== void 0) {
+            watcher.observe(source, propertyName);
         }
     },
 
     notify(source: unknown, args: any) {
-        Observable.getNotifier(source).notify(source, args);
+        getNotifier(source).notify(source, args);
     },
 
     define(target: {}, propertyName: string) {
@@ -62,7 +51,10 @@ export const Observable = {
         Reflect.defineProperty(target, propertyName, {
             enumerable: true,
             get: function(this: any) {
-                Observable.track(this, propertyName);
+                if (watcher !== void 0) {
+                    watcher.observe(this, propertyName);
+                }
+
                 return this[fieldName];
             },
             set: function(this: any, newValue) {
@@ -75,7 +67,7 @@ export const Observable = {
                         this[callbackName](oldValue, newValue);
                     }
 
-                    Observable.notify(this, propertyName);
+                    getNotifier(this).notify(this, propertyName);
                 }
             },
         });
@@ -86,18 +78,105 @@ export const Observable = {
     },
 };
 
+const getNotifier = Observable.getNotifier;
+const queueUpdate = DOM.queueUpdate;
+
 export function observable($target: {}, $prop: string) {
     Observable.define($target, $prop);
 }
 
-export function inspectAndEvaluate<T = unknown>(
-    expression: Expression,
-    scope: unknown,
-    context: ExpressionContext,
-    inspector: GetterInspector
-): T {
-    Observable.setInspector(inspector);
-    const value = expression(scope, context);
-    Observable.clearInspector();
-    return value as T;
+export interface ExpressionObserver {
+    handleExpressionChange(expression: ObservableExpression): void;
+}
+
+interface SubscriptionRecord {
+    source: any;
+    propertyName: string;
+    notifier: Notifier;
+    next: SubscriptionRecord | undefined;
+}
+
+export class ObservableExpression {
+    private needsRefresh = true;
+    private needsQueue = true;
+
+    private first: SubscriptionRecord = this as any;
+    private last: SubscriptionRecord | null = null;
+
+    private source: any = void 0;
+    private propertyName: string | undefined = void 0;
+    private notifier: Notifier | undefined = void 0;
+    private next: SubscriptionRecord | undefined = void 0;
+
+    constructor(private expression: Expression, private observer: ExpressionObserver) {}
+
+    public evaluate(scope: unknown, context: ExpressionContext) {
+        if (this.needsRefresh && this.last !== null) {
+            this.dispose();
+        }
+
+        watcher = this.needsRefresh ? this : void 0;
+        this.needsRefresh = false;
+        const result = this.expression(scope, context);
+        watcher = void 0;
+
+        return result;
+    }
+
+    public dispose() {
+        if (this.last !== null) {
+            let current = this.first;
+
+            while (current !== void 0) {
+                current.notifier.unsubscribe(this, current.propertyName);
+                current = current.next!;
+            }
+
+            this.last = null;
+            this.needsRefresh = true;
+        }
+    }
+
+    /** @internal */
+    public observe(source: unknown, propertyName: string) {
+        const prev = this.last;
+        const notifier = getNotifier(source);
+        const current: SubscriptionRecord = prev === null ? this.first : ({} as any);
+
+        current.source = source;
+        current.propertyName = propertyName;
+        current.notifier = notifier;
+
+        notifier.subscribe(this, propertyName);
+
+        if (prev !== null) {
+            if (!this.needsRefresh) {
+                watcher = void 0;
+                const prevValue = prev.source[prev.propertyName];
+                watcher = this;
+
+                if (source === prevValue) {
+                    this.needsRefresh = true;
+                }
+            }
+
+            prev.next = current;
+        }
+
+        this.last = current!;
+    }
+
+    /** @internal */
+    handleChange() {
+        if (this.needsQueue) {
+            this.needsQueue = false;
+            queueUpdate(this);
+        }
+    }
+
+    /** @internal */
+    call() {
+        this.needsQueue = true;
+        this.observer.handleExpressionChange(this);
+    }
 }


### PR DESCRIPTION
# Description

Up until now, a binding expression in a template could only observe the last property accessed in the expression. This PR enables observation of all properties accessed in the expression.

## Motivation & context

This PR introduces the `ObservableExpression` class, which implements all the machinery needed to evaluate an expression while observing it. Here's how it works:

When Instantiated:
* `ObservableExpression` is first instantiated with a normal `Expression` as well as an `ExpressionObserver`.

When `evaluate` is called:
* The observer sets itself as the `watcher` for all observables and then invokes the expression.
* Each `Observable` invokes `Observable.track()` when its getter is accessed, which gets routed to the current `watcher` so that it knows what object and property was just accessed.
* The `ObservableExpression` then subscribes itself to changes in that property and adds a "record" of that subscription to the end of its linked list of observation records.
* This process continues as along as the expression is executing. The `ObservableExpression` continues to subscribe and add records to its linked list.
* If the value of the previous property is ever the source of the next tracked observation, then we know there was a property chain (e.g. a.b.c). If this occurs, we mark the `ObservableExpression` as `needsRefresh = true` which ensures that the next time `evaluate` is called, the old subscriptions will be disposed and new subscriptions will be set up.

When a `dispose` is called:
* Loop through the linked list of records and unsubscribe each.

A couple of other notes about `ObservableExpression`:
* The `ObservableExpression` itself serves as the first item in its linked list of records so that we can avoid further object initialization for most expressions which will only need to observe one property.
* On successive calls to `evaluate`, if `needsRefresh = false` we do not set the current `watcher` because we don't need to setup observers.
* The `ObservableExpression` takes an `ExpressionObserver` rather than a callback because we want to avoid creating additional objects (via closures) in a hot path such as when instantiating templates.

A few additional changes were made as part of this PR:
* `$controller` was renamed to `$fastController` throughout in order to prevent name clashes.
* Several places where APIs were indirectly referenced were switched to direct references via semi-private knowledge of inner workings of the library (for minor perf. improvements).
* The `repeat` directive can now more easily distinguish between changes to its items expression and changes to the items array.
* All infrastructure for observing an expression is now centralized within a single, reusable class.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

This is a non-breaking change.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.