### PR TITLE
fix: form associate the textarea component

### DIFF
--- a/packages/web-components/fast-components/src/text-area/README.md
+++ b/packages/web-components/fast-components/src/text-area/README.md
@@ -1,4 +1,4 @@
 # fast-text-area
-An implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
+An implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected web-component.
 
 For more information view the [component specification](./text-area.spec.md).

--- a/packages/web-components/fast-components/src/text-area/text-area.ts
+++ b/packages/web-components/fast-components/src/text-area/text-area.ts
@@ -1,4 +1,5 @@
-import { attr, FastElement } from "@microsoft/fast-element";
+import { attr } from "@microsoft/fast-element";
+import { FormAssociated } from "../form-associated";
 
 export enum TextAreaAppearance {
     filled = "filled",
@@ -12,7 +13,7 @@ export enum TextAreaResize {
     vertical = "vertical",
 }
 
-export class TextArea extends FastElement {
+export class TextArea extends FormAssociated<HTMLTextAreaElement> {
     @attr
     public appearance: TextAreaAppearance = TextAreaAppearance.outline;
     private appearanceChanged(): void {
@@ -23,7 +24,11 @@ export class TextArea extends FastElement {
 
     @attr({ attribute: "required", mode: "boolean" })
     public required: boolean;
-    private requiredChanged(): void {
+    protected requiredChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.required = this.required;
+        }
+
         this.required
             ? this.classList.add("required")
             : this.classList.remove("required");
@@ -32,6 +37,10 @@ export class TextArea extends FastElement {
     @attr({ mode: "boolean" })
     public readonly: boolean;
     private readonlyChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.readOnly = this.readonly;
+        }
+
         this.readonly
             ? this.classList.add("readonly")
             : this.classList.remove("readonly");
@@ -49,24 +58,49 @@ export class TextArea extends FastElement {
 
     @attr
     public autofocus: boolean;
+    private autofocusChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.autofocus = this.autofocus;
+        }
+    }
 
     @attr
     public cols: number = 20;
 
     @attr
     public disabled: boolean;
+    protected disabledChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.disabled = this.disabled;
+        }
+    }
 
-    @attr
-    public form: string;
+    @attr({ attribute: "form" })
+    public formId: string;
 
     @attr
     public list: string;
+    private listChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.setAttribute("list", this.list);
+        }
+    }
 
     @attr
     public maxlength: number;
+    private maxlengthChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.maxLength = this.maxlength;
+        }
+    }
 
     @attr
     public minlength: number;
+    private minlengthChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.minLength = this.minlength;
+        }
+    }
 
     @attr
     public name: string;
@@ -79,6 +113,11 @@ export class TextArea extends FastElement {
 
     @attr
     public spellcheck: boolean;
+    private spellcheckChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.spellcheck = this.spellcheck;
+        }
+    }
 
     @attr
     public value: string;
@@ -86,13 +125,21 @@ export class TextArea extends FastElement {
         if (this.textarea && this.value !== this.textarea.value) {
             this.textarea.value = this.value;
         }
+
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.value = this.value;
+        }
     }
+
+    protected proxy: HTMLTextAreaElement = document.createElement("textarea");
 
     public connectedCallback(): void {
         super.connectedCallback();
 
         if (this.value) {
             this.textarea.value = this.value;
+
+            this.setFormValue(this.value, this.value);
         }
     }
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
This PR adds form association support to the textarea web component.
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->