### PR TITLE
fix: update selected, hover and focus high contrast colors for checkbox

### DIFF
--- a/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
@@ -106,12 +106,42 @@ export const CheckboxStyles = css`
             fill: ${SystemColors.FieldText};
         }
 
-        .indeterminate-indicator  {
+        .indeterminate-indicator {
             background: ${SystemColors.FieldText};
         }
         
         :host(:${focusVisible}) .control {
             border-color: ${SystemColors.Highlight};
+        }
+
+        :host(.checked:${focusVisible}) .control {
+            border-color: ${SystemColors.FieldText};
+            box-shadow: 0 0 0 2px ${SystemColors.Field} inset;
+        }
+
+        :host(.checked) .control {
+            background: ${SystemColors.Highlight};
+            border-color: ${SystemColors.Highlight};
+        }
+
+        :host(.checked) .control:hover, .control:active {
+            background: ${SystemColors.HighlightText};
+        }
+
+        :host(.checked) .checked-indicator {
+            fill: ${SystemColors.HighlightText};
+        }
+
+        :host(.checked) .control:hover .checked-indicator {
+            fill: ${SystemColors.Highlight}
+        }
+
+        :host(.checked) .indeterminate-indicator {
+            background: ${SystemColors.HighlightText};
+        }
+
+        :host(.checked) .control:hover .indeterminate-indicator {
+            background: ${SystemColors.Highlight}
         }
 
         :host(.disabled) {
@@ -121,14 +151,17 @@ export const CheckboxStyles = css`
         :host(.disabled) .control {
             forced-color-adjust: none;
             border-color: ${SystemColors.GrayText};
+            background: ${SystemColors.Field};
         }
 
-        :host(.disabled) .indeterminate-indicator {
+        :host(.disabled) .indeterminate-indicator,
+        :host(.checked.disabled) .control:hover .indeterminate-indicator {
             forced-color-adjust: none;
             background: ${SystemColors.GrayText};
         }
 
-        :host(.disabled) .checked-indicator {
+        :host(.disabled) .checked-indicator,
+        :host(.checked.disabled) .control:hover .checked-indicator {
             forced-color-adjust: none;
             fill: ${SystemColors.GrayText};
         }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Update to add high contrast color on checkbox when selected, hovered, and focused.

## Motivation & context
The fix is based on the principles we established in our other checkbox components.
In the checked state, the checkbox background is filled with the Highlight color. When hovering, the colors are inverted. Tabbed focus gets a double border treatment.

rest-hover-focus
![image](https://user-images.githubusercontent.com/37851220/80250288-5de00e00-8628-11ea-8374-83c6ecf667b9.png)
![image](https://user-images.githubusercontent.com/37851220/80250311-6c2e2a00-8628-11ea-8504-c8a1ac271ad7.png)



## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->