### PR TITLE
fix: Add missing hyphens to @param JSDoc tags in context.ts

### DIFF
--- a/packages/fast-element/src/context.ts
+++ b/packages/fast-element/src/context.ts
@@ -198,9 +198,9 @@ export const Context = Object.freeze({
 
     /**
      * Enables an event target to provide a context value.
-     * @param target The target to provide the context value for.
-     * @param context The context to provide the value for.
-     * @param value The value to provide for the context.
+     * @param target - The target to provide the context value for.
+     * @param context - The context to provide the value for.
+     * @param value - The value to provide for the context.
      */
     provide<T extends UnknownContext>(
         target: EventTarget,
@@ -245,9 +245,9 @@ export const Context = Object.freeze({
     /**
      * Defines a getter-only property on the target that will return the context
      * value for the target.
-     * @param target The target to define the property on.
-     * @param propertyName The name of the property to define.
-     * @param context The context that will be used to retrieve the property value.
+     * @param target - The target to define the property on.
+     * @param propertyName - The name of the property to define.
+     * @param context - The context that will be used to retrieve the property value.
      * @remarks
      * Uses the default request strategy to locate the context and will return the
      * initialValue if the context isn't handled.


### PR DESCRIPTION
Fixes #7223: API Extractor produces tsdoc-param-tag-missing-hyphen warnings

Added hyphens between parameter names and descriptions in @param JSDoc tags for the provide() and defineProperty() methods to comply with TSDoc standards.

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->