### PR TITLE
add links to integration docs for frameworks on website

### DIFF
--- a/sites/fast-website/src/app/components/content-placement-container/templates/community.template.ts
+++ b/sites/fast-website/src/app/components/content-placement-container/templates/community.template.ts
@@ -1,13 +1,12 @@
 import { html } from "@microsoft/fast-element";
+import { linkTemplate } from "./link.template";
 
 const communityTemplate = html`
     <site-content-placement icon>
         <div slot="icon" :innerHTML=${x => x.icon}></div>
         <h3>${x => x.header}</h3>
         <p slot="body">${x => x.body}</p>
-        <fast-anchor slot="action" appearance="lightweight" href=${x => x.actionLink}>
-            ${x => x.actionText}
-        </fast-anchor>
+        ${linkTemplate("action")}
     </site-content-placement>
 `;
 

--- a/sites/fast-website/src/app/components/content-placement-container/templates/feature.template.ts
+++ b/sites/fast-website/src/app/components/content-placement-container/templates/feature.template.ts
@@ -1,16 +1,11 @@
 import { html, repeat } from "@microsoft/fast-element";
-
-const linkTemplate = html`
-    <fast-anchor slot="footer" href=${x => x.url} appearance="lightweight">
-        ${x => x.anchorText}
-    </fast-anchor>
-`;
+import { linkTemplate } from "./link.template";
 
 const featureTemplate = html`
     <site-feature-card>
         <h4>${x => x.header}</h4>
         <p slot="body">${x => x.body}</p>
-        ${repeat(x => x.links, linkTemplate)}
+        ${repeat(x => x.links, linkTemplate("footer"))}
     </site-feature-card>
 `;
 

--- a/sites/fast-website/src/app/components/content-placement-container/templates/framework.template.ts
+++ b/sites/fast-website/src/app/components/content-placement-container/templates/framework.template.ts
@@ -1,4 +1,5 @@
-import { html } from "@microsoft/fast-element";
+import { html, repeat } from "@microsoft/fast-element";
+import { linkTemplate } from "./link.template";
 
 const frameworkTemplate = html`
     <site-content-placement>
@@ -7,6 +8,7 @@ const frameworkTemplate = html`
             <small class="headerSubscript">${x => x.headerSubscript}</small>
         </h3>
         <p slot="body">${x => x.body}</p>
+        ${repeat(x => x.links, linkTemplate("action"))}
     </site-content-placement>
 `;
 

--- a/sites/fast-website/src/app/components/content-placement-container/templates/link.template.ts
+++ b/sites/fast-website/src/app/components/content-placement-container/templates/link.template.ts
@@ -1,0 +1,7 @@
+import { html } from "@microsoft/fast-element";
+
+export const linkTemplate = (slot: string) => html`
+    <fast-anchor slot="${slot}" href=${x => x.url} appearance="lightweight">
+        ${x => x.anchorText}
+    </fast-anchor>
+`;

--- a/sites/fast-website/src/app/components/content-placement/content-placement.template.ts
+++ b/sites/fast-website/src/app/components/content-placement/content-placement.template.ts
@@ -8,11 +8,6 @@ export const ContentPlacementTemplate = html<ContentPlacement>`
         </div>
         <slot></slot>
         <slot name="body"></slot>
-        ${when(
-            x => x.icon,
-            html`
-                <slot name="action"></slot>
-            `
-        )}
+        <slot name="action"></slot>
     </fast-card>
 `;

--- a/sites/fast-website/src/app/data/community.data.ts
+++ b/sites/fast-website/src/app/data/community.data.ts
@@ -2,10 +2,9 @@ import DiscordIcon from "svg/icon-discord.svg";
 import GithubIcon from "svg/icon-github.svg";
 import TwitterIcon from "svg/icon-twitter.svg";
 import MediumIcon from "svg/icon-medium.svg";
+import { FeatureLink } from "./feature.data";
 
-export interface CommunityContentPlacementData {
-    actionLink: string;
-    actionText?: string;
+export interface CommunityContentPlacementData extends FeatureLink {
     body?: string;
     header?: string;
     icon: string;
@@ -13,32 +12,32 @@ export interface CommunityContentPlacementData {
 
 export const communityContentPlacementData: CommunityContentPlacementData[] = [
     {
-        actionLink: "https://discord.gg/FcSNfg4",
-        actionText: "Join the Discord Chat",
+        url: "https://discord.gg/FcSNfg4",
+        anchorText: "Join the Discord Chat",
         body:
             "Join our active community on Discord. Follow the latest updates and contributions, ask questions, give feedback, or keep up on our reading list.",
         header: "Discord",
         icon: DiscordIcon,
     },
     {
-        actionLink: "https://twitter.com/FAST_UI",
-        actionText: "Follow us on Twitter",
+        url: "https://twitter.com/FAST_UI",
+        anchorText: "Follow us on Twitter",
         body:
             "Follow along as we share out the latest happenings on Twitter. You will find important updates, announcements, and sneak peeks.",
         header: "Twitter",
         icon: TwitterIcon,
     },
     {
-        actionLink: "https://github.com/microsoft/fast",
-        actionText: "Get Started on GitHub",
+        url: "https://github.com/microsoft/fast",
+        anchorText: "Get Started on GitHub",
         body:
             "Explore the FAST repository on GitHub and try out our components, utilities, and tools. Or, mix-and-match with your own solutions.",
         header: "GitHub",
         icon: GithubIcon,
     },
     {
-        actionLink: "https://medium.com/fast-design",
-        actionText: "Read more on Medium",
+        url: "https://medium.com/fast-design",
+        anchorText: "Read more on Medium",
         header: "Medium",
         icon: MediumIcon,
     },

--- a/sites/fast-website/src/app/data/feature.data.ts
+++ b/sites/fast-website/src/app/data/feature.data.ts
@@ -1,4 +1,4 @@
-interface FeatureLink {
+export interface FeatureLink {
     anchorText: string;
     url: string;
 }

--- a/sites/fast-website/src/app/data/framework.data.ts
+++ b/sites/fast-website/src/app/data/framework.data.ts
@@ -1,7 +1,10 @@
+import { FeatureLink } from "./feature.data";
+
 export interface FrameworkContentPlacementData {
     body?: string;
     header?: string;
     headerSubscript?: string;
+    links?: FeatureLink[];
 }
 
 export const frameworkContentPlacementData: FrameworkContentPlacementData[] = [
@@ -10,31 +13,67 @@ export const frameworkContentPlacementData: FrameworkContentPlacementData[] = [
             "Angular works great with FAST due to its binding system's support for setting both attributes and properties on custom elements.",
         header: "Angular",
         headerSubscript: "8.2.14",
+        links: [
+            {
+                anchorText: "Read Angular docs",
+                url: "/docs/integrations/angular",
+            },
+        ],
     },
     {
         body:
             "FAST works naturally with ASP.NET server-side development. Start building immediately by adding a script tag and using the custom HTML elements.",
         header: "ASP.NET",
+        links: [
+            {
+                anchorText: "Read ASP.NET docs",
+                url: "/docs/integrations/aspnet",
+            },
+        ],
     },
     {
         body:
             "FAST works flawlessly with both Aurelia 1 and Aurelia 2, with full integration into the binding engine and component model.",
         header: "Aurelia",
         headerSubscript: "1 & 2",
+        links: [
+            {
+                anchorText: "Read Aurelia docs",
+                url: "/docs/integrations/aurelia",
+            },
+        ],
     },
     {
         body:
             "FAST integrates nicely with Blazor, a feature of ASP.NET which lets you build interactive web UIs using C# instead of JavaScript.",
         header: "Blazor",
+        links: [
+            {
+                anchorText: "Read Blazor docs",
+                url: "/docs/integrations/blazor",
+            },
+        ],
     },
     {
         body:
             "While we are eagerly awaiting React to fully support custom elements, we provide improved integration support with our fast-react-wrapper.",
         header: "React",
+        links: [
+            {
+                anchorText: "Read React docs",
+                url: "/docs/integrations/react",
+            },
+        ],
     },
     {
         body:
             "Vue fully supports custom elements and by default passes all data to them as attributes. The framework also provides a special syntax to bind properties.",
         header: "Vue",
+        links: [
+            {
+                anchorText: "Read Vue docs",
+                url: "/docs/integrations/vue",
+            },
+        ],
     },
 ];


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR adds links to the framework section on the homepage. Each link maps to the respective integration documentation.

closes #5279 
### 🎫 Issues
N/A

## 👩‍💻 Reviewer Notes
N/A

## 📑 Test Plan
Feel free to pull this down and test. I have tested this change.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

N/A