### PR TITLE
chore: enable HTML formatting in biome

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -16,6 +16,9 @@
         ]
     },
     "html": {
+        "formatter": {
+            "enabled": true
+        },
         "parser": {
             "interpolation": true
         }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Enables Biome's HTML formatter for all HTML files in the repository by adding `html.formatter.enabled: true` to `biome.jsonc`. Previously, the HTML parser was configured (with interpolation support) but HTML files were excluded from formatting. This change ensures HTML files are consistently formatted alongside JS/TS/JSON files.

## 📑 Test Plan

Configuration-only change. Run `npm run format:check` to verify HTML files are now included in Biome's formatting pass.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
