### PR TITLE
fix(fast-element): default event handler behavior should be no capture

### DIFF
--- a/packages/web-components/fast-element/src/directives/binding.ts
+++ b/packages/web-components/fast-element/src/directives/binding.ts
@@ -32,7 +32,7 @@ function triggerBind(
 ): void {
     this.source = source;
     this.context = context;
-    this.target.addEventListener(this.targetName!, this, true);
+    this.target.addEventListener(this.targetName!, this);
 }
 
 function normalUnbind(this: BindingBehavior): void {
@@ -60,7 +60,7 @@ function contentUnbind(this: BindingBehavior): void {
 }
 
 function triggerUnbind(this: BindingBehavior): void {
-    this.target.removeEventListener(this.targetName!, this, true);
+    this.target.removeEventListener(this.targetName!, this);
     this.source = null;
     this.context = null;
 }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Super quick fix to change the default event listener behavior to not capture (this was an oopsie on my part). I'll circle back around and add more tests to binding in general when some time opens up.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**

This is technically a breaking change.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.