### PR TITLE
chore(web-components): add non-min script build

### DIFF
--- a/packages/web-components/fast-components-msft/rollup.config.js
+++ b/packages/web-components/fast-components-msft/rollup.config.js
@@ -23,6 +23,26 @@ export default [
                     },
                 },
             }),
+        ],
+    },
+    {
+        input: "src/index.ts",
+        output: [
+            {
+                file: "dist/fast-components-msft.min.js",
+                format: "esm",
+            },
+        ],
+        plugins: [
+            resolve(),
+            commonJS(),
+            typescript({
+                tsconfigOverride: {
+                    compilerOptions: {
+                        declaration: false,
+                    },
+                },
+            }),
             terser(),
             filesize(),
         ],

--- a/packages/web-components/fast-components/rollup.config.js
+++ b/packages/web-components/fast-components/rollup.config.js
@@ -23,6 +23,26 @@ export default [
                     },
                 },
             }),
+        ],
+    },
+    {
+        input: "src/index.ts",
+        output: [
+            {
+                file: "dist/fast-components.min.js",
+                format: "esm",
+            },
+        ],
+        plugins: [
+            resolve(),
+            commonJS(),
+            typescript({
+                tsconfigOverride: {
+                    compilerOptions: {
+                        declaration: false,
+                    },
+                },
+            }),
             terser(),
             filesize(),
         ],

--- a/packages/web-components/fast-element/rollup.config.js
+++ b/packages/web-components/fast-element/rollup.config.js
@@ -19,6 +19,24 @@ export default [
                     },
                 },
             }),
+        ],
+    },
+    {
+        input: "src/index.ts",
+        output: [
+            {
+                file: "dist/fast-element.min.js",
+                format: "esm",
+            },
+        ],
+        plugins: [
+            typescript({
+                tsconfigOverride: {
+                    compilerOptions: {
+                        declaration: false,
+                    },
+                },
+            }),
             terser(),
             filesize(),
         ],

--- a/packages/web-components/fast-foundation/rollup.config.js
+++ b/packages/web-components/fast-foundation/rollup.config.js
@@ -23,6 +23,26 @@ export default [
                     },
                 },
             }),
+        ],
+    },
+    {
+        input: "src/index.ts",
+        output: [
+            {
+                file: "dist/fast-foundation.min.js",
+                format: "esm",
+            },
+        ],
+        plugins: [
+            resolve(),
+            commonJS(),
+            typescript({
+                tsconfigOverride: {
+                    compilerOptions: {
+                        declaration: false,
+                    },
+                },
+            }),
             terser(),
             filesize(),
         ],


### PR DESCRIPTION
# Description

Add a non-minified script file output to all web components packages.

## Motivation & context

As part of the recent web components build improvements, we added a single file script build, so that customers could simply add a script tag to their page and begin using the components and building their own. As we discussed putting this on CDN we thought it would be nice to have both minified and non-minified versions available. Prior to this PR, the build only emitted minified versions. This PR updates each package to produce two script tag builds, a `.js` that is not minified and a `.min.js` that is.

## Issue type checklist

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

This is a breaking change to the script file name as the `.js` file was previously minified but after this PR is now non-minified, with the `.min.js` now being the minified version.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

