### PR TITLE
feat: adding typeramp values

### DIFF
--- a/packages/web-components/fast-components/src/design-system-provider/index.ts
+++ b/packages/web-components/fast-components/src/design-system-provider/index.ts
@@ -153,6 +153,108 @@ export class FASTDesignSystemProvider extends DesignSystemProvider
     })
     public disabledOpacity: number;
 
+    @attr({ ...fromView, attribute: "type-ramp-minus-2-size" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-minus-2-size",
+        default: "10px",
+    })
+    public typeRampMinus2Size: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-minus-2-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-minus-2-height",
+        default: "16px",
+    })
+    public typeRampMinus2height: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-minus-1-size" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-minus-1-size",
+        default: "12px",
+    })
+    public typeRampMinus1Size: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-minus-1-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-minus-1-height",
+        default: "16px",
+    })
+    public typeRampMinus1Height: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-base-size" })
+    @designSystemProperty({ cssCustomProperty: "type-ramp-base-size", default: "14px" })
+    public typeRampBaseSize: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-base-height" })
+    @designSystemProperty({ cssCustomProperty: "type-ramp-base-height", default: "20px" })
+    public typeRampBaseHeight: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-1-size" })
+    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-1-size", default: "16px" })
+    public typeRampPlus1Size: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-1-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-1-height",
+        default: "24px",
+    })
+    public typeRampPlus1Height: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-2-size" })
+    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-2-size", default: "20px" })
+    public typeRampPlus2Size: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-2-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-2-height",
+        default: "28px",
+    })
+    public typeRampPlus2Height: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-3-size" })
+    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-3-size", default: "28px" })
+    public typeRampPlus3Size: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-3-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-3-height",
+        default: "36px",
+    })
+    public typeRampPlus3Height: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-4-size" })
+    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-4-size", default: "34px" })
+    public typeRampPlus4Size: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-4-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-4-height",
+        default: "44px",
+    })
+    public typeRampPlus4Height: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-5-size" })
+    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-5-size", default: "46px" })
+    public typeRampPlus5Size: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-5-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-5-height",
+        default: "56px",
+    })
+    public typeRampPlus5Height: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-6-size" })
+    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-6-size", default: "60px" })
+    public typeRampPlus6Size: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-6-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-6-height",
+        default: "72px",
+    })
+    public typeRampPlus6Height: string;
+
     @attr({
         attribute: "accent-fill-rest-delta",
         ...fromViewNumber,

--- a/packages/web-components/fast-components/src/design-system-provider/index.ts
+++ b/packages/web-components/fast-components/src/design-system-provider/index.ts
@@ -153,107 +153,131 @@ export class FASTDesignSystemProvider extends DesignSystemProvider
     })
     public disabledOpacity: number;
 
-    @attr({ ...fromView, attribute: "type-ramp-minus-2-size" })
+    @attr({ ...fromView, attribute: "type-ramp-minus-2-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-minus-2-size",
+        cssCustomProperty: "type-ramp-minus-2-font-size",
         default: "10px",
     })
-    public typeRampMinus2Size: string;
+    public typeRampMinus2FontSize: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-minus-2-height" })
+    @attr({ ...fromView, attribute: "type-ramp-minus-2-line-height" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-minus-2-height",
+        cssCustomProperty: "type-ramp-minus-2-line-height",
         default: "16px",
     })
-    public typeRampMinus2height: string;
+    public typeRampMinus2LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-minus-1-size" })
+    @attr({ ...fromView, attribute: "type-ramp-minus-1-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-minus-1-size",
+        cssCustomProperty: "type-ramp-minus-1-font-size",
         default: "12px",
     })
-    public typeRampMinus1Size: string;
+    public typeRampMinus1FontSize: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-minus-1-height" })
+    @attr({ ...fromView, attribute: "type-ramp-minus-1-line-height" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-minus-1-height",
+        cssCustomProperty: "type-ramp-minus-1-line-height",
         default: "16px",
     })
-    public typeRampMinus1Height: string;
+    public typeRampMinus1LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-base-size" })
-    @designSystemProperty({ cssCustomProperty: "type-ramp-base-size", default: "14px" })
-    public typeRampBaseSize: string;
-
-    @attr({ ...fromView, attribute: "type-ramp-base-height" })
-    @designSystemProperty({ cssCustomProperty: "type-ramp-base-height", default: "20px" })
-    public typeRampBaseHeight: string;
-
-    @attr({ ...fromView, attribute: "type-ramp-plus-1-size" })
-    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-1-size", default: "16px" })
-    public typeRampPlus1Size: string;
-
-    @attr({ ...fromView, attribute: "type-ramp-plus-1-height" })
+    @attr({ ...fromView, attribute: "type-ramp-base-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-1-height",
+        cssCustomProperty: "type-ramp-base-font-size",
+        default: "14px",
+    })
+    public typeRampBaseFontSize: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-base-line-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-base-line-height",
+        default: "20px",
+    })
+    public typeRampBaseLineHeight: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-1-font-size" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-1-font-size",
+        default: "16px",
+    })
+    public typeRampPlus1FontSize: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-1-line-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-1-line-height",
         default: "24px",
     })
-    public typeRampPlus1Height: string;
+    public typeRampPlus1LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-2-size" })
-    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-2-size", default: "20px" })
-    public typeRampPlus2Size: string;
-
-    @attr({ ...fromView, attribute: "type-ramp-plus-2-height" })
+    @attr({ ...fromView, attribute: "type-ramp-plus-2-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-2-height",
+        cssCustomProperty: "type-ramp-plus-2-font-size",
+        default: "20px",
+    })
+    public typeRampPlus2FontSize: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-2-line-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-2-line-height",
         default: "28px",
     })
-    public typeRampPlus2Height: string;
+    public typeRampPlus2LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-3-size" })
-    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-3-size", default: "28px" })
-    public typeRampPlus3Size: string;
-
-    @attr({ ...fromView, attribute: "type-ramp-plus-3-height" })
+    @attr({ ...fromView, attribute: "type-ramp-plus-3-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-3-height",
+        cssCustomProperty: "type-ramp-plus-3-font-size",
+        default: "28px",
+    })
+    public typeRampPlus3FontSize: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-3-line-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-3-line-height",
         default: "36px",
     })
-    public typeRampPlus3Height: string;
+    public typeRampPlus3LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-4-size" })
-    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-4-size", default: "34px" })
-    public typeRampPlus4Size: string;
-
-    @attr({ ...fromView, attribute: "type-ramp-plus-4-height" })
+    @attr({ ...fromView, attribute: "type-ramp-plus-4-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-4-height",
+        cssCustomProperty: "type-ramp-plus-4-font-size",
+        default: "34px",
+    })
+    public typeRampPlus4FontSize: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-4-line-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-4-line-height",
         default: "44px",
     })
-    public typeRampPlus4Height: string;
+    public typeRampPlus4LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-5-size" })
-    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-5-size", default: "46px" })
-    public typeRampPlus5Size: string;
-
-    @attr({ ...fromView, attribute: "type-ramp-plus-5-height" })
+    @attr({ ...fromView, attribute: "type-ramp-plus-5-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-5-height",
+        cssCustomProperty: "type-ramp-plus-5-font-size",
+        default: "46px",
+    })
+    public typeRampPlus5FontSize: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-5-line-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-5-line-height",
         default: "56px",
     })
-    public typeRampPlus5Height: string;
+    public typeRampPlus5LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-6-size" })
-    @designSystemProperty({ cssCustomProperty: "type-ramp-plus-6-size", default: "60px" })
-    public typeRampPlus6Size: string;
-
-    @attr({ ...fromView, attribute: "type-ramp-plus-6-height" })
+    @attr({ ...fromView, attribute: "type-ramp-plus-6-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-6-height",
+        cssCustomProperty: "type-ramp-plus-6-font-size",
+        default: "60px",
+    })
+    public typeRampPlus6FontSize: string;
+
+    @attr({ ...fromView, attribute: "type-ramp-plus-6-line-height" })
+    @designSystemProperty({
+        cssCustomProperty: "type-ramp-plus-6-line-height",
         default: "72px",
     })
-    public typeRampPlus6Height: string;
+    public typeRampPlus6LineHeight: string;
 
     @attr({
         attribute: "accent-fill-rest-delta",


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Adds typeramp to the design-system provider as configurable design-system properties.
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->