### PR TITLE
fix: update eslint config to not warn on function args

### DIFF
--- a/packages/utilities/fast-eslint-rules/.eslintrc.js
+++ b/packages/utilities/fast-eslint-rules/.eslintrc.js
@@ -58,6 +58,7 @@ module.exports = {
         "no-prototype-builtins": "off",
         "no-fallthrough": "off",
         "no-unexpected-multiline": "off",
+        "@typescript-eslint/no-unused-vars": ["warn", { args: "none" }],
         "react/no-children-prop": "off",
         "@typescript-eslint/no-explicit-any": "off",
     },


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
It is sometimes nice to know which arguments a function has access to even if the implementation does not use those arguments.

This change configures eslint to not warn when function arguments go unused.

This change is a related to https://github.com/microsoft/fast-dna/pull/3113#discussion_r424000211
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->