### PR TITLE
Remove registry always auth and make pipelines permissive

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
-//registry.npmjs.org/:_authToken=$NPM_TOKEN
-@microsoft:registry=https://registry.npmjs.org/
-always-auth=true
+registry=https://registry.npmjs.org/

--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -36,6 +36,8 @@ extends:
         name: OneESPool  # Name of your hosted pool
         image: HostedPoolWindowsImage  # Name of the image in your pool. If not specified, first image of the pool is used
         os: windows  # OS of the image. Allowed values: windows, linux, macOS
+    settings:
+      networkIsolationPolicy: Permissive
     stages:
     - stage: Stage
       jobs:

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -25,6 +25,8 @@ extends:
         name: OneESPool  # Name of your hosted pool
         image: HostedPoolWindowsImage  # Name of the image in your pool. If not specified, first image of the pool is used
         os: windows  # OS of the image. Allowed values: windows, linux, macOS
+    settings:
+      networkIsolationPolicy: Permissive
     stages:
     - stage: Stage
       jobs:


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change:
- Removes the unnecessary `.npmrc` auth token
- Adds a param to make the pipelines able to access public registries

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.