### PR TITLE
fix: update min / max slider label position

### DIFF
--- a/packages/react/fast-components-styles-msft/src/slider-label/index.ts
+++ b/packages/react/fast-components-styles-msft/src/slider-label/index.ts
@@ -1,7 +1,7 @@
 import { SliderLabelClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { ComponentStyles } from "@microsoft/fast-jss-manager";
-import { toPx } from "@microsoft/fast-jss-utilities";
-import { DesignSystem } from "../design-system";
+import { divide, multiply, toPx } from "@microsoft/fast-jss-utilities";
+import { DesignSystem, DesignSystemResolver } from "../design-system";
 import { neutralForegroundRest, neutralOutlineRest } from "../utilities/color";
 import { applyCursorDefault } from "../utilities/cursor";
 import { heightNumber } from "../utilities/density";
@@ -14,9 +14,9 @@ import {
     highContrastTextForeground,
 } from "../utilities/high-contrast";
 
-function minMaxLabelMargin(config: DesignSystem): string {
-    return toPx(((heightNumber()(config) / 2 + designUnit(config)) / 2) * -1);
-}
+const minMaxLabelMargin: DesignSystemResolver<string> = toPx(
+    multiply(divide(heightNumber(), 4), -1)
+);
 
 const styles: ComponentStyles<SliderLabelClassNameContract, DesignSystem> = {
     sliderLabel: {


### PR DESCRIPTION
# Description

Updated the slider label offset to match with the lower and upper bounds of the slider thumb.

## Motivation & context

The min and max labels were positioned too far outside of the bounds of the control, resulting in alignment discrepancies with other components.

Before and after:
![image](https://user-images.githubusercontent.com/47367562/82600416-c1dfee80-9b62-11ea-9fe8-926e3e26b137.png)

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->