### PR TITLE
fix: high contrast updates on checkbox, radio, switch and tabs, web components

### DIFF
--- a/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
@@ -91,7 +91,7 @@ export const CheckboxStyles = css`
     }
 
     :host(:enabled) .control:active {
-       background: var(--neutral-fill-input-active);
+        background: var(--neutral-fill-input-active);
         border-color: var(--neutral-outline-active);
     }
 
@@ -152,7 +152,7 @@ export const CheckboxStyles = css`
     neutralOutlineRestBehavior,
     forcedColorsStylesheetBehavior(
         css`
-            .control, .control:hover, .control:active {
+            .control {
                 forced-color-adjust: none;
                 border-color: ${SystemColors.FieldText};
                 background: ${SystemColors.Field};
@@ -163,24 +163,29 @@ export const CheckboxStyles = css`
             .indeterminate-indicator {
                 background: ${SystemColors.FieldText};
             }
+            :host(:enabled) .control:hover, .control:active {
+                border-color: ${SystemColors.Highlight};
+                background: ${SystemColors.Field};
+            }
             :host(:${focusVisible}) .control {
                 border-color: ${SystemColors.Highlight};
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host(.checked:${focusVisible}) .control {
-                border-color: ${SystemColors.FieldText};
-                box-shadow: 0 0 0 2px ${SystemColors.Field} inset;
+            :host(.checked:${focusVisible}:enabled) .control {
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
             :host(.checked) .control {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.Highlight};
             }
-            :host(.checked) .control:hover, .control:active {
+            :host(.checked:enabled) .control:hover, .control:active {
+                border-color: ${SystemColors.Highlight};
                 background: ${SystemColors.HighlightText};
             }
             :host(.checked) .checked-indicator {
                 fill: ${SystemColors.HighlightText};
             }
-            :host(.checked) .control:hover .checked-indicator {
+            :host(.checked:enabled) .control:hover .checked-indicator {
                 fill: ${SystemColors.Highlight}
             }
             :host(.checked) .indeterminate-indicator {

--- a/packages/web-components/fast-components/src/radio/radio.styles.ts
+++ b/packages/web-components/fast-components/src/radio/radio.styles.ts
@@ -147,15 +147,18 @@ export const RadioStyles = css`
     neutralOutlineRestBehavior,
     forcedColorsStylesheetBehavior(
         css`
-            .control, .control:hover, .control:active {
+            .control,
+            :host(.checked:enabled) .control {
                 forced-color-adjust: none;
                 border-color: ${SystemColors.FieldText};
                 background: ${SystemColors.Field};
             }
-            :host(:${focusVisible}) .control {
+            :host(:enabled) .control:hover {
                 border-color: ${SystemColors.Highlight};
+                background: ${SystemColors.Field};
             }
-            :host(.checked) .control:hover, .control:active {
+            :host(.checked:enabled) .control:hover,
+            :host(.checked:enabled) .control:active {
                 border-color: ${SystemColors.Highlight};
                 background: ${SystemColors.Highlight};
             }
@@ -163,9 +166,18 @@ export const RadioStyles = css`
                 background: ${SystemColors.Highlight};
                 fill: ${SystemColors.Highlight};
             }
-            :host(.checked) .control:hover .checked-indicator {
+            :host(.checked:enabled) .control:hover .checked-indicator,
+            :host(.checked:enabled) .control:active .checked-indicator {
                 background: ${SystemColors.HighlightText};
                 fill: ${SystemColors.HighlightText};
+            }
+            :host(:${focusVisible}) .control {
+                border-color: ${SystemColors.Highlight};
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
+            }
+            :host(.checked:${focusVisible}:enabled) .control {
+                border-color: ${SystemColors.Highlight};
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
             :host(.disabled) {
                 forced-color-adjust: none;

--- a/packages/web-components/fast-components/src/switch/switch.styles.ts
+++ b/packages/web-components/fast-components/src/switch/switch.styles.ts
@@ -173,31 +173,44 @@ export const SwitchStyles = css`
     neutralOutlineRestBehavior,
     forcedColorsStylesheetBehavior(
         css`
-            .checked-indicator {
+            .checked-indicator,
+            :host(:enabled) .switch:active .checked-indicator {
                 forced-color-adjust: none;
                 background: ${SystemColors.FieldText};
             }
-            .switch, .switch:hover, .switch:active {
+            .switch {
                 forced-color-adjust: none;
                 background: ${SystemColors.Field};
                 border-color: ${SystemColors.FieldText};
+            }
+            :host(:enabled) .switch:hover {
+                background: ${SystemColors.HighlightText};
+                border-color: ${SystemColors.Highlight};
             }
             :host(.checked) .switch {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.Highlight};
             }
+            :host(.checked:enabled) .switch:hover,
+            :host(:enabled) .switch:active {
+                background: ${SystemColors.HighlightText};
+                border-color: ${SystemColors.Highlight};
+            }
             :host(.checked) .checked-indicator {
                 background: ${SystemColors.HighlightText};
+            }
+            :host(.checked:enabled) .switch:hover .checked-indicator {
+                background: ${SystemColors.Highlight};
             }
             :host(.disabled) {
                 opacity: 1;
             }
             :host(:${focusVisible}) .switch {
                 border-color: ${SystemColors.Highlight};
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host(.checked:${focusVisible}) .switch {
-                border-color: ${SystemColors.FieldText};
-                box-shadow: 0 0 0 2px ${SystemColors.Field} inset;
+            :host(.checked:${focusVisible}:enabled) .switch {
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
             :host(.disabled) .checked-indicator {
                 background: ${SystemColors.GrayText};

--- a/packages/web-components/fast-components/src/tabs/tab/tab.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tab/tab.styles.ts
@@ -119,10 +119,19 @@ export const TabStyles = css`
                 forced-color-adjust: none;
                 border-color: transparent;
                 color: ${SystemColors.ButtonText};
+                fill: ${SystemColors.ButtonText};
             }
             :host(:hover),
-            :host(.vertical:hover) {
-                color: ${SystemColors.ButtonText};
+            :host(.vertical:hover),
+            :host([aria-selected="true"]:hover) {
+                background: ${SystemColors.Highlight};
+                color: ${SystemColors.HighlightText};
+                fill: ${SystemColors.HighlightText};
+            }
+            :host([aria-selected="true"]) {
+                background: ${SystemColors.HighlightText};
+                color: ${SystemColors.Highlight};
+                fill: ${SystemColors.Highlight};
             }
             :host(:${focusVisible}) {
                 border-color: ${SystemColors.ButtonText};


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Making sure the colors are correct, in high contrast mode, when the components are at rest, hover, selected, or focused.

## Motivation & context

The background was still showing accent when checked, the fix resolves this issue.
![checkbox-before-after](https://user-images.githubusercontent.com/37851220/82954299-4a92cc00-9f61-11ea-8476-8212fc13e016.jpg)
Add a box-shadow border around checkbox on focus, in both unchecked and checked states.
![checkbox-focused](https://user-images.githubusercontent.com/37851220/82954571-e4f30f80-9f61-11ea-8e3a-ad8a2b99d33e.jpg)

Fixed to remove accent color when the radio is selected. Also added a box-shadow border for focus state.
![radio-before-after](https://user-images.githubusercontent.com/37851220/82955094-ef61d900-9f62-11ea-8309-aa76994bb293.jpg)
![radio-focused](https://user-images.githubusercontent.com/37851220/82955102-f2f56000-9f62-11ea-80c7-b47565fb5dd0.jpg)

When the switch is set to on, you will see the accent color show up when hovering the switch component.
![switch-before-after](https://user-images.githubusercontent.com/37851220/82955456-bd9d4200-9f63-11ea-829d-5beb3a79afe6.jpg)
Also, add a box-shadow border.
![switch-focused](https://user-images.githubusercontent.com/37851220/82955491-d1e13f00-9f63-11ea-89f6-22001650c1b6.jpg)
for focus state.

The tab shows an accent and neutral fill color, when selected. The fix removes the background color and sets the foreground and fill to Highlight.
![tabs-before-after](https://user-images.githubusercontent.com/37851220/82956883-a4e25b80-9f66-11ea-8cd5-f9dc2e91cd6b.jpg)
When hovering over the tabs, the background is set to Highlight, and the foreground and fill colors are HighlightText.
![tabs-hover](https://user-images.githubusercontent.com/37851220/82956997-e5da7000-9f66-11ea-9083-936aed42346d.jpg)



## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->