### PR TITLE
feat: add a gradient accent fill recipe based on hue shifting

### DIFF
--- a/packages/react/fast-components-styles-msft/src/accent-button/index.ts
+++ b/packages/react/fast-components-styles-msft/src/accent-button/index.ts
@@ -24,6 +24,7 @@ import {
     highContrastSelectedOutline,
     highContrastSelector,
 } from "../utilities/high-contrast";
+import { accentFillGradientRest } from "../utilities/color/accent-fill-gradient";
 
 const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
     ...baseButton,
@@ -31,7 +32,8 @@ const styles: ComponentStyles<AccentButtonClassNameContract, DesignSystem> = {
         ...buttonStyles(),
         color: accentForegroundCut,
         fill: accentForegroundCut,
-        background: accentFillRest,
+        // background: accentFillRest,
+        background: accentFillGradientRest,
         "&:hover:enabled, a&:not($button__disabled):hover": {
             background: accentFillHover,
             ...highContrastSelectedOutline,

--- a/packages/react/fast-components-styles-msft/src/utilities/color/accent-fill-gradient.ts
+++ b/packages/react/fast-components-styles-msft/src/utilities/color/accent-fill-gradient.ts
@@ -1,6 +1,6 @@
-import { DesignSystem } from "src";
 import { ColorHSL, hslToRGB, parseColor, rgbToHSL } from "@microsoft/fast-colors";
 import { format } from "@microsoft/fast-jss-utilities";
+import { DesignSystem } from "../../design-system";
 import {
     FillSwatchFamily,
     Swatch,
@@ -11,7 +11,7 @@ import {
     SwatchRecipe,
     SwatchResolver,
 } from "./common";
-import { accentFill } from ".";
+import { accentFill } from "./index";
 
 function gradientSwatchRecipe<T extends SwatchFamily>(
     type: keyof T,
@@ -22,21 +22,23 @@ function gradientSwatchRecipe<T extends SwatchFamily>(
             type,
             callback
         );
-        const color: Swatch = baseRecipe(designSystem);
-        const colorHsl: ColorHSL = rgbToHSL(parseColor(color));
-        let hShifted: number = colorHsl.h + 28;
-        if (hShifted > 360) {
-            hShifted -= 360;
+        const baseColor: Swatch = baseRecipe(designSystem);
+        const baseColorHSL: ColorHSL = rgbToHSL(parseColor(baseColor));
+        let shiftedHue: number = baseColorHSL.h + 28;
+        if (shiftedHue > 360) {
+            shiftedHue -= 360;
         }
-        const secondaryHsl: ColorHSL = ColorHSL.fromObject({
-            h: hShifted,
-            s: colorHsl.s,
-            l: colorHsl.l,
-        });
+        const shiftedColor: Swatch = hslToRGB(
+            ColorHSL.fromObject({
+                h: shiftedHue,
+                s: baseColorHSL.s,
+                l: baseColorHSL.l,
+            })
+        ).toStringHexRGB();
         return format(
             "linear-gradient(0deg, {0} 0%, {1} 100%)",
-            (a: any): string => color,
-            (a: any): string => hslToRGB(secondaryHsl).toStringHexRGB()
+            (a: any): string => baseColor,
+            (a: any): string => shiftedColor
         )(designSystem);
     };
 }

--- a/packages/react/fast-components-styles-msft/src/utilities/color/accent-fill-gradient.ts
+++ b/packages/react/fast-components-styles-msft/src/utilities/color/accent-fill-gradient.ts
@@ -1,0 +1,55 @@
+import { DesignSystem } from "src";
+import { ColorHSL, hslToRGB, parseColor, rgbToHSL } from "@microsoft/fast-colors";
+import { format } from "@microsoft/fast-jss-utilities";
+import {
+    FillSwatchFamily,
+    Swatch,
+    SwatchFamily,
+    SwatchFamilyResolver,
+    swatchFamilyToSwatchRecipeFactory,
+    SwatchFamilyType,
+    SwatchRecipe,
+    SwatchResolver,
+} from "./common";
+import { accentFill } from ".";
+
+function gradientSwatchRecipe<T extends SwatchFamily>(
+    type: keyof T,
+    callback: SwatchFamilyResolver<T>
+): SwatchResolver {
+    return (designSystem: DesignSystem): Swatch => {
+        const baseRecipe: SwatchRecipe = swatchFamilyToSwatchRecipeFactory<T>(
+            type,
+            callback
+        );
+        const color: Swatch = baseRecipe(designSystem);
+        const colorHsl: ColorHSL = rgbToHSL(parseColor(color));
+        let hShifted: number = colorHsl.h + 28;
+        if (hShifted > 360) {
+            hShifted -= 360;
+        }
+        const secondaryHsl: ColorHSL = ColorHSL.fromObject({
+            h: hShifted,
+            s: colorHsl.s,
+            l: colorHsl.l,
+        });
+        return format(
+            "linear-gradient(0deg, {0} 0%, {1} 100%)",
+            (a: any): string => color,
+            (a: any): string => hslToRGB(secondaryHsl).toStringHexRGB()
+        )(designSystem);
+    };
+}
+
+export const accentFillGradientRest: SwatchResolver = gradientSwatchRecipe<
+    FillSwatchFamily
+>(SwatchFamilyType.rest, accentFill);
+export const accentFillGradientHover: SwatchResolver = gradientSwatchRecipe<
+    FillSwatchFamily
+>(SwatchFamilyType.hover, accentFill);
+export const accentFillGradientActive: SwatchResolver = gradientSwatchRecipe<
+    FillSwatchFamily
+>(SwatchFamilyType.active, accentFill);
+export const accentFillGradientFocus: SwatchResolver = gradientSwatchRecipe<
+    FillSwatchFamily
+>(SwatchFamilyType.focus, accentFill);


### PR DESCRIPTION
# Description

Added a gradient fill recipe based on accent color. Works by shifting the hue a currently fixed amount.

![image](https://user-images.githubusercontent.com/47367562/81463476-c671d380-916e-11ea-9b70-e85ec066291b.png)

## Motivation & context

For the new FAST site.

Will need another version or modifier for less saturated version. Looking into an algorithm for that based on designs.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->