### PR TITLE
fix: high contrast color for hover and disabled, in flipper web component

### DIFF
--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -31,7 +31,7 @@ export const FlipperStyles = css`
     :host::before {
         content: "";
         opacity: 0.8;
-        background: var(--neutral-fill-steal-rest);
+        background: var(--neutral-fill-stealth-rest);
         border: calc(var(--outline-width) * 1px) solid var(--neutral-outline-rest);
         border-radius: 50%;
         position: absolute;
@@ -82,28 +82,53 @@ export const FlipperStyles = css`
 
     @media (forced-colors: active) {
         :host {
-            background: ${SystemColors.Canvas}
-            border-color: ${SystemColors.ButtonText};
+            background: ${SystemColors.Canvas};
         }
 
         :host .next,
         :host .previous {
-            color: ${SystemColors.ButtonText}
-            fill: ${SystemColors.ButtonText}
+            color: ${SystemColors.ButtonText};
+            fill: ${SystemColors.ButtonText};
         }
 
         :host::before {
-            background: ${SystemColors.Canvas}
+            background: ${SystemColors.Canvas};
+            border-color: ${SystemColors.ButtonText};
         }
 
         :host(:hover)::before {
-            background: ${SystemColors.Highlight}
+            forced-color-adjust: none;
+            background: ${SystemColors.Highlight};
+            border-color: ${SystemColors.ButtonText};
         }
 
         :host(:hover) .next,
         :host(:hover) .previous {
-            color: ${SystemColors.HighlightText}
-            fill: ${SystemColors.HighlightText}
+            forced-color-adjust: none;
+            color: ${SystemColors.HighlightText};
+            fill: ${SystemColors.HighlightText};
+        }
+        
+        :host(.disabled) {
+            opacity: 1;
+        }
+
+        :host(.disabled)::before,
+        :host(.disabled:hover)::before,
+        :host(.disabled) .next,
+        :host(.disabled) .previous,
+        :host(.disabled:hover) .next,
+        :host(.disabled:hover) .previous {
+            forced-color-adjust: none;
+            background: ${SystemColors.Canvas};
+            border-color: ${SystemColors.GrayText};
+            color: ${SystemColors.GrayText};
+            fill: ${SystemColors.GrayText};
+        }
+
+        :host(:${focusVisible})::before {
+            forced-color-adjust: none;
+            box-shadow: 0 0 0 2px ${SystemColors.ButtonText};
         }
     }
 `.withBehaviors(


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->

## Motivation & context

None of the high contrast colors were showing up, part of the fix was adding a missing semicolon. On hover, we now see Highlight and HighlightText color.
![image](https://user-images.githubusercontent.com/37851220/79602761-f530e880-809f-11ea-9057-9e94b53d8a5b.png)
Added rule sets for disabled state.
before
![image](https://user-images.githubusercontent.com/37851220/79602898-2f9a8580-80a0-11ea-98a2-7edbc834dbef.png)
after
![image](https://user-images.githubusercontent.com/37851220/79602925-39bc8400-80a0-11ea-977a-566205ce45e5.png)
Added focus visible.
![image](https://user-images.githubusercontent.com/37851220/79602988-5c4e9d00-80a0-11ea-9428-500faba125ea.png)


## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->