### PR TITLE
feat: add plugin system to the data dictionary mapping utility

### DIFF
--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.spec.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.spec.ts
@@ -211,6 +211,7 @@ describe("htmlMapper", () => {
                 id: "text",
                 type: "string",
             },
+            mapperPlugins: [],
         });
         expect(dataDictionary[0][""].data).toEqual(text);
     });
@@ -242,6 +243,7 @@ describe("htmlMapper", () => {
                 [ReservedElementMappingKeyword.mapsToTagName]: "div",
                 type: "object",
             },
+            mapperPlugins: [],
         });
         expect(dataDictionary[0][""].data).toEqual(document.createElement("div"));
     });
@@ -273,6 +275,7 @@ describe("htmlMapper", () => {
                     [ReservedElementMappingKeyword.mapsToTagName]: "div",
                     type: "string",
                 },
+                mapperPlugins: [],
             })
         ).toEqual(undefined);
     });
@@ -297,6 +300,7 @@ describe("htmlMapper", () => {
                     [ReservedElementMappingKeyword.mapsToTagName]: "div",
                     type: "object",
                 },
+                mapperPlugins: [],
             })
         ).toEqual(undefined);
     });
@@ -334,6 +338,7 @@ describe("htmlMapper", () => {
                 [ReservedElementMappingKeyword.mapsToTagName]: "div",
                 type: "object",
             },
+            mapperPlugins: [],
         });
 
         expect(dataDictionary[0][""].data).toEqual(mappedElement);
@@ -383,6 +388,7 @@ describe("htmlMapper", () => {
                     },
                 },
             },
+            mapperPlugins: [],
         });
         expect(dataDictionary[0][""].data).toEqual(mappedElement);
     });

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.ts
@@ -28,6 +28,28 @@ export interface MapperConfig<T> {
      * JSON schema
      */
     schema: any;
+
+    /**
+     * The plugins used to map data
+     */
+    mapperPlugins: MapDataPlugin[];
+}
+
+export interface MapDataPlugin {
+    /**
+     * The ids that map to the pluginIdKeyword in the JSON schema
+     */
+    ids: string[];
+
+    /**
+     * The mapping function that returns the mapped values
+     */
+    mapper: (data: any) => any;
+
+    /**
+     * The resolving function that overrides the resolver
+     */
+    resolver: (data: any) => any;
 }
 
 export interface MapDataConfig<T> {
@@ -51,6 +73,11 @@ export interface MapDataConfig<T> {
      * The resolver that resolves the data dictionary into another structure
      */
     resolver: (config: ResolverConfig<T>) => T;
+
+    /**
+     * The plugins used to map data
+     */
+    plugins?: MapDataPlugin[];
 }
 
 interface AttachResolvedDataDictionaryConfig<T> {
@@ -79,6 +106,11 @@ interface AttachResolvedDataDictionaryConfig<T> {
      * The resolver that resolves the data dictionary into another structure
      */
     resolver: (config: ResolverConfig<T>) => T;
+
+    /**
+     * The plugins used to resolve data
+     */
+    resolverPlugins: MapDataPlugin[];
 }
 
 interface ResolveDataInDataDictionaryConfig<T> {
@@ -107,6 +139,11 @@ interface ResolveDataInDataDictionaryConfig<T> {
      * The mapping function
      */
     mapper: (config: MapperConfig<T>) => T;
+
+    /**
+     * The plugins used to map data
+     */
+    mapperPlugins: MapDataPlugin[];
 }
 
 export interface ResolverConfig<T> {
@@ -135,6 +172,11 @@ export interface ResolverConfig<T> {
      * The parent of the dictionary item
      */
     parent: string | null;
+
+    /**
+     * The plugins used to resolve data
+     */
+    resolverPlugins: MapDataPlugin[];
 }
 
 export function resolveDataInDataDictionary<T>(
@@ -171,6 +213,7 @@ export function resolveDataInDataDictionary<T>(
             config.schemaDictionary[
                 config.dataDictionary[0][config.dictionaryId].schemaId
             ],
+        mapperPlugins: config.mapperPlugins,
     });
 
     // call the resolver on all children
@@ -181,6 +224,7 @@ export function resolveDataInDataDictionary<T>(
             resolvedDictionaryIds: config.resolvedDictionaryIds,
             schemaDictionary: config.schemaDictionary,
             mapper: config.mapper,
+            mapperPlugins: config.mapperPlugins,
         });
     });
 }
@@ -197,6 +241,7 @@ function attachResolvedDataDictionary<T>(
             parent: config.dataDictionary[0][config.items[i]].parent
                 ? config.dataDictionary[0][config.items[i]].parent.id
                 : null,
+            resolverPlugins: config.resolverPlugins,
         });
     }
 
@@ -217,6 +262,7 @@ export function mapDataDictionary<T>(config: MapDataConfig<T>): T {
         dictionaryId: clonedData[1],
         schemaDictionary: config.schemaDictionary,
         mapper: config.mapper,
+        mapperPlugins: config.plugins || [],
     });
 
     // resolve the data dictionary items up the tree
@@ -226,6 +272,7 @@ export function mapDataDictionary<T>(config: MapDataConfig<T>): T {
         schemaDictionary: config.schemaDictionary,
         items: resolvedDictionaryIds.reverse(),
         resolver: config.resolver,
+        resolverPlugins: config.plugins || [],
     });
 }
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Creates a new options in the configuration for the `mapDataDictionary` utility that allows for mappers to be assigned using `pluginId` in the JSON schema.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->