### PR TITLE
fix: stackpanel should not throw when itemspan list is too short

### DIFF
--- a/packages/react/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/react/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -247,7 +247,7 @@ describe("stack panel", (): void => {
         );
     });
 
-    test("getMaxScrollDistance returns value corresponding to height of items and viewport", (): void => {
+    test("too short an itemspan list does not throw", (): void => {
         const rendered: any = mount(<StackPanel itemSpan={[]} />);
 
         expect(() => {

--- a/packages/react/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
+++ b/packages/react/fast-components-react-base/src/stack-panel/stack-panel.spec.tsx
@@ -94,6 +94,7 @@ describe("stack panel", (): void => {
         };
         expect(rendered.first().instance()["getViewportSpan"]()).toBe(200);
     });
+
     test("getScrollIntoViewPosition returns expected values", (): void => {
         const rendered: any = mount(
             <StackPanel itemSpan={itemSpans}>{sampleStackPanelItems}</StackPanel>
@@ -244,5 +245,15 @@ describe("stack panel", (): void => {
         expect(rendered.instance().rootElement.current.className).not.toContain(
             managedClasses.stackPanel__scrollable
         );
+    });
+
+    test("getMaxScrollDistance returns value corresponding to height of items and viewport", (): void => {
+        const rendered: any = mount(<StackPanel itemSpan={[]} />);
+
+        expect(() => {
+            rendered.setProps({
+                children: sampleStackPanelItems,
+            });
+        }).not.toThrow();
     });
 });

--- a/packages/react/fast-components-react-base/src/stack-panel/stack-panel.tsx
+++ b/packages/react/fast-components-react-base/src/stack-panel/stack-panel.tsx
@@ -246,10 +246,11 @@ class StackPanel extends Foundation<
      */
     private renderItem = (item: React.ReactNode, index: number): React.ReactChild => {
         if (
-            this.props.virtualize &&
-            !this.props.neverVirtualizeIndexes.includes(index) &&
-            (index < this.state.renderedRangeStartIndex ||
-                index > this.state.renderedRangeEndIndex)
+            index >= this.itemPositions.length ||
+            (this.props.virtualize &&
+                !this.props.neverVirtualizeIndexes.includes(index) &&
+                (index < this.state.renderedRangeStartIndex ||
+                    index > this.state.renderedRangeEndIndex))
         ) {
             return;
         }


### PR DESCRIPTION
# Description
Stop rendering items when we reach the end of a too short itemspan array

## Motivation & context
Could throw otherwise, esp when rendering children before recalculating layout after update.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.