### PR TITLE
fix: update progress from accent fill to accent foreground

### DIFF
--- a/packages/react/fast-components-styles-msft/src/progress/index.ts
+++ b/packages/react/fast-components-styles-msft/src/progress/index.ts
@@ -2,7 +2,7 @@ import { ComponentStyles } from "@microsoft/fast-jss-manager";
 import { ProgressClassNameContract } from "@microsoft/fast-components-class-name-contracts-msft";
 import { directionSwitch, format, multiply, toPx } from "@microsoft/fast-jss-utilities";
 import {
-    accentFillRest,
+    accentForegroundRest,
     neutralFillRest,
     neutralForegroundHint,
 } from "../utilities/color";
@@ -40,7 +40,7 @@ const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = {
             transition: "all 0.2s ease-in-out",
         },
         "& $progress_valueIndicator": {
-            stroke: accentFillRest,
+            stroke: accentForegroundRest,
             transform: directionSwitch("", "scale(1)"),
             [highContrastSelector]: {
                 stroke: HighContrastColor.buttonText,
@@ -88,7 +88,7 @@ const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = {
         width: toPx(multiply(heightNumber(), 2)),
     },
     progress_valueIndicator: {
-        background: accentFillRest,
+        background: accentForegroundRest,
         "border-radius": "100px",
         height: "100%",
         transition: "all 0.2s ease-in-out",
@@ -132,7 +132,7 @@ const styles: ComponentStyles<ProgressClassNameContract, DesignSystem> = {
         position: "absolute",
         opacity: "0",
         height: "100%",
-        "background-color": accentFillRest,
+        "background-color": accentForegroundRest,
         "border-radius": "100px",
         "animation-timing-function": "cubic-bezier(0.4, 0.0, 0.6, 1.0)",
         [highContrastSelector]: {

--- a/packages/web-components/fast-components-msft/src/progress/progress-ring/progress-ring.styles.ts
+++ b/packages/web-components/fast-components-msft/src/progress/progress-ring/progress-ring.styles.ts
@@ -2,7 +2,7 @@ import { css } from "@microsoft/fast-element";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import {
-    accentFillRestBehavior,
+    accentForegroundRestBehavior,
     heightNumber,
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
@@ -29,7 +29,7 @@ export const ProgressRingStyles = css`
     }
 
     .determinate {
-        stroke: ${accentFillRestBehavior.var};
+        stroke: ${accentForegroundRestBehavior.var};
         fill: none;
         stroke-width: 2px;
         stroke-linecap: round;
@@ -39,7 +39,7 @@ export const ProgressRingStyles = css`
     }
 
     .indeterminate-indicator-1 {
-        stroke: ${accentFillRestBehavior.var};
+        stroke: ${accentForegroundRestBehavior.var};
         fill: none;
         stroke-width: 2px;
         stroke-linecap: round;
@@ -73,7 +73,7 @@ export const ProgressRingStyles = css`
         }
     }
 `.withBehaviors(
-    accentFillRestBehavior,
+    accentForegroundRestBehavior,
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
     forcedColorsStylesheetBehavior(

--- a/packages/web-components/fast-components-msft/src/progress/progress/progress.styles.ts
+++ b/packages/web-components/fast-components-msft/src/progress/progress/progress.styles.ts
@@ -2,7 +2,7 @@ import { css } from "@microsoft/fast-element";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import {
-    accentFillRestBehavior,
+    accentForegroundRestBehavior,
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
 } from "../../styles";
@@ -26,7 +26,7 @@ export const ProgressStyles = css`
     }
 
     .determinate {
-        background-color: ${accentFillRestBehavior.var};
+        background-color: ${accentForegroundRestBehavior.var};
         border-radius: calc(var(--design-unit) * 1px);
         height: 100%;
         transition: all 0.2s ease-in-out;
@@ -46,7 +46,7 @@ export const ProgressStyles = css`
         position: absolute;
         opacity: 0;
         height: 100%;
-        background-color: ${accentFillRestBehavior.var};
+        background-color: ${accentForegroundRestBehavior.var};
         border-radius: calc(var(--design-unit) * 1px);
         animation-timing-function: cubic-bezier(0.4, 0.0, 0.6, 1.0);
         width: 40%;
@@ -57,7 +57,7 @@ export const ProgressStyles = css`
         position: absolute;
         opacity: 0;
         height: 100%;
-        background-color: ${accentFillRestBehavior.var};
+        background-color: ${accentForegroundRestBehavior.var};
         border-radius: calc(var(--design-unit) * 1px);
         animation-timing-function: cubic-bezier(0.4, 0.0, 0.6, 1.0);
         width: 60%;
@@ -109,7 +109,7 @@ export const ProgressStyles = css`
         },
     },
 `.withBehaviors(
-    accentFillRestBehavior,
+    accentForegroundRestBehavior,
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
     forcedColorsStylesheetBehavior(

--- a/packages/web-components/fast-components/src/progress/progress-ring/progress-ring.styles.ts
+++ b/packages/web-components/fast-components/src/progress/progress-ring/progress-ring.styles.ts
@@ -2,7 +2,7 @@ import { css } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
-    accentFillRestBehavior,
+    accentForegroundRestBehavior,
     heightNumber,
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
@@ -29,7 +29,7 @@ export const ProgressRingStyles = css`
     }
 
     .determinate {
-        stroke: ${accentFillRestBehavior.var};
+        stroke: ${accentForegroundRestBehavior.var};
         fill: none;
         stroke-width: 2px;
         stroke-linecap: round;
@@ -39,7 +39,7 @@ export const ProgressRingStyles = css`
     }
 
     .indeterminate-indicator-1 {
-        stroke: ${accentFillRestBehavior.var};
+        stroke: ${accentForegroundRestBehavior.var};
         fill: none;
         stroke-width: 2px;
         stroke-linecap: round;
@@ -73,7 +73,7 @@ export const ProgressRingStyles = css`
         }
     }
 `.withBehaviors(
-    accentFillRestBehavior,
+    accentForegroundRestBehavior,
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
     forcedColorsStylesheetBehavior(

--- a/packages/web-components/fast-components/src/progress/progress/progress.styles.ts
+++ b/packages/web-components/fast-components/src/progress/progress/progress.styles.ts
@@ -2,7 +2,7 @@ import { css } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
-    accentFillRestBehavior,
+    accentForegroundRestBehavior,
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
 } from "../../styles/index";
@@ -26,7 +26,7 @@ export const ProgressStyles = css`
     }
 
     .determinate {
-        background-color: ${accentFillRestBehavior.var};
+        background-color: ${accentForegroundRestBehavior.var};
         border-radius: calc(var(--design-unit) * 1px);
         height: 100%;
         transition: all 0.2s ease-in-out;
@@ -46,7 +46,7 @@ export const ProgressStyles = css`
         position: absolute;
         opacity: 0;
         height: 100%;
-        background-color: ${accentFillRestBehavior.var};
+        background-color: ${accentForegroundRestBehavior.var};
         border-radius: calc(var(--design-unit) * 1px);
         animation-timing-function: cubic-bezier(0.4, 0.0, 0.6, 1.0);
         width: 40%;
@@ -57,7 +57,7 @@ export const ProgressStyles = css`
         position: absolute;
         opacity: 0;
         height: 100%;
-        background-color: ${accentFillRestBehavior.var};
+        background-color: ${accentForegroundRestBehavior.var};
         border-radius: calc(var(--design-unit) * 1px);
         animation-timing-function: cubic-bezier(0.4, 0.0, 0.6, 1.0);
         width: 60%;
@@ -109,7 +109,7 @@ export const ProgressStyles = css`
         },
     },
 `.withBehaviors(
-    accentFillRestBehavior,
+    accentForegroundRestBehavior,
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
     forcedColorsStylesheetBehavior(


### PR DESCRIPTION
# Description

Updated progress from accent fill to accent foreground.

## Motivation & context

In dark mode the wrong accent color was used, resulting in low contrast and failing accessibility tests.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast-dna/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast-dna/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->