### PR TITLE
fix: opacity on before pseudo class when hovering

### DIFF
--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -107,6 +107,7 @@ export const FlipperStyles = css`
                 forced-color-adjust: none;
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.ButtonText};
+                opacity: 1;
             }
             :host(:hover) .next,
             :host(:hover) .previous {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Set the opacity to 1 on the before pseudo-class because the highlight color is too dimmed when hovered.

before
![image](https://user-images.githubusercontent.com/37851220/80540831-e9c2a480-895e-11ea-8b7b-4719f64090b6.png)
after
![image](https://user-images.githubusercontent.com/37851220/80540864-f5ae6680-895e-11ea-9ab1-fb7b3784c180.png)


## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->