### PR TITLE
fix: target slotted start and end elements in buttons

### DIFF
--- a/packages/web-components/fast-components-msft/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components-msft/src/styles/patterns/button.ts
@@ -51,21 +51,21 @@ export const BaseButtonStyles = css`
         opacity: var(--disabled-opacity);
     }
 
-    .start,
-    .end,
+    ::slotted([slot="start"]),
+    ::slotted([slot="end"]),
     ::slotted(svg) {
         ${
-            /* Glyph size and margin-left is temporary - 
+            /* Glyph size and margin-left is temporary -
             replace when adaptive typography is figured out */ ""
         } width: 16px;
         height: 16px;
     }
 
-    .start {
+    ::slotted([slot="start"]) {
         margin-inline-end: 11px;
     }
 
-    .end {
+    ::slotted([slot="end"]) {
         margin-inline-start: 11px;
     }
 `;
@@ -73,7 +73,7 @@ export const BaseButtonStyles = css`
 export const AccentButtonStyles = css`
     :host(.accent) .control {
         background: var(--accent-fill-rest);
-        color: var(--accent-foreground-cut-rest);  
+        color: var(--accent-foreground-cut-rest);
     }
 
     :host(.accent) .control:hover {

--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -51,21 +51,21 @@ export const BaseButtonStyles = css`
         opacity: var(--disabled-opacity);
     }
 
-    .start,
-    .end,
+    ::slotted([slot="start"]),
+    ::slotted([slot="end"]),
     ::slotted(svg) {
         ${
-            /* Glyph size and margin-left is temporary - 
+            /* Glyph size and margin-left is temporary -
             replace when adaptive typography is figured out */ ""
         } width: 16px;
         height: 16px;
     }
 
-    .start {
+    ::slotted([slot="start"]) {
         margin-inline-end: 11px;
     }
 
-    .end {
+    ::slotted([slot="end"]) {
         margin-inline-start: 11px;
     }
 `;
@@ -73,7 +73,7 @@ export const BaseButtonStyles = css`
 export const AccentButtonStyles = css`
     :host(.accent) .control {
         background: var(--accent-fill-rest);
-        color: var(--accent-foreground-cut-rest);  
+        color: var(--accent-foreground-cut-rest);
     }
 
     :host(.accent) .control:hover {


### PR DESCRIPTION
# Description
Anchors and buttons were getting empty 16x16 spans. This fix applies the sizing only when there's slotted content.

## Motivation & context
Buttons and anchors were incorrectly getting widened due to the presence of the extra space intended for start/end slots.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
