### PR TITLE
feat(fast-element): add content composition

### DIFF
--- a/packages/web-components/fast-element/docs/ACKNOWLEDGEMENTS.md
+++ b/packages/web-components/fast-element/docs/ACKNOWLEDGEMENTS.md
@@ -7,3 +7,4 @@ There are many great open source projects that have inspired us and enabled us t
 * [Knockout](https://knockoutjs.com/) - One of the first JavaScript libraries (if not the first) to implement an observer system. The original techniques for observables and computed observables have influenced many libraries over the years. Re-interpreting these ideas in terms of modern JavaScript and DOM has helped us to build a powerful and robust system.
 * [lit-html](https://lit-html.polymer-project.org/) - One of the first libraries to leverage standard JavaScript tagged template literals for HTML templates. We were inspired by this technique and wanted to explore whether it could be combined with our idea of arrow function expressions.
 * [Polymer](https://www.polymer-project.org/) - One of the first libraries (if not the first) to embrace Web Components.
+* [Vue](https://vuejs.org/) - We really like the `:` and `@` syntax. Thanks!

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -97,7 +97,7 @@ export interface BehaviorFactory {
     targetIndex: number;
 }
 
-// @public (undocumented)
+// @public
 export class BindingBehavior implements Behavior {
     constructor(target: any, expression: Expression, bind: typeof normalBind, unbind: typeof normalUnbind, updateTarget: typeof updatePropertyTarget, targetName?: string | undefined);
     // Warning: (ae-forgotten-export) The symbol "normalBind" needs to be exported by the entry point index.d.ts
@@ -110,9 +110,9 @@ export class BindingBehavior implements Behavior {
     context: ExecutionContext | null;
     // (undocumented)
     expression: Expression;
-    // (undocumented)
+    // @internal (undocumented)
     handleEvent(event: Event): void;
-    // (undocumented)
+    // @internal (undocumented)
     handleExpressionChange(): void;
     // (undocumented)
     observableExpression: ObservableExpression | null;
@@ -134,18 +134,15 @@ export class BindingBehavior implements Behavior {
     version: number;
 }
 
-// @public (undocumented)
+// @public
 export class BindingDirective extends Directive {
     constructor(expression: Expression);
-    // (undocumented)
     createBehavior(target: any): BindingBehavior;
     // (undocumented)
     createPlaceholder: (index: number) => string;
     // (undocumented)
     expression: Expression;
-    // (undocumented)
     targetAtContent(): void;
-    // (undocumented)
     get targetName(): string | undefined;
     set targetName(value: string | undefined);
     }
@@ -153,7 +150,7 @@ export class BindingDirective extends Directive {
 // @public (undocumented)
 export const booleanConverter: ValueConverter;
 
-// @public (undocumented)
+// @public
 export type Callable = typeof Function.prototype.call | {
     call(): void;
 };
@@ -253,7 +250,7 @@ export abstract class Directive implements BehaviorFactory {
     targetIndex: number;
 }
 
-// @public (undocumented)
+// @public
 export const DOM: Readonly<{
     setHTMLPolicy(policy: TrustedTypesPolicy): void;
     createHTML(html: string): string;
@@ -263,6 +260,7 @@ export const DOM: Readonly<{
     createCustomAttributePlaceholder(attributeName: string, index: number): string;
     createBlockPlaceholder(index: number): string;
     queueUpdate(callable: Callable): void;
+    nextUpdate(): Promise<void>;
     setAttribute(element: HTMLElement, attributeName: string, value: any): void;
     setBooleanAttribute(element: HTMLElement, attributeName: string, value: boolean): void;
 }>;
@@ -295,7 +293,7 @@ export interface ElementViewTemplate {
     create(host: Element): ElementView;
 }
 
-// @public (undocumented)
+// @public
 export const emptyArray: readonly never[];
 
 // @public
@@ -379,15 +377,6 @@ export class FASTElementDefinition {
 // @public
 export function html<TSource = any, TParent = any>(strings: TemplateStringsArray, ...values: TemplateValue<TSource, TParent>[]): ViewTemplate<TSource, TParent>;
 
-// @public (undocumented)
-export class HTMLTemplateBehavior implements Behavior {
-    constructor(template: SyntheticViewTemplate, location: HTMLElement);
-    // (undocumented)
-    bind(source: unknown, context: ExecutionContext): void;
-    // (undocumented)
-    unbind(): void;
-    }
-
 // @public
 export class HTMLView implements ElementView, SyntheticView {
     constructor(fragment: DocumentFragment, behaviors: Behavior[]);
@@ -403,6 +392,8 @@ export class HTMLView implements ElementView, SyntheticView {
     // (undocumented)
     lastChild: Node;
     remove(): void;
+    // (undocumented)
+    source: any | null;
     unbind(): void;
 }
 
@@ -604,17 +595,14 @@ export interface ValueConverter {
 export interface View {
     bind(source: unknown, context: ExecutionContext): void;
     readonly context: ExecutionContext | null;
+    readonly source: any | null;
     unbind(): void;
 }
 
 // @public
-export class ViewTemplate<TSource = any, TParent = any> extends Directive implements ElementViewTemplate, SyntheticViewTemplate {
+export class ViewTemplate<TSource = any, TParent = any> implements ElementViewTemplate, SyntheticViewTemplate {
     constructor(html: string | HTMLTemplateElement, directives: ReadonlyArray<Directive>);
     create(host?: Element): HTMLView;
-    // (undocumented)
-    createBehavior(target: any): HTMLTemplateBehavior;
-    // (undocumented)
-    createPlaceholder: (index: number) => string;
     // (undocumented)
     readonly directives: ReadonlyArray<Directive>;
     // (undocumented)
@@ -622,39 +610,13 @@ export class ViewTemplate<TSource = any, TParent = any> extends Directive implem
     render(source: TSource, host: HTMLElement | string): HTMLView;
     }
 
-// @public (undocumented)
-export function when<T = any, K = any>(expression: Expression<T, K>, template: SyntheticViewTemplate): CaptureType<T>;
-
-// @public (undocumented)
-export class WhenBehavior implements Behavior {
-    constructor(location: Node, expression: Expression, template: SyntheticViewTemplate);
-    // (undocumented)
-    bind(source: unknown, context: ExecutionContext): void;
-    // (undocumented)
-    handleExpressionChange(): void;
-    // (undocumented)
-    unbind(): void;
-    // (undocumented)
-    updateTarget(show: boolean): void;
-    }
-
-// @public (undocumented)
-export class WhenDirective extends Directive {
-    constructor(expression: Expression, template: SyntheticViewTemplate);
-    // (undocumented)
-    createBehavior(target: any): WhenBehavior;
-    // (undocumented)
-    createPlaceholder: (index: number) => string;
-    // (undocumented)
-    expression: Expression;
-    // (undocumented)
-    template: SyntheticViewTemplate;
-}
+// @public
+export function when<T = any, K = any>(condition: Expression<T, K>, templateOrTemplateExpression: SyntheticViewTemplate | Expression<T, SyntheticViewTemplate>): CaptureType<T>;
 
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/dom.d.ts:6:5 - (ae-forgotten-export) The symbol "TrustedTypesPolicy" needs to be exported by the entry point index.d.ts
+// dist/dts/dom.d.ts:9:5 - (ae-forgotten-export) The symbol "TrustedTypesPolicy" needs to be exported by the entry point index.d.ts
 // dist/dts/fast-element.d.ts:16:5 - (ae-forgotten-export) The symbol "getDefinition" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-element/docs/guide/defining-elements.doc.md
+++ b/packages/web-components/fast-element/docs/guide/defining-elements.doc.md
@@ -511,7 +511,7 @@ Some context properties are opt-in because they are more costly to update. So, f
 
 #### Composing Templates
 
-The `ViewTemplate` returned from the `html` tag helper has special handling when it is used inside of another template. The is that you can create templates and compose them into other templates.
+The `ViewTemplate` returned from the `html` tag helper has special handling when it is used inside of another template. This is done so that you can create templates and compose them into other templates.
 
 **Example: Composing Templates**
 

--- a/packages/web-components/fast-element/docs/guide/defining-elements.doc.md
+++ b/packages/web-components/fast-element/docs/guide/defining-elements.doc.md
@@ -406,21 +406,38 @@ const template = html<MyApp>`
 })
 export class MyApp extends FASTElement {
   @observable ready: boolean = false;
+  @observable data: any = null;
 
   connectedCallback() {
     super.connectedCallback();
+    this.loadData();
+  }
 
-    fetch('some/resource').then(response => {
-      // do something with response...
-      this.ready = true;
-    });
+  async loadData() {
+    const response = await fetch('some/resource');
+    const data = await response.json();
+    
+    this.data = data;
+    this.ready = true;
   }
 }
 ```
 
 > **REMINDER:** The `@observable` decorator creates a property that the template system can watch for changes. It is similar to `@attr`, but the property is not surfaced as an HTML attribute on the element itself. While `@attr` can only be used in a `FASTElement`, `@observable` can be used in any class.
 
-> **NOTE**: Additional features are planned for `when` which will enable `elseif` and `else` conditional rendering. Today, you need multiple, separate `when` blocks to achieve the same end result.
+In addition to providing a template to conditionally render, you can also provide an expression that evaluates to a template. This enables you to dynamically change what you are conditionally rendering.
+
+**Example: Conditional Rendering with Dynamic Template**
+
+```TypeScript
+import { FASTElement, customElement, observable, html, when } from '@microsoft/fast-element';
+
+const template = html<MyApp>`
+  <h1>My App</h1>
+
+  ${when(x => x.ready, x => x.dataTemplate}
+`;
+```
 
 #### The Repeat Directive
 
@@ -429,8 +446,7 @@ To render a list of data, use the `repeat` directive, providing the list to rend
 **Example: List Rendering**
 
 ```TypeScript
-import { FASTElement, customElement, observable, html } from '@microsoft/fast-element';
-import { repeat } from '@microsoft/fast-element/directives/repeat';
+import { FASTElement, customElement, observable, html, repeat } from '@microsoft/fast-element';
 
 const template = html<FriendList>`
   <h1>Friends</h1>
@@ -495,14 +511,12 @@ Some context properties are opt-in because they are more costly to update. So, f
 
 #### Composing Templates
 
-The `HTMLTemplate` returned from the `html` tag helper is also a directive itself. As a result, you can create templates and compose them into other templates.
+The `ViewTemplate` returned from the `html` tag helper has special handling when it is used inside of another template. The is that you can create templates and compose them into other templates.
 
 **Example: Composing Templates**
 
 ```TypeScript
-import { FASTElement, customElement, observable, html } from '@microsoft/fast-element';
-import { repeat } from '@microsoft/fast-element/directives/repeat';
-import { when } from '@microsoft/fast-element/directives/when';
+import { FASTElement, customElement, observable, html, repeat, when } from '@microsoft/fast-element';
 
 interface Named {
   name: string;
@@ -563,6 +577,194 @@ export class FriendList extends FASTElement {
   }
 }
 ```
+
+In the above example, we create an independent `nameTemplate` and then use it in two different places. First inside of a `when` template and then later inside of a `repeat` template.
+
+But content composition is actually more powerful than that, because you aren't limited to *static composition* of templates. You can also provide any expression that returns a template. As a result, when the `@observable` dependencies of the expression change, you can dynamically change which template is selected for rendering. If you don't want to render anything, you can also handle that by returning `null` or `undefined`. Here are a few examples of what you can do with content composition:
+
+**Example: Dynamic Composition**
+
+```TypeScript
+const defaultTemplate = html`...`;
+const templatesByType = {
+  foo: html`...`,
+  bar: html`...`,
+  baz: html`...`
+};
+
+const template = html<MyElement>`
+  <div>${x => x.selectTemplate()}</div>
+`;
+
+@customElement({
+  name: 'my-element',
+  template
+})
+export class MyElement extends FASTElement {
+  @observable data;
+
+  selectTemplate() {
+    return templatesByType[this.data.type] || defaultTemplate;
+  }
+}
+```
+
+**Example: Override Templates**
+
+```TypeScript
+const myCustomTemplate = html`...`
+
+@customElement({
+  name: 'my-derived-element',
+  template
+})
+export class MyDerivedElement extends MyElement {
+  selectTemplate() {
+    return myCustomTemplate;
+  }
+}
+```
+
+**Example: Complex Conditional**
+
+```TypeScript
+const dataTemplate = html`...`;
+const loadingTemplate = html`...`;
+
+const template = html<MyElement>`
+  <div>
+    ${x => {
+      if (x.ready) {
+        return dataTemplate;
+      }
+
+      // Any logic can go here to determine which template to use.
+      // Which template to use will be re-evaluated whenever @observable
+      // properties from this method implementation change.
+
+      return loadingTemplate;
+    }}
+  </div>
+`;
+
+@customElement({
+  name: 'my-element',
+  template
+})
+export class MyElement extends FASTElement {
+  @observable ready: boolean = false;
+  @observable data: any = null;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.loadData();
+  }
+
+  async loadData() {
+    const response = await fetch('some/resource');
+    const data = await response.json();
+    
+    this.data = data;
+    this.ready = true;
+  }
+}
+```
+
+**Example: Per Item List Types**
+
+```TypeScript
+const defaultTemplate = html`...`;
+const templatesByType = {
+  foo: html`...`,
+  bar: html`...`,
+  baz: html`...`
+};
+
+const template = html<MyElement>`
+  <ul>
+    ${repeat(x => x.items, html`
+      <li>
+        ${(x, c) = c.parent.selectTemplate(x)}
+      </li>
+    `)}
+  <ul>
+`;
+
+@customElement({
+  name: 'my-element',
+  template
+})
+export class MyElement extends FASTElement {
+  @observable items: any[] = [];
+
+  selectTemplate(item) {
+    return templatesByType[item.type] || defaultTemplate;
+  }
+}
+```
+
+**Example: Custom Rendering Override**
+
+```TypeScript
+const defaultTemplate = html`...`;
+const template = html<MyElement>`
+  <div>${x => x.selectTemplate()}</div>
+`;
+
+@customElement({
+  name: 'my-element',
+  template
+})
+export class MyElement extends FASTElement {
+  selectTemplate() {
+    return defaultTemplate;
+  }
+}
+
+export class MyCustomTemplate implements SyntheticViewTemplate {
+  create(): SyntheticView {
+    // construct your own implementation of SyntheticView
+    return customView;
+  }
+}
+
+const customTemplate = new MyCustomTemplate();
+
+@customElement({
+  name: 'my-derived-element',
+  template
+})
+export class MyDerivedElement extends MyElement {
+  selectTemplate() {
+    return customTemplate;
+  }
+}
+```
+
+> **IMPORTANT:** When composing templates, extract the composed template to an external variable. If you define the template inline, within your method, property, or expression, then each time that is invoked, a new instance of the template will be created, rather than reusing the template. This will result in an unnecessary performance cost.
+
+**Example: The `when` Directive**
+
+Now that we've explained how content composition works, you may find it interesting to know that `when` is actually just *syntax sugar* on top of the core composition system. Let's look at the implementation of `when` itself to see how it works:
+
+```TypeScript
+export function when(condition, templateOrTemplateExpression) {
+    let getTemplate;
+
+    if (typeof templateOrTemplateExpression === "function") {
+        getTemplate = templateOrTemplateExpression;
+    } else {
+        getTemplate = () => templateOrTemplateExpression;
+    }
+
+    return (source, context) => 
+      condition(source, context) 
+        ? getTemplate(source, context) 
+        : null;
+}
+```
+
+As you can see, all that `when` does is compose a new function that checks your condition. If it's true, it invokes your template provider function; if false, it returns null, indicating nothing should be rendered.
 
 ### Referential Directives
 

--- a/packages/web-components/fast-element/docs/guide/defining-elements.doc.md
+++ b/packages/web-components/fast-element/docs/guide/defining-elements.doc.md
@@ -749,13 +749,9 @@ Now that we've explained how content composition works, you may find it interest
 
 ```TypeScript
 export function when(condition, templateOrTemplateExpression) {
-    let getTemplate;
-
-    if (typeof templateOrTemplateExpression === "function") {
-        getTemplate = templateOrTemplateExpression;
-    } else {
-        getTemplate = () => templateOrTemplateExpression;
-    }
+    const getTemplate = typeof templateOrTemplateExpression === "function"
+      ? templateOrTemplateExpression
+      : () => templateOrTemplateExpression;
 
     return (source, context) => 
       condition(source, context) 

--- a/packages/web-components/fast-element/docs/guide/defining-elements.doc.md
+++ b/packages/web-components/fast-element/docs/guide/defining-elements.doc.md
@@ -764,7 +764,7 @@ export function when(condition, templateOrTemplateExpression) {
 }
 ```
 
-As you can see, all that `when` does is compose a new function that checks your condition. If it's true, it invokes your template provider function; if false, it returns null, indicating nothing should be rendered.
+As you can see, all that `when` does is compose a new function that checks your condition. If it's `true,` it invokes your template provider function; if `false`, it returns `null`, indicating nothing should be rendered.
 
 ### Referential Directives
 

--- a/packages/web-components/fast-element/src/__test__/helpers.ts
+++ b/packages/web-components/fast-element/src/__test__/helpers.ts
@@ -1,0 +1,7 @@
+export function toHTML(node: Node): string {
+    return Array.from(node.childNodes)
+        .map((x: any) => {
+            return x.outerHTML || x.textContent;
+        })
+        .join("");
+}

--- a/packages/web-components/fast-element/src/__test__/setup-node.ts
+++ b/packages/web-components/fast-element/src/__test__/setup-node.ts
@@ -10,3 +10,9 @@ if (window.document && !window.document.createRange) {
         },
     });
 }
+
+if (!window.requestAnimationFrame) {
+    window.requestAnimationFrame = function (callback: FrameRequestCallback) {
+        return setTimeout(callback, 4);
+    };
+}

--- a/packages/web-components/fast-element/src/directives/binding.spec.ts
+++ b/packages/web-components/fast-element/src/directives/binding.spec.ts
@@ -1,0 +1,234 @@
+import { expect } from "chai";
+import { BindingDirective } from "./binding";
+import { observable, defaultExecutionContext } from "../observation/observable";
+import { DOM } from "../dom";
+import { html, ViewTemplate } from "../template";
+import { toHTML } from "../__test__/helpers";
+import { SyntheticView, HTMLView } from "../view";
+
+describe("The binding directive", () => {
+    class Model {
+        constructor(value: any) {
+            this.value = value;
+        }
+
+        @observable value: any = null;
+        @observable private trigger = 0;
+
+        forceComputedUpdate() {
+            this.trigger++;
+        }
+
+        get computedValue() {
+            const trigger = this.trigger;
+            return this.value;
+        }
+    }
+
+    function contentBinding(propertyName: keyof Model = "value") {
+        const directive = new BindingDirective(x => x[propertyName]);
+        directive.targetAtContent();
+
+        const node = document.createTextNode(" ");
+        const behavior = directive.createBehavior(node);
+        const parentNode = document.createElement("div");
+
+        parentNode.appendChild(node);
+
+        return { directive, behavior, node, parentNode };
+    }
+
+    context("when binding text content", () => {
+        it("initially sets the text of a node", () => {
+            const { behavior, node } = contentBinding();
+            const model = new Model("This is a test");
+
+            behavior.bind(model, defaultExecutionContext);
+
+            expect(node.textContent).to.equal(model.value);
+        });
+
+        it("updates the text of a node when the expression changes", async () => {
+            const { behavior, node } = contentBinding();
+            const model = new Model("This is a test");
+
+            behavior.bind(model, defaultExecutionContext);
+
+            expect(node.textContent).to.equal(model.value);
+
+            model.value = "This is another test, different from the first.";
+
+            await DOM.nextUpdate();
+
+            expect(node.textContent).to.equal(model.value);
+        });
+    });
+
+    context("when binding template content", () => {
+        it("initially inserts a view based on the template", () => {
+            const { behavior, parentNode } = contentBinding();
+            const template = html`This is a template.`;
+            const model = new Model(template);
+
+            behavior.bind(model, defaultExecutionContext);
+
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+        });
+
+        it("removes an inserted view when the value changes to plain text", async () => {
+            const { behavior, parentNode } = contentBinding();
+            const template = html`This is a template.`;
+            const model = new Model(template);
+
+            behavior.bind(model, defaultExecutionContext);
+
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+
+            model.value = "This is a test.";
+
+            await DOM.nextUpdate();
+
+            expect(toHTML(parentNode)).to.equal(model.value);
+        });
+
+        it("removes an inserted view when the value changes to null", async () => {
+            const { behavior, parentNode } = contentBinding();
+            const template = html`This is a template.`;
+            const model = new Model(template);
+
+            behavior.bind(model, defaultExecutionContext);
+
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+
+            model.value = null;
+
+            await DOM.nextUpdate();
+
+            expect(toHTML(parentNode)).to.equal("");
+        });
+
+        it("removes an inserted view when the value changes to undefined", async () => {
+            const { behavior, parentNode } = contentBinding();
+            const template = html`This is a template.`;
+            const model = new Model(template);
+
+            behavior.bind(model, defaultExecutionContext);
+
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+
+            model.value = void 0;
+
+            await DOM.nextUpdate();
+
+            expect(toHTML(parentNode)).to.equal("");
+        });
+
+        it("updates an inserted view when the value changes to a new template", async () => {
+            const { behavior, parentNode } = contentBinding();
+            const template = html`This is a template.`;
+            const model = new Model(template);
+
+            behavior.bind(model, defaultExecutionContext);
+
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+
+            const newTemplate = html`This is a new template, different from before.`;
+            model.value = newTemplate;
+
+            await DOM.nextUpdate();
+
+            expect(toHTML(parentNode)).to.equal(
+                `This is a new template, different from before.`
+            );
+        });
+
+        it("reuses a previous view when the value changes back from a string", async () => {
+            const { behavior, parentNode, node } = contentBinding();
+            const template = html`This is a template.`;
+            const model = new Model(template);
+
+            behavior.bind(model, defaultExecutionContext);
+
+            const view = (node as any).$fastView as SyntheticView;
+            const capturedTemplate = (node as any).$fastTemplate as ViewTemplate;
+
+            expect(view).to.be.instanceOf(HTMLView);
+            expect(capturedTemplate).to.equal(template);
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+
+            model.value = "This is a test string.";
+
+            await DOM.nextUpdate();
+
+            expect(toHTML(parentNode)).to.equal(model.value);
+
+            model.value = template;
+
+            await DOM.nextUpdate();
+
+            const newView = (node as any).$fastView as SyntheticView;
+            const newCapturedTemplate = (node as any).$fastTemplate as ViewTemplate;
+
+            expect(newView).to.equal(view);
+            expect(newCapturedTemplate).to.equal(capturedTemplate);
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+        });
+
+        it("doesn't compose an already composed view", async () => {
+            const { behavior, parentNode } = contentBinding("computedValue");
+            const template = html`This is a template.`;
+            const model = new Model(template);
+
+            behavior.bind(model, defaultExecutionContext);
+
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+
+            model.value = template;
+            model.forceComputedUpdate();
+
+            await DOM.nextUpdate();
+
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+        });
+    });
+
+    context("when unbinding template content", () => {
+        it("unbinds a composed view", () => {
+            const { behavior, node, parentNode } = contentBinding();
+            const template = html`This is a template.`;
+            const model = new Model(template);
+
+            behavior.bind(model, defaultExecutionContext);
+
+            const newView = (node as any).$fastView as SyntheticView;
+            expect(newView.source).to.equal(model);
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+
+            behavior.unbind();
+
+            expect(newView.source).to.equal(null);
+        });
+
+        it("rebinds a previously unbound composed view", () => {
+            const { behavior, node, parentNode } = contentBinding();
+            const template = html`This is a template.`;
+            const model = new Model(template);
+
+            behavior.bind(model, defaultExecutionContext);
+
+            const view = (node as any).$fastView as SyntheticView;
+            expect(view.source).to.equal(model);
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+
+            behavior.unbind();
+
+            expect(view.source).to.equal(null);
+
+            behavior.bind(model, defaultExecutionContext);
+
+            const newView = (node as any).$fastView as SyntheticView;
+            expect(newView.source).to.equal(model);
+            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+        });
+    });
+});

--- a/packages/web-components/fast-element/src/directives/binding.ts
+++ b/packages/web-components/fast-element/src/directives/binding.ts
@@ -1,6 +1,7 @@
 import { ExecutionContext, Expression, setCurrentEvent } from "../observation/observable";
 import { ObservableExpression } from "../observation/observable";
 import { DOM } from "../dom";
+import { SyntheticView } from "../view";
 import { Directive } from "./directive";
 import { Behavior } from "./behavior";
 
@@ -35,6 +36,24 @@ function normalUnbind(this: BindingBehavior): void {
     this.context = null;
 }
 
+type ComposableView = SyntheticView & {
+    isComposed?: boolean;
+    needsBindOnly?: boolean;
+};
+
+function contentUnbind(this: BindingBehavior): void {
+    this.observableExpression!.dispose();
+    this.source = null;
+    this.context = null;
+
+    const view = this.target.$fastView as ComposableView;
+
+    if (view !== void 0 && view.isComposed) {
+        view.unbind();
+        view.needsBindOnly = true;
+    }
+}
+
 function triggerUnbind(this: BindingBehavior): void {
     this.target.removeEventListener(this.targetName!, this, true);
     this.source = null;
@@ -49,8 +68,67 @@ function updateBooleanAttributeTarget(this: BindingBehavior, value: unknown): vo
     DOM.setBooleanAttribute(this.target, this.targetName!, value as boolean);
 }
 
-function updateTextTarget(this: BindingBehavior, value: unknown): void {
-    this.target.textContent = value as string;
+function updateContentTarget(this: BindingBehavior, value: any): void {
+    // If there's no actual value, then this equates to the
+    // empty string for the purposes of content bindings.
+    if (value === null || value === undefined) {
+        value = "";
+    }
+
+    // If the value has a "create" method, then it's a template-like.
+    if (value.create) {
+        this.target.textContent = "";
+        let view = this.target.$fastView as ComposableView;
+
+        // If there's no previous view that we might be able to
+        // reuse then create a new view from the template.
+        if (view === void 0) {
+            view = value.create() as SyntheticView;
+        } else {
+            // If there is a previous view, but it wasn't created
+            // from the same template as the new value, then we
+            // need to remove the old view if it's still in the DOM
+            // and create a new view from the template.
+            if (this.target.$fastTemplate !== value) {
+                if (view.isComposed) {
+                    view.remove();
+                    view.unbind();
+                }
+
+                view = value.create() as SyntheticView;
+            }
+        }
+
+        // It's possible that the value is the same as the previous template
+        // and that there's actually no need to compose it.
+        if (!view.isComposed) {
+            view.isComposed = true;
+            view.bind(this.source, this.context!);
+            view.insertBefore(this.target);
+            this.target.$fastView = view;
+            this.target.$fastTemplate = value;
+        } else if (view.needsBindOnly) {
+            view.needsBindOnly = false;
+            view.bind(this.source, this.context!);
+        }
+    } else {
+        const view = this.target.$fastView as ComposableView;
+
+        // If there is a view and it's currently composed into
+        // the DOM, then we need to remove it.
+        if (view !== void 0 && view.isComposed) {
+            view.isComposed = false;
+            view.remove();
+
+            if (view.needsBindOnly) {
+                view.needsBindOnly = false;
+            } else {
+                view.unbind();
+            }
+        }
+
+        this.target.textContent = value;
+    }
 }
 
 function updatePropertyTarget(this: BindingBehavior, value: unknown): void {
@@ -96,6 +174,9 @@ function updateClassTarget(this: BindingBehavior, value: string): void {
     }
 }
 
+/**
+ * A directive that configures data binding to element content and attributes.
+ */
 export class BindingDirective extends Directive {
     private cleanedTargetName?: string;
     private originalTargetName?: string;
@@ -106,14 +187,26 @@ export class BindingDirective extends Directive {
     private unbind: typeof normalUnbind = normalUnbind;
     private updateTarget: typeof updateAttributeTarget = updateAttributeTarget;
 
+    /**
+     * Creates an instance of BindingDirective.
+     * @param expression An expression that returns the data used to update the DOM.
+     */
     constructor(public expression: Expression) {
         super();
     }
 
+    /**
+     * Gets the name of the attribute or property that this
+     * binding is targeting.
+     */
     public get targetName(): string | undefined {
         return this.originalTargetName;
     }
 
+    /**
+     * Sets the name of the attribute or property tha this
+     * binding is targeting.
+     */
     public set targetName(value: string | undefined) {
         this.originalTargetName = value;
 
@@ -151,10 +244,20 @@ export class BindingDirective extends Directive {
         }
     }
 
+    /**
+     * Makes this binding target the content of an element rather than
+     * a particular attribute or property.
+     */
     public targetAtContent(): void {
-        this.updateTarget = updateTextTarget;
+        this.updateTarget = updateContentTarget;
+        this.unbind = contentUnbind;
     }
 
+    /**
+     * Creates the runtime BindingBehavior instance based on the configuration
+     * information stored in the BindingDirective.
+     * @param target The target node that the binding behavior should attach to.
+     */
     createBehavior(target: any): BindingBehavior {
         /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
         return new BindingBehavior(
@@ -168,6 +271,10 @@ export class BindingDirective extends Directive {
     }
 }
 
+/**
+ * A behavior that updates content and attributes based on a configured
+ * BindingDirective.
+ */
 export class BindingBehavior implements Behavior {
     public source: unknown = null;
     public context: ExecutionContext | null = null;
@@ -175,6 +282,15 @@ export class BindingBehavior implements Behavior {
     public classVersions: Record<string, number>;
     public version: number;
 
+    /**
+     *
+     * @param target The target of the data updates.
+     * @param expression The expression that returns the latest value for an update.
+     * @param bind The operation to perform during binding.
+     * @param unbind The operation to perform during unbinding.
+     * @param updateTarget The operation to perform when updating.
+     * @param targetName The name of the target attribute or property to update.
+     */
     constructor(
         public target: any,
         public expression: Expression,
@@ -184,12 +300,18 @@ export class BindingBehavior implements Behavior {
         public targetName?: string
     ) {}
 
+    /**
+     * @internal
+     */
     handleExpressionChange(): void {
         this.updateTarget(
             this.observableExpression!.evaluate(this.source, this.context!)
         );
     }
 
+    /**
+     * @internal
+     */
     handleEvent(event: Event): void {
         setCurrentEvent(event);
         const result = this.expression(this.source, this.context!);

--- a/packages/web-components/fast-element/src/directives/when.spec.ts
+++ b/packages/web-components/fast-element/src/directives/when.spec.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import { when } from "./when";
+import { html } from "../template";
+import { Expression, defaultExecutionContext } from "../observation/observable";
+
+describe("The 'when' template function", () => {
+    it("returns an expression", () => {
+        const expression = when(() => true, html`test`);
+        expect(typeof expression).to.equal("function");
+    });
+
+    context("expression", () => {
+        const scope = {};
+        const template = html`template1`;
+
+        it("returns a template when the condition is true", () => {
+            const expression = when(() => true, template) as Expression;
+            const result = expression(scope, defaultExecutionContext);
+            expect(result).to.equal(template);
+        });
+
+        it("returns null when the condition is false", () => {
+            const expression = when(() => false, template) as Expression;
+            const result = expression(scope, defaultExecutionContext);
+            expect(result).to.equal(null);
+        });
+
+        it("evaluates a template expression to get the template, if provided", () => {
+            const expression = when(
+                () => true,
+                () => template
+            ) as Expression;
+            const result = expression(scope, defaultExecutionContext);
+            expect(result).to.equal(template);
+        });
+    });
+});

--- a/packages/web-components/fast-element/src/directives/when.ts
+++ b/packages/web-components/fast-element/src/directives/when.ts
@@ -13,13 +13,10 @@ export function when<T = any, K = any>(
         | SyntheticViewTemplate
         | Expression<T, SyntheticViewTemplate>
 ): CaptureType<T> {
-    let getTemplate: Expression<T, SyntheticViewTemplate>;
-
-    if (typeof templateOrTemplateExpression === "function") {
-        getTemplate = templateOrTemplateExpression;
-    } else {
-        getTemplate = (): SyntheticViewTemplate => templateOrTemplateExpression;
-    }
+    const getTemplate =
+        typeof templateOrTemplateExpression === "function"
+            ? templateOrTemplateExpression
+            : (): SyntheticViewTemplate => templateOrTemplateExpression;
 
     return (source: any, context: ExecutionContext): SyntheticViewTemplate | null =>
         condition(source, context) ? getTemplate(source, context) : null;

--- a/packages/web-components/fast-element/src/directives/when.ts
+++ b/packages/web-components/fast-element/src/directives/when.ts
@@ -21,11 +21,6 @@ export function when<T = any, K = any>(
         getTemplate = (): SyntheticViewTemplate => templateOrTemplateExpression;
     }
 
-    return (source: any, context: ExecutionContext): SyntheticViewTemplate | null => {
-        if (condition(source, context)) {
-            return getTemplate(source, context);
-        }
-
-        return null;
-    };
+    return (source: any, context: ExecutionContext): SyntheticViewTemplate | null =>
+        condition(source, context) ? getTemplate(source, context) : null;
 }

--- a/packages/web-components/fast-element/src/directives/when.ts
+++ b/packages/web-components/fast-element/src/directives/when.ts
@@ -1,77 +1,31 @@
-import { DOM } from "../dom";
 import { CaptureType, SyntheticViewTemplate } from "../template";
-import { SyntheticView } from "../view";
-import {
-    ExecutionContext,
-    Expression,
-    ObservableExpression,
-} from "../observation/observable";
-import { Behavior } from "./behavior";
-import { Directive } from "./directive";
+import { ExecutionContext, Expression } from "../observation/observable";
 
-export class WhenBehavior implements Behavior {
-    private view: SyntheticView | null = null;
-    private cachedView?: SyntheticView;
-    private source: unknown;
-    private observableExpression: ObservableExpression;
-    private context: ExecutionContext | undefined = void 0;
-
-    constructor(
-        private location: Node,
-        expression: Expression,
-        private template: SyntheticViewTemplate
-    ) {
-        this.observableExpression = new ObservableExpression(expression, this);
-    }
-
-    bind(source: unknown, context: ExecutionContext): void {
-        this.source = source;
-        this.context = context;
-        this.updateTarget(this.observableExpression.evaluate(source, context));
-    }
-
-    unbind(): void {
-        if (this.view !== null) {
-            this.view.unbind();
-        }
-
-        this.observableExpression.dispose();
-        this.source = null;
-    }
-
-    handleExpressionChange(): void {
-        this.updateTarget(this.observableExpression.evaluate(this.source, this.context!));
-    }
-
-    updateTarget(show: boolean): void {
-        if (show && this.view == null) {
-            this.view = this.cachedView || (this.cachedView = this.template.create());
-            this.view.bind(this.source, this.context!);
-            this.view.insertBefore(this.location);
-        } else if (!show && this.view !== null) {
-            // do not dispose, since we may want to use the view again
-            this.view.remove();
-            this.view.unbind();
-            this.view = null;
-        }
-    }
-}
-
-export class WhenDirective extends Directive {
-    createPlaceholder: (index: number) => string = DOM.createBlockPlaceholder;
-
-    constructor(public expression: Expression, public template: SyntheticViewTemplate) {
-        super();
-    }
-
-    public createBehavior(target: any): WhenBehavior {
-        return new WhenBehavior(target, this.expression, this.template);
-    }
-}
-
+/**
+ * A directive that enables basic conditional rendering in a template.
+ * @param condition The condition to test for rendering.
+ * @param templateOrTemplateExpression The template or an expression that gets
+ * the template to render when the condition is true.
+ */
 export function when<T = any, K = any>(
-    expression: Expression<T, K>,
-    template: SyntheticViewTemplate
+    condition: Expression<T, K>,
+    templateOrTemplateExpression:
+        | SyntheticViewTemplate
+        | Expression<T, SyntheticViewTemplate>
 ): CaptureType<T> {
-    return new WhenDirective(expression, template);
+    let getTemplate: Expression<T, SyntheticViewTemplate>;
+
+    if (typeof templateOrTemplateExpression === "function") {
+        getTemplate = templateOrTemplateExpression;
+    } else {
+        getTemplate = (): SyntheticViewTemplate => templateOrTemplateExpression;
+    }
+
+    return (source: any, context: ExecutionContext): SyntheticViewTemplate | null => {
+        if (condition(source, context)) {
+            return getTemplate(source, context);
+        }
+
+        return null;
+    };
 }

--- a/packages/web-components/fast-element/src/dom.spec.ts
+++ b/packages/web-components/fast-element/src/dom.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from "chai";
+import { DOM } from "./dom";
+
+describe("The DOM", () => {
+    it("can batch updates", async () => {
+        let work1 = 0;
+        let work2 = 0;
+        const task1 = () => work1++;
+        const task2 = () => work2++;
+
+        DOM.queueUpdate(task1);
+        expect(work1).to.equal(0);
+
+        DOM.queueUpdate(task2);
+        expect(work1).to.equal(0);
+        expect(work2).to.equal(0);
+
+        await DOM.nextUpdate();
+
+        expect(work1).to.equal(1);
+        expect(work2).to.equal(1);
+    });
+});

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -1,3 +1,12 @@
+/**
+ * Represents a callable type such as a function or an object with a "call" method.
+ */
 export type Callable = typeof Function.prototype.call | { call(): void };
 
+/**
+ * A readonly, empty array.
+ * @remarks
+ * Typically returned by APIs that return arrays when there are
+ * no actual items to return.
+ */
 export const emptyArray = Object.freeze([]);

--- a/packages/web-components/fast-element/src/template-compiler.spec.ts
+++ b/packages/web-components/fast-element/src/template-compiler.spec.ts
@@ -4,20 +4,13 @@ import { BindingDirective } from "./directives/binding";
 import { compileTemplate } from "./template-compiler";
 import { Directive } from "./directives/directive";
 import { defaultExecutionContext } from "./observation/observable";
+import { toHTML } from "./__test__/helpers";
 
 describe("The template compiler", () => {
     function compile(html: string, directives: Directive[]) {
         const template = document.createElement("template");
         template.innerHTML = html;
         return compileTemplate(template, directives);
-    }
-
-    function toHTML(fragment: DocumentFragment) {
-        return Array.from(fragment.childNodes)
-            .map(x => {
-                return (x as any).outerHTML || x.textContent;
-            })
-            .join("");
     }
 
     function inline(index: number) {

--- a/packages/web-components/fast-element/src/template.spec.ts
+++ b/packages/web-components/fast-element/src/template.spec.ts
@@ -134,66 +134,43 @@ describe(`The html tag template helper`, () => {
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "at the beginning",
-            template: html<Model>`${stringValue}${numberValue}${x =>
-                x.value}${new TestDirective()}
-            end`,
-            result: `${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
-                0
-            )}${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
+            result: `${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(0)}${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "in the middle",
-            template: html<Model>`beginning
-            ${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
-            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
-                0
-            )}${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`beginning ${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
+            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(0)}${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "at the end",
-            template: html<Model>`beginning
-            ${stringValue}${numberValue}${x => x.value}${new TestDirective()}`,
-            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
-                0
-            )}${DOM.createBlockPlaceholder(1)}`,
+            template: html<Model>`beginning ${stringValue}${numberValue}${x => x.value}${new TestDirective()}`,
+            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(0)}${DOM.createBlockPlaceholder(1)}`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "at the beginning",
-            template: html<Model>`${stringValue}separator${numberValue}separator${x =>
-                x.value}separator${new TestDirective()}
-            end`,
-            result: `${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
-                0
-            )}separator${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`${stringValue}separator${numberValue}separator${x => x.value}separator${new TestDirective()} end`,
+            result: `${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(0)}separator${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "in the middle",
-            template: html<Model>`beginning
-            ${stringValue}separator${numberValue}separator${x =>
-                x.value}separator${new TestDirective()}
-            end`,
-            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
-                0
-            )}separator${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`beginning ${stringValue}separator${numberValue}separator${x => x.value}separator${new TestDirective()} end`,
+            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(0)}separator${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "at the end",
-            template: html<Model>`beginning
-            ${stringValue}separator${numberValue}separator${x =>
-                x.value}separator${new TestDirective()}`,
-            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
-                0
-            )}separator${DOM.createBlockPlaceholder(1)}`,
+            template: html<Model>`beginning ${stringValue}separator${numberValue}separator${x => x.value}separator${new TestDirective()}`,
+            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(0)}separator${DOM.createBlockPlaceholder(1)}`,
             expectDirectives: [BindingDirective, TestDirective],
         },
     ];
@@ -212,9 +189,7 @@ describe(`The html tag template helper`, () => {
     });
 
     it(`captures a case-sensitive property name when used with an expression`, () => {
-        const template = html<Model>`<my-element
-            :someAttribute=${x => x.value}
-        ></my-element>`;
+        const template = html<Model>`<my-element :someAttribute=${x => x.value}></my-element>`;
         const placeholder = DOM.createInterpolationPlaceholder(0);
 
         expect(template.html).to.equal(

--- a/packages/web-components/fast-element/src/template.spec.ts
+++ b/packages/web-components/fast-element/src/template.spec.ts
@@ -108,47 +108,92 @@ describe(`The html tag template helper`, () => {
             result: `beginning ${DOM.createBlockPlaceholder(0)}`,
             expectDirectives: [TestDirective],
         },
+        // template interpolation
+        {
+            type: "template",
+            location: "at the beginning",
+            template: html`${html`sub-template`} end`,
+            result: `${DOM.createInterpolationPlaceholder(0)} end`,
+            expectDirectives: [BindingDirective],
+        },
+        {
+            type: "template",
+            location: "in the middle",
+            template: html`beginning ${html`sub-template`} end`,
+            result: `beginning ${DOM.createInterpolationPlaceholder(0)} end`,
+            expectDirectives: [BindingDirective],
+        },
+        {
+            type: "template",
+            location: "at the end",
+            template: html`beginning ${html`sub-template`}`,
+            result: `beginning ${DOM.createInterpolationPlaceholder(0)}`,
+            expectDirectives: [BindingDirective],
+        },
         // mixed interpolation
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "at the beginning",
-            template: html<Model>`${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
-            result: `${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(0)}${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`${stringValue}${numberValue}${x =>
+                x.value}${new TestDirective()}
+            end`,
+            result: `${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
+                0
+            )}${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "in the middle",
-            template: html<Model>`beginning ${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
-            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(0)}${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`beginning
+            ${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
+            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
+                0
+            )}${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "at the end",
-            template: html<Model>`beginning ${stringValue}${numberValue}${x => x.value}${new TestDirective()}`,
-            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(0)}${DOM.createBlockPlaceholder(1)}`,
+            template: html<Model>`beginning
+            ${stringValue}${numberValue}${x => x.value}${new TestDirective()}`,
+            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
+                0
+            )}${DOM.createBlockPlaceholder(1)}`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "at the beginning",
-            template: html<Model>`${stringValue}separator${numberValue}separator${x => x.value}separator${new TestDirective()} end`,
-            result: `${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(0)}separator${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`${stringValue}separator${numberValue}separator${x =>
+                x.value}separator${new TestDirective()}
+            end`,
+            result: `${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
+                0
+            )}separator${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "in the middle",
-            template: html<Model>`beginning ${stringValue}separator${numberValue}separator${x => x.value}separator${new TestDirective()} end`,
-            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(0)}separator${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`beginning
+            ${stringValue}separator${numberValue}separator${x =>
+                x.value}separator${new TestDirective()}
+            end`,
+            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
+                0
+            )}separator${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "at the end",
-            template: html<Model>`beginning ${stringValue}separator${numberValue}separator${x => x.value}separator${new TestDirective()}`,
-            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(0)}separator${DOM.createBlockPlaceholder(1)}`,
+            template: html<Model>`beginning
+            ${stringValue}separator${numberValue}separator${x =>
+                x.value}separator${new TestDirective()}`,
+            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
+                0
+            )}separator${DOM.createBlockPlaceholder(1)}`,
             expectDirectives: [BindingDirective, TestDirective],
         },
     ];
@@ -167,7 +212,9 @@ describe(`The html tag template helper`, () => {
     });
 
     it(`captures a case-sensitive property name when used with an expression`, () => {
-        const template = html<Model>`<my-element :someAttribute=${x => x.value}></my-element>`;
+        const template = html<Model>`<my-element
+            :someAttribute=${x => x.value}
+        ></my-element>`;
         const placeholder = DOM.createInterpolationPlaceholder(0);
 
         expect(template.html).to.equal(

--- a/packages/web-components/fast-element/src/view.ts
+++ b/packages/web-components/fast-element/src/view.ts
@@ -11,6 +11,11 @@ export interface View {
     readonly context: ExecutionContext | null;
 
     /**
+     * The data that the view is bound to.
+     */
+    readonly source: any | null;
+
+    /**
      * Binds a view's behaviors to its binding source.
      * @param source The binding source for the view's binding behaviors.
      */
@@ -75,11 +80,16 @@ const range = document.createRange();
  * The standard View implementation, which also implements ElementView and SyntheticView.
  */
 export class HTMLView implements ElementView, SyntheticView {
-    private source: any = void 0;
+    public source: any | null = null;
     public context: ExecutionContext | null = null;
     public firstChild: Node;
     public lastChild: Node;
 
+    /**
+     *
+     * @param fragment The html fragment that contains the nodes for this view.
+     * @param behaviors The behaviors to be applied to this view.
+     */
     constructor(private fragment: DocumentFragment, private behaviors: Behavior[]) {
         this.firstChild = fragment.firstChild!;
         this.lastChild = fragment.lastChild!;
@@ -171,7 +181,7 @@ export class HTMLView implements ElementView, SyntheticView {
 
         if (this.source === source) {
             return;
-        } else if (this.source !== void 0) {
+        } else if (this.source !== null) {
             const oldSource = this.source;
 
             this.source = source;
@@ -196,7 +206,7 @@ export class HTMLView implements ElementView, SyntheticView {
      * Unbinds a view's behaviors from its binding source.
      */
     public unbind(): void {
-        if (this.source === void 0) {
+        if (this.source === null) {
             return;
         }
 
@@ -207,7 +217,7 @@ export class HTMLView implements ElementView, SyntheticView {
             behaviors[i].unbind(oldSource);
         }
 
-        this.source = void 0;
+        this.source = null;
     }
 
     /**

--- a/packages/web-components/fast-element/tsconfig.json
+++ b/packages/web-components/fast-element/tsconfig.json
@@ -4,6 +4,7 @@
         "declarationDir": "dist/dts",
         "outDir": "dist/esm",
         "strictNullChecks": true,
+        "experimentalDecorators": true,
         "target": "es2015",
         "module": "ESNext",
         "types": [


### PR DESCRIPTION
# Description

This feature adds the ability for expressions located in arbitrary HTML content to return a template to be rendered into that location.

## Motivation & context

For an overview of the feature, have a read through issue #3039. The technical approach outlined there was exactly what was put into place here. Additionally, some basic cache smarts were added to the content binding mechanism, enabling the entire `when` directive to be deleted and instead simply be *syntax sugar* on top of the low-level composition capabilities. Everything from #3039 is implemented in this PR with the exception of the changes to `repeat`. Those are planned for a separate PR next week.

Unit tests have been added around content composition, `repeat`, and other areas touched by this PR. As part of the unit test writing process, I realized it would be nice to have a helper to await the next dom batch update, so `DOM.nextUpdate(): Promise` was added.

The best place to look for an understanding of the new content composition features is the update to the documentation in this PR.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

Technically, this is a breaking change as it removes `WhenDirective` and `WhenBehavior`. However, to my knowledge, no one was using those directly. Instead, they were using the `when` helper in their templates. The `when` helper remains, but its implementation is now changed to leverage the core composition system.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.