### PR TITLE
fix: replaces childNodes.length check with slotted

### DIFF
--- a/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
@@ -49,6 +49,11 @@ export const CheckboxStyles = css`
         line-height: var(--type-ramp-base-line-height);
     }
 
+    .label__hidden {
+        display: none;
+        visibility: hidden;
+    }
+
     .checked-indicator {
         width: 100%;
         height: 100%;

--- a/packages/web-components/fast-components/src/radio/radio.styles.ts
+++ b/packages/web-components/fast-components/src/radio/radio.styles.ts
@@ -53,6 +53,11 @@ export const RadioStyles = css`
         line-height: var(--type-ramp-base-line-height);
     }
 
+    .label__hidden {
+        display: none;
+        visibility: hidden;
+    }
+
     .checked-indicator {
         position: absolute;
         top: 5px;

--- a/packages/web-components/fast-components/src/switch/switch.styles.ts
+++ b/packages/web-components/fast-components/src/switch/switch.styles.ts
@@ -103,6 +103,11 @@ export const SwitchStyles = css`
         line-height: var(--type-ramp-base-line-height);
     }
 
+    .label__hidden {
+        display: none;
+        visibility: hidden;
+    }
+
     ::slotted(*) {
         ${
             /* Need to discuss with Brian how HorizontalSpacingNumber can work. https://github.com/microsoft/fast-dna/issues/2766 */ ""

--- a/packages/web-components/fast-components/src/text-area/fixtures/text-area.html
+++ b/packages/web-components/fast-components/src/text-area/fixtures/text-area.html
@@ -3,7 +3,7 @@
     <h4>Default</h4>
     <fast-text-area></fast-text-area>
     <fast-text-area>
-        <span slot="label">label</span>
+        <span>label</span>
     </fast-text-area>
 
     <h4>Placeholder</h4>
@@ -17,7 +17,7 @@
     <h4>Disabled</h4>
     <fast-text-area disabled></fast-text-area>
     <fast-text-area disabled>
-        <span slot="label">label</span>
+        <span>label</span>
     </fast-text-area>
     <fast-text-area disabled placeholder="placeholder"></fast-text-area>
 
@@ -45,7 +45,7 @@
     <h5>Default</h5>
     <fast-text-area appearance="filled"></fast-text-area>
     <fast-text-area appearance="filled">
-        <span slot="label">label</span>
+        <span>label</span>
     </fast-text-area>
 
     <h5>Placeholder</h5>
@@ -59,7 +59,7 @@
     <h5>Disabled</h5>
     <fast-text-area appearance="filled" disabled></fast-text-area>
     <fast-text-area appearance="filled" disabled>
-        <span slot="label">label</span>
+        <span >label</span>
     </fast-text-area>
     <fast-text-area appearance="filled" disabled placeholder="placeholder"></fast-text-area>
 
@@ -71,13 +71,13 @@
     <!-- With label -->
     <h4>Visual vs audio label</h4>
     <fast-text-area>
-        <span slot="label" aria-label="Audio label">Visible label</span>
+        <span aria-label="Audio label">Visible label</span>
     </fast-text-area>
 
     <!-- With hidden label -->
     <h4>Audio label only</h4>
     <fast-text-area>
-        <span slot="label" aria-label="Audio label only"></span>
+        <span aria-label="Audio label only"></span>
     </fast-text-area>
 
 </fast-design-system-provider>

--- a/packages/web-components/fast-components/src/text-area/text-area.styles.ts
+++ b/packages/web-components/fast-components/src/text-area/text-area.styles.ts
@@ -86,6 +86,11 @@ export const TextAreaStyles = css`
         margin-bottom: 4px;
     }
 
+    .label__hidden {
+        display: none;
+        visibility: hidden;
+    }
+
     :host([disabled]) .label,
     :host([readonly]) .label,
     :host([readonly]) .control,

--- a/packages/web-components/fast-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/fast-components/src/text-field/text-field.styles.ts
@@ -64,6 +64,11 @@ export const TextFieldStyles = css`
         margin-bottom: 4px;
     }
 
+    .label__hidden {
+        display: none;
+        visibility: hidden;
+    }
+
     .before-content,
     .after-content {
         ${

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
@@ -1,4 +1,4 @@
-import { html, when, slotted } from "@microsoft/fast-element";
+import { html, slotted } from "@microsoft/fast-element";
 import { Checkbox } from "./checkbox.js";
 
 export const CheckboxTemplate = html<Checkbox>`

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
@@ -39,7 +39,7 @@ export const CheckboxTemplate = html<Checkbox>`
             class="${x =>
                 x.defaultSlottedNodes && x.defaultSlottedNodes.length
                     ? "label"
-                    : "label__hidden"}"
+                    : "label label__hidden"}"
         >
             <slot ${slotted("defaultSlottedNodes")}></slot>
         </label>

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
@@ -1,4 +1,4 @@
-import { html, when } from "@microsoft/fast-element";
+import { html, when, slotted } from "@microsoft/fast-element";
 import { Checkbox } from "./checkbox.js";
 
 export const CheckboxTemplate = html<Checkbox>`
@@ -34,9 +34,14 @@ export const CheckboxTemplate = html<Checkbox>`
                 <div part="indeterminate-indicator" class="indeterminate-indicator"></div>
             </slot>
         </div>
-        ${when(
-            x => x.childNodes.length,
-            html` <label part="label" class="label"><slot></slot></label> `
-        )}
+        <label
+            part="label"
+            class="${x =>
+                x.defaultSlottedNodes && x.defaultSlottedNodes.length
+                    ? "label"
+                    : "label__hidden"}"
+        >
+            <slot ${slotted("defaultSlottedNodes")}></slot>
+        </label>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
@@ -32,6 +32,9 @@ export class Checkbox extends FormAssociated<HTMLInputElement> {
         this.defaultChecked = this.checkedAttribute;
     }
 
+    @observable
+    public defaultSlottedNodes: Node[];
+
     /**
      * Initialized to the value of the checked attribute. Can be changed independently of the "checked" attribute,
      * but changing the "checked" attribute always additionally sets this value.

--- a/packages/web-components/fast-foundation/src/radio/radio.template.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.template.ts
@@ -1,4 +1,4 @@
-import { html, when, slotted } from "@microsoft/fast-element";
+import { html, slotted } from "@microsoft/fast-element";
 import { Radio } from "./radio.js";
 
 export const RadioTemplate = html<Radio>`

--- a/packages/web-components/fast-foundation/src/radio/radio.template.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.template.ts
@@ -23,7 +23,7 @@ export const RadioTemplate = html<Radio>`
             class="${x =>
                 x.defaultSlottedNodes && x.defaultSlottedNodes.length
                     ? "label"
-                    : "label__hidden"}"
+                    : "label label__hidden"}"
         >
             <slot ${slotted("defaultSlottedNodes")}></slot>
         </label>

--- a/packages/web-components/fast-foundation/src/radio/radio.template.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.template.ts
@@ -1,4 +1,4 @@
-import { html, when } from "@microsoft/fast-element";
+import { html, when, slotted } from "@microsoft/fast-element";
 import { Radio } from "./radio.js";
 
 export const RadioTemplate = html<Radio>`
@@ -18,13 +18,14 @@ export const RadioTemplate = html<Radio>`
                 <div part="checked-indicator" class="checked-indicator"></div>
             </slot>
         </div>
-        ${when(
-            x => x.childNodes.length,
-            html`
-                <label part="label" class="label">
-                    <slot></slot>
-                </label>
-            `
-        )}
+        <label
+            part="label"
+            class="${x =>
+                x.defaultSlottedNodes && x.defaultSlottedNodes.length
+                    ? "label"
+                    : "label__hidden"}"
+        >
+            <slot ${slotted("defaultSlottedNodes")}></slot>
+        </label>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -49,6 +49,9 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
         this.defaultChecked = this.checkedAttribute;
     }
 
+    @observable
+    public defaultSlottedNodes: Node[];
+
     /**
      * Initialized to the value of the checked attribute. Can be changed independently of the "checked" attribute,
      * but changing the "checked" attribute always additionally sets this value.

--- a/packages/web-components/fast-foundation/src/switch/switch.template.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.template.ts
@@ -18,7 +18,7 @@ export const SwitchTemplate = html<Switch>`
             class="${x =>
                 x.defaultSlottedNodes && x.defaultSlottedNodes.length
                     ? "label"
-                    : "label__hidden"}"
+                    : "label label__hidden"}"
         >
             <slot ${slotted("defaultSlottedNodes")}></slot>
         </label>

--- a/packages/web-components/fast-foundation/src/switch/switch.template.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.template.ts
@@ -1,4 +1,4 @@
-import { html, when, slotted } from "@microsoft/fast-element";
+import { html, slotted } from "@microsoft/fast-element";
 import { Switch } from "./switch.js";
 
 export const SwitchTemplate = html<Switch>`

--- a/packages/web-components/fast-foundation/src/switch/switch.template.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.template.ts
@@ -1,4 +1,4 @@
-import { html, when } from "@microsoft/fast-element";
+import { html, when, slotted } from "@microsoft/fast-element";
 import { Switch } from "./switch.js";
 
 export const SwitchTemplate = html<Switch>`
@@ -13,14 +13,15 @@ export const SwitchTemplate = html<Switch>`
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
         class="${x => (x.checked ? "checked" : "")}"
     >
-        ${when(
-            x => x.childNodes.length,
-            html`
-                <label part="label" class="label" id="switch-label">
-                    <slot></slot>
-                </label>
-            `
-        )}
+        <label
+            part="label"
+            class="${x =>
+                x.defaultSlottedNodes && x.defaultSlottedNodes.length
+                    ? "label"
+                    : "label__hidden"}"
+        >
+            <slot ${slotted("defaultSlottedNodes")}></slot>
+        </label>
         <div part="switch" class="switch">
             <span class="checked-indicator" part="checked-indicator"></span>
         </div>

--- a/packages/web-components/fast-foundation/src/switch/switch.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.ts
@@ -33,6 +33,9 @@ export class Switch extends FormAssociated<HTMLInputElement> {
         this.defaultChecked = this.checkedAttribute;
     }
 
+    @observable
+    public defaultSlottedNodes: Node[];
+
     /**
      * Initialized to the value of the checked attribute. Can be changed independently of the "checked" attribute,
      * but changing the "checked" attribute always additionally sets this value.

--- a/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
@@ -1,4 +1,4 @@
-import { html, ref, when } from "@microsoft/fast-element";
+import { html, ref, when, slotted } from "@microsoft/fast-element";
 import { TextArea, TextAreaResize } from "./text-area.js";
 
 export const TextAreaTemplate = html<TextArea>`
@@ -8,14 +8,12 @@ export const TextAreaTemplate = html<TextArea>`
             ${x => (x.readOnly ? "readonly" : "")}
             ${x => (x.resize !== TextAreaResize.none ? `resize-${x.resize}` : "")}"
     >
-        ${when(
-            x => x.childNodes.length,
-            html`
-                <label part="label" class="label" for="control">
-                    <slot name="label"></slot>
-                </label>
-            `
-        )}
+        <label part="label" for="control" class="${x =>
+            x.defaultSlottedNodes && x.defaultSlottedNodes.length
+                ? "label"
+                : "label__hidden"}">
+            <slot ${slotted("defaultSlottedNodes")}></slot>
+        </label>
         <textarea
             part="control"
             class="control"

--- a/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
@@ -11,7 +11,7 @@ export const TextAreaTemplate = html<TextArea>`
         <label part="label" for="control" class="${x =>
             x.defaultSlottedNodes && x.defaultSlottedNodes.length
                 ? "label"
-                : "label__hidden"}">
+                : "label label__hidden"}">
             <slot ${slotted("defaultSlottedNodes")}></slot>
         </label>
         <textarea

--- a/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
@@ -1,4 +1,4 @@
-import { html, ref, when, slotted } from "@microsoft/fast-element";
+import { html, ref, slotted } from "@microsoft/fast-element";
 import { TextArea, TextAreaResize } from "./text-area.js";
 
 export const TextAreaTemplate = html<TextArea>`

--- a/packages/web-components/fast-foundation/src/text-area/text-area.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.ts
@@ -1,4 +1,4 @@
-import { attr, nullableNumberConverter } from "@microsoft/fast-element";
+import { attr, nullableNumberConverter, observable } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/index.js";
 
 export enum TextAreaAppearance {
@@ -84,6 +84,9 @@ export class TextArea extends FormAssociated<HTMLTextAreaElement> {
             this.proxy.spellcheck = this.spellcheck;
         }
     }
+
+    @observable
+    public defaultSlottedNodes: Node[];
 
     public valueChanged(): void {
         if (this.textarea && this.value !== this.textarea.value) {

--- a/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
@@ -1,4 +1,4 @@
-import { html, ref, when, slotted } from "@microsoft/fast-element";
+import { html, ref, slotted } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns/start-end.js";
 import { TextField } from "./text-field.js";
 

--- a/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
@@ -1,4 +1,4 @@
-import { html, ref, when } from "@microsoft/fast-element";
+import { html, ref, when, slotted } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns/start-end.js";
 import { TextField } from "./text-field.js";
 
@@ -15,10 +15,16 @@ export const TextFieldTemplate = html<TextField>`
             ${x => (x.readOnly ? "readonly" : "")}
         "
     >
-        ${when(
-            x => x.childNodes.length,
-            html` <label part="label" class="label" for="control"><slot></slot></label> `
-        )}
+        <label
+            part="label"
+            for="control"
+            class="${x =>
+                x.defaultSlottedNodes && x.defaultSlottedNodes.length
+                    ? "label"
+                    : "label__hidden"}"
+        >
+            <slot ${slotted("defaultSlottedNodes")}></slot>
+        </label>
         <div class="root" part="root">
             ${startTemplate}
             <input

--- a/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
@@ -21,7 +21,7 @@ export const TextFieldTemplate = html<TextField>`
             class="${x =>
                 x.defaultSlottedNodes && x.defaultSlottedNodes.length
                     ? "label"
-                    : "label__hidden"}"
+                    : "label label__hidden"}"
         >
             <slot ${slotted("defaultSlottedNodes")}></slot>
         </label>

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -1,4 +1,4 @@
-import { attr, nullableNumberConverter } from "@microsoft/fast-element";
+import { attr, nullableNumberConverter, observable } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/index.js";
 import { StartEnd } from "../patterns/start-end.js";
 import { applyMixins } from "../utilities/index.js";
@@ -99,6 +99,9 @@ export class TextField extends FormAssociated<HTMLInputElement> {
             this.proxy.spellcheck = this.spellcheck;
         }
     }
+
+    @observable
+    public defaultSlottedNodes: Node[];
 
     private valueChanged(): void {
         if (this.proxy instanceof HTMLElement) {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
This fix removes `childNodes.length` check and replaces it with the `slotted` directive. `childNodes.length` is a one-time render. If child nodes changes, `childNodes.length` won't update because it's not observable.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->