### PR TITLE
fix: overflow issue between 661px and 800px widths

### DIFF
--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
@@ -23,8 +23,8 @@ export const FastFrameStyles = css`
     }
 
     :host {
-				--gutter: 20;
-				max-width: 95vw;
+        --gutter: 20;
+        max-width: 95vw;
     }
 
     .icon {

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
@@ -24,7 +24,7 @@ export const FastFrameStyles = css`
 
     :host {
         --gutter: 20;
-        max-width: 95vw;
+        max-width: 94vw;
     }
 
     .icon {
@@ -329,6 +329,9 @@ export const FastFrameStyles = css`
     
     }
     @media screen and (max-width: 480px) {
+				:host {
+						max-width: 100vw;
+				}
         .preview {
             right: -88%;
             width: 70%;

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
@@ -23,7 +23,8 @@ export const FastFrameStyles = css`
     }
 
     :host {
-        --gutter: 20;
+				--gutter: 20;
+				max-width: 95vw;
     }
 
     .icon {

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
@@ -24,7 +24,7 @@ export const FastFrameStyles = css`
 
     :host {
         --gutter: 20;
-        max-width: 94vw;
+        max-width: 100vw;
     }
 
     .icon {
@@ -329,9 +329,6 @@ export const FastFrameStyles = css`
     
     }
     @media screen and (max-width: 480px) {
-				:host {
-						max-width: 100vw;
-				}
         .preview {
             right: -88%;
             width: 70%;

--- a/sites/fast-website/src/public/index.html
+++ b/sites/fast-website/src/public/index.html
@@ -50,7 +50,7 @@
           </div>
         </section>
 
-        <section class="section fast-frame-section" id="adaptive-ui">
+        <section class="fast-frame-section" id="adaptive-ui">
           <div class="section-content">
             <site-section-header class="fast-frame-header">
               <fast-badge slot="badge" class="section-badge">FLEXIBLE AND ADAPTABLE</fast-badge>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Added max-width of 95vw to fast-frame styles host.  Between 661px and 800px screen width there was an overflow issue that this resolves.

Before:
<img width="846" alt="Screen Shot 2020-06-05 at 9 45 36 AM" src="https://user-images.githubusercontent.com/26206206/83904054-0e572c80-a714-11ea-8a9f-a4512577ba63.png">
<img width="846" alt="Screen Shot 2020-06-05 at 9 45 52 AM" src="https://user-images.githubusercontent.com/26206206/83904064-157e3a80-a714-11ea-9b8c-053713d02eba.png">


After:
<img width="776" alt="Screen Shot 2020-06-05 at 5 05 33 PM" src="https://user-images.githubusercontent.com/26206206/83930979-2bf5b780-a74f-11ea-9470-bf85a8858f75.png">
<img width="776" alt="Screen Shot 2020-06-05 at 5 05 50 PM" src="https://user-images.githubusercontent.com/26206206/83930980-31eb9880-a74f-11ea-9ad5-2a409330f5fa.png">



## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->