### PR TITLE
fix: update high contrast on styles

### DIFF
--- a/packages/web-components/fast-components-msft/src/card/card.styles.ts
+++ b/packages/web-components/fast-components-msft/src/card/card.styles.ts
@@ -1,8 +1,6 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
-import { SystemColors } from "@microsoft/fast-web-utilities";
-import { forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
-import { elevation, neutralLayerCardBehavior } from "../styles";
+import { elevation } from "../styles";
 
 export const CardStyles = css`
     ${display("block")} :host {
@@ -15,16 +13,6 @@ export const CardStyles = css`
         background: var(--neutral-layer-card);
         border-radius: calc(var(--elevated-corner-radius) * 1px);
         ${elevation};
+        border: calc(var(--outline-width) * 1px) solid transparent;
     }
-`.withBehaviors(
-    neutralLayerCardBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            :host {
-                forced-color-adjust: none;
-                border: calc(var(--outline-width) * 1px) solid ${SystemColors.CanvasText};
-                background: ${SystemColors.Canvas};
-            }
-        `
-    )
-);
+`;

--- a/packages/web-components/fast-components-msft/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/fast-components-msft/src/checkbox/checkbox.styles.ts
@@ -121,9 +121,13 @@ export const CheckboxStyles = css`
     neutralOutlineRestBehavior,
     forcedColorsStylesheetBehavior(
         css`
-            .control, .control:hover, .control:active {
+            .control {
                 forced-color-adjust: none;
                 border-color: ${SystemColors.FieldText};
+                background: ${SystemColors.Field};
+            }
+            :host(:enabled) .control:hover, .control:active {
+                border-color: ${SystemColors.Highlight};
                 background: ${SystemColors.Field};
             }
             .checked-indicator {
@@ -134,10 +138,10 @@ export const CheckboxStyles = css`
             }
             :host(:${focusVisible}) .control {
                 border-color: ${SystemColors.Highlight};
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host(.checked:${focusVisible}) .control {
-                border-color: ${SystemColors.FieldText};
-                box-shadow: 0 0 0 2px ${SystemColors.Field} inset;
+            :host(.checked:${focusVisible}:enabled) .control {
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
             :host(.checked) .control {
                 background: ${SystemColors.Highlight};

--- a/packages/web-components/fast-components-msft/src/dialog/dialog.styles.ts
+++ b/packages/web-components/fast-components-msft/src/dialog/dialog.styles.ts
@@ -42,5 +42,6 @@ export const DialogStyles = css`
         height: var(--dialog-height);
         background: var(--background-color);
         z-index: 1;
+        border: calc(var(--outline-width) * 1px) solid transparent;
     }
 `;

--- a/packages/web-components/fast-components-msft/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components-msft/src/flipper/flipper.styles.ts
@@ -136,7 +136,8 @@ export const FlipperStyles = css`
             }
             :host(:${focusVisible})::before {
                 forced-color-adjust: none;
-                box-shadow: 0 0 0 2px ${SystemColors.ButtonText};
+                border-color: ${SystemColors.Highlight};
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
         `
     )

--- a/packages/web-components/fast-components-msft/src/radio/radio.styles.ts
+++ b/packages/web-components/fast-components-msft/src/radio/radio.styles.ts
@@ -119,15 +119,24 @@ export const RadioStyles = css`
     neutralOutlineRestBehavior,
     forcedColorsStylesheetBehavior(
         css`
-            .control, .control:hover, .control:active {
+            .control {
                 forced-color-adjust: none;
                 border-color: ${SystemColors.FieldText};
                 background: ${SystemColors.Field};
             }
+            :host(:enabled) .control:hover, .control:active {
+                border-color: ${SystemColors.Highlight};
+                background: ${SystemColors.Field};
+            }
             :host(:${focusVisible}) .control {
                 border-color: ${SystemColors.Highlight};
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host(.checked) .control:hover, .control:active {
+            :host(.checked:${focusVisible}:enabled) .control {
+                border-color: ${SystemColors.Highlight};
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
+            }
+            :host(.checked:enabled) .control:hover, .control:active {
                 border-color: ${SystemColors.Highlight};
                 background: ${SystemColors.Highlight};
             }

--- a/packages/web-components/fast-components-msft/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components-msft/src/slider/slider.styles.ts
@@ -135,7 +135,9 @@ export const SliderStyles = css`
                 background: ${SystemColors.FieldText};
             }
             :host(:${focusVisible}) .thumb-cursor {
+                background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.Highlight};
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
             :host(.disabled) {
                 opacity: 1;

--- a/packages/web-components/fast-components-msft/src/switch/switch.styles.ts
+++ b/packages/web-components/fast-components-msft/src/switch/switch.styles.ts
@@ -165,31 +165,44 @@ export const SwitchStyles = css`
     neutralOutlineRestBehavior,
     forcedColorsStylesheetBehavior(
         css`
-            .checked-indicator {
+            .checked-indicator,
+            :host(:enabled) .switch:active .checked-indicator {
                 forced-color-adjust: none;
                 background: ${SystemColors.FieldText};
             }
-            .switch, .switch:hover, .switch:active {
+            .switch {
                 forced-color-adjust: none;
                 background: ${SystemColors.Field};
                 border-color: ${SystemColors.FieldText};
+            }
+            :host(:enabled) .switch:hover {
+                background: ${SystemColors.HighlightText};
+                border-color: ${SystemColors.Highlight};
             }
             :host(.checked) .switch {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.Highlight};
             }
+            :host(.checked:enabled) .switch:hover,
+            :host(:enabled) .switch:active {
+                background: ${SystemColors.HighlightText};
+                border-color: ${SystemColors.Highlight};
+            }
             :host(.checked) .checked-indicator {
                 background: ${SystemColors.HighlightText};
             }
-            :host(.disabled) {
-                opacity: 1;
+            :host(.checked:enabled) .switch:hover .checked-indicator {
+                background: ${SystemColors.Highlight};
             }
             :host(:${focusVisible}) .switch {
                 border-color: ${SystemColors.Highlight};
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host(.checked:${focusVisible}) .switch {
-                border-color: ${SystemColors.FieldText};
-                box-shadow: 0 0 0 2px ${SystemColors.Field} inset;
+            :host(.checked:${focusVisible}:enabled) .switch {
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
+            }
+            :host(.disabled) {
+                opacity: 1;
             }
             :host(.disabled) .checked-indicator {
                 background: ${SystemColors.GrayText};

--- a/packages/web-components/fast-components-msft/src/tabs/tab/tab.styles.ts
+++ b/packages/web-components/fast-components-msft/src/tabs/tab/tab.styles.ts
@@ -86,10 +86,19 @@ export const TabStyles = css`
                 forced-color-adjust: none;
                 border-color: transparent;
                 color: ${SystemColors.ButtonText};
+                fill: ${SystemColors.ButtonText};
             }
             :host(:hover),
-            :host(.vertical:hover) {
-                color: ${SystemColors.ButtonText};
+            :host(.vertical:hover),
+            :host([aria-selected="true"]:hover) {
+                background: ${SystemColors.Highlight};
+                color: ${SystemColors.HighlightText};
+                fill: ${SystemColors.HighlightText};
+            }
+            :host([aria-selected="true"]) {
+                background: ${SystemColors.HighlightText};
+                color: ${SystemColors.Highlight};
+                fill: ${SystemColors.Highlight};
             }
             :host(:${focusVisible}) {
                 border-color: ${SystemColors.ButtonText};

--- a/packages/web-components/fast-components-msft/src/text-field/text-field.styles.ts
+++ b/packages/web-components/fast-components-msft/src/text-field/text-field.styles.ts
@@ -156,9 +156,12 @@ export const TextFieldStyles = css`
                 border-color: ${SystemColors.GrayText};
                 background: ${SystemColors.Field};
             }
-            :host(:focus-within) .root {
+            :host(:focus-within:enabled) .root {
                 border-color: ${SystemColors.Highlight};
                 box-shadow: 0 0 0 1px ${SystemColors.Highlight} inset;
+            }
+            .control {
+                color: ${SystemColors.ButtonText};
             }
         `
     )


### PR DESCRIPTION
…ipper, radio, slider, switch, tabs, and text-field

<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Fixes high contrast on the card, checkbox, dialog, flipper, radio, slider, switch, tabs, and text-field, components.

## Motivation & context

Fixed the white background on the checkbox component when hovered. 
![checkbox-msft-hover](https://user-images.githubusercontent.com/37851220/83076191-f7d11700-a029-11ea-9650-70336c0f8212.jpg)
Fixed the white background on the radio component when hovered. 
![radio-msft-hover](https://user-images.githubusercontent.com/37851220/83080195-70d46c80-a032-11ea-8a5e-182d68082616.jpg)
Fixed the issue on the switch control for both on/off state, to show the correct color when hovering.
![switch-msft-hover](https://user-images.githubusercontent.com/37851220/83080274-a37e6500-a032-11ea-8aa3-65a889a19a58.jpg)
The foreground on the read-only text field now shows the correct color.
![text-field-msft-read-only](https://user-images.githubusercontent.com/37851220/83080527-4c2cc480-a033-11ea-8c83-fc6777d607b4.jpg)
The tab content now changes to highlight when selected.
![tabs-msft-selected](https://user-images.githubusercontent.com/37851220/83080795-03294000-a034-11ea-97e3-7b36d24f405a.jpg)
Fixed the focus state on the thumb cursor in the slider component.
![slider-msft-thumb-focus](https://user-images.githubusercontent.com/37851220/83081273-1dafe900-a035-11ea-9f8d-570d91887748.jpg)
Fixed the focus state on the flipper component.
![flipper-msft-focus](https://user-images.githubusercontent.com/37851220/83081439-87c88e00-a035-11ea-98ca-0abece684b6e.jpg)
Add a transparent border on the main style of the dialog component, so we don't have to add a border in high contrast mode. The system will just change the border-color.
![dialog-msft-border](https://user-images.githubusercontent.com/37851220/83082154-73859080-a037-11ea-87c0-8fc7c6b4c416.jpg)

I also updated the border on the card component. Removed the additional work in high contrast and just set a transparent border on the Card style. The system will add the border color for us in high contrast.


## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->