### PR TITLE
fix: high contrast focus border on toggle when unselected

### DIFF
--- a/packages/react/fast-components-styles-msft/src/toggle/index.ts
+++ b/packages/react/fast-components-styles-msft/src/toggle/index.ts
@@ -138,6 +138,7 @@ const styles: ComponentStyles<ToggleClassNameContract, DesignSystem> = {
                     toPx<DesignSystem>(outlineWidth),
                     () => HighContrastColor.buttonText
                 ),
+                "border-color": HighContrastColor.buttonText,
             },
         }),
         [highContrastSelector]: {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

When you tab into the toggle component it would add the inner border but main border was not changing color. I added a high contrast border on the apply focus state. This will give a clearer indication that the toggle has been focused.

close #2926

before
![image](https://user-images.githubusercontent.com/37851220/79318004-4c299880-7ebb-11ea-9f25-50fea64aa7e1.png)

after
![image](https://user-images.githubusercontent.com/37851220/79318020-521f7980-7ebb-11ea-9435-1935b012945f.png)

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->