### PR TITLE
fix: slider vertical navigation and value setting bugs

### DIFF
--- a/packages/web-components/fast-components-msft/src/radio-group/fixtures/radio-group.html
+++ b/packages/web-components/fast-components-msft/src/radio-group/fixtures/radio-group.html
@@ -1,9 +1,4 @@
 <fast-design-system-provider use-defaults>
-    <style type="text/css">
-        label {
-            color: --var(neutral-foreground-rest);
-        }
-    </style>
     <h1>Radio Group</h1>
 
     <h4>Defaults</h4>
@@ -18,7 +13,7 @@
     <h4>Single radio</h4>
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
         <fast-radio-group name="players">
-            <label slot="label">Best basketball players</label>
+            <label style="color: --var(neutral-foreground-rest)" slot="label">Best basketball players</label>
             <fast-radio value="airjordan">Michael Jordan</fast-radio>
         </fast-radio-group>
     </div>

--- a/packages/web-components/fast-components-msft/src/radio-group/fixtures/radio-group.html
+++ b/packages/web-components/fast-components-msft/src/radio-group/fixtures/radio-group.html
@@ -1,10 +1,15 @@
 <fast-design-system-provider use-defaults>
+    <style type="text/css">
+        label {
+            color: --var(neutral-foreground-rest);
+        }
+    </style>
     <h1>Radio Group</h1>
 
     <h4>Defaults</h4>
     <div>
         <fast-radio-group name="numbers">
-            <label slot="label">Numbers</label>
+            <label style="color: --var(neutral-foreground-rest)" slot="label">Numbers</label>
             <fast-radio value="one">One</fast-radio>
             <fast-radio value="two">Two</fast-radio>
         </fast-radio-group>

--- a/packages/web-components/fast-components-msft/src/slider/fixtures/slider.html
+++ b/packages/web-components/fast-components-msft/src/slider/fixtures/slider.html
@@ -29,7 +29,7 @@
             </fast-slider>
         </div>
         <h4>Vertical</h4>
-        <div style="display: flex; flex-direction: column; justify-content: space-evenly; width: 500px; height: 100vh">
+        <div style="display: flex; flex-direction: column; justify-content: space-evenly; width: 500px;">
             <fast-slider orientation="vertical" min="0" max="100" step="10" value="50" style="height: 300px; width: 50px;">
                 <fast-slider-label
                     position="0"
@@ -81,7 +81,7 @@
             </div>
 
             <!-- Custom labels (rtl) -->
-            <h4 style="margin-top: 20px;">Custom labels and rtl support</h4>
+            <h4 style="margin-top: 60px;">Custom labels and rtl support</h4>
             <div style="display: flex; flex-direction: column; align-items: flex-start; height:min-content">
                 <label for="rtl-slider" style="margin-left: 8px;">rtl support</label>
                 <div dir="rtl" style="width: 100%;">
@@ -122,7 +122,7 @@
             </div>
 
             <!-- Using slot for custom thumb -->
-            <h4>Custom thumb</h4>
+            <h4 style="margin-top: 60px;">Custom thumb</h4>
             <fast-slider
                 min="0"
                 max="100"
@@ -197,7 +197,7 @@
             </fast-slider>
 
             <!-- Custom labels and thumb hide marks on labels -->
-            <h4>Custom labels and thumb and hidden marks on labels</h4>
+            <h4 style="margin-top: 60px;">Custom labels and thumb and hidden marks on labels</h4>
             <fast-slider
                 min="0"
                 max="100"
@@ -254,7 +254,7 @@
             </fast-slider>
 
             <!-- Disabled -->
-            <h4>Disabled</h4>
+            <h4 style="margin-top: 60px;">Disabled</h4>
             <fast-slider
                 min="0"
                 max="100"

--- a/packages/web-components/fast-components-msft/src/slider/fixtures/slider.html
+++ b/packages/web-components/fast-components-msft/src/slider/fixtures/slider.html
@@ -1,41 +1,16 @@
 <fast-design-system-provider use-defaults>
-    <div style="display: flex; flex-direction: column; justify-content: space-evenly; width: 500px; height: 100vh">
-
-        <fast-slider orientation="vertical" min="0" max="100" step="10" value="70" style="height: 300px; width: 50px;">
-            <fast-slider-label
-                position="0"
-            >
-                0&#8451;
-            </fast-slider-label>            
-            <fast-slider-label
-                position="10"
-            >
-                10&#8451;
-            </fast-slider-label>
-            <fast-slider-label
-                position="90"
-            >
-                90&#8451;
-            </fast-slider-label>
-            <fast-slider-label
-            position="100"
-        >
-            100&#8451;
-        </fast-slider-label>
-        </fast-slider>
-
-        <!-- No max or min -->
-        <fast-slider></fast-slider>
-
-        <!-- Text Labels -->
-        <div style="display: flex; flex-direction: column; height:min-content">
-            <label for="slider1" style="margin-left: 8px;">Temperature:</label>
-            <fast-slider
-                id="slider1"
-                min="0"
-                max="100"
-                step="10"
-            >
+    <div style="display: flex; flex-direction: column; justify-content: space-evenly; width: 500px;">
+        <h4>Toggle orientation</h4>
+        <div style="margin-bottom: 60px;">
+            <button style="width: 90px;margin: 10px;" onclick="const slider = document.getElementById('switcher'); slider.getAttribute('orientation') === 'horizontal' ? slider.setAttribute('orientation', 'vertical') : slider.setAttribute('orientation', 'horizontal');">
+                Toggle orientation
+            </button>
+            <fast-slider id="switcher" orientation="vertical" min="0" max="100" step="10" value="70">
+                <fast-slider-label
+                    position="0"
+                >
+                    0&#8451;
+                </fast-slider-label>
                 <fast-slider-label
                     position="10"
                 >
@@ -46,242 +21,302 @@
                 >
                     90&#8451;
                 </fast-slider-label>
+                <fast-slider-label
+                position="100"
+            >
+                100&#8451;
+            </fast-slider-label>
             </fast-slider>
         </div>
+        <h4>Vertical</h4>
+        <div style="display: flex; flex-direction: column; justify-content: space-evenly; width: 500px; height: 100vh">
+            <fast-slider orientation="vertical" min="0" max="100" step="10" value="50" style="height: 300px; width: 50px;">
+                <fast-slider-label
+                    position="0"
+                >
+                    0&#8451;
+                </fast-slider-label>            
+                <fast-slider-label
+                    position="10"
+                >
+                    10&#8451;
+                </fast-slider-label>
+                <fast-slider-label
+                    position="90"
+                >
+                    90&#8451;
+                </fast-slider-label>
+                <fast-slider-label
+                    position="100"
+                >
+                    100&#8451;
+                </fast-slider-label>
+            </fast-slider>
 
-        <!-- Custom labels (rtl) -->
-        <div style="display: flex; flex-direction: column; align-items: flex-start; height:min-content">
-            <label for="rtl-slider" style="margin-left: 8px;">rtl support</label>
-            <div dir="rtl" style="width: 100%;">
+            <!-- No max or min -->
+            <h4>Defaults</h4>
+            <fast-slider></fast-slider>
+
+            <!-- Text Labels -->
+            <h4>Text labels</h4>
+            <div style="display: flex; flex-direction: column; height:min-content">
+                <label for="slider1" style="margin-left: 8px;">Temperature:</label>
                 <fast-slider
-                    id="rtl-slider"
+                    id="slider1"
                     min="0"
                     max="100"
                     step="10"
-                    value="80"
                 >
                     <fast-slider-label
                         position="10"
                     >
-                        10
+                        10&#8451;
                     </fast-slider-label>
                     <fast-slider-label
-                        position="20"
+                        position="90"
                     >
-                        20
-                    </fast-slider-label>
-                    <fast-slider-label
-                        position="40"
-                    >
-                        40
-                    </fast-slider-label>
-                    <fast-slider-label
-                        position="60"
-                    >
-                        60
-                    </fast-slider-label>                                                
-                    <fast-slider-label
-                        position="80"
-                    >
-                        80
+                        90&#8451;
                     </fast-slider-label>
                 </fast-slider>
             </div>
-        </div>
 
-        <!-- Using slot for custom thumb -->
-        <fast-slider
-            min="0"
-            max="100"
-            step="10"
-        >
-            <fast-slider-label
-                position="0"
-            >
-                0
-            </fast-slider-label>
-            <fast-slider-label
-                position="10"
-            >
-                10
-            </fast-slider-label>
-            <fast-slider-label
-                position="20"
-            >
-                20
-            </fast-slider-label>
-            <fast-slider-label
-                position="30"
-            >
-                30
-            </fast-slider-label>
-            <fast-slider-label
-                position="40"
-            >
-                40
-            </fast-slider-label>
-            <fast-slider-label
-                position="50"
-            >
-                50
-            </fast-slider-label>
-            <fast-slider-label
-                position="60"
-            >
-                60
-            </fast-slider-label>
-            <fast-slider-label
-                position="70"
-            >
-                70
-            </fast-slider-label>
-            <fast-slider-label
-                position="80"
-            >
-                80
-            </fast-slider-label>
-            <fast-slider-label
-                position="90"
-            >
-                90
-            </fast-slider-label>
-            <fast-slider-label
-                position="100"
-            >
-                100
-            </fast-slider-label>
-            <svg
-                slot="thumb"
-                xmlns="http://www.w3.org/2000/svg"
-                height="13"
-                width="16"
-                viewBox="0 0 16 13"
-            >
-                <path
-                    d="M0 0H16V13H0V0ZM15 12V1H1V12H15ZM12 3V4H4V3H12ZM5 7V10H2V7H5ZM4 9V8H3V9H4ZM6.5 10V7H9.5V10H6.5ZM7.5 8V9H8.5V8H7.5ZM11 10V7H14V10H11ZM12 8V9H13V8H12Z"
-                />
-            </svg>
-        </fast-slider>
+            <!-- Custom labels (rtl) -->
+            <h4 style="margin-top: 20px;">Custom labels and rtl support</h4>
+            <div style="display: flex; flex-direction: column; align-items: flex-start; height:min-content">
+                <label for="rtl-slider" style="margin-left: 8px;">rtl support</label>
+                <div dir="rtl" style="width: 100%;">
+                    <fast-slider
+                        id="rtl-slider"
+                        min="0"
+                        max="100"
+                        step="10"
+                        value="80"
+                    >
+                        <fast-slider-label
+                            position="10"
+                        >
+                            10
+                        </fast-slider-label>
+                        <fast-slider-label
+                            position="20"
+                        >
+                            20
+                        </fast-slider-label>
+                        <fast-slider-label
+                            position="40"
+                        >
+                            40
+                        </fast-slider-label>
+                        <fast-slider-label
+                            position="60"
+                        >
+                            60
+                        </fast-slider-label>                                                
+                        <fast-slider-label
+                            position="80"
+                        >
+                            80
+                        </fast-slider-label>
+                    </fast-slider>
+                </div>
+            </div>
 
-        <!-- Custom labels and thumb hide marks on labels -->
-
-        <fast-slider
-            min="0"
-            max="100"
-            step="10"
-        >
-            <fast-slider-label
-                position="0"
-                hide-mark="true"
+            <!-- Using slot for custom thumb -->
+            <h4>Custom thumb</h4>
+            <fast-slider
+                min="0"
+                max="100"
+                step="10"
             >
+                <fast-slider-label
+                    position="0"
+                >
+                    0
+                </fast-slider-label>
+                <fast-slider-label
+                    position="10"
+                >
+                    10
+                </fast-slider-label>
+                <fast-slider-label
+                    position="20"
+                >
+                    20
+                </fast-slider-label>
+                <fast-slider-label
+                    position="30"
+                >
+                    30
+                </fast-slider-label>
+                <fast-slider-label
+                    position="40"
+                >
+                    40
+                </fast-slider-label>
+                <fast-slider-label
+                    position="50"
+                >
+                    50
+                </fast-slider-label>
+                <fast-slider-label
+                    position="60"
+                >
+                    60
+                </fast-slider-label>
+                <fast-slider-label
+                    position="70"
+                >
+                    70
+                </fast-slider-label>
+                <fast-slider-label
+                    position="80"
+                >
+                    80
+                </fast-slider-label>
+                <fast-slider-label
+                    position="90"
+                >
+                    90
+                </fast-slider-label>
+                <fast-slider-label
+                    position="100"
+                >
+                    100
+                </fast-slider-label>
                 <svg
+                    slot="thumb"
                     xmlns="http://www.w3.org/2000/svg"
-                    height="16"
+                    height="13"
                     width="16"
-                    viewBox="0 0 16 16"
+                    viewBox="0 0 16 13"
                 >
                     <path
-                        d="M11.0625 9.79688L13 16L8 12.1562L3 16L4.9375 9.79688L0 6H6.125L8 0L9.875 6H16L11.0625 9.79688ZM11.1016 13.2812C10.9036 12.6354 10.7057 11.9948 10.5078 11.3594C10.3099 10.7188 10.1068 10.0755 9.89844 9.42969C10.4349 9.02865 10.9635 8.625 11.4844 8.21875C12.0052 7.8125 12.5312 7.40625 13.0625 7H9.14062L8 3.35156L6.85938 7H2.9375C3.46875 7.40625 3.99479 7.8125 4.51562 8.21875C5.03646 8.625 5.5651 9.02865 6.10156 9.42969C5.89323 10.0755 5.6901 10.7188 5.49219 11.3594C5.29427 11.9948 5.09635 12.6354 4.89844 13.2812L8 10.8906L11.1016 13.2812Z"
+                        d="M0 0H16V13H0V0ZM15 12V1H1V12H15ZM12 3V4H4V3H12ZM5 7V10H2V7H5ZM4 9V8H3V9H4ZM6.5 10V7H9.5V10H6.5ZM7.5 8V9H8.5V8H7.5ZM11 10V7H14V10H11ZM12 8V9H13V8H12Z"
                     />
                 </svg>
-            </fast-slider-label>
-            <fast-slider-label
-                position="50"
-                hide-mark="true"
+            </fast-slider>
+
+            <!-- Custom labels and thumb hide marks on labels -->
+            <h4>Custom labels and thumb and hidden marks on labels</h4>
+            <fast-slider
+                min="0"
+                max="100"
+                step="10"
             >
-                50
-            </fast-slider-label>            
-            <fast-slider-label
-                position="100"
-                hide-mark="true"
-            >
+                <fast-slider-label
+                    position="0"
+                    hide-mark="true"
+                >
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        height="16"
+                        width="16"
+                        viewBox="0 0 16 16"
+                    >
+                        <path
+                            d="M11.0625 9.79688L13 16L8 12.1562L3 16L4.9375 9.79688L0 6H6.125L8 0L9.875 6H16L11.0625 9.79688ZM11.1016 13.2812C10.9036 12.6354 10.7057 11.9948 10.5078 11.3594C10.3099 10.7188 10.1068 10.0755 9.89844 9.42969C10.4349 9.02865 10.9635 8.625 11.4844 8.21875C12.0052 7.8125 12.5312 7.40625 13.0625 7H9.14062L8 3.35156L6.85938 7H2.9375C3.46875 7.40625 3.99479 7.8125 4.51562 8.21875C5.03646 8.625 5.5651 9.02865 6.10156 9.42969C5.89323 10.0755 5.6901 10.7188 5.49219 11.3594C5.29427 11.9948 5.09635 12.6354 4.89844 13.2812L8 10.8906L11.1016 13.2812Z"
+                        />
+                    </svg>
+                </fast-slider-label>
+                <fast-slider-label
+                    position="50"
+                    hide-mark="true"
+                >
+                    50
+                </fast-slider-label>            
+                <fast-slider-label
+                    position="100"
+                    hide-mark="true"
+                >
+                    <svg
+                        width="14px"
+                        height="14px"
+                        viewBox="0 0 14 14"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <title>Clock Icon</title>
+                        <path
+                            d="M7 14C6.35417 14 5.73177 13.9167 5.13281 13.75C4.53906 13.5833 3.98177 13.349 3.46094 13.0469C2.94531 12.7396 2.47396 12.375 2.04688 11.9531C1.625 11.526 1.26042 11.0547 0.953125 10.5391C0.651042 10.0182 0.416667 9.46094 0.25 8.86719C0.0833333 8.26823 0 7.64583 0 7C0 6.35417 0.0833333 5.73438 0.25 5.14062C0.416667 4.54167 0.651042 3.98438 0.953125 3.46875C1.26042 2.94792 1.625 2.47656 2.04688 2.05469C2.47396 1.6276 2.94531 1.26302 3.46094 0.960938C3.98177 0.653646 4.53906 0.416667 5.13281 0.25C5.73177 0.0833333 6.35417 0 7 0C7.64583 0 8.26562 0.0833333 8.85938 0.25C9.45833 0.416667 10.0156 0.653646 10.5312 0.960938C11.0521 1.26302 11.5234 1.6276 11.9453 2.05469C12.3724 2.47656 12.737 2.94792 13.0391 3.46875C13.3464 3.98438 13.5833 4.54167 13.75 5.14062C13.9167 5.73438 14 6.35417 14 7C14 7.64583 13.9167 8.26823 13.75 8.86719C13.5833 9.46094 13.3464 10.0182 13.0391 10.5391C12.737 11.0547 12.3724 11.526 11.9453 11.9531C11.5234 12.375 11.0521 12.7396 10.5312 13.0469C10.0156 13.349 9.45833 13.5833 8.85938 13.75C8.26562 13.9167 7.64583 14 7 14ZM7 1C6.17188 1 5.39323 1.15885 4.66406 1.47656C3.9401 1.78906 3.30469 2.21875 2.75781 2.76562C2.21615 3.30729 1.78646 3.94271 1.46875 4.67188C1.15625 5.39583 1 6.17188 1 7C1 7.82812 1.15625 8.60677 1.46875 9.33594C1.78646 10.0599 2.21615 10.6953 2.75781 11.2422C3.30469 11.7839 3.9401 12.2135 4.66406 12.5312C5.39323 12.8438 6.17188 13 7 13C7.82812 13 8.60417 12.8438 9.32812 12.5312C10.0573 12.2135 10.6927 11.7839 11.2344 11.2422C11.7812 10.6953 12.2109 10.0599 12.5234 9.33594C12.8411 8.60677 13 7.82812 13 7C13 6.17188 12.8411 5.39583 12.5234 4.67188C12.2109 3.94271 11.7812 3.30729 11.2344 2.76562C10.6927 2.21875 10.0573 1.78906 9.32812 1.47656C8.60417 1.15885 7.82812 1 7 1ZM7 7V3H6V8H10V7H7Z"
+                        />
+                    </svg>
+                </fast-slider-label>
                 <svg
-                    width="14px"
-                    height="14px"
-                    viewBox="0 0 14 14"
+                    slot="thumb"
+                    width="16px"
+                    height="16px"
+                    viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
                 >
-                    <title>Clock Icon</title>
                     <path
-                        d="M7 14C6.35417 14 5.73177 13.9167 5.13281 13.75C4.53906 13.5833 3.98177 13.349 3.46094 13.0469C2.94531 12.7396 2.47396 12.375 2.04688 11.9531C1.625 11.526 1.26042 11.0547 0.953125 10.5391C0.651042 10.0182 0.416667 9.46094 0.25 8.86719C0.0833333 8.26823 0 7.64583 0 7C0 6.35417 0.0833333 5.73438 0.25 5.14062C0.416667 4.54167 0.651042 3.98438 0.953125 3.46875C1.26042 2.94792 1.625 2.47656 2.04688 2.05469C2.47396 1.6276 2.94531 1.26302 3.46094 0.960938C3.98177 0.653646 4.53906 0.416667 5.13281 0.25C5.73177 0.0833333 6.35417 0 7 0C7.64583 0 8.26562 0.0833333 8.85938 0.25C9.45833 0.416667 10.0156 0.653646 10.5312 0.960938C11.0521 1.26302 11.5234 1.6276 11.9453 2.05469C12.3724 2.47656 12.737 2.94792 13.0391 3.46875C13.3464 3.98438 13.5833 4.54167 13.75 5.14062C13.9167 5.73438 14 6.35417 14 7C14 7.64583 13.9167 8.26823 13.75 8.86719C13.5833 9.46094 13.3464 10.0182 13.0391 10.5391C12.737 11.0547 12.3724 11.526 11.9453 11.9531C11.5234 12.375 11.0521 12.7396 10.5312 13.0469C10.0156 13.349 9.45833 13.5833 8.85938 13.75C8.26562 13.9167 7.64583 14 7 14ZM7 1C6.17188 1 5.39323 1.15885 4.66406 1.47656C3.9401 1.78906 3.30469 2.21875 2.75781 2.76562C2.21615 3.30729 1.78646 3.94271 1.46875 4.67188C1.15625 5.39583 1 6.17188 1 7C1 7.82812 1.15625 8.60677 1.46875 9.33594C1.78646 10.0599 2.21615 10.6953 2.75781 11.2422C3.30469 11.7839 3.9401 12.2135 4.66406 12.5312C5.39323 12.8438 6.17188 13 7 13C7.82812 13 8.60417 12.8438 9.32812 12.5312C10.0573 12.2135 10.6927 11.7839 11.2344 11.2422C11.7812 10.6953 12.2109 10.0599 12.5234 9.33594C12.8411 8.60677 13 7.82812 13 7C13 6.17188 12.8411 5.39583 12.5234 4.67188C12.2109 3.94271 11.7812 3.30729 11.2344 2.76562C10.6927 2.21875 10.0573 1.78906 9.32812 1.47656C8.60417 1.15885 7.82812 1 7 1ZM7 7V3H6V8H10V7H7Z"
+                        d="M15.4922 9.5H5.26562C5.26562 9.88542 5.32552 10.2344 5.44531 10.5469C5.5651 10.8594 5.72917 11.138 5.9375 11.3828C6.14583 11.6224 6.39062 11.8307 6.67188 12.0078C6.95312 12.1797 7.2526 12.3229 7.57031 12.4375C7.88802 12.5521 8.21615 12.638 8.55469 12.6953C8.89844 12.7474 9.23698 12.7734 9.57031 12.7734C9.99219 12.7734 10.3906 12.7396 10.7656 12.6719C11.1406 12.6042 11.5052 12.513 11.8594 12.3984C12.2188 12.2786 12.5729 12.138 12.9219 11.9766C13.2708 11.8151 13.6276 11.638 13.9922 11.4453V14.8359C13.5859 15.0339 13.1823 15.2057 12.7812 15.3516C12.3854 15.4922 11.9844 15.612 11.5781 15.7109C11.1719 15.8099 10.7578 15.8828 10.3359 15.9297C9.91406 15.9766 9.47656 16 9.02344 16C8.42448 16 7.84635 15.9323 7.28906 15.7969C6.73177 15.6562 6.20833 15.4583 5.71875 15.2031C5.22917 14.9427 4.78125 14.6276 4.375 14.2578C3.96875 13.888 3.61979 13.4714 3.32812 13.0078C3.03646 12.5443 2.8099 12.0391 2.64844 11.4922C2.48698 10.9453 2.40625 10.3646 2.40625 9.75C2.40625 9.09375 2.49479 8.46875 2.67188 7.875C2.85417 7.27604 3.11458 6.72656 3.45312 6.22656C3.79167 5.72656 4.20312 5.28385 4.6875 4.89844C5.17708 4.50781 5.72656 4.1901 6.33594 3.94531C6.0026 4.27865 5.74219 4.67448 5.55469 5.13281C5.3724 5.58594 5.25521 6.04167 5.20312 6.5H10.8984C10.8984 5.92708 10.8385 5.42708 10.7188 5C10.6042 4.56771 10.4167 4.21094 10.1562 3.92969C9.89583 3.64323 9.5599 3.42969 9.14844 3.28906C8.73698 3.14323 8.23958 3.07031 7.65625 3.07031C6.96875 3.07031 6.28125 3.17448 5.59375 3.38281C4.90625 3.58594 4.2526 3.86979 3.63281 4.23438C3.01302 4.59896 2.44271 5.03125 1.92188 5.53125C1.40104 6.02604 0.963542 6.5651 0.609375 7.14844C0.6875 6.47135 0.830729 5.82552 1.03906 5.21094C1.2526 4.59115 1.52344 4.01823 1.85156 3.49219C2.1849 2.96094 2.57292 2.48177 3.01562 2.05469C3.45833 1.6224 3.94792 1.25521 4.48438 0.953125C5.02604 0.645833 5.60938 0.411458 6.23438 0.25C6.85938 0.0833333 7.52344 0 8.22656 0C8.63281 0 9.03906 0.0364583 9.44531 0.109375C9.85677 0.182292 10.2552 0.283854 10.6406 0.414062C11.4115 0.679688 12.099 1.04948 12.7031 1.52344C13.3073 1.99219 13.8151 2.53646 14.2266 3.15625C14.638 3.77083 14.9505 4.45052 15.1641 5.19531C15.3828 5.9349 15.4922 6.70573 15.4922 7.50781V9.5Z"
                     />
                 </svg>
-            </fast-slider-label>
-            <svg
-                slot="thumb"
-                width="16px"
-                height="16px"
-                viewBox="0 0 16 16"
-                xmlns="http://www.w3.org/2000/svg"
-            >
-                <path
-                    d="M15.4922 9.5H5.26562C5.26562 9.88542 5.32552 10.2344 5.44531 10.5469C5.5651 10.8594 5.72917 11.138 5.9375 11.3828C6.14583 11.6224 6.39062 11.8307 6.67188 12.0078C6.95312 12.1797 7.2526 12.3229 7.57031 12.4375C7.88802 12.5521 8.21615 12.638 8.55469 12.6953C8.89844 12.7474 9.23698 12.7734 9.57031 12.7734C9.99219 12.7734 10.3906 12.7396 10.7656 12.6719C11.1406 12.6042 11.5052 12.513 11.8594 12.3984C12.2188 12.2786 12.5729 12.138 12.9219 11.9766C13.2708 11.8151 13.6276 11.638 13.9922 11.4453V14.8359C13.5859 15.0339 13.1823 15.2057 12.7812 15.3516C12.3854 15.4922 11.9844 15.612 11.5781 15.7109C11.1719 15.8099 10.7578 15.8828 10.3359 15.9297C9.91406 15.9766 9.47656 16 9.02344 16C8.42448 16 7.84635 15.9323 7.28906 15.7969C6.73177 15.6562 6.20833 15.4583 5.71875 15.2031C5.22917 14.9427 4.78125 14.6276 4.375 14.2578C3.96875 13.888 3.61979 13.4714 3.32812 13.0078C3.03646 12.5443 2.8099 12.0391 2.64844 11.4922C2.48698 10.9453 2.40625 10.3646 2.40625 9.75C2.40625 9.09375 2.49479 8.46875 2.67188 7.875C2.85417 7.27604 3.11458 6.72656 3.45312 6.22656C3.79167 5.72656 4.20312 5.28385 4.6875 4.89844C5.17708 4.50781 5.72656 4.1901 6.33594 3.94531C6.0026 4.27865 5.74219 4.67448 5.55469 5.13281C5.3724 5.58594 5.25521 6.04167 5.20312 6.5H10.8984C10.8984 5.92708 10.8385 5.42708 10.7188 5C10.6042 4.56771 10.4167 4.21094 10.1562 3.92969C9.89583 3.64323 9.5599 3.42969 9.14844 3.28906C8.73698 3.14323 8.23958 3.07031 7.65625 3.07031C6.96875 3.07031 6.28125 3.17448 5.59375 3.38281C4.90625 3.58594 4.2526 3.86979 3.63281 4.23438C3.01302 4.59896 2.44271 5.03125 1.92188 5.53125C1.40104 6.02604 0.963542 6.5651 0.609375 7.14844C0.6875 6.47135 0.830729 5.82552 1.03906 5.21094C1.2526 4.59115 1.52344 4.01823 1.85156 3.49219C2.1849 2.96094 2.57292 2.48177 3.01562 2.05469C3.45833 1.6224 3.94792 1.25521 4.48438 0.953125C5.02604 0.645833 5.60938 0.411458 6.23438 0.25C6.85938 0.0833333 7.52344 0 8.22656 0C8.63281 0 9.03906 0.0364583 9.44531 0.109375C9.85677 0.182292 10.2552 0.283854 10.6406 0.414062C11.4115 0.679688 12.099 1.04948 12.7031 1.52344C13.3073 1.99219 13.8151 2.53646 14.2266 3.15625C14.638 3.77083 14.9505 4.45052 15.1641 5.19531C15.3828 5.9349 15.4922 6.70573 15.4922 7.50781V9.5Z"
-                />
-            </svg>
-        </fast-slider>
+            </fast-slider>
 
-        <!-- Disabled -->
-        <fast-slider
-            min="0"
-            max="100"
-            step="5"
-            disabled
-        >
-            <fast-slider-label
-                position="0"
+            <!-- Disabled -->
+            <h4>Disabled</h4>
+            <fast-slider
+                min="0"
+                max="100"
+                step="5"
+                disabled
             >
-                0
-            </fast-slider-label>
-            <fast-slider-label
-                position="10"
-            >
-                10
-            </fast-slider-label>
-            <fast-slider-label
-                position="20"
-            >
-                20
-            </fast-slider-label>
-            <fast-slider-label
-                position="30"
-            >
-                30
-            </fast-slider-label>
-            <fast-slider-label
-                position="40"
-            >
-                40
-            </fast-slider-label>
-            <fast-slider-label
-                position="50"
-            >
-                50
-            </fast-slider-label>
-            <fast-slider-label
-                position="60"
-            >
-                60
-            </fast-slider-label>
-            <fast-slider-label
-                position="70"
-            >
-                70
-            </fast-slider-label>
-            <fast-slider-label
-                position="80"
-            >
-                80
-            </fast-slider-label>
-            <fast-slider-label
-                position="90"
-            >
-                90
-            </fast-slider-label>
-            <fast-slider-label
-                position="100"
-            >
-                100
-            </fast-slider-label>
-        </fast-slider>
+                <fast-slider-label
+                    position="0"
+                >
+                    0
+                </fast-slider-label>
+                <fast-slider-label
+                    position="10"
+                >
+                    10
+                </fast-slider-label>
+                <fast-slider-label
+                    position="20"
+                >
+                    20
+                </fast-slider-label>
+                <fast-slider-label
+                    position="30"
+                >
+                    30
+                </fast-slider-label>
+                <fast-slider-label
+                    position="40"
+                >
+                    40
+                </fast-slider-label>
+                <fast-slider-label
+                    position="50"
+                >
+                    50
+                </fast-slider-label>
+                <fast-slider-label
+                    position="60"
+                >
+                    60
+                </fast-slider-label>
+                <fast-slider-label
+                    position="70"
+                >
+                    70
+                </fast-slider-label>
+                <fast-slider-label
+                    position="80"
+                >
+                    80
+                </fast-slider-label>
+                <fast-slider-label
+                    position="90"
+                >
+                    90
+                </fast-slider-label>
+                <fast-slider-label
+                    position="100"
+                >
+                    100
+                </fast-slider-label>
+            </fast-slider>
+        </div>
     </div>
 </fast-design-system-provider>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -4,7 +4,7 @@
     <h4>Defaults</h4>
     <div>
         <fast-radio-group name="numbers">
-            <label slot="label">Numbers</label>
+            <label style="color: var(--neutral-foreground-rest);" slot="label">Numbers</label>
             <fast-radio value="one">One</fast-radio>
             <fast-radio value="two">Two</fast-radio>
         </fast-radio-group>
@@ -12,7 +12,7 @@
 
     <div>
         <fast-radio-group orientation="vertical" name="trees">
-            <label slot="label">Trees</label>
+            <label style="color: var(--neutral-foreground-rest);" slot="label">Trees</label>
             <fast-radio value="fir">Fir</fast-radio>
             <fast-radio value="juniper">Juniper</fast-radio>
             <fast-radio value="hemlock">Hemlock</fast-radio>
@@ -22,18 +22,18 @@
 
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
         <fast-radio-group name="players">
-            <label slot="label">Best basketball players</label>
+            <label style="color: var(--neutral-foreground-rest);" slot="label">Best basketball players</label>
             <fast-radio value="airjordan">Michael Jordan</fast-radio>
         </fast-radio-group>
     </div>
 
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
-        <label>Single radio (no group)</label>
+        <label style="color: var(--neutral-foreground-rest);">Single radio (no group)</label>
         <fast-radio value="single-life">Single life</fast-radio>
     </div>
 
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
-        <label id="label1">Outside label</label>
+        <label style="color: var(--neutral-foreground-rest);" id="label1">Outside label</label>
         <fast-radio-group required="true" aria-labelledby="label1" name="fruits">
             <fast-radio value="apples">Apples</fast-radio>
             <fast-radio value="oranges">Oranges</fast-radio>
@@ -60,7 +60,7 @@
     </div>
 
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
-        <label id="label2">Disabled radio group</label>
+        <label style="color: var(--neutral-foreground-rest);" id="label2">Disabled radio group</label>
         <fast-radio-group disabled aria-labelledby="label2" name="cars">
             <fast-radio value="lambo">Lamborghini</fast-radio>
             <fast-radio value="ferari">Ferari</fast-radio>
@@ -68,7 +68,7 @@
     </div>
 
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
-        <label id="label3">readonly radio group</label>
+        <label style="color: var(--neutral-foreground-rest);" id="label3">readonly radio group</label>
         <fast-radio-group readonly aria-labelledby="label3" name="office">
             <fast-radio value="word">Word</fast-radio>
             <fast-radio value="excel">Excel</fast-radio>
@@ -76,7 +76,7 @@
     </div>
 
     <div style="display: flex; flex-direction: column;margin-top: 12px;">
-        <label id="label4">Preset selected-value</label>
+        <label style="color: var(--neutral-foreground-rest);" id="label4">Preset selected-value</label>
         <fast-radio-group value="maverick" aria-labelledby="label4" name="best-pilot">
             <fast-radio value="ice-man">Ice Man</fast-radio>
             <fast-radio value="maverick">Maverick</fast-radio>

--- a/packages/web-components/fast-components/src/slider/fixtures/base.html
+++ b/packages/web-components/fast-components/src/slider/fixtures/base.html
@@ -76,28 +76,29 @@
                 </fast-slider-label>          
         </fast-slider>
 
-
         <!-- Min above 0 -->
-        <fast-slider
-            min="5"
-            max="15"
-            step="1"
-            value="10"
-        >
-                <fast-slider-label
-                    hide-mark="true"
-                    position="5"
-                >
-                    5
-                </fast-slider-label>
-                <fast-slider-label
-                    hide-mark="true"
-                    position="15"
-                >
-                    15
-                </fast-slider-label>
-        </fast-slider>
-
+        <div style="width: 160px;">
+            <fast-slider
+                min="5"
+                max="15"
+                step="1"
+                value="10"
+                style="min-width: unset;"
+            >
+                    <fast-slider-label
+                        hide-mark="true"
+                        position="5"
+                    >
+                        5
+                    </fast-slider-label>
+                    <fast-slider-label
+                        hide-mark="true"
+                        position="15"
+                    >
+                        15
+                    </fast-slider-label>
+            </fast-slider>
+        </div>
 
         <!-- Text Labels -->
         <div style="display: flex; flex-direction: column; height:min-content">

--- a/packages/web-components/fast-components/src/slider/fixtures/base.html
+++ b/packages/web-components/fast-components/src/slider/fixtures/base.html
@@ -77,6 +77,28 @@
         </fast-slider>
 
 
+        <!-- Min above 0 -->
+        <fast-slider
+            min="5"
+            max="15"
+            step="1"
+            value="10"
+        >
+                <fast-slider-label
+                    hide-mark="true"
+                    position="5"
+                >
+                    5
+                </fast-slider-label>
+                <fast-slider-label
+                    hide-mark="true"
+                    position="15"
+                >
+                    15
+                </fast-slider-label>
+        </fast-slider>
+
+
         <!-- Text Labels -->
         <div style="display: flex; flex-direction: column; height:min-content">
             <label for="slider1" style="margin-left: 8px; color: var(--neutral-foreground-rest);">Temperature:</label>

--- a/packages/web-components/fast-components/src/slider/fixtures/base.html
+++ b/packages/web-components/fast-components/src/slider/fixtures/base.html
@@ -1,5 +1,6 @@
 <fast-design-system-provider use-defaults>
     <div style="display: flex; flex-direction: column; justify-content: space-evenly; width: 500px;">
+        <h4>Toggle orientation</h4>
         <div style="margin-bottom: 60px;">
             <button style="width: 90px;margin: 10px;" onclick="const slider = document.getElementById('switcher'); slider.getAttribute('orientation') === 'horizontal' ? slider.setAttribute('orientation', 'vertical') : slider.setAttribute('orientation', 'horizontal');">
                 Toggle orientation
@@ -28,12 +29,19 @@
             </fast-slider>
         </div>
         <!-- No max or min -->
+        <h4>Defaults</h4>
         <fast-slider></fast-slider>
 
         <!-- Margin offsets -->
+        <h4>horizontal with left offset</h4>
         <fast-slider style="margin-left:100px"></fast-slider>
 
+        <!-- Margin offsets vertical -->
+        <h4>Vertical with top offset</h4>
+        <fast-slider orientation="vertical", style="margin-left:100px"></fast-slider>
+
         <!-- Negative positions -->
+        <h4>Negative positions</h4>
         <fast-slider
             min="-3"
             max="3"
@@ -77,6 +85,7 @@
         </fast-slider>
 
         <!-- Min above 0 -->
+        <h4>Min value greater than 0</h4>
         <div style="width: 160px;">
             <fast-slider
                 min="5"
@@ -101,6 +110,7 @@
         </div>
 
         <!-- Text Labels -->
+        <h4>Text labels</h4>
         <div style="display: flex; flex-direction: column; height:min-content">
             <label for="slider1" style="margin-left: 8px; color: var(--neutral-foreground-rest);">Temperature:</label>
             <fast-slider
@@ -123,6 +133,7 @@
         </div>
 
         <!-- Custom labels (rtl) -->
+        <h4>Custom labels (rtl)</h4>
         <div style="display: flex; flex-direction: column; align-items: flex-start; height:min-content">
             <label for="rtl-slider" style="margin-left: 8px; color: var(--neutral-foreground-rest);">rtl support</label>
             <div dir="rtl" style="width: 100%;">
@@ -163,6 +174,7 @@
         </div>
 
         <!-- Using slot for custom thumb -->
+        <h4>Custom thumb</h4>
         <fast-slider
             min="0"
             max="100"
@@ -236,8 +248,34 @@
             </svg>
         </fast-slider>
 
-        <!-- Custom labels and thumb hide marks on labels -->
+        <!-- vertical orientation -->
+        <h4>Vertical</h4>
+        <fast-slider orientation="vertical" min="0" max="100" step="10" value="50" style="height: 300px; width: 50px;">
+            <fast-slider-label
+                position="0"
+            >
+                0&#8451;
+            </fast-slider-label>            
+            <fast-slider-label
+                position="10"
+            >
+                10&#8451;
+            </fast-slider-label>
+            <fast-slider-label
+                position="90"
+            >
+                90&#8451;
+            </fast-slider-label>
+            <fast-slider-label
+                position="100"
+            >
+                100&#8451;
+            </fast-slider-label>
+        </fast-slider>
 
+
+        <!-- Custom labels and thumb hide marks on labels -->
+        <h4>Custom labels and thumb, hide marks on labels</h4>
         <fast-slider
             min="0"
             max="100"
@@ -294,6 +332,7 @@
         </fast-slider>
 
         <!-- Disabled -->
+        <h4>Disabled</h4>
         <fast-slider
             min="0"
             max="100"

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -22,7 +22,6 @@ export const SliderStyles = css`
     }
 
     ${display("inline-grid")} :host {
-        --track-size: calc(var(--design-unit) * 2);
         --thumb-size: calc(${heightNumber} * 0.5 - var(--design-unit));
         --thumb-translate: calc(var(--thumb-size) * 0.5);
         --track-overhang: calc((var(--design-unit) / 2) * -1);
@@ -89,14 +88,14 @@ export const SliderStyles = css`
         left: calc(var(--track-overhang) * 1px);
         align-self: start;
         margin-top: calc(var(--design-unit) * 1px);
-        height: calc(var(--track-size) * 1px);
+        height: 4px;
     }
     :host(.vertical) .track {
         top: calc(var(--track-overhang) * 1px);
         bottom: calc(var(--track-overhang) * 1px);
         justify-self: start;
         margin-left: calc(var(--design-unit) * 1px);
-        width: calc(var(--track-size) * 1px);
+        width: 4px;
         height: 100%;
     }
     .track {

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -6,6 +6,7 @@ import {
     keyCodeArrowRight,
     keyCodeArrowUp,
     keyCodeEnter,
+    keyCodeTab,
 } from "@microsoft/fast-web-utilities";
 import { RadioControl } from "../radio/index";
 
@@ -252,6 +253,9 @@ export class RadioGroup extends FASTElement {
     public keydownHandler = (e: KeyboardEvent): void => {
         const group: RadioControl[] = this.getFilteredRadioButtons();
         let index: number = 0;
+        if (e.keyCode !== keyCodeTab) {
+            e.preventDefault();
+        }
         switch (e.keyCode) {
             case keyCodeEnter:
                 this.checkFocusedRadio();

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -7,6 +7,7 @@ import {
     keyCodeArrowUp,
     keyCodeEnd,
     keyCodeHome,
+    keyCodeTab,
     Orientation,
 } from "@microsoft/fast-web-utilities";
 import { FormAssociated } from "../form-associated/index";
@@ -133,6 +134,7 @@ export class Slider extends FormAssociated<HTMLInputElement>
         this.setupTrackConstraints();
         this.setupListeners();
         this.setupDefaultValue();
+        this.setThumbPositionForOrientation(this.direction);
     }
 
     public disconnectedCallback(): void {
@@ -167,6 +169,10 @@ export class Slider extends FormAssociated<HTMLInputElement>
 
     protected keypressHandler = (e: KeyboardEvent) => {
         super.keypressHandler(e);
+        if (e.keyCode !== keyCodeTab) {
+            e.preventDefault();
+        }
+
         if (e.keyCode === keyCodeHome) {
             this.value = `${this.min}`;
         } else if (e.keyCode === keyCodeEnd) {
@@ -215,7 +221,7 @@ export class Slider extends FormAssociated<HTMLInputElement>
     private setupTrackConstraints = (): void => {
         this.trackWidth = this.track.clientWidth;
         this.trackMinWidth = this.track.clientLeft;
-        this.trackHeight = this.track.clientHeight;
+        this.trackHeight = this.track.getBoundingClientRect().bottom;
         this.trackMinHeight = this.track.getBoundingClientRect().top;
     };
 
@@ -299,12 +305,12 @@ export class Slider extends FormAssociated<HTMLInputElement>
     };
 
     private clickHandler = (e: MouseEvent) => {
+        e.preventDefault();
         if (!this.disabled && !this.readOnly) {
             this.trackWidth = this.track.clientWidth;
             if (this.trackWidth === 0) {
                 this.trackWidth = 1;
             }
-            e.preventDefault();
             (e.target as HTMLElement).focus();
             window.addEventListener("mouseup", this.handleWindowMouseUp);
             window.addEventListener("mousemove", this.handleMouseMove);
@@ -313,6 +319,7 @@ export class Slider extends FormAssociated<HTMLInputElement>
                 this.orientation === Orientation.horizontal
                     ? e.pageX - this.getBoundingClientRect().left
                     : e.pageY;
+
             this.value = `${this.calculateNewValue(controlValue)}`;
             this.updateForm();
         }

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -221,8 +221,9 @@ export class Slider extends FormAssociated<HTMLInputElement>
     private setupTrackConstraints = (): void => {
         this.trackWidth = this.track.clientWidth;
         this.trackMinWidth = this.track.clientLeft;
-        this.trackHeight = this.track.getBoundingClientRect().bottom;
-        this.trackMinHeight = this.track.getBoundingClientRect().top;
+        const clientRect: DOMRect = this.track.getBoundingClientRect();
+        this.trackHeight = clientRect.bottom;
+        this.trackMinHeight = clientRect.top;
     };
 
     private setupListeners = (): void => {


### PR DESCRIPTION
# Description
* fixed issue with arrow keys navigating the whole page as well as the silder
* fixed bug where initial value of slider was not setting the thumb position correctly
* fixed bug in vertical orientation where movement via mouse was not correct
* Added headers to all the examples in slider and radio-group
* Fixed color for radio-group slotted labels in fast-components

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.