### PR TITLE
feat: add vertical and horizontal orientation for radio-group

### DIFF
--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -10,6 +10,15 @@
         </fast-radio-group>
     </div>
 
+    <div>
+        <fast-radio-group orientation="vertical" name="Bourbon">
+            <label slot="label">Bourbon</label>
+            <fast-radio value="elijahcraig">Elijah Craig</fast-radio>
+            <fast-radio value="woodford">Woodford Reserve</fast-radio>
+            <fast-radio value="elmerlee">Elmer T Lee</fast-radio>
+        </fast-radio-group>
+    </div>
+
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
         <fast-radio-group name="players">
             <label slot="label">Best basketball players</label>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -11,11 +11,12 @@
     </div>
 
     <div>
-        <fast-radio-group orientation="vertical" name="Bourbon">
-            <label slot="label">Bourbon</label>
-            <fast-radio value="elijahcraig">Elijah Craig</fast-radio>
-            <fast-radio value="woodford">Woodford Reserve</fast-radio>
-            <fast-radio value="elmerlee">Elmer T Lee</fast-radio>
+        <fast-radio-group orientation="vertical" name="trees">
+            <label slot="label">Trees</label>
+            <fast-radio value="fir">Fir</fast-radio>
+            <fast-radio value="juniper">Juniper</fast-radio>
+            <fast-radio value="hemlock">Hemlock</fast-radio>
+            <fast-radio value="pine">Pine</fast-radio>
         </fast-radio-group>
     </div>
 

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -7,9 +7,14 @@ export const RadioGroupStyles = css`
         margin: calc(var(--design-unit) * 1px) 0;
         flex-direction: column;
     }
-
     .positioning-region {
         display: flex;
         flex-wrap: wrap;
+    }
+    .vertical {
+        flex-direction: column;
+    }
+    .horizontal {
+        flex-direction: row;
     }
 `;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
@@ -1,5 +1,6 @@
 import { html, slotted } from "@microsoft/fast-element";
-import { RadioGroup, RadioOrientation } from "./radio-group";
+import { Orientation } from "@microsoft/fast-web-utilities";
+import { RadioGroup } from "./radio-group";
 
 export const RadioGroupTemplate = html<RadioGroup>`
     <template
@@ -10,9 +11,7 @@ export const RadioGroupTemplate = html<RadioGroup>`
         <slot name="label"></slot>
         <div
             class="positioning-region ${x =>
-                x.orientation === RadioOrientation.horizontal
-                    ? "horizontal"
-                    : "vertical"}"
+                x.orientation === Orientation.horizontal ? "horizontal" : "vertical"}"
             part="positioning-region"
         >
             <slot ${slotted("slottedRadioButtons")}> </slot>

--- a/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.template.ts
@@ -1,5 +1,5 @@
 import { html, slotted } from "@microsoft/fast-element";
-import { RadioGroup } from "./radio-group";
+import { RadioGroup, RadioOrientation } from "./radio-group";
 
 export const RadioGroupTemplate = html<RadioGroup>`
     <template
@@ -8,7 +8,13 @@ export const RadioGroupTemplate = html<RadioGroup>`
         aria-readonly="${x => x.readOnly}"
     >
         <slot name="label"></slot>
-        <div class="positioning-region" part="positioning-region">
+        <div
+            class="positioning-region ${x =>
+                x.orientation === RadioOrientation.horizontal
+                    ? "horizontal"
+                    : "vertical"}"
+            part="positioning-region"
+        >
             <slot ${slotted("slottedRadioButtons")}> </slot>
         </div>
     </template>

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -1,4 +1,5 @@
 import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { Orientation } from "@microsoft/fast-web-utilities";
 import {
     keyCodeArrowDown,
     keyCodeArrowLeft,
@@ -7,11 +8,6 @@ import {
     keyCodeEnter,
 } from "@microsoft/fast-web-utilities";
 import { RadioControl } from "../radio";
-
-export enum RadioOrientation {
-    horizontal = "horizontal",
-    vertical = "vertical",
-}
 
 export class RadioGroup extends FASTElement {
     @attr({ attribute: "readonly", mode: "boolean" })
@@ -56,7 +52,7 @@ export class RadioGroup extends FASTElement {
     public value: string;
 
     @attr
-    public orientation: RadioOrientation = RadioOrientation.horizontal;
+    public orientation: Orientation = Orientation.horizontal;
 
     @observable slottedRadioButtons: RadioControl[];
     private selectedRadio: RadioControl | null;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.ts
@@ -8,6 +8,11 @@ import {
 } from "@microsoft/fast-web-utilities";
 import { RadioControl } from "../radio";
 
+export enum RadioOrientation {
+    horizontal = "horizontal",
+    vertical = "vertical",
+}
+
 export class RadioGroup extends FASTElement {
     @attr({ attribute: "readonly", mode: "boolean" })
     public readOnly: boolean;
@@ -49,6 +54,9 @@ export class RadioGroup extends FASTElement {
 
     @attr
     public value: string;
+
+    @attr
+    public orientation: RadioOrientation = RadioOrientation.horizontal;
 
     @observable slottedRadioButtons: RadioControl[];
     private selectedRadio: RadioControl | null;


### PR DESCRIPTION
# Description
In response to #3069 adding the orientation attribute to fast-radio-group to allow for vertical orientation and a default of horizontal.

## Motivation & context

Motivation described in proposal #3069.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
