### PR TITLE
DRAFT: fix: tree view items should not emit selected event until selected prop has changed

### DIFF
--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2485,8 +2485,6 @@ export class TreeItem extends FoundationElement {
     focusable: boolean;
     static focusItem(el: HTMLElement): void;
     // (undocumented)
-    handleClick: (e: MouseEvent) => void | boolean;
-    // (undocumented)
     handleExpandCollapseButtonClick: (e: MouseEvent) => void;
     // (undocumented)
     readonly isNestedItem: () => boolean;
@@ -2521,6 +2519,8 @@ export class TreeView extends FoundationElement {
     currentSelected: HTMLElement | TreeItem | null;
     // (undocumented)
     handleBlur: (e: FocusEvent) => void;
+    // (undocumented)
+    handleClick(e: Event): boolean;
     // (undocumented)
     handleFocus: (e: FocusEvent) => void;
     // (undocumented)

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -26,7 +26,6 @@ export const treeItemTemplate: (
             x.childItems && x.childItemLength() > 0 ? x.expanded : void 0}"
         aria-selected="${x => x.selected}"
         aria-disabled="${x => x.disabled}"
-        @click="${(x, c) => x.handleClick(c.event as MouseEvent)}"
         ${children({
             property: "childItems",
             filter: elements(),

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -37,6 +37,11 @@ export class TreeItem extends FoundationElement {
      */
     @attr({ mode: "boolean" })
     public expanded: boolean = false;
+    private expandedChanged(): void {
+        if (this.$fastController.isConnected) {
+            this.$emit("expanded-change", this);
+        }
+    }
 
     /**
      * When true, the control will appear selected by user interaction.
@@ -46,6 +51,11 @@ export class TreeItem extends FoundationElement {
      */
     @attr({ mode: "boolean" })
     public selected: boolean;
+    private selectedChanged(): void {
+        if (this.$fastController.isConnected) {
+            this.$emit("selected-change", this);
+        }
+    }
 
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled | disabled HTML attribute} for more information.
@@ -96,23 +106,8 @@ export class TreeItem extends FoundationElement {
     }
 
     public handleExpandCollapseButtonClick = (e: MouseEvent): void => {
-        if (!this.disabled) {
-            e.preventDefault();
-            this.setExpanded(!this.expanded);
-        }
-    };
-
-    public handleClick = (e: MouseEvent): void | boolean => {
-        if (!e.defaultPrevented) {
-            const target = e.composedPath();
-            const clickedTreeItem = target.find(
-                (t: EventTarget) => t instanceof HTMLElement && isTreeItemElement(t)
-            );
-            if ((clickedTreeItem as any) === this) {
-                this.handleSelected();
-            }
-            // do not prevent default as it completely eats the click
-            return true;
+        if (!this.disabled && !e.defaultPrevented) {
+            this.expanded = !this.expanded;
         }
     };
 
@@ -128,15 +123,6 @@ export class TreeItem extends FoundationElement {
     public readonly isNestedItem = (): boolean => {
         return isTreeItemElement(this.parentElement as Element);
     };
-
-    private handleSelected(e?: Event): void {
-        this.$emit("selected-change", e);
-    }
-
-    private setExpanded(expanded: boolean): void {
-        this.expanded = expanded;
-        this.$emit("expanded-change", this);
-    }
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
@@ -21,6 +21,7 @@ export const treeViewTemplate: (
         @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
         @focusout="${(x, c) => x.handleBlur(c.event as FocusEvent)}"
         @focusin="${(x, c) => x.handleFocus(c.event as FocusEvent)}"
+        @click="${(x, c) => x.handleClick(c.event as MouseEvent)}"
     >
         <slot ${slotted("slottedTreeItems")}></slot>
     </template>


### PR DESCRIPTION
## 📖 Description

Draft pr for discussion

### 🎫 Issues

## 👩‍💻 Reviewer Notes


## 📑 Test Plan

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
