### PR TITLE
Add missing title to frontpage and docs where missing

### DIFF
--- a/sites/website/src/_includes/doc.njk
+++ b/sites/website/src/_includes/doc.njk
@@ -1,5 +1,6 @@
 ---
 layout: root.njk
+title: FAST
 ---
 <div class="docs-wrapper">
     <div class="doc-root">

--- a/sites/website/src/_includes/frontpage.njk
+++ b/sites/website/src/_includes/frontpage.njk
@@ -1,6 +1,7 @@
 ---
 layout: root.njk
 tag: home
+title: FAST
 ---
 <div class="frontpage">
     <section class="section">


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change adds "FAST" as the page title if it is missing from the doc, and to the front page.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

- Publish the site