### PR TITLE
fix: use the vscode values instead of enum in a web component attribute definition

### DIFF
--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.spec.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.spec.ts
@@ -1003,7 +1003,14 @@ describe("mapWebComponentDefinitionToJSONSchema", () => {
                                 description: attrDescription,
                                 type: DataType.string,
                                 default: "foobar",
-                                enum: attrEnum,
+                                values: [
+                                    {
+                                        name: attrEnum[0],
+                                    },
+                                    {
+                                        name: attrEnum[1],
+                                    },
+                                ],
                                 required: false,
                             },
                         ],

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.spec.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.spec.ts
@@ -1038,4 +1038,59 @@ describe("mapWebComponentDefinitionToJSONSchema", () => {
             },
         ]);
     });
+    test("should map an optional number enum in attributes to the enum in a JSON schema", () => {
+        const name: string = "foo";
+        const description: string = "foo tag";
+        const attrName: string = "attr";
+        const attrDescription: string = "An attribute";
+        const attrEnum: number[] = [1, 2];
+
+        expect(
+            mapWebComponentDefinitionToJSONSchema({
+                version: 1,
+                tags: [
+                    {
+                        name,
+                        description: "foo tag",
+                        attributes: [
+                            {
+                                name: attrName,
+                                description: attrDescription,
+                                type: DataType.number,
+                                default: "foobar",
+                                values: [
+                                    {
+                                        name: attrEnum[0].toString(),
+                                    },
+                                    {
+                                        name: attrEnum[1].toString(),
+                                    },
+                                ],
+                                required: false,
+                            },
+                        ],
+                        slots: [],
+                    },
+                ],
+            })
+        ).toEqual([
+            {
+                $schema: "http://json-schema.org/schema#",
+                $id: name,
+                id: name,
+                title: description,
+                type: "object",
+                version: 1,
+                [ReservedElementMappingKeyword.mapsToTagName]: name,
+                properties: {
+                    [attrName]: {
+                        [ReservedElementMappingKeyword.mapsToAttribute]: attrName,
+                        title: attrDescription,
+                        enum: attrEnum,
+                        type: DataType.number,
+                    },
+                },
+            },
+        ]);
+    });
 });

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.ts
@@ -366,12 +366,16 @@ function mapAttributesToJSONSchema(
 ): { [key: string]: any } {
     return attributes.reduce(
         (accumulation: { [key: string]: any }, attribute: WebComponentAttribute) => {
-            const optionalAttributeProperties: { enum?: string[] } = {};
+            const optionalAttributeProperties: { enum?: Array<string | number> } = {};
 
             if (attribute.values) {
-                optionalAttributeProperties.enum = attribute.values.map(attribute => {
-                    return attribute.name;
-                });
+                optionalAttributeProperties.enum = attribute.values.map(
+                    attributeValue => {
+                        return attribute.type === DataType.number
+                            ? parseInt(attributeValue.name, 10)
+                            : attributeValue.name;
+                    }
+                );
             }
 
             return {

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.ts
@@ -366,10 +366,12 @@ function mapAttributesToJSONSchema(
 ): { [key: string]: any } {
     return attributes.reduce(
         (accumulation: { [key: string]: any }, attribute: WebComponentAttribute) => {
-            const optionalAttributeProperties: Partial<WebComponentAttribute> = {};
+            const optionalAttributeProperties: { enum?: string[] } = {};
 
-            if (attribute.enum) {
-                optionalAttributeProperties.enum = attribute.enum;
+            if (attribute.values) {
+                optionalAttributeProperties.enum = attribute.values.map(attribute => {
+                    return attribute.name;
+                });
             }
 
             return {

--- a/packages/tooling/fast-tooling/src/data-utilities/web-component.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/web-component.ts
@@ -1,5 +1,12 @@
 import { DataType } from "./types";
 
+export interface WebComponentAttributeValues {
+    /**
+     * The value
+     */
+    name: string;
+}
+
 export interface WebComponentAttribute {
     /**
      * The name of the attribute
@@ -22,9 +29,9 @@ export interface WebComponentAttribute {
     default: any;
 
     /**
-     * The enum values if this is a set of values
+     * A list of values
      */
-    enum?: any[];
+    values?: WebComponentAttributeValues[];
 
     /**
      * Whether this was attribute is required


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Instead of using the JSON schema `enum` property this updates to use the `customData` format used by vscode seen [here](https://github.com/Microsoft/vscode-html-languageservice/blob/master/docs/customData.md).

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->