### PR TITLE
feat(fast-foundation): add element test helper

### DIFF
--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -28,7 +28,7 @@
     "prettier:diff": "prettier --config ../../../.prettierrc \"**/*.ts\" --list-different",
     "eslint": "eslint . --ext .ts",
     "eslint:fix": "eslint . --ext .ts --fix",
-    "test": "npm run test-node:verbose",
+    "test": "npm run test-chrome:verbose",
     "test-node": "mocha --reporter min --exit dist/esm/__test__/setup-node.js './dist/esm/**/*.spec.js'",
     "test-node:verbose": "mocha --reporter spec --exit dist/esm/__test__/setup-node.js './dist/esm/**/*.spec.js'",
     "test-chrome": "karma start karma.conf.js --browsers=ChromeHeadlessOpt --single-run --coverage",

--- a/packages/web-components/fast-foundation/src/fixture.spec.ts
+++ b/packages/web-components/fast-foundation/src/fixture.spec.ts
@@ -1,0 +1,85 @@
+import { expect } from "chai";
+import {
+    attr,
+    customElement,
+    FASTElement,
+    html,
+    DOM,
+    observable,
+} from "@microsoft/fast-element";
+import { uniqueName, fixture } from "./fixture";
+
+describe("The fixture helper", () => {
+    const name = uniqueName();
+    const template = html<MyElement>`${x => x.value}<slot></slot>`;
+
+    @customElement({
+        name,
+        template,
+    })
+    class MyElement extends FASTElement {
+        @attr value = "value";
+    }
+
+    class MyModel {
+        @observable value = "different value";
+    }
+
+    it("can create a fixture for an element by name", async () => {
+        const { element } = await fixture(name);
+        expect(element).to.be.instanceOf(MyElement);
+    });
+
+    it("can create a fixture for an element by template", async () => {
+        const { element } = await fixture(html`
+      <${name}>
+        Some content here.
+      </${name}>
+    `);
+
+        expect(element).to.be.instanceOf(MyElement);
+        expect(element.innerText.trim()).to.equal("Some content here.");
+    });
+
+    it("can connect an element", async () => {
+        const { element, connect } = await fixture(name);
+
+        expect(element.isConnected).to.equal(false);
+
+        await connect();
+
+        expect(element.isConnected).to.equal(true);
+    });
+
+    it("can disconnect an element", async () => {
+        const { element, connect, disconnect } = await fixture(name);
+
+        expect(element.isConnected).to.equal(false);
+
+        await connect();
+
+        expect(element.isConnected).to.equal(true);
+
+        await disconnect();
+
+        expect(element.isConnected).to.equal(false);
+    });
+
+    it("can bind an element to data", async () => {
+        const source = new MyModel();
+        const { element } = await fixture<MyElement>(
+            html<MyModel>`
+      <${name} value=${x => x.value}></${name}>
+    `,
+            { source }
+        );
+
+        expect(element.value).to.equal(source.value);
+
+        source.value = "something else";
+
+        await DOM.nextUpdate();
+
+        expect(element.value).to.equal(source.value);
+    });
+});

--- a/packages/web-components/fast-foundation/src/fixture.spec.ts
+++ b/packages/web-components/fast-foundation/src/fixture.spec.ts
@@ -7,10 +7,10 @@ import {
     DOM,
     observable,
 } from "@microsoft/fast-element";
-import { uniqueName, fixture } from "./fixture";
+import { uniqueElementName, fixture } from "./fixture";
 
 describe("The fixture helper", () => {
-    const name = uniqueName();
+    const name = uniqueElementName();
     const template = html<MyElement>`${x => x.value}<slot></slot>`;
 
     @customElement({

--- a/packages/web-components/fast-foundation/src/fixture.ts
+++ b/packages/web-components/fast-foundation/src/fixture.ts
@@ -32,7 +32,7 @@ function findElement(view: HTMLView): HTMLElement {
     return current as any;
 }
 
-export function uniqueName(): string {
+export function uniqueElementName(): string {
     return `fast-unique-${Math.random().toString(36).substring(7)}`;
 }
 

--- a/packages/web-components/fast-foundation/src/fixture.ts
+++ b/packages/web-components/fast-foundation/src/fixture.ts
@@ -5,20 +5,80 @@ import {
     ViewTemplate,
 } from "@microsoft/fast-element";
 
+/**
+ * Options used to customize the creation of the test fixture.
+ */
 export interface FixtureOptions {
+    /**
+     * The document to run the fixture in.
+     * @defaultValue `globalThis.document`
+     */
     document?: Document;
+
+    /**
+     * The parent element to append the fixture to.
+     * @defaultValue An instance of `HTMLDivElement`.
+     */
     parent?: HTMLElement;
+
+    /**
+     * The data source to bind the HTML to.
+     * @defaultValue An empty object.
+     */
     source?: any;
+
+    /**
+     * The execution context to use during binding.
+     * @defaultValue {@link @microsoft/fast-element#defaultExecutionContext}
+     */
     context?: ExecutionContext;
 }
 
 export interface Fixture<TElement = HTMLElement> {
+    /**
+     * The document the fixture is running in.
+     */
     document: Document;
+
+    /**
+     * The template the fixture was created from.
+     */
     template: ViewTemplate;
+
+    /**
+     * The view that was created from the fixture's template.
+     */
     view: HTMLView;
+
+    /**
+     * The parent element that the view was appended to.
+     * @remarks
+     * This element will be appended to the DOM only
+     * after {@link Fixture.connect} has been called.
+     */
     parent: HTMLElement;
+
+    /**
+     * The first element in the {@link Fixture.view}.
+     */
     element: TElement;
+
+    /**
+     * Adds the {@link Fixture.parent} to the DOM, causing the
+     * connect lifecycle to begin.
+     * @remarks
+     * Yields control to the caller one Microtask later, in order to
+     * ensure that the DOM has settled.
+     */
     connect(): Promise<void>;
+
+    /**
+     * Removes the {@link Fixture.parent} from the DOM, causing the
+     * disconnect lifecycle to begin.
+     * @remarks
+     * Yields control to the caller one Microtask later, in order to
+     * ensure that the DOM has settled.
+     */
     disconnect(): Promise<void>;
 }
 
@@ -32,10 +92,21 @@ function findElement(view: HTMLView): HTMLElement {
     return current as any;
 }
 
+/**
+ * Creates a random, unique name suitable for use as a Custom Element name.
+ */
 export function uniqueElementName(): string {
     return `fast-unique-${Math.random().toString(36).substring(7)}`;
 }
 
+/**
+ * Creates a test fixture suitable for testing custom elements, templates, and bindings.
+ * @param templateOrElementName An HTML template or single element name to create the fixture for.
+ * @param options Enables customizing fixture creation behavior.
+ * @remarks
+ * Yields control to the caller one Microtask later, in order to
+ * ensure that the DOM has settled.
+ */
 export async function fixture<TElement = HTMLElement>(
     templateOrElementName: ViewTemplate | string,
     options: FixtureOptions = {}
@@ -58,6 +129,8 @@ export async function fixture<TElement = HTMLElement>(
 
     customElements.upgrade(parent);
 
+    // Hook into the Microtask Queue to ensure the DOM is settled
+    // before yielding control to the caller.
     await Promise.resolve();
 
     const connect = async () => {

--- a/packages/web-components/fast-foundation/src/fixture.ts
+++ b/packages/web-components/fast-foundation/src/fixture.ts
@@ -1,0 +1,92 @@
+import {
+    defaultExecutionContext,
+    ExecutionContext,
+    HTMLView,
+    ViewTemplate,
+} from "@microsoft/fast-element";
+
+export interface FixtureOptions {
+    document?: Document;
+    parent?: HTMLElement;
+    source?: any;
+    context?: ExecutionContext;
+}
+
+export interface Fixture<TElement = HTMLElement> {
+    document: Document;
+    template: ViewTemplate;
+    view: HTMLView;
+    parent: HTMLElement;
+    element: TElement;
+    connect(): Promise<void>;
+    disconnect(): Promise<void>;
+}
+
+function findElement(view: HTMLView): HTMLElement {
+    let current: Node | null = view.firstChild;
+
+    while (current !== null && current.nodeType !== 1) {
+        current = current.nextSibling;
+    }
+
+    return current as any;
+}
+
+export function uniqueName(): string {
+    return `fast-unique-${Math.random().toString(36).substring(7)}`;
+}
+
+export async function fixture<TElement = HTMLElement>(
+    templateOrElementName: ViewTemplate | string,
+    options: FixtureOptions = {}
+): Promise<Fixture<TElement>> {
+    if (typeof templateOrElementName === "string") {
+        const html = `<${templateOrElementName}></${templateOrElementName}>`;
+        templateOrElementName = new ViewTemplate(html, []);
+    }
+
+    const view = templateOrElementName.create();
+    const document = options.document || globalThis.document;
+    const parent = options.parent || document.createElement("div");
+    const source = options.source || {};
+    const context = options.context || defaultExecutionContext;
+    const element = findElement(view) as any;
+    let isConnected = false;
+
+    view.bind(source, context);
+    view.appendTo(parent);
+
+    customElements.upgrade(parent);
+
+    await Promise.resolve();
+
+    const connect = async () => {
+        if (isConnected) {
+            return;
+        }
+
+        isConnected = true;
+        document.body.appendChild(parent);
+        await Promise.resolve();
+    };
+
+    const disconnect = async () => {
+        if (!isConnected) {
+            return;
+        }
+
+        isConnected = false;
+        document.body.removeChild(parent);
+        await Promise.resolve();
+    };
+
+    return {
+        document,
+        template: templateOrElementName,
+        view,
+        parent,
+        element,
+        connect,
+        disconnect,
+    };
+}

--- a/packages/web-components/fast-foundation/src/utilities/composed-parent.spec.ts
+++ b/packages/web-components/fast-foundation/src/utilities/composed-parent.spec.ts
@@ -2,7 +2,7 @@ import { composedParent } from "./composed-parent";
 import { expect } from "chai";
 
 describe("The composedParent function", () => {
-    it("returns the parent of an an element, if it has one", () => {
+    it("returns the parent of an element, if it has one", () => {
         const parent = document.createElement("div");
         const child = document.createElement("div");
         parent.appendChild(child);


### PR DESCRIPTION
# Description

Creates a new `fixture` helper function to set up custom element tests. Also a `uniqueElementName` helper was added to facilitate generating unique element names for test scenarios.

## Motivation & context

We need some basic utilities to aid in testing web components, including creating them, binding them, and pushing them through their lifecycle, while being able to make assertions along the way.

See `fixture.spec.ts` for example usage.
This PR is dependent on APIs in this PR: https://github.com/microsoft/fast-dna/pull/3182

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

Note: I'll push another commit in a bit that adds code docs.

## Next Steps

After we get some usage of this within our components, I'd like to move this either to its own package, like `@microsoft/fast-testing` where we could also add other test helpers and make this available for the community to use.