### PR TITLE
feat: wrap attr and observable into designSystemProperty decorator

### DIFF
--- a/packages/web-components/fast-components/src/design-system-provider/index.ts
+++ b/packages/web-components/fast-components/src/design-system-provider/index.ts
@@ -50,7 +50,10 @@ export class FASTDesignSystemProvider extends DesignSystemProvider
     })
     public accentPalette: string[];
 
-    @designSystemProperty({ default: fastDesignSystemDefaults.density, converter: nullableNumberConverter })
+    @designSystemProperty({
+        default: fastDesignSystemDefaults.density,
+        converter: nullableNumberConverter,
+    })
     public density: 0;
 
     @designSystemProperty({
@@ -67,7 +70,7 @@ export class FASTDesignSystemProvider extends DesignSystemProvider
     @designSystemProperty({
         attribute: "base-height-multiplier",
         default: fastDesignSystemDefaults.baseHeightMultiplier,
-        converter: nullableNumberConverter
+        converter: nullableNumberConverter,
     })
     public baseHeightMultiplier: number;
 

--- a/packages/web-components/fast-components/src/design-system-provider/index.ts
+++ b/packages/web-components/fast-components/src/design-system-provider/index.ts
@@ -23,44 +23,39 @@ export class FASTDesignSystemProvider extends DesignSystemProvider
     /**
      * Define design system property attributes
      */
-    @attr({ attribute: "background-color", ...fromView })
     @designSystemProperty({
-        cssCustomProperty: "background-color",
+        attribute: "background-color",
         default: fastDesignSystemDefaults.backgroundColor,
     })
     public backgroundColor: string;
 
-    @attr({ attribute: "accent-base-color", ...fromView })
     @designSystemProperty({
+        attribute: "accent-base-color",
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.accentBaseColor,
     })
     public accentBaseColor: string;
 
-    @observable
     @designSystemProperty({
+        attribute: false,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralPalette,
     })
     public neutralPalette: string[];
 
-    @observable
     @designSystemProperty({
+        attribute: false,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.accentPalette,
     })
     public accentPalette: string[];
 
-    @attr(fromViewNumber)
-    @designSystemProperty({ default: fastDesignSystemDefaults.density })
+    @designSystemProperty({ default: fastDesignSystemDefaults.density, converter: nullableNumberConverter })
     public density: 0;
 
-    @attr({
-        attribute: "design-unit",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
-        cssCustomProperty: "design-unit",
+        attribute: "design-unit",
+        converter: nullableNumberConverter,
         default: fastDesignSystemDefaults.designUnit,
     })
     public designUnit: number;
@@ -70,563 +65,453 @@ export class FASTDesignSystemProvider extends DesignSystemProvider
         ...fromViewNumber,
     })
     @designSystemProperty({
-        cssCustomProperty: "base-height-multiplier",
+        attribute: "base-height-multiplier",
         default: fastDesignSystemDefaults.baseHeightMultiplier,
+        converter: nullableNumberConverter
     })
     public baseHeightMultiplier: number;
 
-    @attr({
-        attribute: "base-horizontal-spacing-multiplier",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
-        cssCustomProperty: "base-horizontal-spacing-multiplier",
+        attribute: "base-horizontal-spacing-multiplier",
+        converter: nullableNumberConverter,
         default: fastDesignSystemDefaults.baseHorizontalSpacingMultiplier,
     })
     public baseHorizontalSpacingMultiplier: number;
 
-    @attr({
-        attribute: "corner-radius",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
-        cssCustomProperty: "corner-radius",
+        attribute: "corner-radius",
+        converter: nullableNumberConverter,
         default: fastDesignSystemDefaults.cornerRadius,
     })
     public cornerRadius: number;
 
-    @attr({
-        attribute: "elevated-corner-radius",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
-        cssCustomProperty: "elevated-corner-radius",
+        attribute: "elevated-corner-radius",
+        converter: nullableNumberConverter,
         default: fastDesignSystemDefaults.elevatedCornerRadius,
     })
     public elevatedCornerRadius: number;
 
-    @attr({
+    @designSystemProperty({
         attribute: "outline-width",
         converter: nullableNumberConverter,
-        ...fromView,
-    })
-    @designSystemProperty({
-        cssCustomProperty: "outline-width",
         default: fastDesignSystemDefaults.outlineWidth,
     })
     public outlineWidth: number;
 
-    @attr({
-        attribute: "focus-outline-width",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
-        cssCustomProperty: "focus-outline-width",
+        attribute: "focus-outline-width",
+        converter: nullableNumberConverter,
         default: fastDesignSystemDefaults.focusOutlineWidth,
     })
     public focusOutlineWidth: number;
 
-    @attr({
-        attribute: "disabled-opacity",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
-        cssCustomProperty: "disabled-opacity",
+        attribute: "disabled-opacity",
+        converter: nullableNumberConverter,
         default: fastDesignSystemDefaults.disabledOpacity,
     })
     public disabledOpacity: number;
 
-    @attr({ ...fromView, attribute: "type-ramp-minus-2-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-minus-2-font-size",
+        attribute: "type-ramp-minus-2-font-size",
         default: "10px",
     })
     public typeRampMinus2FontSize: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-minus-2-line-height" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-minus-2-line-height",
+        attribute: "type-ramp-minus-2-line-height",
         default: "16px",
     })
     public typeRampMinus2LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-minus-1-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-minus-1-font-size",
+        attribute: "type-ramp-minus-1-font-size",
         default: "12px",
     })
     public typeRampMinus1FontSize: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-minus-1-line-height" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-minus-1-line-height",
+        attribute: "type-ramp-minus-1-line-height",
         default: "16px",
     })
     public typeRampMinus1LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-base-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-base-font-size",
+        attribute: "type-ramp-base-font-size",
         default: "14px",
     })
     public typeRampBaseFontSize: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-base-line-height" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-base-line-height",
+        attribute: "type-ramp-base-line-height",
         default: "20px",
     })
     public typeRampBaseLineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-1-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-1-font-size",
+        attribute: "type-ramp-plus-1-font-size",
         default: "16px",
     })
     public typeRampPlus1FontSize: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-1-line-height" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-1-line-height",
+        attribute: "type-ramp-plus-1-line-height",
         default: "24px",
     })
     public typeRampPlus1LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-2-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-2-font-size",
+        attribute: "type-ramp-plus-2-font-size",
         default: "20px",
     })
     public typeRampPlus2FontSize: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-2-line-height" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-2-line-height",
+        attribute: "type-ramp-plus-2-line-height",
         default: "28px",
     })
     public typeRampPlus2LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-3-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-3-font-size",
+        attribute: "type-ramp-plus-3-font-size",
         default: "28px",
     })
     public typeRampPlus3FontSize: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-3-line-height" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-3-line-height",
+        attribute: "type-ramp-plus-3-line-height",
         default: "36px",
     })
     public typeRampPlus3LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-4-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-4-font-size",
+        attribute: "type-ramp-plus-4-font-size",
         default: "34px",
     })
     public typeRampPlus4FontSize: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-4-line-height" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-4-line-height",
+        attribute: "type-ramp-plus-4-line-height",
         default: "44px",
     })
     public typeRampPlus4LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-5-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-5-font-size",
+        attribute: "type-ramp-plus-5-font-size",
         default: "46px",
     })
     public typeRampPlus5FontSize: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-5-line-height" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-5-line-height",
+        attribute: "type-ramp-plus-5-line-height",
         default: "56px",
     })
     public typeRampPlus5LineHeight: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-6-font-size" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-6-font-size",
+        attribute: "type-ramp-plus-6-font-size",
         default: "60px",
     })
     public typeRampPlus6FontSize: string;
 
-    @attr({ ...fromView, attribute: "type-ramp-plus-6-line-height" })
     @designSystemProperty({
-        cssCustomProperty: "type-ramp-plus-6-line-height",
+        attribute: "type-ramp-plus-6-line-height",
         default: "72px",
     })
     public typeRampPlus6LineHeight: string;
 
-    @attr({
-        attribute: "accent-fill-rest-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "accent-fill-rest-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.accentFillRestDelta,
     })
     public accentFillRestDelta: number;
 
-    @attr({
-        attribute: "accent-fill-hover-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "accent-fill-hover-delta",
         cssCustomProperty: false,
+        converter: nullableNumberConverter,
         default: fastDesignSystemDefaults.accentFillHoverDelta,
     })
     public accentFillHoverDelta: number;
 
-    @attr({
-        attribute: "accent-fill-active-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "accent-fill-active-delta",
         cssCustomProperty: false,
+        converter: nullableNumberConverter,
         default: fastDesignSystemDefaults.accentFillActiveDelta,
     })
     public accentFillActiveDelta: number;
 
-    @attr({
-        attribute: "accent-fill-focus-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "accent-fill-focus-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.accentFillFocusDelta,
     })
     public accentFillFocusDelta: number;
 
-    @attr({
-        attribute: "accent-fill-selected-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "accent-fill-selected-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.accentFillSelectedDelta,
     })
     public accentFillSelectedDelta: number;
 
-    @attr({
-        attribute: "accent-foreground-rest-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "accent-foreground-rest-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.accentForegroundRestDelta,
     })
     public accentForegroundRestDelta: number;
 
-    @attr({
-        attribute: "accent-foreground-hover-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "accent-foreground-hover-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.accentForegroundHoverDelta,
     })
     public accentForegroundHoverDelta: number;
 
-    @attr({
-        attribute: "accent-foreground-active-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "accent-foreground-active-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.accentForegroundActiveDelta,
     })
     public accentForegroundActiveDelta: number;
 
-    @attr({
-        attribute: "accent-foreground-focus-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "accent-foreground-focus-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.accentForegroundFocusDelta,
     })
     public accentForegroundFocusDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-rest-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-rest-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillRestDelta,
     })
     public neutralFillRestDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-hover-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-hover-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillHoverDelta,
     })
     public neutralFillHoverDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-active-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-active-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillActiveDelta,
     })
     public neutralFillActiveDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-focus-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-focus-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillFocusDelta,
     })
     public neutralFillFocusDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-selected-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-selected-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillSelectedDelta,
     })
     public neutralFillSelectedDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-input-rest-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-input-rest-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillInputRestDelta,
     })
     public neutralFillInputRestDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-input-hover-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-input-hover-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillInputHoverDelta,
     })
     public neutralFillInputHoverDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-input-active-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-input-active-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillInputActiveDelta,
     })
     public neutralFillInputActiveDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-input-focus-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-input-focus-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillInputFocusDelta,
     })
     public neutralFillInputFocusDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-input-selected-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-input-selected-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillInputSelectedDelta,
     })
     public neutralFillInputSelectedDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-stealth-rest-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-stealth-rest-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillStealthRestDelta,
     })
     public neutralFillStealthRestDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-stealth-hover-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-stealth-hover-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillStealthHoverDelta,
     })
     public neutralFillStealthHoverDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-stealth-active-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-stealth-active-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillStealthActiveDelta,
     })
     public neutralFillStealthActiveDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-stealth-focus-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-stealth-focus-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillStealthFocusDelta,
     })
     public neutralFillStealthFocusDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-stealth-selected-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-stealth-selected-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillStealthSelectedDelta,
     })
     public neutralFillStealthSelectedDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-toggle-hover-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-toggle-hover-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillToggleHoverDelta,
     })
     public neutralFillToggleHoverDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-toggle-hover-active",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-toggle-hover-active",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillToggleActiveDelta,
     })
     public neutralFillToggleActiveDelta: number;
 
-    @attr({
-        attribute: "neutral-fill-toggle-hover-focus",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-toggle-hover-focus",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillToggleFocusDelta,
     })
     public neutralFillToggleFocusDelta: number;
 
-    @attr({
-        attribute: "base-layer-luminance",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "base-layer-luminance",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.baseLayerLuminance,
     })
     public baseLayerLuminance: number; // 0...1
 
-    @attr({
-        attribute: "neutral-fill-card-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-fill-card-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralFillCardDelta,
     })
     public neutralFillCardDelta: number;
 
-    @attr({
-        attribute: "neutral-foreground-hover-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-foreground-hover-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralForegroundHoverDelta,
     })
     public neutralForegroundHoverDelta: number;
 
-    @attr({
-        attribute: "neutral-foreground-active-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-foreground-active-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralForegroundActiveDelta,
     })
     public neutralForegroundActiveDelta: number;
 
-    @attr({
-        attribute: "neutral-foreground-focus-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-foreground-focus-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralForegroundFocusDelta,
     })
     public neutralForegroundFocusDelta: number;
 
-    @attr({
-        attribute: "neutral-divider-rest-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-divider-rest-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralDividerRestDelta,
     })
     public neutralDividerRestDelta: number;
 
-    @attr({
-        attribute: "neutral-outline-rest-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-outline-rest-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralOutlineRestDelta,
     })
     public neutralOutlineRestDelta: number;
 
-    @attr({
-        attribute: "neutral-outline-hover-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-outline-hover-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralOutlineHoverDelta,
     })
     public neutralOutlineHoverDelta: number;
 
-    @attr({
-        attribute: "neutral-outline-active-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-outline-active-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralOutlineActiveDelta,
     })
     public neutralOutlineActiveDelta: number;
 
-    @attr({
-        attribute: "neutral-outline-focus-delta",
-        ...fromViewNumber,
-    })
     @designSystemProperty({
+        attribute: "neutral-outline-focus-delta",
+        converter: nullableNumberConverter,
         cssCustomProperty: false,
         default: fastDesignSystemDefaults.neutralOutlineFocusDelta,
     })

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
@@ -44,7 +44,7 @@ export function designSystemProperty<T extends DesignSystemProvider>(
             observable(source, prop);
         } else {
             /**
-             * Default to fromView so we don't preform a bunch of DOM writes
+             * Default to fromView so we don't perform un-necessary DOM writes
              */
             if (config.mode === void 0) {
                 config = { ...config, mode: "fromView" };

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
@@ -7,13 +7,23 @@ import { DesignSystemProvider } from "./design-system-provider.js";
 /**
  * Decorator to declare a property as a design-system property.
  * Accepts a config object with the following:
- *
+ * 
  * default:
  * The default value of the property. Will be assigned when the use-defaults attribute is used.
  *
+ * attribute?:
+ * The HTML attribute to map the property to - defaults to the property name.
+ * 
+ * mode?:
+ * The attr mode - see https://github.com/microsoft/fast-dna/blob/master/packages/web-components/fast-element/docs/guide/building-components.md#customizing-attributes
+ * Defaults to "fromView"
+ * 
+ * converter?:
+ * The attr converter - see https://github.com/microsoft/fast-dna/blob/master/packages/web-components/fast-element/docs/guide/building-components.md#customizing-attributes
+ *
  * cssCustomProperty?:
  * An optional property to control the name of the css custom property being created.
- * If omitted, the css custom property will share a name with the decorated property name.
+ * If omitted, the css custom property will share a name with attribute if specified, otherwise the property name being decorated.
  * If assigned a false value, no css custom property will be created.
  */
 export function designSystemProperty<T extends DesignSystemProvider>(

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
@@ -7,17 +7,17 @@ import { DesignSystemProvider } from "./design-system-provider.js";
 /**
  * Decorator to declare a property as a design-system property.
  * Accepts a config object with the following:
- * 
+ *
  * default:
  * The default value of the property. Will be assigned when the use-defaults attribute is used.
  *
  * attribute?:
  * The HTML attribute to map the property to - defaults to the property name.
- * 
+ *
  * mode?:
  * The attr mode - see https://github.com/microsoft/fast-dna/blob/master/packages/web-components/fast-element/docs/guide/building-components.md#customizing-attributes
  * Defaults to "fromView"
- * 
+ *
  * converter?:
  * The attr converter - see https://github.com/microsoft/fast-dna/blob/master/packages/web-components/fast-element/docs/guide/building-components.md#customizing-attributes
  *
@@ -47,7 +47,7 @@ export function designSystemProperty<T extends DesignSystemProvider>(
              * Default to fromView so we don't preform a bunch of DOM writes
              */
             if (config.mode === void 0) {
-                config = {...config, mode: "fromView"}
+                config = { ...config, mode: "fromView" };
             }
 
             attr(config as DecoratorAttributeConfiguration)(source, prop);

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
@@ -47,7 +47,7 @@ export function designSystemProperty<T extends DesignSystemProvider>(
              * Default to fromView so we don't preform a bunch of DOM writes
              */
             if (config.mode === void 0) {
-                config.mode = "fromView";
+                config = {...config, mode: "fromView"}
             }
 
             attr(config as DecoratorAttributeConfiguration)(source, prop);

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
@@ -1,7 +1,7 @@
 import {
+    attr,
     DecoratorAttributeConfiguration,
     observable,
-    attr,
 } from "@microsoft/fast-element";
 import { DesignSystemProvider } from "./design-system-provider.js";
 /**
@@ -67,8 +67,3 @@ export interface DecoratorDesignSystemPropertyConfiguration
     cssCustomProperty?: string | false;
     default: any;
 }
-
-export type DesignSystemPropertyDeclarationConfig = Pick<
-    DecoratorDesignSystemPropertyConfiguration,
-    "cssCustomProperty" | "default"
->;

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
@@ -33,6 +33,13 @@ export function designSystemProperty<T extends DesignSystemProvider>(
         if (attribute === false) {
             observable(source, prop);
         } else {
+            /**
+             * Default to fromView so we don't preform a bunch of DOM writes
+             */
+            if (config.mode === void 0) {
+                config.mode = "fromView";
+            }
+
             attr(config as DecoratorAttributeConfiguration)(source, prop);
         }
 

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-property.ts
@@ -1,3 +1,8 @@
+import {
+    DecoratorAttributeConfiguration,
+    observable,
+    attr,
+} from "@microsoft/fast-element";
 import { DesignSystemProvider } from "./design-system-provider.js";
 /**
  * Decorator to declare a property as a design-system property.
@@ -12,20 +17,34 @@ import { DesignSystemProvider } from "./design-system-provider.js";
  * If assigned a false value, no css custom property will be created.
  */
 export function designSystemProperty<T extends DesignSystemProvider>(
-    config: DesignSystemPropertyDeclarationConfig
+    config: DecoratorDesignSystemPropertyConfiguration
 ): (source: T, property: string) => void {
     const decorator = (
         source: T,
         prop: string,
-        config: DesignSystemPropertyDeclarationConfig
+        config: DecoratorDesignSystemPropertyConfiguration
     ) => {
+        const { cssCustomProperty, attribute } = config;
+
         if (!source.designSystemProperties) {
             source.designSystemProperties = {};
         }
 
+        if (attribute === false) {
+            observable(source, prop);
+        } else {
+            attr(config as DecoratorAttributeConfiguration)(source, prop);
+        }
+
         source.designSystemProperties[prop] = {
             cssCustomProperty:
-                config.cssCustomProperty === void 0 ? prop : config.cssCustomProperty,
+                cssCustomProperty === false
+                    ? false
+                    : typeof cssCustomProperty === "string"
+                    ? cssCustomProperty
+                    : typeof attribute === "string"
+                    ? attribute
+                    : prop,
             default: config.default,
         };
     };
@@ -35,7 +54,14 @@ export function designSystemProperty<T extends DesignSystemProvider>(
     };
 }
 
-export interface DesignSystemPropertyDeclarationConfig {
+export interface DecoratorDesignSystemPropertyConfiguration
+    extends Omit<DecoratorAttributeConfiguration, "attribute"> {
+    attribute?: string | false;
     cssCustomProperty?: string | false;
     default: any;
 }
+
+export type DesignSystemPropertyDeclarationConfig = Pick<
+    DecoratorDesignSystemPropertyConfiguration,
+    "cssCustomProperty" | "default"
+>;

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
@@ -46,7 +46,7 @@ export const designSystemConsumerBehavior: Behavior = {
     },
 
     /* eslint-disable-next-line */
-    unbind<T extends DesignSystemConsumer & HTMLElement>(source: T) { },
+    unbind<T extends DesignSystemConsumer & HTMLElement>(source: T) {},
 };
 
 export class DesignSystemProvider extends FASTElement
@@ -190,10 +190,12 @@ export class DesignSystemProvider extends FASTElement
      * by the decorator.
      */
     public designSystemProperties: {
-        [propertyName: string]: Required<Pick<
-            DecoratorDesignSystemPropertyConfiguration,
-            "cssCustomProperty" | "default"
-        >>;
+        [propertyName: string]: Required<
+            Pick<
+                DecoratorDesignSystemPropertyConfiguration,
+                "cssCustomProperty" | "default"
+            >
+        >;
     };
 
     /**
@@ -389,11 +391,11 @@ export class DesignSystemProvider extends FASTElement
     public evaluate(definition: CSSCustomPropertyDefinition): string {
         return typeof definition.value === "function"
             ? // use spread on the designSystem object to circumvent memoization
-            // done in the color recipes - we use the same *reference* in WC
-            // for performance improvements but that throws off the recipes
-            // We should look at making the recipes use simple args that
-            // we can individually memoize.
-            definition.value({ ...this.designSystem })
+              // done in the color recipes - we use the same *reference* in WC
+              // for performance improvements but that throws off the recipes
+              // We should look at making the recipes use simple args that
+              // we can individually memoize.
+              definition.value({ ...this.designSystem })
             : definition.value;
     }
     /**

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
@@ -13,7 +13,7 @@ import {
     CSSCustomPropertyTarget,
 } from "../custom-properties/index.js";
 import { composedParent } from "../utilities/index.js";
-import { DesignSystemPropertyDeclarationConfig } from "./design-system-property.js";
+import { DecoratorDesignSystemPropertyConfiguration } from "./design-system-property.js";
 
 const supportsAdoptedStylesheets = "adoptedStyleSheets" in window.ShadowRoot.prototype;
 
@@ -46,7 +46,7 @@ export const designSystemConsumerBehavior: Behavior = {
     },
 
     /* eslint-disable-next-line */
-    unbind<T extends DesignSystemConsumer & HTMLElement>(source: T) {},
+    unbind<T extends DesignSystemConsumer & HTMLElement>(source: T) { },
 };
 
 export class DesignSystemProvider extends FASTElement
@@ -190,7 +190,10 @@ export class DesignSystemProvider extends FASTElement
      * by the decorator.
      */
     public designSystemProperties: {
-        [propertyName: string]: Required<DesignSystemPropertyDeclarationConfig>;
+        [propertyName: string]: Required<Pick<
+            DecoratorDesignSystemPropertyConfiguration,
+            "cssCustomProperty" | "default"
+        >>;
     };
 
     /**
@@ -386,11 +389,11 @@ export class DesignSystemProvider extends FASTElement
     public evaluate(definition: CSSCustomPropertyDefinition): string {
         return typeof definition.value === "function"
             ? // use spread on the designSystem object to circumvent memoization
-              // done in the color recipes - we use the same *reference* in WC
-              // for performance improvements but that throws off the recipes
-              // We should look at making the recipes use simple args that
-              // we can individually memoize.
-              definition.value({ ...this.designSystem })
+            // done in the color recipes - we use the same *reference* in WC
+            // for performance improvements but that throws off the recipes
+            // We should look at making the recipes use simple args that
+            // we can individually memoize.
+            definition.value({ ...this.designSystem })
             : definition.value;
     }
     /**


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
The `@designSystemProperty` decorator originally made an assumption that the property being decorated was *also* an observable property. 

This change removes that assumption and does work to set up the attr / observable itself.
<!--- Describe your changes. -->

## Motivation & context
closes #3110
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->