### PR TITLE
fix: selected tab becoming undefined when tab slot pass anything except icon or text node

### DIFF
--- a/packages/web-components/fast-components-msft/src/tabs/fixtures/tabs.html
+++ b/packages/web-components/fast-components-msft/src/tabs/fixtures/tabs.html
@@ -31,7 +31,7 @@
             Tab three content. This is for testing.
         </fast-tab-panel>
     </fast-tabs>
-    <h4>Suplemental content</h4>
+    <h4>Supplemental content</h4>
     <fast-tabs>
         <div slot="start">
             <button>1</button>
@@ -56,7 +56,7 @@
             Tab three content. This is for testing.
         </fast-tab-panel>
     </fast-tabs>
-    <h4>Suplemental content - Vertical</h4>
+    <h4>Supplemental content - Vertical</h4>
     <fast-tabs orientation="vertical">
         <div slot="start">
             <button>1</button>

--- a/packages/web-components/fast-components/src/tabs/fixtures/base.html
+++ b/packages/web-components/fast-components/src/tabs/fixtures/base.html
@@ -36,6 +36,21 @@
             Tab three content. This is for testing.
         </fast-tab-panel>
     </fast-tabs>
+    <h4>Div and Paragraph Elements in Tab</h4>
+    <fast-tabs>
+        <fast-tab id="TabOne">Tab one</fast-tab>
+        <fast-tab id="TabTwo"><p class="element-tab">div tab</p></fast-tab>
+        <fast-tab id="TabThree"><div class="element-tab">paragraph tab</div></fast-tab>
+        <fast-tab-panel>
+            Tab one content. This is for testing.
+        </fast-tab-panel>
+        <fast-tab-panel>
+            Tab two content. This is for testing.
+        </fast-tab-panel>
+        <fast-tab-panel>
+            Tab three content. This is for testing.
+        </fast-tab-panel>
+    </fast-tabs>
     <h4>Icons - horizontal</h4>
     <fast-tabs id="myTab" activeId="TabTwo">
         <fast-tab>
@@ -91,7 +106,7 @@
             Tab three content. This is for testing.
         </fast-tab-panel>
     </fast-tabs>
-    <h4>Suplemental content</h4>
+    <h4>Supplemental content</h4>
     <fast-tabs>
         <div slot="start">
             <button>1</button>
@@ -116,7 +131,7 @@
             Tab three content. This is for testing.
         </fast-tab-panel>
     </fast-tabs>
-    <h4>Suplemental content - Vertical</h4>
+    <h4>Supplemental content - Vertical</h4>
     <fast-tabs orientation="vertical">
         <div slot="start">
             <button>1</button>

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -208,7 +208,7 @@ export class Tabs extends FASTElement {
     }
 
     private handleTabClick = (event: MouseEvent): void => {
-        const selectedTab = event.target as HTMLElement;
+        const selectedTab = event.currentTarget as HTMLElement;
         this.prevActiveTabIndex = this.activeTabIndex;
         this.activeTabIndex = Array.from(this.tabs).indexOf(selectedTab);
         if (selectedTab.nodeType === 1) {


### PR DESCRIPTION

<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
-Updated selectedTab to be the `event.currentTarget` to ensure the selected tab is always an existing tab so the activeid does not become undefined.
-Added fixture example to check for this

## Motivation & context

<!--- What problem does this change solve? -->
Solves the issue of any element except a text node or icon being passed to the tabs causes the tabs to switch to  the first tab even when selecting the other tabs.

Before:
![Screen-Recording-2020-06-22-at-9](https://user-images.githubusercontent.com/31681651/85317166-cd307d80-b472-11ea-9a9f-967b0e5142b7.gif)

After:
![Screen-Recording-2020-06-22-at-1](https://user-images.githubusercontent.com/31681651/85317324-1254af80-b473-11ea-875b-5c6100994003.gif)

<!--- Provide a link if you are addressing an open issue. -->
closes #3349 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast-dna/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast-dna/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-dna/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST-DNA, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->