### PR TITLE
fix: high contrast color on tab indicator

### DIFF
--- a/packages/web-components/fast-components/src/tabs/tab/tab.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tab/tab.styles.ts
@@ -7,6 +7,7 @@ import {
     neutralForegroundHoverBehavior,
     neutralForegroundRestBehavior,
 } from "../../styles/recipes";
+import { SystemColors } from "../../styles/system-colors";
 
 export const TabStyles = css`
     ${display("inline-flex")} :host {
@@ -69,6 +70,24 @@ export const TabStyles = css`
     }
 
     :host(.vertical:hover[aria-selected="true"]) {
+    }
+
+    @media (forced-colors: active) {
+        :host {
+            forced-color-adjust: none;
+            border-color: transparent;
+            color: ${SystemColors.ButtonText};
+        }
+
+        :host(:hover),
+        :host(.vertical:hover) {
+            color: ${SystemColors.ButtonText};
+        }
+
+        :host(:${focusVisible}) {
+            border-color: ${SystemColors.ButtonText};
+            box-shadow: none;
+        }
     }
 `.withBehaviors(
     neutralFocusBehavior,

--- a/packages/web-components/fast-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tabs.styles.ts
@@ -1,6 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "../styles";
 import { accentFillRestBehavior, neutralForegroundRestBehavior } from "../styles/recipes";
+import { SystemColors } from "../styles/system-colors";
 
 export const TabsStyles = css`
     ${display("grid")} :host {
@@ -92,5 +93,13 @@ export const TabsStyles = css`
 
     :host(.vertical) .activeIndicatorTransition {
         transition: transform 0.2s linear;
+    }
+
+    @media (forced-colors: active) {
+        .activeIndicator,
+        :host(.vertical) .activeIndicator {
+            forced-color-adjust: none;
+            background: ${SystemColors.Highlight};
+        }
     }
 `.withBehaviors(accentFillRestBehavior, neutralForegroundRestBehavior);


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Adding forced colors to fix high contrast.

## Motivation & context
Adding forced colors to tab to remove borders, and tabs to set high contrast color on the indicator.
before
![image](https://user-images.githubusercontent.com/37851220/80265110-4e25f100-864b-11ea-9f16-60d2d017724c.png)
after
![image](https://user-images.githubusercontent.com/37851220/80265131-5a11b300-864b-11ea-9d49-b99c40974d1e.png)


## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->