### PR TITLE
fix: bug in positioning when negative numbers were involved

### DIFF
--- a/packages/web-components/fast-components/src/slider/fixtures/base.html
+++ b/packages/web-components/fast-components/src/slider/fixtures/base.html
@@ -33,6 +33,50 @@
         <!-- Margin offsets -->
         <fast-slider style="margin-left:100px"></fast-slider>
 
+        <!-- Negative positions -->
+        <fast-slider
+            min="-3"
+            max="3"
+            step="1"
+        >
+                <fast-slider-label
+                    position="-3"
+                >
+                    -3
+                </fast-slider-label>
+                <fast-slider-label
+                position="-2"
+                >
+                    -2
+                </fast-slider-label>
+                <fast-slider-label
+                    position="-1"
+                >
+                    -1
+                </fast-slider-label>
+                <fast-slider-label
+                    position="0"
+                >
+                    0
+                </fast-slider-label>
+                <fast-slider-label
+                    position="1"
+                >
+                    1
+                </fast-slider-label>
+                <fast-slider-label
+                    position="2"
+                >
+                    2
+                </fast-slider-label>
+                <fast-slider-label
+                    position="3"
+                >
+                    3
+                </fast-slider-label>          
+        </fast-slider>
+
+
         <!-- Text Labels -->
         <div style="display: flex; flex-direction: column; height:min-content">
             <label for="slider1" style="margin-left: 8px; color: var(--neutral-foreground-rest);">Temperature:</label>

--- a/packages/web-components/fast-foundation/src/slider/slider-utilities.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider-utilities.ts
@@ -9,8 +9,7 @@ export function convertPixelToPercent(
     maxPosition: number,
     direction?: Direction
 ): number {
-    let pct: number = limit(0, 1, (pixelPos - minPosition) / maxPosition);
-
+    let pct: number = limit(0, 1, (pixelPos - minPosition) / (maxPosition - minPosition));
     if (direction === Direction.rtl) {
         pct = 1 - pct;
     }

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -186,10 +186,13 @@ export class Slider extends FormAssociated<HTMLInputElement>
     };
 
     private setThumbPositionForOrientation = (direction: Direction): void => {
-        const percentage: number =
-            direction !== Direction.rtl
-                ? (1 - Number(this.value) / (Number(this.max) - Number(this.min))) * 100
-                : (Number(this.value) / (Number(this.max) - Number(this.min))) * 100;
+        const newPct: number = convertPixelToPercent(
+            Number(this.value),
+            Number(this.min),
+            Number(this.max),
+            direction
+        );
+        const percentage: number = (1 - newPct) * 100;
         if (this.orientation === Orientation.horizontal) {
             this.position = this.isDragging
                 ? `right: ${percentage}%; transition: all 0.1s ease;`
@@ -224,7 +227,7 @@ export class Slider extends FormAssociated<HTMLInputElement>
 
     private setupDefaultValue = (): void => {
         if (this.value === "") {
-            this.value = `${this.convertToConstrainedValue((this.max - this.min) / 2)}`;
+            this.value = `${this.convertToConstrainedValue((this.max + this.min) / 2)}`;
             this.updateForm();
         }
     };
@@ -316,17 +319,12 @@ export class Slider extends FormAssociated<HTMLInputElement>
     };
 
     private convertToConstrainedValue = (value: number): number => {
-        const remainderVal: number = value % Number(this.step);
-        const constrainedVal: number =
+        let constrainedValue: number = value - this.min;
+        const remainderVal: number = constrainedValue % Number(this.step);
+        constrainedValue =
             remainderVal >= Number(this.step) / 2
-                ? value - remainderVal + Number(this.step)
-                : value - remainderVal;
-
-        if (constrainedVal < this.min || constrainedVal > this.max) {
-            // TODO here until we figure out how this happens
-            return Number(this.value);
-        } else {
-            return constrainedVal;
-        }
+                ? constrainedValue - remainderVal + Number(this.step)
+                : constrainedValue - remainderVal;
+        return constrainedValue + this.min;
     };
 }


### PR DESCRIPTION
# Description
Existing value and positioning calculations would break when negative values were used for positioning, min, max.

<!--- Describe your changes. -->
* Unified the percentage calc for label positioning and thumb positioning
* Made the calculations work when min or position values are negative numbers

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.