### PR TITLE
feat: add first class prop for aria-label to radio and checkbox

### DIFF
--- a/packages/react/fast-components-react-base/src/checkbox/checkbox.props.ts
+++ b/packages/react/fast-components-react-base/src/checkbox/checkbox.props.ts
@@ -3,6 +3,7 @@ import {
     CheckboxClassNameContract,
     ManagedClasses,
 } from "@microsoft/fast-components-class-name-contracts-base";
+import { Omit } from "utility-types";
 
 /**
  * @deprecated
@@ -14,7 +15,10 @@ export enum CheckboxSlot {
 }
 
 export type CheckboxManagedClasses = ManagedClasses<CheckboxClassNameContract>;
-export type CheckboxUnhandledProps = React.HTMLAttributes<HTMLDivElement>;
+export type CheckboxUnhandledProps = Omit<
+    React.HTMLAttributes<HTMLDivElement>,
+    "aria-label"
+>;
 export interface CheckboxHandledProps extends CheckboxManagedClasses {
     /**
      * The id of the checkbox input element
@@ -50,6 +54,12 @@ export interface CheckboxHandledProps extends CheckboxManagedClasses {
      * The checkbox label
      */
     label?: (className: string) => React.ReactNode;
+
+    /**
+     * The checkbox aria-label
+     * This is necessary due to how unhandledProps are passed to the root of the component
+     */
+    ariaLabel?: string;
 
     /**
      * The value of the checkbox

--- a/packages/react/fast-components-react-base/src/checkbox/checkbox.schema.2.ts
+++ b/packages/react/fast-components-react-base/src/checkbox/checkbox.schema.2.ts
@@ -27,6 +27,11 @@ export default {
             title: "Input element ID",
             type: "string",
         },
+        ariaLabel: {
+            title: "Aria-label",
+            type: "string",
+            examples: ["label"],
+        },
         name: {
             title: "Name",
             type: "string",

--- a/packages/react/fast-components-react-base/src/checkbox/checkbox.schema.ts
+++ b/packages/react/fast-components-react-base/src/checkbox/checkbox.schema.ts
@@ -25,6 +25,11 @@ export default {
             title: "Input element ID",
             type: "string",
         },
+        ariaLabel: {
+            title: "Aria-label",
+            type: "string",
+            examples: ["label"],
+        },
         name: {
             title: "Name",
             type: "string",

--- a/packages/react/fast-components-react-base/src/checkbox/checkbox.spec.tsx
+++ b/packages/react/fast-components-react-base/src/checkbox/checkbox.spec.tsx
@@ -51,14 +51,14 @@ describe("checkbox", (): void => {
         };
 
         const unhandledProps: CheckboxUnhandledProps = {
-            "aria-label": "label",
+            "aria-hidden": true,
         };
 
         const props: CheckboxProps = { ...handledProps, ...unhandledProps };
 
         const rendered: any = shallow(<Checkbox {...props} />);
 
-        expect(rendered.first().prop("aria-label")).toEqual("label");
+        expect(rendered.first().prop("aria-hidden")).toEqual(true);
     });
 
     test("should add a class and `disabled` attribute to the input element when the disabled prop is true", () => {
@@ -82,6 +82,14 @@ describe("checkbox", (): void => {
         );
 
         expect(rendered.find(".input-class").prop("name")).toBe(checkboxName);
+    });
+
+    test("should apply a aria-label to the input element when the `ariaLabel` prop is passed", (): void => {
+        const rendered: any = mount(
+            <Checkbox managedClasses={managedClasses} inputId="id" ariaLabel="label" />
+        );
+
+        expect(rendered.find("input").prop("aria-label")).toBe("label");
     });
 
     test("should initialize as unchecked if the `checked` prop is not provided", () => {

--- a/packages/react/fast-components-react-base/src/checkbox/checkbox.tsx
+++ b/packages/react/fast-components-react-base/src/checkbox/checkbox.tsx
@@ -52,6 +52,7 @@ class Checkbox extends Foundation<
      * Handled props instantiation
      */
     protected handledProps: HandledProps<CheckboxHandledProps> = {
+        ariaLabel: void 0,
         checked: void 0,
         disabled: void 0,
         inputId: void 0,
@@ -114,6 +115,7 @@ class Checkbox extends Foundation<
                     ref={this.inputRef}
                     onChange={this.handleCheckboxChange}
                     disabled={this.props.disabled || null}
+                    aria-label={this.props.ariaLabel || null}
                     checked={this.state.checked}
                     value={this.props.value}
                 />

--- a/packages/react/fast-components-react-base/src/radio/radio.props.ts
+++ b/packages/react/fast-components-react-base/src/radio/radio.props.ts
@@ -3,6 +3,7 @@ import {
     ManagedClasses,
     RadioClassNameContract,
 } from "@microsoft/fast-components-class-name-contracts-base";
+import { Omit } from "utility-types";
 
 export interface RadioHandledProps extends RadioManagedClasses {
     /**
@@ -36,12 +37,21 @@ export interface RadioHandledProps extends RadioManagedClasses {
     label?: (className: string) => React.ReactNode;
 
     /**
+     * The radio aria-label
+     * This is necessary due to how unhandledProps are passed to the root of the component
+     */
+    ariaLabel?: string;
+
+    /**
      * The value of the radio
      */
     value?: string;
 }
 
-export type RadioUnhandledProps = React.HTMLAttributes<HTMLDivElement>;
+export type RadioUnhandledProps = Omit<
+    React.HTMLAttributes<HTMLDivElement>,
+    "aria-label"
+>;
 /**
  * @deprecated
  */

--- a/packages/react/fast-components-react-base/src/radio/radio.schema.2.ts
+++ b/packages/react/fast-components-react-base/src/radio/radio.schema.2.ts
@@ -24,6 +24,11 @@ export default {
             title: "Disabled",
             type: "boolean",
         },
+        ariaLabel: {
+            title: "Aria-label",
+            type: "string",
+            examples: ["label"],
+        },
         name: {
             title: "Name",
             type: "string",

--- a/packages/react/fast-components-react-base/src/radio/radio.schema.ts
+++ b/packages/react/fast-components-react-base/src/radio/radio.schema.ts
@@ -22,6 +22,11 @@ export default {
             title: "Disabled",
             type: "boolean",
         },
+        ariaLabel: {
+            title: "Aria-label",
+            type: "string",
+            examples: ["label"],
+        },
         name: {
             title: "Name",
             type: "string",

--- a/packages/react/fast-components-react-base/src/radio/radio.spec.tsx
+++ b/packages/react/fast-components-react-base/src/radio/radio.spec.tsx
@@ -191,6 +191,14 @@ describe("radio", (): void => {
         expect(onChange).toHaveBeenCalledTimes(2);
     });
 
+    test("should apply a aria-label to the input element when the `ariaLabel` prop is passed", (): void => {
+        const rendered: any = mount(
+            <Radio managedClasses={managedClasses} inputId="id" ariaLabel="label" />
+        );
+
+        expect(rendered.find("input").prop("aria-label")).toBe("label");
+    });
+
     test("should apply a value prop to the input element", (): void => {
         const rendered: any = mount(
             <Radio managedClasses={managedClasses} inputId="id" value="myValue" />

--- a/packages/react/fast-components-react-base/src/radio/radio.tsx
+++ b/packages/react/fast-components-react-base/src/radio/radio.tsx
@@ -42,6 +42,7 @@ class Radio extends Foundation<RadioHandledProps, RadioUnhandledProps, RadioStat
      * Handled props instantiation
      */
     protected handledProps: HandledProps<RadioHandledProps> = {
+        ariaLabel: void 0,
         inputId: void 0,
         checked: void 0,
         disabled: void 0,
@@ -75,6 +76,7 @@ class Radio extends Foundation<RadioHandledProps, RadioUnhandledProps, RadioStat
                     name={this.props.name}
                     onChange={this.handleRadioChange}
                     disabled={this.props.disabled || null}
+                    aria-label={this.props.ariaLabel || null}
                     checked={this.state.checked}
                     value={this.props.value}
                 />


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
This PR adds a first class prop for aria-hidden to the radio and checkbox input elements. Due to the way that unhandled props are passed, adding a non-visible label to the checkbox or radio is currently not fully possible. Previously attempts were made to use the hidden attribute on the label element, but the global attribute here actually breaks the relationship. If the label is not visibly present, it is not passed on to AT either.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->