### PR TITLE
fix: move high contrast styles to use forced color stylesheet behavior

### DIFF
--- a/packages/web-components/fast-components/src/button/button.styles.ts
+++ b/packages/web-components/fast-components/src/button/button.styles.ts
@@ -2,6 +2,8 @@ import { css } from "@microsoft/fast-element";
 import {
     AccentButtonStyles,
     BaseButtonStyles,
+    disabledCursor,
+    focusVisible,
     HypertextStyles,
     LightweightButtonStyles,
     OutlineButtonStyles,
@@ -29,6 +31,8 @@ import {
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
 } from "../styles/recipes";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
+import { SystemColors } from "../styles/system-colors";
 
 export const ButtonStyles = css`
     ${BaseButtonStyles}
@@ -57,5 +61,79 @@ export const ButtonStyles = css`
     neutralForegroundRestBehavior,
     neutralOutlineActiveBehavior,
     neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior
+    neutralOutlineRestBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            :host(.disabled),
+            :host(.disabled) .control {
+                forced-color-adjust: none;
+                background: ${SystemColors.ButtonFace};
+                border-color: ${SystemColors.GrayText};
+                color: ${SystemColors.GrayText};
+                cursor: ${disabledCursor};
+                opacity: 1;
+            }
+            :host(.accent) .control {
+                forced-color-adjust: none;
+                background: ${SystemColors.Highlight};
+                color: ${SystemColors.HighlightText};
+            }
+    
+            :host(.accent) .control:hover {
+                background: ${SystemColors.HighlightText};
+                border-color: ${SystemColors.Highlight};
+                color: ${SystemColors.Highlight};
+            }
+    
+            :host(.accent:${focusVisible}) .control {
+                border-color: ${SystemColors.ButtonText};
+                box-shadow: 0 0 0 2px ${SystemColors.HighlightText} inset;
+            }
+    
+            :host(.accent.disabled) .control,
+            :host(.accent.disabled) .control:hover {
+                background: ${SystemColors.ButtonFace};
+                border-color: ${SystemColors.GrayText};
+                color: ${SystemColors.GrayText};
+            }
+            :host(.lightweight) .control:hover {
+                forced-color-adjust: none;
+                color: ${SystemColors.Highlight};
+            }
+    
+            :host(.lightweight) .control:hover .content::before {
+                background: ${SystemColors.Highlight};
+            }
+    
+            :host(.lightweight.disabled) .control {
+                forced-color-adjust: none;
+                color: ${SystemColors.GrayText};
+            }
+        
+            :host(.lightweight.disabled) .control:hover .content::before {
+                background: none;
+            }
+            :host(.outline.disabled) .control {
+                border-color: ${SystemColors.GrayText};
+            }
+            :host(.stealth) .control {
+                forced-color-adjust: none;
+                background: none;
+                border-color: transparent;
+                color: ${SystemColors.ButtonText};
+                fill: currentColor;
+            }
+            :host(.stealth) .control:hover,
+            :host(.stealth:${focusVisible}) .control {
+                background: ${SystemColors.Highlight};
+                border-color: ${SystemColors.Highlight};
+                color: ${SystemColors.HighlightText};
+            }
+            :host(.stealth.disabled) .control {
+                background: none;
+                border-color: transparent;
+                color: ${SystemColors.GrayText};
+            }
+        `
+    )
 );

--- a/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
@@ -10,6 +10,7 @@ import {
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
 } from "../styles/recipes";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const CheckboxStyles = css`
     ${display("inline-flex")} :host {
@@ -94,82 +95,69 @@ export const CheckboxStyles = css`
     :host(.disabled) {
         opacity: var(--disabled-opacity);
     }
-
-    @media (forced-colors: active) {
-        .control, .control:hover, .control:active {
-            forced-color-adjust: none;
-            border-color: ${SystemColors.FieldText};
-            background: ${SystemColors.Field};
-        }
-        
-        .checked-indicator {
-            fill: ${SystemColors.FieldText};
-        }
-
-        .indeterminate-indicator {
-            background: ${SystemColors.FieldText};
-        }
-        
-        :host(:${focusVisible}) .control {
-            border-color: ${SystemColors.Highlight};
-        }
-
-        :host(.checked:${focusVisible}) .control {
-            border-color: ${SystemColors.FieldText};
-            box-shadow: 0 0 0 2px ${SystemColors.Field} inset;
-        }
-
-        :host(.checked) .control {
-            background: ${SystemColors.Highlight};
-            border-color: ${SystemColors.Highlight};
-        }
-
-        :host(.checked) .control:hover, .control:active {
-            background: ${SystemColors.HighlightText};
-        }
-
-        :host(.checked) .checked-indicator {
-            fill: ${SystemColors.HighlightText};
-        }
-
-        :host(.checked) .control:hover .checked-indicator {
-            fill: ${SystemColors.Highlight}
-        }
-
-        :host(.checked) .indeterminate-indicator {
-            background: ${SystemColors.HighlightText};
-        }
-
-        :host(.checked) .control:hover .indeterminate-indicator {
-            background: ${SystemColors.Highlight}
-        }
-
-        :host(.disabled) {
-            opacity: 1;
-        }
-
-        :host(.disabled) .control {
-            forced-color-adjust: none;
-            border-color: ${SystemColors.GrayText};
-            background: ${SystemColors.Field};
-        }
-
-        :host(.disabled) .indeterminate-indicator,
-        :host(.checked.disabled) .control:hover .indeterminate-indicator {
-            forced-color-adjust: none;
-            background: ${SystemColors.GrayText};
-        }
-
-        :host(.disabled) .checked-indicator,
-        :host(.checked.disabled) .control:hover .checked-indicator {
-            forced-color-adjust: none;
-            fill: ${SystemColors.GrayText};
-        }
-    }
 `.withBehaviors(
     neutralFillInputHoverBehavior,
     neutralFillInputRestBehavior,
     neutralForegroundRestBehavior,
     neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior
+    neutralOutlineRestBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            .control, .control:hover, .control:active {
+                forced-color-adjust: none;
+                border-color: ${SystemColors.FieldText};
+                background: ${SystemColors.Field};
+            }
+            .checked-indicator {
+                fill: ${SystemColors.FieldText};
+            }
+            .indeterminate-indicator {
+                background: ${SystemColors.FieldText};
+            }
+            :host(:${focusVisible}) .control {
+                border-color: ${SystemColors.Highlight};
+            }
+            :host(.checked:${focusVisible}) .control {
+                border-color: ${SystemColors.FieldText};
+                box-shadow: 0 0 0 2px ${SystemColors.Field} inset;
+            }
+            :host(.checked) .control {
+                background: ${SystemColors.Highlight};
+                border-color: ${SystemColors.Highlight};
+            }
+            :host(.checked) .control:hover, .control:active {
+                background: ${SystemColors.HighlightText};
+            }
+            :host(.checked) .checked-indicator {
+                fill: ${SystemColors.HighlightText};
+            }
+            :host(.checked) .control:hover .checked-indicator {
+                fill: ${SystemColors.Highlight}
+            }
+            :host(.checked) .indeterminate-indicator {
+                background: ${SystemColors.HighlightText};
+            }
+            :host(.checked) .control:hover .indeterminate-indicator {
+                background: ${SystemColors.Highlight}
+            }
+            :host(.disabled) {
+                opacity: 1;
+            }
+            :host(.disabled) .control {
+                forced-color-adjust: none;
+                border-color: ${SystemColors.GrayText};
+                background: ${SystemColors.Field};
+            }
+            :host(.disabled) .indeterminate-indicator,
+            :host(.checked.disabled) .control:hover .indeterminate-indicator {
+                forced-color-adjust: none;
+                background: ${SystemColors.GrayText};
+            }
+            :host(.disabled) .checked-indicator,
+            :host(.checked.disabled) .control:hover .checked-indicator {
+                forced-color-adjust: none;
+                fill: ${SystemColors.GrayText};
+            }
+        `
+    )
 );

--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -12,6 +12,7 @@ import {
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
 } from "../styles/recipes";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const FlipperStyles = css`
     ${display("inline-flex")} :host {
@@ -79,58 +80,6 @@ export const FlipperStyles = css`
     :host::-moz-focus-inner {
         border: 0;
     }
-
-    @media (forced-colors: active) {
-        :host {
-            background: ${SystemColors.Canvas};
-        }
-
-        :host .next,
-        :host .previous {
-            color: ${SystemColors.ButtonText};
-            fill: ${SystemColors.ButtonText};
-        }
-
-        :host::before {
-            background: ${SystemColors.Canvas};
-            border-color: ${SystemColors.ButtonText};
-        }
-
-        :host(:hover)::before {
-            forced-color-adjust: none;
-            background: ${SystemColors.Highlight};
-            border-color: ${SystemColors.ButtonText};
-        }
-
-        :host(:hover) .next,
-        :host(:hover) .previous {
-            forced-color-adjust: none;
-            color: ${SystemColors.HighlightText};
-            fill: ${SystemColors.HighlightText};
-        }
-        
-        :host(.disabled) {
-            opacity: 1;
-        }
-
-        :host(.disabled)::before,
-        :host(.disabled:hover)::before,
-        :host(.disabled) .next,
-        :host(.disabled) .previous,
-        :host(.disabled:hover) .next,
-        :host(.disabled:hover) .previous {
-            forced-color-adjust: none;
-            background: ${SystemColors.Canvas};
-            border-color: ${SystemColors.GrayText};
-            color: ${SystemColors.GrayText};
-            fill: ${SystemColors.GrayText};
-        }
-
-        :host(:${focusVisible})::before {
-            forced-color-adjust: none;
-            box-shadow: 0 0 0 2px ${SystemColors.ButtonText};
-        }
-    }
 `.withBehaviors(
     neutralFillStealthActiveBehavior,
     neutralFillStealthHoverBehavior,
@@ -139,5 +88,51 @@ export const FlipperStyles = css`
     neutralForegroundRestBehavior,
     neutralOutlineActiveBehavior,
     neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior
+    neutralOutlineRestBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            :host {
+                background: ${SystemColors.Canvas};
+            }
+            :host .next,
+            :host .previous {
+                color: ${SystemColors.ButtonText};
+                fill: ${SystemColors.ButtonText};
+            }
+            :host::before {
+                background: ${SystemColors.Canvas};
+                border-color: ${SystemColors.ButtonText};
+            }
+            :host(:hover)::before {
+                forced-color-adjust: none;
+                background: ${SystemColors.Highlight};
+                border-color: ${SystemColors.ButtonText};
+            }
+            :host(:hover) .next,
+            :host(:hover) .previous {
+                forced-color-adjust: none;
+                color: ${SystemColors.HighlightText};
+                fill: ${SystemColors.HighlightText};
+            }
+            :host(.disabled) {
+                opacity: 1;
+            }
+            :host(.disabled)::before,
+            :host(.disabled:hover)::before,
+            :host(.disabled) .next,
+            :host(.disabled) .previous,
+            :host(.disabled:hover) .next,
+            :host(.disabled:hover) .previous {
+                forced-color-adjust: none;
+                background: ${SystemColors.Canvas};
+                border-color: ${SystemColors.GrayText};
+                color: ${SystemColors.GrayText};
+                fill: ${SystemColors.GrayText};
+            }
+            :host(:${focusVisible})::before {
+                forced-color-adjust: none;
+                box-shadow: 0 0 0 2px ${SystemColors.ButtonText};
+            }
+        `
+    )
 );

--- a/packages/web-components/fast-components/src/progress/progress-ring/progress-ring.styles.ts
+++ b/packages/web-components/fast-components/src/progress/progress-ring/progress-ring.styles.ts
@@ -7,6 +7,7 @@ import {
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
 } from "../../styles/recipes";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const ProgressRingStyles = css`
     ${display("flex")} :host {
@@ -58,25 +59,6 @@ export const ProgressRingStyles = css`
         stroke: var(--neutral-foreground-hint);
     }
 
-    @media (forced-colors: active) {
-        .indeterminate-indicator-1,
-        .determinate {
-            stroke: ${SystemColors.FieldText};
-        }
-
-        .background {
-            stroke: ${SystemColors.Field};
-        }
-
-        :host(.paused) .indeterminate-indicator-1 {
-            stroke: ${SystemColors.Field};
-        }
-
-        :host(.paused) .determinate {
-            stroke: ${SystemColors.GrayText};
-        }
-    }
-
     @keyframes spin-infinite {
         0% {
             stroke-dasharray: 0.01px 43.97px;
@@ -94,5 +76,22 @@ export const ProgressRingStyles = css`
 `.withBehaviors(
     accentFillRestBehavior,
     neutralFillRestBehavior,
-    neutralForegroundHintBehavior
+    neutralForegroundHintBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            .indeterminate-indicator-1,
+            .determinate {
+                stroke: ${SystemColors.FieldText};
+            }
+            .background {
+                stroke: ${SystemColors.Field};
+            }
+            :host(.paused) .indeterminate-indicator-1 {
+                stroke: ${SystemColors.Field};
+            }
+            :host(.paused) .determinate {
+                stroke: ${SystemColors.GrayText};
+            }
+        `
+    )
 );

--- a/packages/web-components/fast-components/src/progress/progress-ring/progress-ring.styles.ts
+++ b/packages/web-components/fast-components/src/progress/progress-ring/progress-ring.styles.ts
@@ -7,7 +7,7 @@ import {
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
 } from "../../styles/recipes";
-import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
+import { forcedColorsStylesheetBehavior } from "../../styles/match-media-stylesheet-behavior";
 
 export const ProgressRingStyles = css`
     ${display("flex")} :host {

--- a/packages/web-components/fast-components/src/progress/progress/progress.styles.ts
+++ b/packages/web-components/fast-components/src/progress/progress/progress.styles.ts
@@ -6,7 +6,7 @@ import {
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
 } from "../../styles/recipes";
-import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
+import { forcedColorsStylesheetBehavior } from "../../styles/match-media-stylesheet-behavior";
 
 export const ProgressStyles = css`
     ${display("flex")} :host {

--- a/packages/web-components/fast-components/src/progress/progress/progress.styles.ts
+++ b/packages/web-components/fast-components/src/progress/progress/progress.styles.ts
@@ -6,6 +6,7 @@ import {
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
 } from "../../styles/recipes";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const ProgressStyles = css`
     ${display("flex")} :host {
@@ -73,26 +74,6 @@ export const ProgressStyles = css`
         background-color: var(--neutral-foreground-hint);
     }
 
-    @media (forced-colors: active) {
-        .indeterminate-indicator-1, .indeterminate-indicator-2, .determinate  {
-            forced-color-adjust: none;
-            background-color: ${SystemColors.FieldText};
-        }
-
-        .progress {
-            background-color: ${SystemColors.Field};
-            border: calc(var(--outline-width) * 1px) solid ${SystemColors.FieldText};
-        }
-
-        :host(.paused) .indeterminate-indicator-1, .indeterminate-indicator-2 {
-            background-color: ${SystemColors.Field};
-        }
-
-        :host(.paused) .determinate {
-            background-color: ${SystemColors.GrayText};
-        }
-    }
-
     @keyframes indeterminate-1 {
         0% {
             opacity: 1;
@@ -131,5 +112,26 @@ export const ProgressStyles = css`
 `.withBehaviors(
     accentFillRestBehavior,
     neutralFillRestBehavior,
-    neutralForegroundHintBehavior
+    neutralForegroundHintBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            .indeterminate-indicator-1,
+            .indeterminate-indicator-2,
+            .determinate {
+                forced-color-adjust: none;
+                background-color: ${SystemColors.FieldText};
+            }
+            .progress {
+                background-color: ${SystemColors.Field};
+                border: calc(var(--outline-width) * 1px) solid ${SystemColors.FieldText};
+            }
+            :host(.paused) .indeterminate-indicator-1,
+            .indeterminate-indicator-2 {
+                background-color: ${SystemColors.Field};
+            }
+            :host(.paused) .determinate {
+                background-color: ${SystemColors.GrayText};
+            }
+        `
+    )
 );

--- a/packages/web-components/fast-components/src/radio/radio.styles.ts
+++ b/packages/web-components/fast-components/src/radio/radio.styles.ts
@@ -10,6 +10,7 @@ import {
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
 } from "../styles/recipes";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const RadioStyles = css`
     ${display("inline-flex")} :host {
@@ -92,58 +93,51 @@ export const RadioStyles = css`
     :host(.disabled) {
         opacity: var(--disabled-opacity);
     }
-
-    @media (forced-colors: active) {
-        .control, .control:hover, .control:active {
-            forced-color-adjust: none;
-            border-color: ${SystemColors.FieldText};
-            background: ${SystemColors.Field};
-        }
-
-        :host(:${focusVisible}) .control {
-            border-color: ${SystemColors.Highlight};
-        }
-
-        :host(.checked) .control:hover, .control:active {
-            border-color: ${SystemColors.Highlight};
-            background: ${SystemColors.Highlight};
-        }
-
-        :host(.checked) .checked-indicator {
-            background: ${SystemColors.Highlight};
-            fill: ${SystemColors.Highlight};
-        }
-
-        :host(.checked) .control:hover .checked-indicator {
-            background: ${SystemColors.HighlightText};
-            fill: ${SystemColors.HighlightText};
-        }
-
-        :host(.disabled) {
-            forced-color-adjust: none;
-            opacity: 1;
-        }
-
-        :host(.disabled) .label {
-            color: ${SystemColors.GrayText};
-        }
-
-        :host(.disabled) .control,
-        :host(.checked.disabled) .control:hover, .control:active {
-            background: ${SystemColors.Field};
-            border-color: ${SystemColors.GrayText};
-        }
-
-        :host(.disabled) .checked-indicator,
-        :host(.checked.disabled) .control:hover .checked-indicator {
-            fill: ${SystemColors.GrayText};
-            background: ${SystemColors.GrayText};
-        }
-    }
 `.withBehaviors(
     neutralFillInputHoverBehavior,
     neutralFillInputRestBehavior,
     neutralForegroundRestBehavior,
     neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior
+    neutralOutlineRestBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            .control, .control:hover, .control:active {
+                forced-color-adjust: none;
+                border-color: ${SystemColors.FieldText};
+                background: ${SystemColors.Field};
+            }
+            :host(:${focusVisible}) .control {
+                border-color: ${SystemColors.Highlight};
+            }
+            :host(.checked) .control:hover, .control:active {
+                border-color: ${SystemColors.Highlight};
+                background: ${SystemColors.Highlight};
+            }
+            :host(.checked) .checked-indicator {
+                background: ${SystemColors.Highlight};
+                fill: ${SystemColors.Highlight};
+            }
+            :host(.checked) .control:hover .checked-indicator {
+                background: ${SystemColors.HighlightText};
+                fill: ${SystemColors.HighlightText};
+            }
+            :host(.disabled) {
+                forced-color-adjust: none;
+                opacity: 1;
+            }
+            :host(.disabled) .label {
+                color: ${SystemColors.GrayText};
+            }
+            :host(.disabled) .control,
+            :host(.checked.disabled) .control:hover, .control:active {
+                background: ${SystemColors.Field};
+                border-color: ${SystemColors.GrayText};
+            }
+            :host(.disabled) .checked-indicator,
+            :host(.checked.disabled) .control:hover .checked-indicator {
+                fill: ${SystemColors.GrayText};
+                background: ${SystemColors.GrayText};
+            }
+        `
+    )
 );

--- a/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
@@ -3,6 +3,7 @@ import { display } from "../styles";
 import { SystemColors } from "../styles/system-colors";
 import { heightNumber } from "../styles/size";
 import { neutralOutlineRestBehavior } from "../styles/recipes";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const SliderLabelStyles = css`
     ${display("block")} :host {
@@ -60,20 +61,24 @@ export const SliderLabelStyles = css`
     :host(.disabled) {
         opacity: var(--disabled-opacity);
     }
-    @media (forced-colors: active) {
-        .mark {
-            forced-color-adjust: none;
-            background: ${SystemColors.FieldText};
-        }
-        :host(.disabled) {
-            forced-color-adjust: none;
-            opacity: 1;
-        }
-        :host(.disabled) .label {
-            color: ${SystemColors.GrayText};
-        }
-        :host(.disabled) .mark {
-            background: ${SystemColors.GrayText};
-        }
-    }
-`.withBehaviors(neutralOutlineRestBehavior);
+`.withBehaviors(
+    neutralOutlineRestBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            .mark {
+                forced-color-adjust: none;
+                background: ${SystemColors.FieldText};
+            }
+            :host(.disabled) {
+                forced-color-adjust: none;
+                opacity: 1;
+            }
+            :host(.disabled) .label {
+                color: ${SystemColors.GrayText};
+            }
+            :host(.disabled) .mark {
+                background: ${SystemColors.GrayText};
+            }
+        `
+    )
+);

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -10,6 +10,7 @@ import {
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
 } from "../styles/recipes";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const SliderStyles = css`
     :host([hidden]) {
@@ -105,44 +106,40 @@ export const SliderStyles = css`
     :host(.disabled) {
         opacity: var(--disabled-opacity);
     }
-
-    @media (forced-colors: active) {
-        .thumb-cursor {
-            forced-color-adjust: none;
-            border-color: ${SystemColors.FieldText};
-            background: ${SystemColors.FieldText};
-        }
-
-        .thumb-cursor:hover,
-        .thumb-cursor:active {
-            background: ${SystemColors.Highlight};
-        }
-
-        .track {
-            forced-color-adjust: none;
-            background: ${SystemColors.FieldText};
-        }
-        
-        :host(:${focusVisible}) .thumb-cursor {
-            border-color: ${SystemColors.Highlight};
-        }
-
-        :host(.disabled) {
-            opacity: 1;
-            cursor: ${disabledCursor};
-        }
-
-        :host(.disabled) .slider,
-        :host(.disabled) .track,
-        :host(.disabled) .thumb-cursor {
-            forced-color-adjust: none;
-            background: ${SystemColors.GrayText};
-        }
-    }
 `.withBehaviors(
     neutralForegroundActiveBehavior,
     neutralForegroundHoverBehavior,
     neutralForegroundRestBehavior,
     neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior
+    neutralOutlineRestBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            .thumb-cursor {
+                forced-color-adjust: none;
+                border-color: ${SystemColors.FieldText};
+                background: ${SystemColors.FieldText};
+            }
+            .thumb-cursor:hover,
+            .thumb-cursor:active {
+                background: ${SystemColors.Highlight};
+            }
+            .track {
+                forced-color-adjust: none;
+                background: ${SystemColors.FieldText};
+            }
+            :host(:${focusVisible}) .thumb-cursor {
+                border-color: ${SystemColors.Highlight};
+            }
+            :host(.disabled) {
+                opacity: 1;
+                cursor: ${disabledCursor};
+            }
+            :host(.disabled) .slider,
+            :host(.disabled) .track,
+            :host(.disabled) .thumb-cursor {
+                forced-color-adjust: none;
+                background: ${SystemColors.GrayText};
+            }
+        `
+    )
 );

--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -2,8 +2,6 @@ import { css } from "@microsoft/fast-element";
 import { display } from "../display";
 import { focusVisible } from "../focus";
 import { heightNumber } from "../size";
-import { SystemColors } from "../system-colors";
-import { disabledCursor } from "../disabled";
 
 export const BaseButtonStyles = css`
     ${display("inline-block")} :host {
@@ -71,19 +69,6 @@ export const BaseButtonStyles = css`
     .end {
         margin-inline-start: 11px;
     }
-
-    @media (forced-colors: active) {
-        :host(.disabled),
-        :host(.disabled) .control {
-            forced-color-adjust: none;
-            background: ${SystemColors.ButtonFace};
-            border-color: ${SystemColors.GrayText};
-            color: ${SystemColors.GrayText};
-            cursor: ${disabledCursor};
-            fill: ${SystemColors.GrayText};
-            opacity: 1;
-        }
-    }
 `;
 
 export const AccentButtonStyles = css`
@@ -102,30 +87,6 @@ export const AccentButtonStyles = css`
 
     :host(.accent) .control:${focusVisible} {
         box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset var(--neutral-focus-inner-accent);
-    }
-
-    @media (forced-colors: active) {
-        :host(.accent) .control {
-            forced-color-adjust: none;
-            background: ${SystemColors.Highlight};
-            color: ${SystemColors.HighlightText};
-        }
-
-        :host(.accent) .control:hover {
-            background: ${SystemColors.HighlightText};
-            border-color: ${SystemColors.Highlight};
-            color: ${SystemColors.Highlight};
-        }
-
-        :host(.accent:${focusVisible}) .control {
-            border-color: ${SystemColors.ButtonText};
-            box-shadow: 0 0 0 2px ${SystemColors.HighlightText} inset;
-        }
-
-        :host(.accent.disabled) .control {
-            background: ${SystemColors.ButtonFace};
-            color: ${SystemColors.GrayText};
-        }
     }
 `;
 
@@ -201,26 +162,6 @@ export const LightweightButtonStyles = css`
         background: var(--neutral-foreground-rest);
         height: calc(var(--focus-outline-width) * 1px);
     }
-
-    @media (forced-colors: active) {
-        :host(.lightweight) .control:hover {
-            forced-color-adjust: none;
-            color: ${SystemColors.Highlight};
-        }
-
-        :host(.lightweight) .control:hover .content::before {
-            background: ${SystemColors.Highlight};
-        }
-
-        :host(.lightweight.disabled) .control {
-            forced-color-adjust: none;
-            color: ${SystemColors.GrayText};
-        }
-    
-        :host(.lightweight.disabled) .control:hover .content::before {
-            background: none;
-        }
-    }
 `;
 
 export const OutlineButtonStyles = css`
@@ -236,12 +177,6 @@ export const OutlineButtonStyles = css`
     :host(.outline) .control:active {
         border-color: var(--neutral-outline-active);
     }
-
-    @media (forced-colors: active) {
-        :host(.outline.disabled) .control {
-            border-color: ${SystemColors.GrayText};
-        }
-    }
 `;
 
 export const StealthButtonStyles = css`
@@ -255,12 +190,5 @@ export const StealthButtonStyles = css`
 
     :host(.stealth) .control:active {
         background: var(--neutral-fill-stealth-active);
-    }
-
-    @media (forced-colors: active) {
-        :host(.stealth.disabled) .control {
-            background: none;
-            border-color: transparent;
-        }
     }
 `;

--- a/packages/web-components/fast-components/src/switch/switch.styles.ts
+++ b/packages/web-components/fast-components/src/switch/switch.styles.ts
@@ -14,6 +14,7 @@ import {
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
 } from "../styles/recipes";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const SwitchStyles = css`
     :host([hidden]) {
@@ -131,50 +132,6 @@ export const SwitchStyles = css`
     :host(.checked) .checked-message {
         display: block;
     }
-
-    @media (forced-colors: active) {
-        .checked-indicator {
-            forced-color-adjust: none;
-            background: ${SystemColors.FieldText};
-        }
-
-        .switch, .switch:hover, .switch:active {
-            forced-color-adjust: none;
-            background: ${SystemColors.Field};
-            border-color: ${SystemColors.FieldText};
-        }
-
-        :host(.checked) .switch {
-            background: ${SystemColors.Highlight};
-            border-color: ${SystemColors.Highlight};
-        }
-
-        :host(.checked) .checked-indicator {
-            background: ${SystemColors.HighlightText};
-        }
-
-        :host(.disabled) {
-            opacity: 1;
-        }
-
-        :host(:${focusVisible}) .switch {
-            border-color: ${SystemColors.Highlight};
-        }
-
-        :host(.checked:${focusVisible}) .switch {
-            border-color: ${SystemColors.FieldText};
-            box-shadow: 0 0 0 2px ${SystemColors.Field} inset;
-        }
-
-        :host(.disabled) .checked-indicator {
-            background: ${SystemColors.GrayText};
-        }
-
-        :host(.disabled) .switch {
-            background: ${SystemColors.Field};
-            border-color: ${SystemColors.GrayText};
-        }
-    }
 `.withBehaviors(
     accentFillRestBehavior,
     accentForegroundCutRestBehavior,
@@ -184,5 +141,42 @@ export const SwitchStyles = css`
     neutralForegroundRestBehavior,
     neutralOutlineActiveBehavior,
     neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior
+    neutralOutlineRestBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            .checked-indicator {
+                forced-color-adjust: none;
+                background: ${SystemColors.FieldText};
+            }
+            .switch, .switch:hover, .switch:active {
+                forced-color-adjust: none;
+                background: ${SystemColors.Field};
+                border-color: ${SystemColors.FieldText};
+            }
+            :host(.checked) .switch {
+                background: ${SystemColors.Highlight};
+                border-color: ${SystemColors.Highlight};
+            }
+            :host(.checked) .checked-indicator {
+                background: ${SystemColors.HighlightText};
+            }
+            :host(.disabled) {
+                opacity: 1;
+            }
+            :host(:${focusVisible}) .switch {
+                border-color: ${SystemColors.Highlight};
+            }
+            :host(.checked:${focusVisible}) .switch {
+                border-color: ${SystemColors.FieldText};
+                box-shadow: 0 0 0 2px ${SystemColors.Field} inset;
+            }
+            :host(.disabled) .checked-indicator {
+                background: ${SystemColors.GrayText};
+            }
+            :host(.disabled) .switch {
+                background: ${SystemColors.Field};
+                border-color: ${SystemColors.GrayText};
+            }
+        `
+    )
 );

--- a/packages/web-components/fast-components/src/tabs/tab/tab.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tab/tab.styles.ts
@@ -8,6 +8,7 @@ import {
     neutralForegroundRestBehavior,
 } from "../../styles/recipes";
 import { SystemColors } from "../../styles/system-colors";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const TabStyles = css`
     ${display("inline-flex")} :host {
@@ -71,27 +72,26 @@ export const TabStyles = css`
 
     :host(.vertical:hover[aria-selected="true"]) {
     }
-
-    @media (forced-colors: active) {
-        :host {
-            forced-color-adjust: none;
-            border-color: transparent;
-            color: ${SystemColors.ButtonText};
-        }
-
-        :host(:hover),
-        :host(.vertical:hover) {
-            color: ${SystemColors.ButtonText};
-        }
-
-        :host(:${focusVisible}) {
-            border-color: ${SystemColors.ButtonText};
-            box-shadow: none;
-        }
-    }
 `.withBehaviors(
     neutralFocusBehavior,
     neutralForegroundRestBehavior,
     neutralForegroundHoverBehavior,
-    neutralForegroundActiveBehavior
+    neutralForegroundActiveBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            :host {
+                forced-color-adjust: none;
+                border-color: transparent;
+                color: ${SystemColors.ButtonText};
+            }
+            :host(:hover),
+            :host(.vertical:hover) {
+                color: ${SystemColors.ButtonText};
+            }
+            :host(:${focusVisible}) {
+                border-color: ${SystemColors.ButtonText};
+                box-shadow: none;
+            }
+        `
+    )
 );

--- a/packages/web-components/fast-components/src/tabs/tab/tab.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tab/tab.styles.ts
@@ -8,7 +8,7 @@ import {
     neutralForegroundRestBehavior,
 } from "../../styles/recipes";
 import { SystemColors } from "../../styles/system-colors";
-import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
+import { forcedColorsStylesheetBehavior } from "../../styles/match-media-stylesheet-behavior";
 
 export const TabStyles = css`
     ${display("inline-flex")} :host {

--- a/packages/web-components/fast-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tabs.styles.ts
@@ -2,6 +2,7 @@ import { css } from "@microsoft/fast-element";
 import { display } from "../styles";
 import { accentFillRestBehavior, neutralForegroundRestBehavior } from "../styles/recipes";
 import { SystemColors } from "../styles/system-colors";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const TabsStyles = css`
     ${display("grid")} :host {
@@ -94,12 +95,16 @@ export const TabsStyles = css`
     :host(.vertical) .activeIndicatorTransition {
         transition: transform 0.2s linear;
     }
-
-    @media (forced-colors: active) {
-        .activeIndicator,
-        :host(.vertical) .activeIndicator {
-            forced-color-adjust: none;
-            background: ${SystemColors.Highlight};
-        }
-    }
-`.withBehaviors(accentFillRestBehavior, neutralForegroundRestBehavior);
+`.withBehaviors(
+    accentFillRestBehavior,
+    neutralForegroundRestBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            .activeIndicator,
+            :host(.vertical) .activeIndicator {
+                forced-color-adjust: none;
+                background: ${SystemColors.Highlight};
+            }
+        `
+    )
+);

--- a/packages/web-components/fast-components/src/text-area/text-area.styles.ts
+++ b/packages/web-components/fast-components/src/text-area/text-area.styles.ts
@@ -12,6 +12,7 @@ import {
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
 } from "../styles/recipes";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const TextAreaStyles = css`
     ${display("inline-block")} :host {
@@ -102,12 +103,6 @@ export const TextAreaStyles = css`
     :host([disabled]) {
         opacity: var(--disabled-opacity);
     }
-
-    @media (forced-colors: active) {
-        :host([disabled]) {
-            opacity: 1;
-        }
-    }
 `.withBehaviors(
     neutralFillHoverBehavior,
     neutralFillInputHoverBehavior,
@@ -116,5 +111,12 @@ export const TextAreaStyles = css`
     neutralFocusBehavior,
     neutralForegroundRestBehavior,
     neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior
+    neutralOutlineRestBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            :host([disabled]) {
+                opacity: 1;
+            }
+        `
+    )
 );

--- a/packages/web-components/fast-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/fast-components/src/text-field/text-field.styles.ts
@@ -13,6 +13,7 @@ import {
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
 } from "../styles/recipes";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const TextFieldStyles = css`
     ${display("inline-block")} :host {
@@ -117,41 +118,6 @@ export const TextFieldStyles = css`
     :host(.disabled) {
         opacity: var(--disabled-opacity);
     }
-
-    @media (forced-colors: active) {
-        .root, :host(.filled) .root {
-            forced-color-adjust: none;
-            background: ${SystemColors.Field};
-            border-color: ${SystemColors.FieldText};
-        }
-
-        :host(:hover:not(.disabled)) .root,
-        :host(.filled:hover:not(.disabled)) .root,
-        :host(.filled:hover) .root {
-            background: ${SystemColors.Field};
-            border-color: ${SystemColors.Highlight};
-        }
-
-        .before-content,
-        .after-content {
-            fill: ${SystemColors.ButtonText};
-        }
-
-        :host(.disabled) {
-            opacity: 1;
-        }
-        
-        :host(.disabled) .root,
-        :host(.filled:hover.disabled) .root {
-            border-color: ${SystemColors.GrayText};
-            background: ${SystemColors.Field};
-        }
-
-        :host(:focus-within) .root {
-            border-color: ${SystemColors.Highlight};
-            box-shadow: 0 0 0 1px ${SystemColors.Highlight} inset;
-        }
-    }
 `.withBehaviors(
     neutralFillHoverBehavior,
     neutralFillInputHoverBehavior,
@@ -160,5 +126,37 @@ export const TextFieldStyles = css`
     neutralFocusBehavior,
     neutralForegroundRestBehavior,
     neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior
+    neutralOutlineRestBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            .root,
+            :host(.filled) .root {
+                forced-color-adjust: none;
+                background: ${SystemColors.Field};
+                border-color: ${SystemColors.FieldText};
+            }
+            :host(:hover:not(.disabled)) .root,
+            :host(.filled:hover:not(.disabled)) .root,
+            :host(.filled:hover) .root {
+                background: ${SystemColors.Field};
+                border-color: ${SystemColors.Highlight};
+            }
+            .before-content,
+            .after-content {
+                fill: ${SystemColors.ButtonText};
+            }
+            :host(.disabled) {
+                opacity: 1;
+            }
+            :host(.disabled) .root,
+            :host(.filled:hover.disabled) .root {
+                border-color: ${SystemColors.GrayText};
+                background: ${SystemColors.Field};
+            }
+            :host(:focus-within) .root {
+                border-color: ${SystemColors.Highlight};
+                box-shadow: 0 0 0 1px ${SystemColors.Highlight} inset;
+            }
+        `
+    )
 );


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Following the work on adding a forced-colors behavior function. I have gone through to move all of our high contrast styles from forced-colors media query into `forcedColorsStylesheetBehavior`. This implementation will conditionally apply high-contrast styles to the components.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->