### PR TITLE
fix: add custom-properties exports to fast-components bundle

### DIFF
--- a/packages/web-components/fast-components/src/index.ts
+++ b/packages/web-components/fast-components/src/index.ts
@@ -3,6 +3,7 @@ export * from "./badge";
 export * from "./button";
 export * from "./card";
 export * from "./checkbox";
+export * from "./custom-properties";
 export * from "./design-system-provider";
 export * from "./dialog";
 export * from "./divider";


### PR DESCRIPTION
# Description

This commit adds `cssCustomPropertyBehaviorFactory` to the bundled exports.

## Motivation & context

Closes #3077

As mentioned in [this comment](https://github.com/microsoft/fast-dna/pull/3061#discussion_r421011341), the `cssCustomPropertyBehaviorFactory` wasn't getting exported via the index bundle.


## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
