### PR TITLE
fix: screen reader for anchors and buttons and tab focus inside fast-frame component 

### DIFF
--- a/sites/fast-website/src/app/components/content-placement-container/templates/feature.template.ts
+++ b/sites/fast-website/src/app/components/content-placement-container/templates/feature.template.ts
@@ -3,10 +3,18 @@ import { html } from "@microsoft/fast-element";
 const featureTemplate = html`<site-feature-card>
     <h4>${x => x.header}</h4>
     <p slot="body">${x => x.body}</p>
-    <fast-anchor slot="footer" href=${x => x.githubLink} appearance="lightweight"
+    <fast-anchor
+        slot="footer"
+        href=${x => x.githubLink}
+        appearance="lightweight"
+        aria-label=${x => x.header}
         >View Github</fast-anchor
     >
-    <fast-anchor slot="footer" href=${x => x.documentationLink} appearance="lightweight"
+    <fast-anchor
+        slot="footer"
+        href=${x => x.documentationLink}
+        appearance="lightweight"
+        aria-label=${x => x.header}
         >Read Documentation</fast-anchor
     >
 </site-feature-card> `;

--- a/sites/fast-website/src/app/components/content-placement-container/templates/feature.template.ts
+++ b/sites/fast-website/src/app/components/content-placement-container/templates/feature.template.ts
@@ -3,18 +3,10 @@ import { html } from "@microsoft/fast-element";
 const featureTemplate = html`<site-feature-card>
     <h4>${x => x.header}</h4>
     <p slot="body">${x => x.body}</p>
-    <fast-anchor
-        slot="footer"
-        href=${x => x.githubLink}
-        appearance="lightweight"
-        aria-label=${x => x.header}
+    <fast-anchor slot="footer" href=${x => x.githubLink} appearance="lightweight"
         >View Github</fast-anchor
     >
-    <fast-anchor
-        slot="footer"
-        href=${x => x.documentationLink}
-        appearance="lightweight"
-        aria-label=${x => x.header}
+    <fast-anchor slot="footer" href=${x => x.documentationLink} appearance="lightweight"
         >Read Documentation</fast-anchor
     >
 </site-feature-card> `;

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -63,6 +63,7 @@ export const FastFrameTemplate = html<FastFrame>`
 
                                     html<string>`
                                         <site-color-swatch
+                                            tabindex="0"
                                             value="${x => x}"
                                             background-color="${x => x}"
                                             checked="${(x, c) =>
@@ -84,6 +85,7 @@ export const FastFrameTemplate = html<FastFrame>`
 
                                     html<string>`
                                         <site-color-swatch
+                                            tabindex="0"
                                             value="${x => x}"
                                             background-color="${x => x}"
                                             checked="${(x, c) =>
@@ -255,7 +257,7 @@ export const FastFrameTemplate = html<FastFrame>`
                                     position="0"
                                 >
                                     0
-                                </fast-slider-label>            
+                                </fast-slider-label>
                                 <fast-slider-label
                                     hide-mark
                                     position="6"
@@ -329,11 +331,11 @@ export const FastFrameTemplate = html<FastFrame>`
                     </div>
                 </fast-card>
                 <div
-                    aria-hidden="${x => !x.expanded}"
                     class="preview-controls"
                 >
                     <fast-progress></fast-progress>
-                    <fast-menu tabIndex="${x => (x.expanded ? "0" : "-1")}">
+                    <fast-menu tabIndex="${x =>
+                        !x.expanded && x.isResponsive ? "-1" : "0"}">
                         <fast-menu-item role="menuitem">Menu item 1</fast-menu-item>
                         <fast-menu-item role="menuitem">Menu item 2</fast-menu-item>
                         <fast-menu-item role="menuitem">Menu item 3</fast-menu-item>
@@ -343,39 +345,44 @@ export const FastFrameTemplate = html<FastFrame>`
                     <div class="control-container">
                         <div class="control-container-column">
                             <fast-radio tabIndex="${x =>
-                                x.expanded ? "0" : "-1"}">Radio 1</fast-radio>
+                                !x.expanded && x.isResponsive
+                                    ? "-1"
+                                    : "0"}">Radio 1</fast-radio>
                             <fast-radio tabIndex="${x =>
-                                x.expanded ? "0" : "-1"}">Radio 2</fast-radio>
+                                !x.expanded && x.isResponsive
+                                    ? "-1"
+                                    : "0"}">Radio 2</fast-radio>
                         </div>
                         <div class="control-container-grid">
                             <fast-switch tabIndex="${x =>
-                                x.expanded ? "0" : "-1"}"></fast-switch>
+                                !x.expanded && x.isResponsive
+                                    ? "-1"
+                                    : "0"}"></fast-switch>
                             <p>Toggle</p>
                             <fast-checkbox tabIndex="${x =>
-                                x.expanded
-                                    ? "0"
-                                    : "-1"}" class="checkbox"></fast-checkbox>
+                                !x.expanded && x.isResponsive
+                                    ? "-1"
+                                    : "0"}" class="checkbox"></fast-checkbox>
                             <p class="checkbox-label">Checkbox</p>
                         </div>
                     </div>
                     <fast-text-field placeholder="Text field" tabIndex="${x =>
-                        x.expanded ? "0" : "-1"}"></fast-text-field>
+                        !x.expanded && x.isResponsive ? "-1" : "0"}"></fast-text-field>
                     <div class="control-container-2">
                         <fast-slider tabIndex="${x =>
-                            x.expanded ? "0" : "-1"}"></fast-slider>
-                        <fast-flipper aria-hidden="false" tabIndex="${x =>
-                            x.expanded ? "0" : "-1"}"></fast-flipper>
-                        <fast-flipper disabled tabIndex="${x =>
-                            x.expanded ? "0" : "-1"}"></fast-flipper>
+                            !x.expanded && x.isResponsive ? "-1" : "0"}"></fast-slider>
+                        <fast-flipper aria-label="Example 'flipper' button" tabIndex="${x =>
+                            !x.expanded && x.isResponsive ? "-1" : "0"}"></fast-flipper>
+                        <fast-flipper disabled aria-label="Example disabled 'flipper' button"></fast-flipper>
                     </div>
                     <div class="control-container">
-                        <fast-button appearance="accent" tabIndex="${x =>
-                            x.expanded ? "0" : "-1"}">
+                        <fast-button appearance="accent" aria-label="Example 'download' button" tabIndex="${x =>
+                            !x.expanded && x.isResponsive ? "-1" : "0"}">
                             Button
                             <span slot="start">${DownloadIcon}</span>
                         </fast-button>
-                        <fast-button appearance="neutral" tabIndex="${x =>
-                            x.expanded ? "0" : "-1"}">
+                        <fast-button appearance="neutral" aria-label="Example 'play' button" tabIndex="${x =>
+                            !x.expanded && x.isResponsive ? "-1" : "0"}">
                             Button
                             <span slot="start">${PlayIcon}</span>
                         </fast-button>

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -334,7 +334,7 @@ export const FastFrameTemplate = html<FastFrame>`
                     class="preview-controls"
                 >
                     <fast-progress></fast-progress>
-                    <fast-menu tabIndex="${x =>
+                    <fast-menu tabindex="${x =>
                         !x.expanded && x.isResponsive ? "-1" : "0"}">
                         <fast-menu-item role="menuitem">Menu item 1</fast-menu-item>
                         <fast-menu-item role="menuitem">Menu item 2</fast-menu-item>
@@ -344,44 +344,43 @@ export const FastFrameTemplate = html<FastFrame>`
                     </fast-menu>
                     <div class="control-container">
                         <div class="control-container-column">
-                            <fast-radio tabIndex="${x =>
+                            <fast-radio tabindex="${x =>
                                 !x.expanded && x.isResponsive
                                     ? "-1"
                                     : "0"}">Radio 1</fast-radio>
-                            <fast-radio tabIndex="${x =>
+                            <fast-radio tabindex="${x =>
                                 !x.expanded && x.isResponsive
                                     ? "-1"
                                     : "0"}">Radio 2</fast-radio>
                         </div>
                         <div class="control-container-grid">
-                            <fast-switch tabIndex="${x =>
+                            <fast-switch tabindex="${x =>
                                 !x.expanded && x.isResponsive
                                     ? "-1"
                                     : "0"}"></fast-switch>
                             <p>Toggle</p>
-                            <fast-checkbox tabIndex="${x =>
+                            <fast-checkbox tabindex="${x =>
                                 !x.expanded && x.isResponsive
                                     ? "-1"
                                     : "0"}" class="checkbox"></fast-checkbox>
                             <p class="checkbox-label">Checkbox</p>
                         </div>
                     </div>
-                    <fast-text-field placeholder="Text field" tabIndex="${x =>
+                    <fast-text-field placeholder="Text field" tabindex="${x =>
                         !x.expanded && x.isResponsive ? "-1" : "0"}"></fast-text-field>
                     <div class="control-container-2">
-                        <fast-slider tabIndex="${x =>
+                        <fast-slider tabindex="${x =>
                             !x.expanded && x.isResponsive ? "-1" : "0"}"></fast-slider>
-                        <fast-flipper aria-label="Example 'flipper' button" tabIndex="${x =>
-                            !x.expanded && x.isResponsive ? "-1" : "0"}"></fast-flipper>
-                        <fast-flipper disabled aria-label="Example disabled 'flipper' button"></fast-flipper>
+                        <fast-flipper></fast-flipper>
+                        <fast-flipper disabled></fast-flipper>
                     </div>
                     <div class="control-container">
-                        <fast-button appearance="accent" aria-label="Example 'download' button" tabIndex="${x =>
+                        <fast-button appearance="accent" aria-label="Example 'download' button" tabindex="${x =>
                             !x.expanded && x.isResponsive ? "-1" : "0"}">
                             Button
                             <span slot="start">${DownloadIcon}</span>
                         </fast-button>
-                        <fast-button appearance="neutral" aria-label="Example 'play' button" tabIndex="${x =>
+                        <fast-button appearance="neutral" aria-label="Example 'play' button" tabindex="${x =>
                             !x.expanded && x.isResponsive ? "-1" : "0"}">
                             Button
                             <span slot="start">${PlayIcon}</span>

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -334,8 +334,7 @@ export const FastFrameTemplate = html<FastFrame>`
                     class="preview-controls"
                 >
                     <fast-progress></fast-progress>
-                    <fast-menu tabindex="${x =>
-                        !x.expanded && x.isResponsive ? "-1" : "0"}">
+                    <fast-menu tabindex="${x => x.setTabIndex()}">
                         <fast-menu-item role="menuitem">Menu item 1</fast-menu-item>
                         <fast-menu-item role="menuitem">Menu item 2</fast-menu-item>
                         <fast-menu-item role="menuitem">Menu item 3</fast-menu-item>
@@ -345,43 +344,33 @@ export const FastFrameTemplate = html<FastFrame>`
                     <div class="control-container">
                         <div class="control-container-column">
                             <fast-radio tabindex="${x =>
-                                !x.expanded && x.isResponsive
-                                    ? "-1"
-                                    : "0"}">Radio 1</fast-radio>
+                                x.setTabIndex()}">Radio 1</fast-radio>
                             <fast-radio tabindex="${x =>
-                                !x.expanded && x.isResponsive
-                                    ? "-1"
-                                    : "0"}">Radio 2</fast-radio>
+                                x.setTabIndex()}">Radio 2</fast-radio>
                         </div>
                         <div class="control-container-grid">
-                            <fast-switch tabindex="${x =>
-                                !x.expanded && x.isResponsive
-                                    ? "-1"
-                                    : "0"}"></fast-switch>
+                            <fast-switch tabindex="${x => x.setTabIndex()}"></fast-switch>
                             <p>Toggle</p>
                             <fast-checkbox tabindex="${x =>
-                                !x.expanded && x.isResponsive
-                                    ? "-1"
-                                    : "0"}" class="checkbox"></fast-checkbox>
+                                x.setTabIndex()}" class="checkbox"></fast-checkbox>
                             <p class="checkbox-label">Checkbox</p>
                         </div>
                     </div>
                     <fast-text-field placeholder="Text field" tabindex="${x =>
-                        !x.expanded && x.isResponsive ? "-1" : "0"}"></fast-text-field>
+                        x.setTabIndex()}"></fast-text-field>
                     <div class="control-container-2">
-                        <fast-slider tabindex="${x =>
-                            !x.expanded && x.isResponsive ? "-1" : "0"}"></fast-slider>
+                        <fast-slider tabindex="${x => x.setTabIndex()}"></fast-slider>
                         <fast-flipper></fast-flipper>
                         <fast-flipper disabled></fast-flipper>
                     </div>
                     <div class="control-container">
                         <fast-button appearance="accent" aria-label="Example 'download' button" tabindex="${x =>
-                            !x.expanded && x.isResponsive ? "-1" : "0"}">
+                            x.setTabIndex()}">
                             Button
                             <span slot="start">${DownloadIcon}</span>
                         </fast-button>
                         <fast-button appearance="neutral" aria-label="Example 'play' button" tabindex="${x =>
-                            !x.expanded && x.isResponsive ? "-1" : "0"}">
+                            x.setTabIndex()}">
                             Button
                             <span slot="start">${PlayIcon}</span>
                         </fast-button>

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
@@ -74,6 +74,9 @@ export class FastFrame extends FASTElement {
     @observable
     public expanded: boolean;
 
+    @observable
+    public isResponsive: boolean = false;
+
     public accentChangeHandler = (e: CustomEvent): void => {
         if (e.target instanceof SiteColorSwatch) {
             if (e.target.checked) {
@@ -170,8 +173,8 @@ export class FastFrame extends FASTElement {
         this.backgroundColor = this.previewBackgroundPalette[this.lastSelectedIndex];
     };
 
-    private resetExpanded = (): void => {
-        this.expanded = false;
+    private resetExpandedResponsive = (): void => {
+        (this.expanded = false), (this.isResponsive = !this.isResponsive);
     };
 
     constructor() {
@@ -184,6 +187,6 @@ export class FastFrame extends FASTElement {
 
         window
             .matchMedia(`(max-width: ${drawerBreakpoint})`)
-            .addListener(this.resetExpanded);
+            .addListener(this.resetExpandedResponsive);
     }
 }

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
@@ -41,6 +41,8 @@ export class FastFrame extends FASTElement {
 
     private darkPallette: string[] = this.previewBackgroundPalette;
 
+    private mql: MediaQueryList = window.matchMedia(`(max-width: ${drawerBreakpoint})`);
+
     @observable
     public lastSelectedIndex: number = 0;
 
@@ -72,10 +74,10 @@ export class FastFrame extends FASTElement {
     public lightness: number;
 
     @observable
-    public expanded: boolean;
+    public expanded: boolean = false;
 
     @observable
-    public isResponsive: boolean = false;
+    public isMobile: boolean = this.mql.matches;
 
     public accentChangeHandler = (e: CustomEvent): void => {
         if (e.target instanceof SiteColorSwatch) {
@@ -173,9 +175,12 @@ export class FastFrame extends FASTElement {
         this.backgroundColor = this.previewBackgroundPalette[this.lastSelectedIndex];
     };
 
-    private resetExpandedResponsive = (): void => {
-        (this.expanded = false), (this.isResponsive = !this.isResponsive);
+    private resetExpandedResponsive = (e): void => {
+        this.expanded = false;
+        this.isMobile = e.matches;
     };
+
+    public setTabIndex = (): string => (!this.expanded && this.isMobile ? "-1" : "0");
 
     constructor() {
         super();
@@ -185,8 +190,6 @@ export class FastFrame extends FASTElement {
         this.saturation = accentColorHSL.s;
         this.lightness = accentColorHSL.l;
 
-        window
-            .matchMedia(`(max-width: ${drawerBreakpoint})`)
-            .addListener(this.resetExpandedResponsive);
+        this.mql.addListener(this.resetExpandedResponsive);
     }
 }

--- a/sites/fast-website/src/app/components/side-navigation/side-navigation.template.ts
+++ b/sites/fast-website/src/app/components/side-navigation/side-navigation.template.ts
@@ -14,7 +14,7 @@ export const SideNavigationTemplate = html<SideNavigation>`
                                 href=${x => x.actionLink}
                                 appearance="lightweight"
                                 :innerHTML=${x => x.icon}
-                                aria-label=${x => x.header}
+                                aria-label=${x => x.actionText}
                             ></fast-anchor>
                         </li>
                     `

--- a/sites/fast-website/src/app/components/side-navigation/side-navigation.template.ts
+++ b/sites/fast-website/src/app/components/side-navigation/side-navigation.template.ts
@@ -14,6 +14,7 @@ export const SideNavigationTemplate = html<SideNavigation>`
                                 href=${x => x.actionLink}
                                 appearance="lightweight"
                                 :innerHTML=${x => x.icon}
+                                aria-label=${x => x.header}
                             ></fast-anchor>
                         </li>
                     `

--- a/sites/fast-website/src/app/data/community.data.ts
+++ b/sites/fast-website/src/app/data/community.data.ts
@@ -38,7 +38,7 @@ export const communityContentPlacementData: CommunityContentPlacementData[] = [
     },
     {
         actionLink: "https://medium.com/fast-dna",
-        actionText: "Follow us on Medium",
+        actionText: "Read more on Medium",
         header: "Medium",
         icon: MediumIcon,
     },

--- a/sites/fast-website/src/app/data/community.data.ts
+++ b/sites/fast-website/src/app/data/community.data.ts
@@ -38,6 +38,7 @@ export const communityContentPlacementData: CommunityContentPlacementData[] = [
     },
     {
         actionLink: "https://medium.com/fast-dna",
+        actionText: "Follow us on Medium",
         header: "Medium",
         icon: MediumIcon,
     },


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

While using screen readers like VoiceOver, Narrator, and NVDA, and tabbing onto anchors and buttons, that only have icons, the screen readers only read out 'link'. I went through and added aria-label on any anchors and buttons that only displays an icon.
When tabbing through the fast-frame component, while in full screen, I was unable to tab into the controls in the last column, because they were set to tabIndex="-1". I added an isResponsive observable that will toggle the tabIndex between the full and mobile size window.
Also set tabIndex="0" on the color swatch item.

Known issue that I will tackle separately as to not hold up these changes. They could be changes that have to be made within the components.

Running NVDA, the aria-label does not get read on the anchor and button components.
NVDA and Narrator do not read out the fast-text-field component when aria-label is added. The only time it will read the aria-label is when a value is set to it.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast-dna/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast-dna/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->