### PR TITLE
chore(web-components): add unpkg config for nicer cdn urls

### DIFF
--- a/packages/web-components/fast-components-msft/package.json
+++ b/packages/web-components/fast-components-msft/package.json
@@ -15,8 +15,9 @@
   "bugs": {
     "url": "https://github.com/Microsoft/fast-dna/issues/new/choose"
   },
-  "main": "./dist/esm/index.js",
-  "types": "./dist/fast-components-msft.d.ts",
+  "main": "dist/esm/index.js",
+  "types": "dist/fast-components-msft.d.ts",
+  "unpkg": "dist/fast-components-msft.min.js",
   "scripts": {
     "clean:dist": "node ../../../build/clean.js dist",
     "doc": "api-extractor run --local",

--- a/packages/web-components/fast-components/package.json
+++ b/packages/web-components/fast-components/package.json
@@ -15,8 +15,9 @@
   "bugs": {
     "url": "https://github.com/Microsoft/fast-dna/issues/new/choose"
   },
-  "main": "./dist/esm/index.js",
-  "types": "./dist/fast-components.d.ts",
+  "main": "dist/esm/index.js",
+  "types": "dist/fast-components.d.ts",
+  "unpkg": "dist/fast-components.min.js",
   "scripts": {
     "clean:dist": "node ../../../build/clean.js dist",
     "doc": "api-extractor run --local",

--- a/packages/web-components/fast-element/package.json
+++ b/packages/web-components/fast-element/package.json
@@ -15,8 +15,9 @@
   "bugs": {
     "url": "https://github.com/Microsoft/fast-dna/issues/new/choose"
   },
-  "main": "./dist/esm/index.js",
-  "types": "./dist/fast-element.d.ts",
+  "main": "dist/esm/index.js",
+  "types": "dist/fast-element.d.ts",
+  "unpkg": "dist/fast-element.min.js",
   "scripts": {
     "clean:dist": "node ../../../build/clean.js dist",
     "doc": "api-extractor run --local",

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -15,8 +15,9 @@
   "bugs": {
     "url": "https://github.com/Microsoft/fast-dna/issues/new/choose"
   },
-  "main": "./dist/esm/index.js",
-  "types": "./dist/fast-foundation.d.ts",
+  "main": "dist/esm/index.js",
+  "types": "dist/fast-foundation.d.ts",
+  "unpkg": "dist/fast-foundation.min.js",
   "scripts": {
     "clean:dist": "node ../../../build/clean.js dist",
     "doc": "api-extractor run --local",


### PR DESCRIPTION
# Description

Adds new configuration to the `package.json` files for web components that enable clean CDN URLs for the latest script-file builds of our libraries. This is leveraging [unpkg](https://unpkg.com/). The URLs will be as follows:

* https://unpkg.com/@microsoft/fast-element
* https://unpkg.com/@microsoft/fast-foundation
* https://unpkg.com/@microsoft/fast-components
* https://unpkg.com/@microsoft/fast-components-msft

## Issue type checklist

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.