### PR TITLE
fix: move appearance class application to template

### DIFF
--- a/packages/web-components/fast-components/src/button/button.template.ts
+++ b/packages/web-components/fast-components/src/button/button.template.ts
@@ -3,24 +3,26 @@ import { endTemplate, startTemplate } from "../patterns/start-end";
 import { Button } from "./";
 
 export const ButtonTemplate = html<Button>`
-    <button
-        class="control"
-        ?autofocus=${x => x.autofocus}
-        ?disabled=${x => x.disabled}
-        form=${x => x.formId}
-        formaction=${x => x.formaction}
-        formenctype=${x => x.formenctype}
-        formmethod=${x => x.formmethod}
-        formnovalidate=${x => x.formnovalidate}
-        formtarget=${x => x.formtarget}
-        name=${x => x.name}
-        type=${x => x.type}
-        value=${x => x.value}
-    >
-        ${startTemplate}
-        <span class="content" part="content">
-            <slot></slot>
-        </span>
-        ${endTemplate}
-    </button>
+    <template class="${x => x.appearance}">
+        <button
+            class="control"
+            ?autofocus=${x => x.autofocus}
+            ?disabled=${x => x.disabled}
+            form=${x => x.formId}
+            formaction=${x => x.formaction}
+            formenctype=${x => x.formenctype}
+            formmethod=${x => x.formmethod}
+            formnovalidate=${x => x.formnovalidate}
+            formtarget=${x => x.formtarget}
+            name=${x => x.name}
+            type=${x => x.type}
+            value=${x => x.value}
+        >
+            ${startTemplate}
+            <span class="content" part="content">
+                <slot></slot>
+            </span>
+            ${endTemplate}
+        </button>
+    </template>
 `;

--- a/packages/web-components/fast-components/src/button/button.ts
+++ b/packages/web-components/fast-components/src/button/button.ts
@@ -13,15 +13,6 @@ export type ButtonAppearance =
 export class Button extends FormAssociated<HTMLInputElement> {
     @attr
     public appearance: ButtonAppearance = "neutral";
-    public appearanceChanged(
-        oldValue: ButtonAppearance,
-        newValue: ButtonAppearance
-    ): void {
-        if (oldValue !== newValue) {
-            this.classList.add(newValue);
-            this.classList.remove(oldValue);
-        }
-    }
 
     @attr({ mode: "boolean" })
     public autofocus: boolean;


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Move class setter to template.
<!--- Describe your changes. -->

## Motivation & context
Setting the class in the change callback can cause a runtime error because the `appearance` value is initialized in the constructor, which in turn calls the change callback and sets the class attribute. Setting element attributes in the constructor causes a runtime error in Chromium and is to be avoided.

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->