### PR TITLE
chore: add additional native element definitions to the site-utilities

### DIFF
--- a/sites/site-utilities/src/definitions/fast-components/index.ts
+++ b/sites/site-utilities/src/definitions/fast-components/index.ts
@@ -1,57 +1,22 @@
-import { fastAnchorDefinition } from "./fast-anchor.definition";
-export { fastAnchorDefinition };
-
-import { fastBadgeDefinition } from "./fast-badge.definition";
-export { fastBadgeDefinition };
-
-import { fastButtonDefinition } from "./fast-button.definition";
-export { fastButtonDefinition };
-
-import { fastCardDefinition } from "./fast-card.definition";
-export { fastCardDefinition };
-
-import { fastCheckboxDefinition } from "./fast-checkbox.definition";
-export { fastCheckboxDefinition };
-
-import { fastDialogDefinition } from "./fast-dialog.definition";
-export { fastDialogDefinition };
-
-import { fastDividerDefinition } from "./fast-divider.definition";
-export { fastDividerDefinition };
-
-import { fastFlipperDefinition } from "./fast-flipper.definition";
-export { fastFlipperDefinition };
-
-import { fastMenuDefinition } from "./fast-menu.definition";
-import { fastMenuItemDefinition } from "./fast-menu-item.definition";
-export { fastMenuDefinition, fastMenuItemDefinition };
-
-import { fastProgressDefinition } from "./fast-progress.definition";
-export { fastProgressDefinition };
-
-import { fastProgressRingDefinition } from "./fast-progress-ring.definition";
-export { fastProgressRingDefinition };
-
-import { fastRadioDefinition } from "./fast-radio.definition";
-export { fastRadioDefinition };
-
-import { fastRadioGroupDefinition } from "./fast-radio-group.definition";
-export { fastRadioGroupDefinition };
-
-import { fastSliderLabelDefinition } from "./fast-slider-label.definition";
-import { fastSliderDefinition } from "./fast-slider.definition";
-export { fastSliderLabelDefinition, fastSliderDefinition };
-
-import { fastSwitchDefinition } from "./fast-switch.definition";
-export { fastSwitchDefinition };
-
-import { fastTabDefinition } from "./fast-tab.definition";
-import { fastTabPanelDefinition } from "./fast-tab-panel.definition";
-import { fastTabsDefinition } from "./fast-tabs.definition";
-export { fastTabsDefinition, fastTabPanelDefinition, fastTabDefinition };
-
-import { fastTextAreaDefinition } from "./fast-text-area.definition";
-export { fastTextAreaDefinition };
-
-import { fastTextFieldDefinition } from "./fast-text-field.definition";
-export { fastTextFieldDefinition };
+export * from "./fast-anchor.definition";
+export * from "./fast-badge.definition";
+export * from "./fast-button.definition";
+export * from "./fast-card.definition";
+export * from "./fast-checkbox.definition";
+export * from "./fast-dialog.definition";
+export * from "./fast-divider.definition";
+export * from "./fast-flipper.definition";
+export * from "./fast-menu.definition";
+export * from "./fast-menu-item.definition";
+export * from "./fast-progress.definition";
+export * from "./fast-progress-ring.definition";
+export * from "./fast-radio.definition";
+export * from "./fast-radio-group.definition";
+export * from "./fast-slider-label.definition";
+export * from "./fast-slider.definition";
+export * from "./fast-switch.definition";
+export * from "./fast-tab.definition";
+export * from "./fast-tab-panel.definition";
+export * from "./fast-tabs.definition";
+export * from "./fast-text-area.definition";
+export * from "./fast-text-field.definition";

--- a/sites/site-utilities/src/definitions/native/heading.definition.ts
+++ b/sites/site-utilities/src/definitions/native/heading.definition.ts
@@ -1,0 +1,73 @@
+import { WebComponentDefinition } from "@microsoft/fast-tooling/dist/data-utilities/web-component";
+
+export const headingDefinition: WebComponentDefinition = {
+    version: 1,
+    tags: [
+        {
+            name: "h1",
+            description: "The heading element",
+            attributes: [],
+            slots: [
+                {
+                    name: "",
+                    description: "The default slot",
+                },
+            ],
+        },
+        {
+            name: "h2",
+            description: "The heading element",
+            attributes: [],
+            slots: [
+                {
+                    name: "",
+                    description: "The default slot",
+                },
+            ],
+        },
+        {
+            name: "h3",
+            description: "The heading element",
+            attributes: [],
+            slots: [
+                {
+                    name: "",
+                    description: "The default slot",
+                },
+            ],
+        },
+        {
+            name: "h4",
+            description: "The heading element",
+            attributes: [],
+            slots: [
+                {
+                    name: "",
+                    description: "The default slot",
+                },
+            ],
+        },
+        {
+            name: "h5",
+            description: "The heading element",
+            attributes: [],
+            slots: [
+                {
+                    name: "",
+                    description: "The default slot",
+                },
+            ],
+        },
+        {
+            name: "h6",
+            description: "The heading element",
+            attributes: [],
+            slots: [
+                {
+                    name: "",
+                    description: "The default slot",
+                },
+            ],
+        },
+    ],
+};

--- a/sites/site-utilities/src/definitions/native/image.definition.ts
+++ b/sites/site-utilities/src/definitions/native/image.definition.ts
@@ -1,12 +1,11 @@
 import { WebComponentDefinition } from "@microsoft/fast-tooling/dist/data-utilities/web-component";
 import { DataType } from "@microsoft/fast-tooling";
 
-export const imageId = "img";
 export const imageDefinition: WebComponentDefinition = {
     version: 1,
     tags: [
         {
-            name: imageId,
+            name: "img",
             description: "The image element",
             attributes: [
                 {

--- a/sites/site-utilities/src/definitions/native/index.ts
+++ b/sites/site-utilities/src/definitions/native/index.ts
@@ -1,5 +1,5 @@
-import { imageDefinition } from "./image.definition";
-export { imageDefinition };
-
-import { labelDefinition } from "./label.definition";
-export { labelDefinition };
+export * from "./heading.definition";
+export * from "./image.definition";
+export * from "./label.definition";
+export * from "./paragraph.definition";
+export * from "./span.definition";

--- a/sites/site-utilities/src/definitions/native/paragraph.definition.ts
+++ b/sites/site-utilities/src/definitions/native/paragraph.definition.ts
@@ -1,11 +1,11 @@
 import { WebComponentDefinition } from "@microsoft/fast-tooling/dist/data-utilities/web-component";
 
-export const labelDefinition: WebComponentDefinition = {
+export const paragraphDefinition: WebComponentDefinition = {
     version: 1,
     tags: [
         {
-            name: "label",
-            description: "The label element",
+            name: "p",
+            description: "The paragraph element",
             attributes: [],
             slots: [
                 {

--- a/sites/site-utilities/src/definitions/native/span.definition.ts
+++ b/sites/site-utilities/src/definitions/native/span.definition.ts
@@ -1,11 +1,11 @@
 import { WebComponentDefinition } from "@microsoft/fast-tooling/dist/data-utilities/web-component";
 
-export const labelDefinition: WebComponentDefinition = {
+export const spanDefinition: WebComponentDefinition = {
     version: 1,
     tags: [
         {
-            name: "label",
-            description: "The label element",
+            name: "span",
+            description: "The span element",
             attributes: [],
             slots: [
                 {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Adds the `<h1> - <h6>`, `<p>` and `<span>` elements to the `sites/site-utilities` definitions.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
This provides more native elements to use in the Component Explorer and Creator. It is very useful in cases where an element will not look right unless there is some text content inside it, such as `<fast-card>`.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->