### PR TITLE
fix: improve performance of finding contextual design-system-providers

### DIFF
--- a/packages/web-components/fast-components/src/custom-properties/behavior.ts
+++ b/packages/web-components/fast-components/src/custom-properties/behavior.ts
@@ -37,14 +37,14 @@ export function cssCustomPropertyBehaviorFactory(
         bind(source: typeof FASTElement): void {
             const target = this.host(source);
 
-            if (target) {
+            if (target !== null) {
                 target.registerCSSCustomProperty(this);
             }
         },
         unbind(source: typeof FASTElement): void {
             const target = this.host(source);
 
-            if (target) {
+            if (target !== null) {
                 target.unregisterCSSCustomProperty(this);
             }
         },

--- a/packages/web-components/fast-components/src/custom-properties/behavior.ts
+++ b/packages/web-components/fast-components/src/custom-properties/behavior.ts
@@ -34,14 +34,14 @@ export function cssCustomPropertyBehaviorFactory(
         name,
         value,
         host,
-        bind(source: typeof FASTElement | HTMLElement): void {
+        bind(source: typeof FASTElement): void {
             const target = this.host(source);
 
             if (target) {
                 target.registerCSSCustomProperty(this);
             }
         },
-        unbind(source: typeof FASTElement | HTMLElement): void {
+        unbind(source: typeof FASTElement): void {
             const target = this.host(source);
 
             if (target) {

--- a/packages/web-components/fast-components/src/design-system-consumer/design-system-consumer.ts
+++ b/packages/web-components/fast-components/src/design-system-consumer/design-system-consumer.ts
@@ -1,9 +1,20 @@
-import { Behavior, FASTElement } from "@microsoft/fast-element";
+import { Behavior } from "@microsoft/fast-element";
 import { composedParent } from "../utilities";
 import { DesignSystemProvider, isDesignSystemProvider } from "../design-system-provider";
 
 export interface DesignSystemConsumer {
     provider: DesignSystemProvider | null;
+}
+
+/**
+ * Determines if the element has a design-system-provider context
+ * @param element
+ */
+export function isDesignSystemConsumer(
+    element: HTMLElement | DesignSystemConsumer
+): element is DesignSystemConsumer {
+    const provider = (element as DesignSystemProvider).provider;
+    return provider instanceof HTMLElement && isDesignSystemProvider(provider);
 }
 
 /**
@@ -26,7 +37,7 @@ export class DesignSystemConsumerBehavior<T extends DesignSystemConsumer & HTMLE
 export function findProvider(
     self: HTMLElement & Partial<DesignSystemConsumer>
 ): DesignSystemProvider | null {
-    if (self.provider instanceof DesignSystemProvider) {
+    if (isDesignSystemConsumer(self)) {
         return self.provider;
     }
 
@@ -34,11 +45,11 @@ export function findProvider(
 
     while (parent !== null) {
         if (isDesignSystemProvider(parent)) {
-            self.provider = parent as DesignSystemProvider;
+            self.provider = parent; // Store provider on ourselves for future reference
             return parent;
-        } else if ((parent as any).provider instanceof DesignSystemProvider) {
-            self.provider = (parent as any).provider;
-            return (parent as any).provider;
+        } else if (isDesignSystemConsumer(parent)) {
+            self.provider = parent.provider;
+            return parent.provider;
         } else {
             parent = composedParent(parent);
         }

--- a/packages/web-components/fast-components/src/design-system-consumer/design-system-consumer.ts
+++ b/packages/web-components/fast-components/src/design-system-consumer/design-system-consumer.ts
@@ -1,6 +1,6 @@
-import { Behavior } from "@microsoft/fast-element";
+import { Behavior, FASTElement } from "@microsoft/fast-element";
 import { composedParent } from "../utilities";
-import { DesignSystemProvider } from "../design-system-provider";
+import { DesignSystemProvider, isDesignSystemProvider } from "../design-system-provider";
 
 export interface DesignSystemConsumer {
     provider: DesignSystemProvider | null;
@@ -23,12 +23,22 @@ export class DesignSystemConsumerBehavior<T extends DesignSystemConsumer & HTMLE
  * Resolves the nearest DesignSystemProvider element to an element.
  * @param self The element from which to begin
  */
-export function findProvider(self: HTMLElement): DesignSystemProvider | null {
+export function findProvider(
+    self: HTMLElement & Partial<DesignSystemConsumer>
+): DesignSystemProvider | null {
+    if (self.provider instanceof DesignSystemProvider) {
+        return self.provider;
+    }
+
     let parent = composedParent(self);
 
     while (parent !== null) {
-        if ((parent as any).isDesignSystemProvider) {
-            return parent as any;
+        if (isDesignSystemProvider(parent)) {
+            self.provider = parent as DesignSystemProvider;
+            return parent;
+        } else if ((parent as any).provider instanceof DesignSystemProvider) {
+            self.provider = (parent as any).provider;
+            return (parent as any).provider;
         } else {
             parent = composedParent(parent);
         }

--- a/packages/web-components/fast-components/src/design-system-consumer/design-system-consumer.ts
+++ b/packages/web-components/fast-components/src/design-system-consumer/design-system-consumer.ts
@@ -32,6 +32,10 @@ export class DesignSystemConsumerBehavior<T extends DesignSystemConsumer & HTMLE
 
 /**
  * Resolves the nearest DesignSystemProvider element to an element.
+ *
+ * When the provider is found, this function will store the provider on
+ * the `self` so that it can quickly be retrieved by other future invocations
+ * of this function.
  * @param self The element from which to begin
  */
 export function findProvider(


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Improves the performance of the algorithm for finding an element's contextual design-system-provider element.
<!--- Describe your changes. -->

## Motivation & context
A previous change adjusted the recipe system to associate with stylesheets instead of components. In introducing that change, a side effect was that each recipe was resolving the design-system-provider independently, leading to a significant amount of duplicated work.

This change adjust the `findProvider` algorithm used by recipes to first check to see if a provider has been stored on the source object. If it has, a reference to that provider will be returned. Additionally, when a provider is found, a reference top the provider is stored on the source object for future invocations of the function. This means each element is only finding the provider once.

This change also introduces a check to determine if the parent element *has* a design system provider context. If it does, a reference to that provider will be returned. This will improved resolution speed of nested scenarios.

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->