### PR TITLE
feat: add radio-group component

### DIFF
--- a/packages/web-components/fast-components/src/radio-group/README.md
+++ b/packages/web-components/fast-components/src/radio-group/README.md
@@ -1,4 +1,4 @@
 # fast-radio-group
-An implementation of a [radio](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio) as a form-connected web-component.
+An implementation of a [radio-group](https://w3c.github.io/aria-practices/#radiobutton).
 
 For more information view the [component specification](./radio-group.spec.md).

--- a/packages/web-components/fast-components/src/radio-group/README.md
+++ b/packages/web-components/fast-components/src/radio-group/README.md
@@ -1,0 +1,4 @@
+# fast-radio-group
+An implementation of a [radio](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio) as a form-connected web-component.
+
+For more information view the [component specification](./radio-group.spec.md).

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -32,13 +32,15 @@
     </div>
 
     <div role="toolbar" style="display: flex; flex-direction: column;margin-top: 12px;">
-        <button>go</button>
-        <fast-radio-group required="true" name="navigation">
-            <fast-radio value="back">back</fast-radio>
-            <fast-radio value="forward">forward</fast-radio>
-            <fast-radio value="refresh">refresh</fast-radio>
-        </fast-radio-group>
-        <button>stop</button>
+        <div style="display: flex; flex-direction: row; align-items: stretch; width: 100%">
+            <button style="width: 40px;margin-right: 4px;">go</button>
+            <fast-radio-group required="true" name="navigation">
+                <fast-radio value="back">back</fast-radio>
+                <fast-radio value="forward">forward</fast-radio>
+                <fast-radio value="refresh">refresh</fast-radio>
+            </fast-radio-group>
+            <button style="width: 40px;margin-left: 4px;">stop</button>            
+        </div>
     </div>
 
     <div style="display: flex; flex-direction: column;margin-top: 12px;">

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -4,6 +4,7 @@
     <h4>Defaults</h4>
     <div>
         <fast-radio-group name="numbers">
+            <label slot="label">Numbers</label>
             <fast-radio value="one">One</fast-radio>
             <fast-radio value="two">Two</fast-radio>
         </fast-radio-group>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -32,4 +32,12 @@
             <fast-radio value="excel">Excel</fast-radio>
         </fast-radio-group>
     </div>
+
+    <div style="display: flex; flex-direction: column;margin-top: 12px;">
+        <label id="label4">Preset selected-value</label>
+        <fast-radio-group selected-value="maverick" aria-labelledby="label4" name="fruits">
+            <fast-radio value="iceman">Ice Man</fast-radio>
+            <fast-radio value="maverick">Maverick</fast-radio>
+        </fast-radio-group>
+    </div>
 </fast-design-system-provider>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -14,6 +14,7 @@
         <fast-radio-group aria-labelledby="label1" name="fruits">
             <fast-radio value="apples">Apples</fast-radio>
             <fast-radio value="oranges">Oranges</fast-radio>
+            <fast-radio value="bananas">Bananas</fast-radio>
         </fast-radio-group>
     </div>
 

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -16,7 +16,7 @@
 
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
         <label id="label1">Outside label</label>
-        <fast-radio-group aria-labelledby="label1" name="fruits">
+        <fast-radio-group required="true" aria-labelledby="label1" name="fruits">
             <fast-radio value="apples">Apples</fast-radio>
             <fast-radio value="oranges">Oranges</fast-radio>
             <fast-radio value="bananas">Bananas</fast-radio>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -1,0 +1,19 @@
+<fast-design-system-provider use-defaults>
+    <h1>Radio Group</h1>
+
+    <h4>Defaults</h4>
+    <div>
+        <fast-radio-group name="numbers">
+            <fast-radio value="one">One</fast-radio>
+            <fast-radio value="two">Two</fast-radio>
+        </fast-radio-group>
+    </div>
+
+    <div style="display: flex; flex-direction: column;margin-top: 12px;">
+        <label id="label1">Outside label</label>
+        <fast-radio-group aria-labelledby="label1" name="fruits">
+            <fast-radio value="apples">Apples</fast-radio>
+            <fast-radio value="oranges">Oranges</fast-radio>
+        </fast-radio-group>
+    </div>
+</fast-design-system-provider>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -41,9 +41,11 @@
 
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
         <label id="label4">Preset selected-value</label>
-        <fast-radio-group selected-value="maverick" aria-labelledby="label4" name="fruits">
-            <fast-radio value="iceman">Ice Man</fast-radio>
+        <fast-radio-group value="maverick" aria-labelledby="label4" name="best-pilot">
+            <fast-radio value="ice-man">Ice Man</fast-radio>
             <fast-radio value="maverick">Maverick</fast-radio>
+            <fast-radio value="viper">Viper</fast-radio>
+            <fast-radio value="jester">Jester</fast-radio>
         </fast-radio-group>
     </div>
 </fast-design-system-provider>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -31,6 +31,16 @@
         </fast-radio-group>
     </div>
 
+    <div role="toolbar" style="display: flex; flex-direction: column;margin-top: 12px;">
+        <button>go</button>
+        <fast-radio-group required="true" name="navigation">
+            <fast-radio value="back">back</fast-radio>
+            <fast-radio value="forward">forward</fast-radio>
+            <fast-radio value="refresh">refresh</fast-radio>
+        </fast-radio-group>
+        <button>stop</button>
+    </div>
+
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
         <label id="label2">Disabled radio group</label>
         <fast-radio-group disabled aria-labelledby="label2" name="cars">

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -11,6 +11,13 @@
     </div>
 
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
+        <fast-radio-group name="players">
+            <label slot="label">Best basketball players</label>
+            <fast-radio value="airjordan">Michael Jordan</fast-radio>
+        </fast-radio-group>
+    </div>
+
+    <div style="display: flex; flex-direction: column;margin-top: 12px;">
         <label>Single radio (no group)</label>
         <fast-radio value="single-life">Single life</fast-radio>
     </div>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -10,6 +10,11 @@
     </div>
 
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
+        <label>Single radio (no group)</label>
+        <fast-radio value="single-life">Single life</fast-radio>
+    </div>
+
+    <div style="display: flex; flex-direction: column;margin-top: 12px;">
         <label id="label1">Outside label</label>
         <fast-radio-group aria-labelledby="label1" name="fruits">
             <fast-radio value="apples">Apples</fast-radio>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -16,4 +16,20 @@
             <fast-radio value="oranges">Oranges</fast-radio>
         </fast-radio-group>
     </div>
+
+    <div style="display: flex; flex-direction: column;margin-top: 12px;">
+        <label id="label2">Disabled radio group</label>
+        <fast-radio-group disabled aria-labelledby="label2" name="cars">
+            <fast-radio value="lambo">Lamborghini</fast-radio>
+            <fast-radio value="ferari">Ferari</fast-radio>
+        </fast-radio-group>
+    </div>
+
+    <div style="display: flex; flex-direction: column;margin-top: 12px;">
+        <label id="label3">readonly radio group</label>
+        <fast-radio-group readonly aria-labelledby="label3" name="office">
+            <fast-radio value="word">Word</fast-radio>
+            <fast-radio value="excel">Excel</fast-radio>
+        </fast-radio-group>
+    </div>
 </fast-design-system-provider>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -28,6 +28,12 @@
             <fast-radio value="apples">Apples</fast-radio>
             <fast-radio value="oranges">Oranges</fast-radio>
             <fast-radio value="bananas">Bananas</fast-radio>
+            <fast-radio value="kiwi">Kiwi</fast-radio>
+            <fast-radio value="grapefruit">Grapefruit</fast-radio>
+            <fast-radio value="mango">Mango</fast-radio>
+            <fast-radio value="blueberries">Blueberries</fast-radio>
+            <fast-radio value="strawberries">Strawberries</fast-radio>
+            <fast-radio value="pineapple">Pineapple</fast-radio>
         </fast-radio-group>
     </div>
 

--- a/packages/web-components/fast-components/src/radio-group/index.ts
+++ b/packages/web-components/fast-components/src/radio-group/index.ts
@@ -1,0 +1,14 @@
+import { customElement } from "@microsoft/fast-element";
+import { RadioGroup } from "./radio-group";
+import { RadioGroupTemplate as template } from "./radio-group.template";
+import { RadioGroupStyles as styles } from "./radio-group.styles";
+
+@customElement({
+    name: "fast-radio-group",
+    template,
+    styles,
+})
+export class FASTRadioGroup extends RadioGroup {}
+export * from "./radio-group.template";
+export * from "./radio-group.styles";
+export * from "./radio-group";

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -49,7 +49,6 @@ Radio group allows the user to be presented with a list of all the options visib
 
 ### Anatomy and Appearance
 *Parts:*
-- label
 - control
 
 *Template:*

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -39,6 +39,10 @@ Radio group allows the user to be presented with a list of all the options visib
 
 *Attributes:*
 - `selected-value` - allows user to set the initial radio selected within the group independent of value.
+- `readonly`
+  - If there is a selected radio button in the group it should be submitted with the form but none of the radio buttons should be editable.
+- `disabled`
+  - All of the radio buttons should be disabled from user interaction and will not be submitted with the form data.
 
 *Slots:*
 - default slot for radio items

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -56,7 +56,10 @@ Radio group allows the user to be presented with a list of all the options visib
 <template
     role="radiogroup"
 >
-    <slot></slot>
+    <slot name="label"></slot>
+    <div class="control" part="control">
+        <slot ${slotted("slottedRadioButtons")}> </slot>
+    </div>
 </template>
 ```
 

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -48,6 +48,21 @@ Radio group allows the user to be presented with a list of all the options visib
 - `change` - raise the change event for external parties to be informed of the selected value change.
 
 ### Anatomy and Appearance
+*Parts:*
+- label
+- control
+
+*Template:*
+```
+<template
+    role="radiogroup"
+>
+    <div part="control" class="control">
+        <slot></slot>
+    </div>
+</template>
+```
+
 
 ### Accessibility
 

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -5,9 +5,6 @@
 As defined by the W3C:
 > A radio group is a set of checkable buttons, known as radio buttons, where no more than one of the buttons can be checked at a time. Some implementations may initialize the set with all buttons in the unchecked state in order to force the user to check one of the buttons before moving past a certain point in the workflow.
 
-### Background
-
-
 ### Use Cases
 
 Radio group allows the user to be presented with a list of all the options visible which can facilitate the comparison of choice.

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -38,7 +38,6 @@ Radio group allows the user to be presented with a list of all the options visib
 - `fast-radio-group`
 
 *Attributes:*
-- `value` - represents the value of the selected radio button within the group.
 - `selected-value` - allows user to set the initial radio selected within the group independent of value.
 
 *Slots:*

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -56,9 +56,7 @@ Radio group allows the user to be presented with a list of all the options visib
 <template
     role="radiogroup"
 >
-    <div part="control" class="control">
-        <slot></slot>
-    </div>
+    <slot></slot>
 </template>
 ```
 

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -1,0 +1,73 @@
+# Radio group
+
+## Overview
+
+As defined by the W3C:
+> A radio group is a set of checkable buttons, known as radio buttons, where no more than one of the buttons can be checked at a time. Some implementations may initialize the set with all buttons in the unchecked state in order to force the user to check one of the buttons before moving past a certain point in the workflow.
+
+### Background
+
+
+### Use Cases
+
+Radio group allows the user to be presented with a list of all the options visible which can facilitate the comparison of choice.
+  
+### Features
+
+- **Selection:** A radio group can only support single select
+
+
+### Prior Art/Examples
+- [Material UI](https://material-ui.com/api/radio-group/)
+- [Lightning Design](https://www.lightningdesignsystem.com/components/radio-group/)
+- [Carbon design](https://www.carbondesignsystem.com/components/radio-button/code)
+- [Ant Design](https://ant.design/components/radio/)
+- [Atlassian](https://atlaskit.atlassian.com/packages/core/radio)
+- [Windows (UWP)](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/radio-button)
+
+---
+
+## Design
+
+### API
+
+*The key elements of the component's public API surface:*
+
+**Radio Group**
+*Component name:*
+- `fast-radio-group`
+
+*Attributes:*
+- `value` - represents the value of the selected radio button within the group.
+- `selected-value` - allows user to set the initial radio selected within the group independent of value.
+
+*Slots:*
+- default slot for radio items
+
+*Events*
+- `change` - raise the change event for external parties to be informed of the selected value change.
+
+### Anatomy and Appearance
+
+### Accessibility
+
+Keyboard interaction will work as described by [W3C](https://w3c.github.io/aria-practices/#radiobutton)
+
+- Tab and Shift + Tab: Move focus into and out of the radio group. When focus moves into a radio group :
+ - If a radio button is checked, focus is set on the checked button.
+ - If none of the radio buttons are checked, focus is set on the first radio button in the group.
+- Space: checks the focused radio button if it is not already checked.
+- Right Arrow and Down Arrow: move focus to the next radio button in the group, uncheck the previously focused button, and check the newly focused button. If focus is on the last button, focus moves to the first button.
+- Left Arrow and Up Arrow: move focus to the previous radio button in the group, uncheck the previously focused button, and check the newly focused button. If focus is on the first button, focus moves to the last button.
+
+
+Radio group:
+```html
+<fast-radio-group selected-value="3">
+    <fast-radio value="1">One</fast-radio>
+    <fast-radio value="2">Two</fast-radio>
+    <fast-radio value="3" checked>Three</fast-radio>
+    <fast-radio value="4" disabled>Four</fast-radio>
+</fast-radio-group>
+```
+

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -35,7 +35,7 @@ Radio group allows the user to be presented with a list of all the options visib
 - `fast-radio-group`
 
 *Attributes:*
-- `selected-value` - allows user to set the initial radio selected within the group independent of value.
+- `value` - allows user to set the initial radio selected within the group independent of value.
 - `readonly`
   - If there is a selected radio button in the group it should be submitted with the form but none of the radio buttons should be editable.
 - `disabled`
@@ -43,9 +43,8 @@ Radio group allows the user to be presented with a list of all the options visib
 
 *Slots:*
 - default slot for radio items
+- label - provide a label for the radio group
 
-*Events*
-- `change` - raise the change event for external parties to be informed of the selected value change.
 
 ### Anatomy and Appearance
 *Parts:*

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -35,7 +35,7 @@ Radio group allows the user to be presented with a list of all the options visib
 - `fast-radio-group`
 
 *Attributes:*
-- `value` - allows user to set the initial radio selected within the group independent of value.
+- `value` - allows user to set the initial radio selected within the group.
 - `readonly`
   - If there is a selected radio button in the group it should be submitted with the form but none of the radio buttons should be editable.
 - `disabled`
@@ -48,7 +48,7 @@ Radio group allows the user to be presented with a list of all the options visib
 
 ### Anatomy and Appearance
 *Parts:*
-- control
+- positioning-region
 
 *Template:*
 ```
@@ -56,7 +56,7 @@ Radio group allows the user to be presented with a list of all the options visib
     role="radiogroup"
 >
     <slot name="label"></slot>
-    <div class="control" part="control">
+    <div class="positioning-region" part="positioning-region">
         <slot ${slotted("slottedRadioButtons")}> </slot>
     </div>
 </template>

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -30,7 +30,7 @@ Radio group allows the user to be presented with a list of all the options visib
 
 *The key elements of the component's public API surface:*
 
-**Radio Group**
+**Radio group**
 *Component name:*
 - `fast-radio-group`
 

--- a/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.spec.md
@@ -74,10 +74,11 @@ Keyboard interaction will work as described by [W3C](https://w3c.github.io/aria-
 - Right Arrow and Down Arrow: move focus to the next radio button in the group, uncheck the previously focused button, and check the newly focused button. If focus is on the last button, focus moves to the first button.
 - Left Arrow and Up Arrow: move focus to the previous radio button in the group, uncheck the previously focused button, and check the newly focused button. If focus is on the first button, focus moves to the last button.
 
+Additional support for keyboard interaction while in a toolbar as described by [W3C](https://w3c.github.io/aria-practices/#for-radio-group-contained-in-a-toolbar)
 
 Radio group:
 ```html
-<fast-radio-group selected-value="3">
+<fast-radio-group value="3">
     <fast-radio value="1">One</fast-radio>
     <fast-radio value="2">Two</fast-radio>
     <fast-radio value="3" checked>Three</fast-radio>

--- a/packages/web-components/fast-components/src/radio-group/radio-group.stories.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.stories.ts
@@ -1,0 +1,13 @@
+import { FASTDesignSystemProvider } from "../design-system-provider";
+import Examples from "./fixtures/base.html";
+import { FASTRadioGroup } from "./";
+
+// Prevent tree-shaking
+FASTRadioGroup;
+FASTDesignSystemProvider;
+
+export default {
+    title: "RadioGroup",
+};
+
+export const RadioGroup = () => Examples;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -14,17 +14,12 @@ export const RadioGroupStyles = css`
         user-select: none;
         position: relative;
         flex-direction: row;
+        box-sizing: border-box;
+        cursor: pointer;
         transition: all 0.2s ease-in-out;
     }
 
-    .control {
-        position: relative;
-        box-sizing: border-box;
-        outline: none;
-        cursor: pointer;
-    }
-
-    :host(:${focusVisible}) .control {
+    :host(:${focusVisible}) {
         box-shadow: 0 0 0 1px var(--neutral-focus) inset;
         border-color: var(--neutral-focus);
     }
@@ -35,7 +30,7 @@ export const RadioGroupStyles = css`
 `.withBehaviors(
     forcedColorsStylesheetBehavior(
         css`
-            :host(:${focusVisible}) .control {
+            :host(:${focusVisible}) {
                 border-color: ${SystemColors.Highlight};
             }
     
@@ -43,7 +38,7 @@ export const RadioGroupStyles = css`
                 opacity: 1;
             }
     
-            :host(.disabled) .control {
+            :host(.disabled) {
                 forced-color-adjust: none;
                 border-color: ${SystemColors.GrayText};
             }

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -3,6 +3,7 @@ import { display } from "../styles";
 import { focusVisible } from "../styles/focus";
 import { SystemColors } from "../styles/system-colors";
 import { heightNumber } from "../styles/size";
+import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const RadioGroupStyles = css`
     ${display("inline-flex")} :host {
@@ -10,12 +11,7 @@ export const RadioGroupStyles = css`
         align-items: center;
         outline: none;
         margin: calc(var(--design-unit) * 1px) 0;
-        ${
-            /*
-             * Chromium likes to select label text or the default slot when
-             * the radio button is clicked. Maybe there is a better solution here?
-             */ ""
-        } user-select: none;
+        user-select: none;
         position: relative;
         flex-direction: row;
         transition: all 0.2s ease-in-out;
@@ -36,19 +32,21 @@ export const RadioGroupStyles = css`
     :host(.disabled) {
         opacity: var(--disabled-opacity);
     }
-
-    @media (forced-colors: active) {  
-        :host(:${focusVisible}) .control {
-            border-color: ${SystemColors.Highlight};
-        }
-
-        :host(.disabled) {
-            opacity: 1;
-        }
-
-        :host(.disabled) .control {
-            forced-color-adjust: none;
-            border-color: ${SystemColors.GrayText};
-        }
-    }
-`;
+`.withBehaviors(
+    forcedColorsStylesheetBehavior(
+        css`
+            :host(:${focusVisible}) .control {
+                border-color: ${SystemColors.Highlight};
+            }
+    
+            :host(.disabled) {
+                opacity: 1;
+            }
+    
+            :host(.disabled) .control {
+                forced-color-adjust: none;
+                border-color: ${SystemColors.GrayText};
+            }
+        `
+    )
+);

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -1,44 +1,16 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "../styles";
-import { focusVisible } from "../styles/focus";
-import { SystemColors } from "../styles/system-colors";
-import { heightNumber } from "../styles/size";
-import { forcedColorsStylesheetBehavior } from "../styles/match-media-stylesheet-behavior";
 
 export const RadioGroupStyles = css`
-    ${display("inline-flex")} :host {
-        --input-size: calc((${heightNumber} / 2) + var(--design-unit));
-        align-items: center;
-        outline: none;
+    ${display("flex")} :host {
+        align-items: flex-start;
         margin: calc(var(--design-unit) * 1px) 0;
-        user-select: none;
         position: relative;
+        flex-direction: column;
+    }
+
+    .control {
+        display: inline-flex;
         flex-direction: row;
     }
-
-    :host(:${focusVisible}) {
-        box-shadow: 0 0 0 1px var(--neutral-focus) inset;
-        border-color: var(--neutral-focus);
-    }
-
-    :host(.disabled) {
-        opacity: var(--disabled-opacity);
-    }
-`.withBehaviors(
-    forcedColorsStylesheetBehavior(
-        css`
-            :host(:${focusVisible}) {
-                border-color: ${SystemColors.Highlight};
-            }
-    
-            :host(.disabled) {
-                opacity: 1;
-            }
-    
-            :host(.disabled) {
-                forced-color-adjust: none;
-                border-color: ${SystemColors.GrayText};
-            }
-        `
-    )
-);
+`;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -1,0 +1,54 @@
+import { css } from "@microsoft/fast-element";
+import { disabledCursor, display } from "../styles";
+import { focusVisible } from "../styles/focus";
+import { SystemColors } from "../styles/system-colors";
+import { heightNumber } from "../styles/size";
+
+export const RadioGroupStyles = css`
+    ${display("inline-flex")} :host {
+        --input-size: calc((${heightNumber} / 2) + var(--design-unit));
+        align-items: center;
+        outline: none;
+        margin: calc(var(--design-unit) * 1px) 0;
+        ${
+            /*
+             * Chromium likes to select label text or the default slot when
+             * the radio button is clicked. Maybe there is a better solution here?
+             */ ""
+        } user-select: none;
+        position: relative;
+        flex-direction: row;
+        transition: all 0.2s ease-in-out;
+    }
+
+    .control {
+        position: relative;
+        box-sizing: border-box;
+        outline: none;
+        cursor: pointer;
+    }
+
+    :host(:${focusVisible}) .control {
+        box-shadow: 0 0 0 1px var(--neutral-focus) inset;
+        border-color: var(--neutral-focus);
+    }
+
+    :host(.disabled) {
+        opacity: var(--disabled-opacity);
+    }
+
+    @media (forced-colors: active) {  
+        :host(:${focusVisible}) .control {
+            border-color: ${SystemColors.Highlight};
+        }
+
+        :host(.disabled) {
+            opacity: 1;
+        }
+
+        :host(.disabled) .control {
+            forced-color-adjust: none;
+            border-color: ${SystemColors.GrayText};
+        }
+    }
+`;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -1,5 +1,5 @@
 import { css } from "@microsoft/fast-element";
-import { disabledCursor, display } from "../styles";
+import { display } from "../styles";
 import { focusVisible } from "../styles/focus";
 import { SystemColors } from "../styles/system-colors";
 import { heightNumber } from "../styles/size";

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -14,9 +14,6 @@ export const RadioGroupStyles = css`
         user-select: none;
         position: relative;
         flex-direction: row;
-        box-sizing: border-box;
-        cursor: pointer;
-        transition: all 0.2s ease-in-out;
     }
 
     :host(:${focusVisible}) {

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -5,7 +5,6 @@ export const RadioGroupStyles = css`
     ${display("flex")} :host {
         align-items: flex-start;
         margin: calc(var(--design-unit) * 1px) 0;
-        position: relative;
         flex-direction: column;
     }
 

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -9,7 +9,8 @@ export const RadioGroupStyles = css`
     }
 
     .positioning-region {
-        display: inline-flex;
+        display: flex;
+        flex-wrap: wrap;
         flex-direction: row;
     }
 `;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -9,7 +9,7 @@ export const RadioGroupStyles = css`
         flex-direction: column;
     }
 
-    .control {
+    .positioning-region {
         display: inline-flex;
         flex-direction: row;
     }

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -11,6 +11,5 @@ export const RadioGroupStyles = css`
     .positioning-region {
         display: flex;
         flex-wrap: wrap;
-        flex-direction: row;
     }
 `;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
@@ -7,6 +7,9 @@ export const RadioGroupTemplate = html<RadioGroup>`
         aria-disabled="${x => x.disabled}"
         aria-readonly="${x => x.readOnly}"
     >
-        <slot ${slotted("slottedRadioButtons")}> </slot>
+        <slot name="label"></slot>
+        <div class="control" part="control">
+            <slot ${slotted("slottedRadioButtons")}> </slot>
+        </div>
     </template>
 `;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
@@ -1,4 +1,4 @@
-import { html } from "@microsoft/fast-element";
+import { html, slotted } from "@microsoft/fast-element";
 import { RadioGroup } from "./radio-group";
 
 export const RadioGroupTemplate = html<RadioGroup>`
@@ -9,7 +9,7 @@ export const RadioGroupTemplate = html<RadioGroup>`
         tabindex="${x => (x.disabled ? null : 0)}"
     >
         <div part="control" class="control">
-            <slot> </slot>
+            <slot ${slotted("slottedRadioButtons")}> </slot>
         </div>
     </template>
 `;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
@@ -7,8 +7,6 @@ export const RadioGroupTemplate = html<RadioGroup>`
         ?aria-disabled="${x => x.disabled}"
         ?aria-readonly="${x => x.readOnly}"
     >
-        <div part="control" class="control">
-            <slot ${slotted("slottedRadioButtons")}> </slot>
-        </div>
+        <slot ${slotted("slottedRadioButtons")}> </slot>
     </template>
 `;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
@@ -1,0 +1,15 @@
+import { html } from "@microsoft/fast-element";
+import { RadioGroup } from "./radio-group";
+
+export const RadioGroupTemplate = html<RadioGroup>`
+    <template
+        role="radio"
+        ?aria-disabled="${x => x.disabled}"
+        ?aria-readonly="${x => x.readOnly}"
+        tabindex="${x => (x.disabled ? null : 0)}"
+    >
+        <div part="control" class="control">
+            <slot> </slot>
+        </div>
+    </template>
+`;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
@@ -3,10 +3,9 @@ import { RadioGroup } from "./radio-group";
 
 export const RadioGroupTemplate = html<RadioGroup>`
     <template
-        role="radio"
+        role="radiogroup"
         ?aria-disabled="${x => x.disabled}"
         ?aria-readonly="${x => x.readOnly}"
-        tabindex="${x => (x.disabled ? null : 0)}"
     >
         <div part="control" class="control">
             <slot ${slotted("slottedRadioButtons")}> </slot>

--- a/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
@@ -4,8 +4,8 @@ import { RadioGroup } from "./radio-group";
 export const RadioGroupTemplate = html<RadioGroup>`
     <template
         role="radiogroup"
-        ?aria-disabled="${x => x.disabled}"
-        ?aria-readonly="${x => x.readOnly}"
+        aria-disabled="${x => x.disabled}"
+        aria-readonly="${x => x.readOnly}"
     >
         <slot ${slotted("slottedRadioButtons")}> </slot>
     </template>

--- a/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
@@ -8,7 +8,7 @@ export const RadioGroupTemplate = html<RadioGroup>`
         aria-readonly="${x => x.readOnly}"
     >
         <slot name="label"></slot>
-        <div class="control" part="control">
+        <div class="positioning-region" part="positioning-region">
             <slot ${slotted("slottedRadioButtons")}> </slot>
         </div>
     </template>

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -176,16 +176,11 @@ export class RadioGroup extends FASTElement {
                         this.moveToRadioByIndex(group, index, inToolbar);
                         break;
                     } else if (index === group.indexOf(this.selectedRadio!)) {
-                        console.log("breaking, 1st else if");
                         break;
                     } else if (index + 1 >= group.length) {
                         if (inToolbar) {
-                            console.log(
-                                "we are inside a toolbar don't set index to 0, move focus to next group"
-                            );
                             break;
                         } else {
-                            console.log("setting index to 0 not in toolbar");
                             index = 0;
                         }
                     } else {

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -46,9 +46,9 @@ export class RadioGroup extends FASTElement {
         });
     }
 
-    @attr({ attribute: "selected-value" })
-    public selectedValue: string;
-    private selectedValueChanged(): void {
+    @attr
+    public value: string;
+    private valueChanged(): void {
         this.$emit("change");
     }
 
@@ -78,10 +78,7 @@ export class RadioGroup extends FASTElement {
                 radio.setAttribute("readonly", "");
             }
 
-            if (
-                this.selectedValue &&
-                this.selectedValue === radio.getAttribute("value")
-            ) {
+            if (this.value && this.value === radio.getAttribute("value")) {
                 this.selectedRadio = radio;
                 radio.setAttribute("checked", "");
                 radio.setAttribute("tabindex", "0");
@@ -90,7 +87,7 @@ export class RadioGroup extends FASTElement {
             }
         });
 
-        if (this.selectedValue === undefined) {
+        if (this.value === undefined) {
             radioButtons[0].setAttribute("tabindex", "0");
         }
     }
@@ -117,7 +114,7 @@ export class RadioGroup extends FASTElement {
                 }
             });
             this.selectedRadio = changedRadio;
-            this.selectedValue = changedRadio.value;
+            this.value = changedRadio.value;
         }
     };
 

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -9,7 +9,7 @@ import { FASTRadio } from "../radio";
 
 export class RadioGroup extends FASTElement {
     @attr({ attribute: "readonly", mode: "boolean" })
-    public readOnly: boolean; // Map to proxy element
+    public readOnly: boolean;
     private readOnlyChanged(): void {
         const filteredRadios = this.getFilteredRadioButtons();
         if (filteredRadios !== undefined) {
@@ -24,7 +24,7 @@ export class RadioGroup extends FASTElement {
     }
 
     @attr({ attribute: "disabled", mode: "boolean" })
-    public disabled: boolean; // Map to proxy element
+    public disabled: boolean;
     private disabledChanged(): void {
         const filteredRadios = this.getFilteredRadioButtons();
         if (filteredRadios !== undefined) {
@@ -39,7 +39,7 @@ export class RadioGroup extends FASTElement {
     }
 
     @attr
-    public name: string; // Map to proxy element
+    public name: string;
     protected nameChanged(): void {
         this.getFilteredRadioButtons().forEach((radio: HTMLElement) => {
             radio.setAttribute("name", this.name);

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -1,6 +1,6 @@
 import { attr, observable, FASTElement } from "@microsoft/fast-element";
 import { keyCodeArrowLeft, keyCodeArrowDown } from "@microsoft/fast-web-utilities";
-import { FASTRadio } from "src/radio";
+import { FASTRadio } from "../radio";
 
 export class RadioGroup extends FASTElement {
     @attr({ attribute: "readonly", mode: "boolean" })
@@ -25,6 +25,8 @@ export class RadioGroup extends FASTElement {
     public selectedValue: string;
     private selectedValueChanged(): void {}
 
+    @observable slottedRadioButtons: Node[];
+
     constructor() {
         super();
         this.addEventListener("keydown", this.keydownHandler);
@@ -32,26 +34,53 @@ export class RadioGroup extends FASTElement {
 
     public connectedCallback(): void {
         super.connectedCallback();
-        for (let index = 0; index < this.children.length; index++) {
-            const radio: FASTRadio = this.children[index] as FASTRadio;
+
+        this.getFilteredRadioButtons().forEach((radio: HTMLElement) => {
             radio.addEventListener("change", this.handleRadioChange);
-        }
+            if (this.name !== undefined) {
+                radio.setAttribute("name", this.name);
+            }
+        });
+        // for (let index = 0; index < this.children.length; index++) {
+        //     const radio: FASTRadio = this.children[index] as FASTRadio;
+        //     radio.addEventListener("change", this.handleRadioChange);
+        //     if (this.name !== undefined) {
+        //         radio.setAttribute("name", this.name);
+        //     }
+        // }
     }
 
+    private getFilteredRadioButtons = (): any => {
+        return this.slottedRadioButtons.filter((node: Node) => {
+            if (node instanceof HTMLElement) {
+                return node as HTMLElement;
+            }
+        });
+    };
+
     private handleRadioChange = (e): void => {
-        const radio: FASTRadio = e.target as FASTRadio;
-        console.log(
-            "radio value:",
-            radio.value,
-            " checked:",
-            radio.checked,
-            " name:",
-            radio.name
-        );
+        const changedRadio: FASTRadio = e.target as FASTRadio;
+        if (changedRadio.checked) {
+            //loop through and uncheck everybody else
+            // for (let index = 0; index < this.children.length; index++) {
+            //     const radio: FASTRadio = this.children[index] as FASTRadio;
+            //     if (radio !== changedRadio) {
+            //         radio.checked = false;
+            //     }
+            // }
+            this.getFilteredRadioButtons().forEach((radio: FASTRadio) => {
+                if (radio !== changedRadio) {
+                    radio.checked = false;
+                }
+            });
+        }
     };
 
     public keydownHandler = (e: KeyboardEvent): void => {
         switch (e.keyCode) {
+            case keyCodeArrowLeft:
+            case keyCodeArrowDown:
+                break;
             case keyCodeArrowLeft:
             case keyCodeArrowDown:
                 break;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -1,0 +1,60 @@
+import { attr, observable, FASTElement } from "@microsoft/fast-element";
+import { keyCodeArrowLeft, keyCodeArrowDown } from "@microsoft/fast-web-utilities";
+import { FASTRadio } from "src/radio";
+
+export class RadioGroup extends FASTElement {
+    @attr({ attribute: "readonly", mode: "boolean" })
+    public readOnly: boolean; // Map to proxy element
+    private readOnlyChanged(): void {
+        // TODO: set readonly on all the radio children
+    }
+
+    @attr({ attribute: "disabled", mode: "boolean" })
+    public disabled: boolean; // Map to proxy element
+    private disabledChanged(): void {
+        // TODO: set disabled on all the radio children
+    }
+
+    @attr
+    public name: string; // Map to proxy element
+    protected nameChanged(): void {
+        // TODO: set name attribute on all the radio children
+    }
+
+    @observable
+    public selectedValue: string;
+    private selectedValueChanged(): void {}
+
+    constructor() {
+        super();
+        this.addEventListener("keydown", this.keydownHandler);
+    }
+
+    public connectedCallback(): void {
+        super.connectedCallback();
+        for (let index = 0; index < this.children.length; index++) {
+            const radio: FASTRadio = this.children[index] as FASTRadio;
+            radio.addEventListener("change", this.handleRadioChange);
+        }
+    }
+
+    private handleRadioChange = (e): void => {
+        const radio: FASTRadio = e.target as FASTRadio;
+        console.log(
+            "radio value:",
+            radio.value,
+            " checked:",
+            radio.checked,
+            " name:",
+            radio.name
+        );
+    };
+
+    public keydownHandler = (e: KeyboardEvent): void => {
+        switch (e.keyCode) {
+            case keyCodeArrowLeft:
+            case keyCodeArrowDown:
+                break;
+        }
+    };
+}

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -84,8 +84,15 @@ export class RadioGroup extends FASTElement {
             ) {
                 this.selectedRadio = radio;
                 radio.setAttribute("checked", "");
+                radio.setAttribute("tabindex", "0");
+            } else {
+                radio.setAttribute("tabindex", "-1");
             }
         });
+
+        if (this.selectedValue === undefined) {
+            radioButtons[0].setAttribute("tabindex", "0");
+        }
     }
 
     private getFilteredRadioButtons = (): any[] => {
@@ -106,6 +113,7 @@ export class RadioGroup extends FASTElement {
             this.getFilteredRadioButtons().forEach((radio: FASTRadio) => {
                 if (radio !== changedRadio) {
                     radio.checked = false;
+                    radio.setAttribute("tabindex", "-1");
                 }
             });
             this.selectedRadio = changedRadio;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -81,14 +81,17 @@ export class RadioGroup extends FASTElement {
         }
     };
 
-    private moveToRadioByIndex = (group: HTMLElement[], index: number) => {};
+    private moveToRadioByIndex = (group: any[], index: number) => {
+        (group[index] as FASTRadio).checked = true;
+        group[index].focus();
+    };
 
     public keydownHandler = (e: KeyboardEvent): void => {
         const group = this.getFilteredRadioButtons();
         let index: number = 0;
         switch (e.keyCode) {
-            case keyCodeArrowRight:
-            case keyCodeArrowUp:
+            case keyCodeArrowLeft:
+            case keyCodeArrowDown:
                 index = group.indexOf(this) + 1;
                 index = index === group.length ? 0 : index;
                 while (index < group.length) {
@@ -104,8 +107,8 @@ export class RadioGroup extends FASTElement {
                     }
                 }
                 break;
-            case keyCodeArrowLeft:
-            case keyCodeArrowDown:
+            case keyCodeArrowRight:
+            case keyCodeArrowUp:
                 index = group.indexOf(this) - 1;
                 index = index < 0 ? group.length - 1 : index;
                 while (index >= 0) {

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -1,5 +1,10 @@
 import { attr, observable, FASTElement } from "@microsoft/fast-element";
-import { keyCodeArrowLeft, keyCodeArrowDown } from "@microsoft/fast-web-utilities";
+import {
+    keyCodeArrowLeft,
+    keyCodeArrowDown,
+    keyCodeArrowRight,
+    keyCodeArrowUp,
+} from "@microsoft/fast-web-utilities";
 import { FASTRadio } from "../radio";
 
 export class RadioGroup extends FASTElement {
@@ -76,13 +81,45 @@ export class RadioGroup extends FASTElement {
         }
     };
 
+    private moveToRadioByIndex = (group: HTMLElement[], index: number) => {};
+
     public keydownHandler = (e: KeyboardEvent): void => {
+        const group = this.getFilteredRadioButtons();
+        let index: number = 0;
         switch (e.keyCode) {
-            case keyCodeArrowLeft:
-            case keyCodeArrowDown:
+            case keyCodeArrowRight:
+            case keyCodeArrowUp:
+                index = group.indexOf(this) + 1;
+                index = index === group.length ? 0 : index;
+                while (index < group.length) {
+                    if (!group[index].disabled) {
+                        this.moveToRadioByIndex(group, index);
+                        break;
+                    } else if (index === group.indexOf(this)) {
+                        break;
+                    } else if (index + 1 >= group.length) {
+                        index = 0;
+                    } else {
+                        index += 1;
+                    }
+                }
                 break;
             case keyCodeArrowLeft:
             case keyCodeArrowDown:
+                index = group.indexOf(this) - 1;
+                index = index < 0 ? group.length - 1 : index;
+                while (index >= 0) {
+                    if (!group[index].disabled) {
+                        this.moveToRadioByIndex(group, index);
+                        break;
+                    } else if (index === group.indexOf(this)) {
+                        break;
+                    } else if (index - 1 < 0) {
+                        index = group.length - 1;
+                    } else {
+                        index -= 1;
+                    }
+                }
                 break;
         }
     };

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -158,9 +158,13 @@ export class RadioGroup extends FASTElement {
                 }
                 break;
             case keyCodeArrowRight:
-            case keyCodeArrowUp:
+            case keyCodeArrowDown:
                 index = this.selectedRadio ? group.indexOf(this.selectedRadio) + 1 : 1;
-                if (index === group.length && inToolbar) {
+                if (
+                    index === group.length &&
+                    inToolbar &&
+                    e.keyCode === keyCodeArrowRight
+                ) {
                     this.moveRightOffGroup();
                     return;
                 } else if (index === group.length) {
@@ -190,10 +194,10 @@ export class RadioGroup extends FASTElement {
                 }
                 break;
             case keyCodeArrowLeft:
-            case keyCodeArrowDown:
+            case keyCodeArrowUp:
                 index = this.selectedRadio ? group.indexOf(this.selectedRadio) - 1 : 0;
 
-                if (index < 0 && inToolbar) {
+                if (index < 0 && inToolbar && e.keyCode === keyCodeArrowLeft) {
                     this.moveLeftOffGroup();
                     return;
                 }

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -5,7 +5,7 @@ import {
     keyCodeArrowRight,
     keyCodeArrowUp,
 } from "@microsoft/fast-web-utilities";
-import { FASTRadio } from "../radio";
+import { RadioControl } from "../radio";
 
 export class RadioGroup extends FASTElement {
     @attr({ attribute: "readonly", mode: "boolean" })
@@ -13,7 +13,7 @@ export class RadioGroup extends FASTElement {
     private readOnlyChanged(): void {
         const filteredRadios = this.getFilteredRadioButtons();
         if (filteredRadios !== undefined) {
-            filteredRadios.forEach((radio: FASTRadio) => {
+            filteredRadios.forEach((radio: HTMLInputElement) => {
                 if (this.disabled) {
                     radio.setAttribute("readonly", "");
                 } else {
@@ -28,7 +28,7 @@ export class RadioGroup extends FASTElement {
     private disabledChanged(): void {
         const filteredRadios = this.getFilteredRadioButtons();
         if (filteredRadios !== undefined) {
-            filteredRadios.forEach((radio: FASTRadio) => {
+            filteredRadios.forEach((radio: HTMLInputElement) => {
                 if (this.disabled) {
                     radio.setAttribute("disabled", "");
                 } else {
@@ -41,19 +41,16 @@ export class RadioGroup extends FASTElement {
     @attr
     public name: string;
     protected nameChanged(): void {
-        this.getFilteredRadioButtons().forEach((radio: FASTRadio) => {
+        this.getFilteredRadioButtons().forEach((radio: HTMLInputElement) => {
             radio.setAttribute("name", this.name);
         });
     }
 
     @attr
     public value: string;
-    private valueChanged(): void {
-        this.$emit("change");
-    }
 
-    @observable slottedRadioButtons: HTMLElement[];
-    private selectedRadio: FASTRadio;
+    @observable slottedRadioButtons: RadioControl[];
+    private selectedRadio: RadioControl;
 
     constructor() {
         super();
@@ -62,10 +59,9 @@ export class RadioGroup extends FASTElement {
 
     public connectedCallback(): void {
         super.connectedCallback();
-
-        const radioButtons: FASTRadio[] = this.getFilteredRadioButtons();
-        radioButtons.forEach((radio: FASTRadio) => {
-            radio.addEventListener("change", this.handleRadioChange);
+        this.addEventListener("change", this.handleRadioChange);
+        const radioButtons: RadioControl[] = this.getFilteredRadioButtons();
+        radioButtons.forEach((radio: RadioControl) => {
             if (this.name !== undefined) {
                 radio.setAttribute("name", this.name);
             }
@@ -92,12 +88,12 @@ export class RadioGroup extends FASTElement {
         }
     }
 
-    private getFilteredRadioButtons = (): FASTRadio[] => {
-        const radioButtons: FASTRadio[] = [];
+    private getFilteredRadioButtons = (): RadioControl[] => {
+        const radioButtons: RadioControl[] = [];
         if (this.slottedRadioButtons !== undefined) {
-            this.slottedRadioButtons.forEach((item: HTMLElement) => {
+            this.slottedRadioButtons.forEach((item: any) => {
                 if (item instanceof HTMLElement) {
-                    radioButtons.push(item as any);
+                    radioButtons.push(item as HTMLInputElement);
                 }
             });
         }
@@ -105,9 +101,9 @@ export class RadioGroup extends FASTElement {
     };
 
     private handleRadioChange = (e: CustomEvent): void => {
-        const changedRadio: FASTRadio = e.target as FASTRadio;
+        const changedRadio: HTMLInputElement = e.target as HTMLInputElement;
         if (changedRadio.checked) {
-            this.getFilteredRadioButtons().forEach((radio: FASTRadio) => {
+            this.getFilteredRadioButtons().forEach((radio: HTMLInputElement) => {
                 if (radio !== changedRadio) {
                     radio.checked = false;
                     radio.setAttribute("tabindex", "-1");
@@ -118,8 +114,8 @@ export class RadioGroup extends FASTElement {
         }
     };
 
-    private moveToRadioByIndex = (group: FASTRadio[], index: number) => {
-        const radio: FASTRadio = group[index];
+    private moveToRadioByIndex = (group: RadioControl[], index: number) => {
+        const radio: RadioControl = group[index];
         if (!radio.readOnly) {
             radio.checked = true;
         }
@@ -128,7 +124,7 @@ export class RadioGroup extends FASTElement {
     };
 
     public keydownHandler = (e: KeyboardEvent): void => {
-        const group: FASTRadio[] = this.getFilteredRadioButtons();
+        const group: RadioControl[] = this.getFilteredRadioButtons();
         let index: number = 0;
         switch (e.keyCode) {
             case keyCodeArrowRight:

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -13,7 +13,7 @@ export class RadioGroup extends FASTElement {
     private readOnlyChanged(): void {
         const filteredRadios = this.getFilteredRadioButtons();
         if (filteredRadios !== undefined) {
-            filteredRadios.forEach((radio: HTMLElement) => {
+            filteredRadios.forEach((radio: FASTRadio) => {
                 if (this.disabled) {
                     radio.setAttribute("readonly", "");
                 } else {
@@ -28,7 +28,7 @@ export class RadioGroup extends FASTElement {
     private disabledChanged(): void {
         const filteredRadios = this.getFilteredRadioButtons();
         if (filteredRadios !== undefined) {
-            filteredRadios.forEach((radio: HTMLElement) => {
+            filteredRadios.forEach((radio: FASTRadio) => {
                 if (this.disabled) {
                     radio.setAttribute("disabled", "");
                 } else {
@@ -41,7 +41,7 @@ export class RadioGroup extends FASTElement {
     @attr
     public name: string;
     protected nameChanged(): void {
-        this.getFilteredRadioButtons().forEach((radio: HTMLElement) => {
+        this.getFilteredRadioButtons().forEach((radio: FASTRadio) => {
             radio.setAttribute("name", this.name);
         });
     }
@@ -52,8 +52,8 @@ export class RadioGroup extends FASTElement {
         this.$emit("change");
     }
 
-    @observable slottedRadioButtons: Node[];
-    private selectedRadio: FASTRadio | HTMLElement;
+    @observable slottedRadioButtons: HTMLElement[];
+    private selectedRadio: FASTRadio;
 
     constructor() {
         super();
@@ -63,8 +63,8 @@ export class RadioGroup extends FASTElement {
     public connectedCallback(): void {
         super.connectedCallback();
 
-        const radioButtons: HTMLElement[] = this.getFilteredRadioButtons();
-        radioButtons.forEach((radio: HTMLElement) => {
+        const radioButtons: FASTRadio[] = this.getFilteredRadioButtons();
+        radioButtons.forEach((radio: FASTRadio) => {
             radio.addEventListener("change", this.handleRadioChange);
             if (this.name !== undefined) {
                 radio.setAttribute("name", this.name);
@@ -92,16 +92,16 @@ export class RadioGroup extends FASTElement {
         }
     }
 
-    private getFilteredRadioButtons = (): any[] => {
+    private getFilteredRadioButtons = (): FASTRadio[] => {
+        const radioButtons: FASTRadio[] = [];
         if (this.slottedRadioButtons !== undefined) {
-            return this.slottedRadioButtons.filter((node: Node) => {
-                if (node instanceof HTMLElement) {
-                    return node as HTMLElement;
+            this.slottedRadioButtons.forEach((item: HTMLElement) => {
+                if (item instanceof HTMLElement) {
+                    radioButtons.push(item as any);
                 }
             });
-        } else {
-            return [];
         }
+        return radioButtons;
     };
 
     private handleRadioChange = (e: CustomEvent): void => {
@@ -118,8 +118,8 @@ export class RadioGroup extends FASTElement {
         }
     };
 
-    private moveToRadioByIndex = (group: any[], index: number) => {
-        const radio: FASTRadio = group[index] as FASTRadio;
+    private moveToRadioByIndex = (group: FASTRadio[], index: number) => {
+        const radio: FASTRadio = group[index];
         if (!radio.readOnly) {
             radio.checked = true;
         }
@@ -128,7 +128,7 @@ export class RadioGroup extends FASTElement {
     };
 
     public keydownHandler = (e: KeyboardEvent): void => {
-        const group = this.getFilteredRadioButtons();
+        const group: FASTRadio[] = this.getFilteredRadioButtons();
         let index: number = 0;
         switch (e.keyCode) {
             case keyCodeArrowRight:

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -12,7 +12,6 @@ export class RadioGroup extends FASTElement {
     public readOnly: boolean; // Map to proxy element
     private readOnlyChanged(): void {
         const filteredRadios = this.getFilteredRadioButtons();
-        console.log("filteredRadios:", filteredRadios);
         if (filteredRadios !== undefined) {
             filteredRadios.forEach((radio: HTMLElement) => {
                 if (this.disabled) {
@@ -75,6 +74,13 @@ export class RadioGroup extends FASTElement {
 
             if (this.readOnly) {
                 radio.setAttribute("readonly", "");
+            }
+
+            if (
+                this.selectedValue &&
+                this.selectedValue === radio.getAttribute("value")
+            ) {
+                radio.setAttribute("checked", "");
             }
         });
     }

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -129,9 +129,9 @@ export class RadioGroup extends FASTElement {
         switch (e.keyCode) {
             case keyCodeArrowRight:
             case keyCodeArrowUp:
-                index = group.indexOf(this.selectedRadio) + 1;
+                index = this.selectedRadio ? group.indexOf(this.selectedRadio) + 1 : 1;
                 index = index === group.length ? 0 : index;
-                while (index < group.length) {
+                while (index < group.length && group.length > 1) {
                     if (!group[index].disabled) {
                         this.moveToRadioByIndex(group, index);
                         break;
@@ -149,7 +149,7 @@ export class RadioGroup extends FASTElement {
                 index = group.indexOf(this.selectedRadio) - 1;
                 index = index < 0 ? group.length - 1 : index;
 
-                while (index >= 0) {
+                while (index >= 0 && group.length > 1) {
                     if (!group[index].disabled) {
                         this.moveToRadioByIndex(group, index);
                         break;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -144,10 +144,6 @@ export class RadioGroup extends FASTElement {
             } else {
                 radio.checked = true;
             }
-        } else {
-            if (radio !== this.selectedRadio) {
-                radio.setAttribute("tabindex", "-1");
-            }
         }
         this.selectedRadio = radio;
         radio.focus();
@@ -222,7 +218,6 @@ export class RadioGroup extends FASTElement {
         let index: number = 0;
         switch (e.keyCode) {
             case keyCodeEnter:
-                console.log("enter key hit");
                 this.checkSelectedRadio();
                 break;
             case keyCodeArrowRight:

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -196,8 +196,12 @@ export class RadioGroup extends FASTElement {
         );
     };
 
-    private shouldMoveOffGroupToTheLeft = (index: number, keyCode: number): boolean => {
-        return index < 0 && this.isInsideToolbar && keyCode === keyCodeArrowLeft;
+    private shouldMoveOffGroupToTheLeft = (
+        group: RadioControl[],
+        keyCode: number
+    ): boolean => {
+        const index = this.selectedRadio ? group.indexOf(this.selectedRadio) : 0;
+        return index <= 0 && this.isInsideToolbar && keyCode === keyCodeArrowLeft;
     };
 
     private checkSelectedRadio = (): void => {
@@ -249,13 +253,11 @@ export class RadioGroup extends FASTElement {
                 break;
             case keyCodeArrowLeft:
             case keyCodeArrowUp:
-                index = this.selectedRadio ? group.indexOf(this.selectedRadio) - 1 : 0;
-
-                if (this.shouldMoveOffGroupToTheLeft(index, e.keyCode)) {
+                if (this.shouldMoveOffGroupToTheLeft(group, e.keyCode)) {
                     this.moveLeftOffGroup();
                     return;
                 }
-
+                index = this.selectedRadio ? group.indexOf(this.selectedRadio) - 1 : 0;
                 index = index < 0 ? group.length - 1 : index;
 
                 while (index >= 0 && group.length > 1) {

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -82,7 +82,7 @@ export class RadioGroup extends FASTElement {
 
             if (this.value && this.value === radio.getAttribute("value")) {
                 this.selectedRadio = radio;
-                radio.setAttribute("checked", "");
+                radio.checked = true;
                 radio.setAttribute("tabindex", "0");
             } else {
                 radio.setAttribute("tabindex", "-1");
@@ -133,18 +133,30 @@ export class RadioGroup extends FASTElement {
 
     private moveToRadioByIndex = (group: RadioControl[], index: number) => {
         const radio: RadioControl = group[index];
-        if (!radio.readOnly && !this.isInsideToolbar) {
-            radio.checked = true;
+        if (!this.isInsideToolbar) {
             radio.setAttribute("tabindex", "0");
+            if (radio.readOnly) {
+                this.getFilteredRadioButtons().forEach((nextRadio: HTMLInputElement) => {
+                    if (nextRadio !== radio) {
+                        nextRadio.setAttribute("tabindex", "-1");
+                    }
+                });
+            } else {
+                radio.checked = true;
+            }
         } else {
-            radio.setAttribute("tabindex", "-1");
+            if (radio !== this.selectedRadio) {
+                radio.setAttribute("tabindex", "-1");
+            }
         }
         this.selectedRadio = radio;
         radio.focus();
     };
 
     private moveRightOffGroup = () => {
-        this.selectedRadio = null;
+        if (!this.selectedRadio?.checked) {
+            this.selectedRadio = null;
+        }
         (this.nextElementSibling as HTMLInputElement).focus();
     };
 
@@ -173,6 +185,7 @@ export class RadioGroup extends FASTElement {
                 this.selectedRadio = null;
             }
         }
+        e.preventDefault();
     };
 
     private shouldMoveOffGroupToTheRight = (
@@ -209,7 +222,7 @@ export class RadioGroup extends FASTElement {
         let index: number = 0;
         switch (e.keyCode) {
             case keyCodeEnter:
-                index = this.selectedRadio ? group.indexOf(this.selectedRadio) + 1 : 1;
+                console.log("enter key hit");
                 this.checkSelectedRadio();
                 break;
             case keyCodeArrowRight:

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -58,10 +58,10 @@ export class RadioGroup extends FASTElement {
     constructor() {
         super();
         this.addEventListener("keydown", this.keydownHandler);
-        this.addEventListener("change", this.handleRadioChange);
+        this.addEventListener("change", this.radioChangeHandler);
         this.addEventListener("keypress", this.keypressHandler);
         this.addEventListener("click", this.clickHandler);
-        this.addEventListener("focusout", this.handleFocusOut);
+        this.addEventListener("focusout", this.focusOutHandler);
     }
 
     public connectedCallback(): void {
@@ -117,7 +117,7 @@ export class RadioGroup extends FASTElement {
         }
     };
 
-    private handleRadioChange = (e: CustomEvent): void => {
+    private radioChangeHandler = (e: CustomEvent): void => {
         const changedRadio: HTMLInputElement = e.target as HTMLInputElement;
         if (changedRadio.checked) {
             this.getFilteredRadioButtons().forEach((radio: HTMLInputElement) => {
@@ -162,7 +162,7 @@ export class RadioGroup extends FASTElement {
     };
 
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    private handleFocusOut = (e: FocusEvent) => {
+    private focusOutHandler = (e: FocusEvent) => {
         const group: RadioControl[] = this.getFilteredRadioButtons();
         if (!this.selectedRadio) {
             group[0].setAttribute("tabindex", "0");
@@ -217,6 +217,7 @@ export class RadioGroup extends FASTElement {
     };
 
     /* keyboard handling per https://w3c.github.io/aria-practices/#for-radio-groups-not-contained-in-a-toolbar */
+    /* navigation is different when there is an ancestor with role='toolbar' */
     public keydownHandler = (e: KeyboardEvent): void => {
         const group: RadioControl[] = this.getFilteredRadioButtons();
         let index: number = 0;
@@ -233,6 +234,7 @@ export class RadioGroup extends FASTElement {
                 } else if (index === group.length) {
                     index = 0;
                 }
+                /* looping to get to next radio that is not disabled */
                 /* matching native radio/radiogroup which does not select an item if there is only 1 in the group */
                 while (index < group.length && group.length > 1) {
                     if (!group[index].disabled) {
@@ -260,6 +262,7 @@ export class RadioGroup extends FASTElement {
                 index = this.selectedRadio ? group.indexOf(this.selectedRadio) - 1 : 0;
                 index = index < 0 ? group.length - 1 : index;
 
+                /* looping to get to next radio that is not disabled */
                 while (index >= 0 && group.length > 1) {
                     if (!group[index].disabled) {
                         this.moveToRadioByIndex(group, index);

--- a/packages/web-components/fast-components/src/radio/radio.template.ts
+++ b/packages/web-components/fast-components/src/radio/radio.template.ts
@@ -7,9 +7,9 @@ export const RadioTemplate = html<Radio>`
         class="${x => (x.checked ? "checked" : "")} ${x =>
             x.readOnly ? "readonly" : ""}"
         aria-checked="${x => x.checked}"
-        ?aria-required="${x => x.required}"
-        ?aria-disabled="${x => x.disabled}"
-        ?aria-readonly="${x => x.readOnly}"
+        aria-required="${x => x.required}"
+        aria-disabled="${x => x.disabled}"
+        aria-readonly="${x => x.readOnly}"
         @keypress="${(x, c) => x.keypressHandler(c.event as KeyboardEvent)}"
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
     >

--- a/packages/web-components/fast-components/src/radio/radio.template.ts
+++ b/packages/web-components/fast-components/src/radio/radio.template.ts
@@ -10,7 +10,6 @@ export const RadioTemplate = html<Radio>`
         ?aria-required="${x => x.required}"
         ?aria-disabled="${x => x.disabled}"
         ?aria-readonly="${x => x.readOnly}"
-        tabindex="${x => (x.disabled ? null : 0)}"
         @keypress="${(x, c) => x.keypressHandler(c.event as KeyboardEvent)}"
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
     >

--- a/packages/web-components/fast-components/src/radio/radio.ts
+++ b/packages/web-components/fast-components/src/radio/radio.ts
@@ -101,7 +101,7 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
     public connectedCallback(): void {
         super.connectedCallback();
         if (
-            this.parentElement?.tagName !== "FAST-RADIO-GROUP" &&
+            this.parentElement?.getAttribute("role") !== "radiogroup" &&
             this.getAttribute("tabindex") === null
         ) {
             if (!this.disabled) {

--- a/packages/web-components/fast-components/src/radio/radio.ts
+++ b/packages/web-components/fast-components/src/radio/radio.ts
@@ -2,7 +2,16 @@ import { attr, observable } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
 import { FormAssociated } from "../form-associated";
 
-export class Radio extends FormAssociated<HTMLInputElement> {
+export interface RadioControl {
+    checked: boolean;
+    disabled: boolean;
+    readOnly: boolean;
+    focus: () => void;
+    setAttribute: (name: string, value: string) => void;
+    getAttribute: (name: string) => string | null;
+}
+
+export class Radio extends FormAssociated<HTMLInputElement> implements RadioControl {
     @attr({ attribute: "readonly", mode: "boolean" })
     public readOnly: boolean; // Map to proxy element
     private readOnlyChanged(): void {

--- a/packages/web-components/fast-components/src/radio/radio.ts
+++ b/packages/web-components/fast-components/src/radio/radio.ts
@@ -91,6 +91,9 @@ export class Radio extends FormAssociated<HTMLInputElement> {
 
     public connectedCallback(): void {
         super.connectedCallback();
+        if (this.parentElement?.tagName !== "FAST-RADIO-GROUP") {
+            this.setAttribute("tabindex", "0");
+        }
         this.updateForm();
     }
 

--- a/packages/web-components/fast-components/src/radio/radio.ts
+++ b/packages/web-components/fast-components/src/radio/radio.ts
@@ -91,8 +91,13 @@ export class Radio extends FormAssociated<HTMLInputElement> {
 
     public connectedCallback(): void {
         super.connectedCallback();
-        if (this.parentElement?.tagName !== "FAST-RADIO-GROUP") {
-            this.setAttribute("tabindex", "0");
+        if (
+            this.parentElement?.tagName !== "FAST-RADIO-GROUP" &&
+            this.getAttribute("tabindex") === null
+        ) {
+            if (!this.disabled) {
+                this.setAttribute("tabindex", "0");
+            }
         }
         this.updateForm();
     }

--- a/packages/web-components/fast-components/src/radio/radio.ts
+++ b/packages/web-components/fast-components/src/radio/radio.ts
@@ -103,7 +103,7 @@ export class Radio extends FormAssociated<HTMLInputElement> {
         super.keypressHandler(e);
         switch (e.keyCode) {
             case keyCodeSpace:
-                if (!this.checked) {
+                if (!this.checked && !this.readOnly) {
                     this.checked = true;
                 }
                 break;

--- a/specs/README.md
+++ b/specs/README.md
@@ -25,7 +25,7 @@ Here you'll find specifications for custom elements and other library features.
 | [Number field](./number-field.md) | :white_check_mark: | -- |
 | [Progress](../packages/web-components/fast-components/src/progress/progress.spec.md) | :white_check_mark: | :white_check_mark: |
 | [Radio](../packages/web-components/fast-components/src/radio/radio.spec.md) | :white_check_mark: | :white_check_mark: |
- RadioGroup | -- | -- |
+| [Radio group](../packages/web-components/fast-components/src/radio-group/radio-group.spec.md) | :white_check_mark: | :white_check_mark: |
 | Rating | -- | -- |
 | Select | -- | -- |
 | [Slider](../packages/web-components/fast-components/src/slider/slider.spec.md) | :white_check_mark: | :white_check_mark: |


### PR DESCRIPTION
# Description
* Add radio group component
* tabindex support for tab navigation
* arrow key navigation

radio-group component allows children radio buttons to be treated as a single select group.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
