### PR TITLE
fix: children components not always added to the internal slotted radio control collection

### DIFF
--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -95,7 +95,7 @@ export class RadioGroup extends FASTElement {
             }
         });
 
-        if (this.value === undefined) {
+        if (this.value === undefined && radioButtons && radioButtons.length > 0) {
             radioButtons[0].setAttribute("tabindex", "0");
             this.focusedRadio = radioButtons[0];
         }

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -95,7 +95,7 @@ export class RadioGroup extends FASTElement {
             }
         });
 
-        if (this.value === undefined && radioButtons && radioButtons.length > 0) {
+        if (this.value === undefined && radioButtons.length > 0) {
             radioButtons[0].setAttribute("tabindex", "0");
             this.focusedRadio = radioButtons[0];
         }

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -110,7 +110,7 @@ export class RadioGroup extends FASTElement {
         if (this.slottedRadioButtons !== undefined) {
             this.slottedRadioButtons.forEach((item: any) => {
                 if (item instanceof HTMLElement) {
-                    radioButtons.push(item as HTMLInputElement);
+                    radioButtons.push(item as any);
                 }
             });
         }


### PR DESCRIPTION
# Description
Some child elements in the default slot were getting filtered out of the slottedRadios collection thus breaking the group related functionality, also there was no check to see there was a collection and at least one item in that collection before setting focus to the first element.

<!--- Describe your changes. -->
* now checking there is at least one element in the radio collection before setting default focus
* replaced HTMLInputElement with any to avoid compilation error and to allow more component types to be in the collection

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.