### PR TITLE
fix(fast-element): seal the default execution context

### DIFF
--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -284,7 +284,7 @@ Observable.defineProperty(ExecutionContext.prototype, "length");
  * The default execution context used in binding expressions.
  * @public
  */
-export const defaultExecutionContext = new ExecutionContext();
+export const defaultExecutionContext = Object.seal(new ExecutionContext());
 
 /**
  * The signature of an arrow function capable of being evaluated


### PR DESCRIPTION
# Description

This PR invokes `Object.seal` on the `defaultExeuctionContext` so that its properties cannot be removed or reconfigured, and additional properties cannot be added. This will prevent intentional or unintentional alterations to the context which would affect all views across the system.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

Technically a breaking change, but not likely to affect anyone who isn't doing something they shouldn't be.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.