### PR TITLE
chore: fix React Components link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ FAST-DNA is a mono repository managed with [Lerna](https://github.com/lerna/lern
 ### Component Explorer
 ![CD - Component Explorer](https://github.com/microsoft/fast-dna/workflows/CD%20-%20Component%20Explorer/badge.svg?branch=master&event=push)
 
-Launch our [Component Explorer](https://explore.fast.design) to experience our [Microsoft React Components](https://github.com/microsoft/fast-dna/tree/master/packages/fast-components-react-msft) package and development tools.
+Launch our [Component Explorer](https://explore.fast.design) to experience our [Microsoft React Components](https://github.com/microsoft/fast-dna/tree/master/packages/react/fast-components-react-msft) package and development tools.
 
 View the [staging site](https://fast-explore-stage.azurewebsites.net/) to see unpublished changes currently staged for release in the master branch.
 


### PR DESCRIPTION
Hi, this just fix the Microsoft React Components link in the README.md. 