### PR TITLE
fix(fast-element): generalize value converter and move out of beta

### DIFF
--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -37,12 +37,10 @@ export type AttributeConfiguration = {
 
 // @public
 export class AttributeDefinition implements Accessor {
-    // Warning: (ae-incompatible-release-tags) The symbol "__constructor" is marked as @public, but its signature references "ValueConverter" which is marked as @beta
     constructor(Owner: Function, name: string, attribute?: string, mode?: AttributeMode, converter?: ValueConverter);
     readonly attribute: string;
     // @internal
     static collect(Owner: Function, ...attributeLists: (ReadonlyArray<string | AttributeConfiguration> | undefined)[]): ReadonlyArray<AttributeDefinition>;
-    // Warning: (ae-incompatible-release-tags) The symbol "converter" is marked as @public, but its signature references "ValueConverter" which is marked as @beta
     readonly converter?: ValueConverter;
     getValue(source: HTMLElement): any;
     readonly mode: AttributeMode;
@@ -122,8 +120,6 @@ export interface BindingObserver<TSource = any, TReturn = any, TParent = any> ex
     observe(source: TSource, context: ExecutionContext): TReturn;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "booleanConverter" is marked as @public, but its signature references "ValueConverter" which is marked as @beta
-//
 // @public
 export const booleanConverter: ValueConverter;
 
@@ -333,8 +329,6 @@ export interface Notifier {
     unsubscribe(subscriber: Subscriber, propertyToUnwatch?: any): void;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "nullableNumberConverter" is marked as @public, but its signature references "ValueConverter" which is marked as @beta
-//
 // @public
 export const nullableNumberConverter: ValueConverter;
 
@@ -473,10 +467,10 @@ export interface SyntheticViewTemplate<TSource = any, TParent = any> {
 // @public
 export type TemplateValue<TScope, TParent = any> = Binding<TScope, any, TParent> | string | number | Directive | CaptureType<TScope>;
 
-// @beta
+// @public
 export interface ValueConverter {
-    fromView(value: string): any;
-    toView(value: any): string | null;
+    fromView(value: any): any;
+    toView(value: any): any;
 }
 
 // @public
@@ -502,7 +496,6 @@ export function when<TSource = any, TReturn = any>(binding: Binding<TSource, TRe
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/attributes.d.ts:40:5 - (ae-incompatible-release-tags) The symbol "converter" is marked as @public, but its signature references "ValueConverter" which is marked as @beta
 // dist/dts/dom.d.ts:17:5 - (ae-forgotten-export) The symbol "TrustedTypesPolicy" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-element/src/attributes.ts
+++ b/packages/web-components/fast-element/src/attributes.ts
@@ -3,23 +3,22 @@ import { DOM } from "./dom";
 import { Notifier } from "./observation/notifier";
 
 /**
- * Represents objects that can convert values to a string
- * acceptable by the DOM, or from a DOM string into a primitive
- * type appropriate for a property.
- * @beta
+ * Represents objects that can convert values to and from
+ * view or model representations.
+ * @public
  */
 export interface ValueConverter {
     /**
-     * Converts a value to a DOM string.
-     * @param value - The value to convert to a DOM string.
+     * Converts a value from its representation in the model, to a representation for the view.
+     * @param value - The value to convert to a view representation.
      */
-    toView(value: any): string | null;
+    toView(value: any): any;
 
     /**
-     * Converts a DOM string to a typed value.
-     * @param value - The DOM string to convert to a typed value.
+     * Converts a value from its representation in the view, to a representation for the model.
+     * @param value - The value to convert to a model representation.
      */
-    fromView(value: string): any;
+    fromView(value: any): any;
 }
 
 /**


### PR DESCRIPTION
# Description

This PR generalizes the input/output types of the `ValueConverter` interface so that it can be useful in other contexts, not just attribute definitions. One example I have is for use in a two-way binding feature that could be added in the future. This PR does not include such a feature, but simply generalizes the interface to allow for more scenarios. Code docs have been updated to reflect the change. This should be non-breaking as the types have been loosened.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.