### PR TITLE
feat(fast-html): add |binding:none non-reactive static accessor syntax

### DIFF
--- a/packages/fast-html/README.md
+++ b/packages/fast-html/README.md
@@ -235,6 +235,16 @@ Browser-only bindings:
 {{text}}
 ```
 
+#### Static accessor
+
+A static accessor reads a property value once when the element connects and does not set up any reactive observers. Use `|binding:none` to opt out of reactivity:
+
+```html
+{{text|binding:none}}
+```
+
+This is equivalent to a one-time read of `x.text` — changes to the property after the initial render will not update the DOM.
+
 #### Event binding
 
 Event bindings must include the `()` as well as being preceeded by `@` in keeping with `@microsoft/fast-element` tagged template `html` syntax.

--- a/packages/fast-html/README.md
+++ b/packages/fast-html/README.md
@@ -229,6 +229,17 @@ Browser-only bindings:
 - Event bindings
 - Attribute directives
 
+#### Binding arguments
+
+Content bindings support pipe-separated arguments that modify binding behaviour:
+
+```
+{{path|key1:value1|key2:value2}}
+```
+
+- The **first segment** (before the first `|`) is always the property path.
+- Each **subsequent segment** is a `key:value` pair that configures how the binding behaves.
+
 #### Content binding
 
 ```html

--- a/packages/fast-html/api-extractor.json
+++ b/packages/fast-html/api-extractor.json
@@ -1,10 +1,10 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "../../api-extractor.json",
-  "mainEntryPointFilePath": "./dist/dts/index.d.ts",
-  "dtsRollup": {
-    "enabled": true,
-    "untrimmedFilePath": "./dist/fast-html.untrimmed.d.ts",
-    "betaTrimmedFilePath": "./dist/fast-html.d.ts"
-  }
+    "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+    "extends": "../../api-extractor.json",
+    "mainEntryPointFilePath": "./dist/dts/index.d.ts",
+    "dtsRollup": {
+        "enabled": true,
+        "untrimmedFilePath": "./dist/fast-html.untrimmed.d.ts",
+        "betaTrimmedFilePath": "./dist/fast-html.d.ts"
+    }
 }

--- a/packages/fast-html/src/components/element.ts
+++ b/packages/fast-html/src/components/element.ts
@@ -53,7 +53,7 @@ async function waitForAncestorHydration(element: HTMLElement): Promise<void> {
  * @public
  */
 export function RenderableFASTElement<T extends Constructable<FASTElement>>(
-    BaseCtor: T
+    BaseCtor: T,
 ): T {
     const C = class extends BaseCtor {
         deferHydration: boolean = true;
@@ -89,7 +89,7 @@ export function RenderableFASTElement<T extends Constructable<FASTElement>>(
 
     attr({ mode: "boolean", attribute: deferHydrationAttribute })(
         C.prototype,
-        "deferHydration"
+        "deferHydration",
     );
 
     return C;

--- a/packages/fast-html/src/components/index.ts
+++ b/packages/fast-html/src/components/index.ts
@@ -1,9 +1,9 @@
 export { RenderableFASTElement } from "./element.js";
 export { ObserverMap } from "./observer-map.js";
 export {
-    ObserverMapOption,
-    TemplateElement,
     type ElementOptions,
     type ElementOptionsDictionary,
     type HydrationLifecycleCallbacks,
+    ObserverMapOption,
+    TemplateElement,
 } from "./template.js";

--- a/packages/fast-html/src/components/observer-map.ts
+++ b/packages/fast-html/src/components/observer-map.ts
@@ -1,6 +1,6 @@
 import { Observable } from "@microsoft/fast-element/observable.js";
-import { assignObservables, deepMerge } from "./utilities.js";
 import type { JSONSchema, Schema } from "./schema.js";
+import { assignObservables, deepMerge } from "./utilities.js";
 
 /**
  * ObserverMap provides functionality for caching binding paths, extracting root properties,
@@ -30,7 +30,7 @@ export class ObserverMap {
 
             this.classPrototype[changedMethodName] = this.defineChanged(
                 propertyName,
-                existingChangedMethod
+                existingChangedMethod,
             );
         }
     }
@@ -46,7 +46,7 @@ export class ObserverMap {
         target: any,
         rootProperty: string,
         object: any,
-        schema: Schema
+        schema: Schema,
     ): typeof Proxy {
         let proxiedObject = object;
 
@@ -55,7 +55,7 @@ export class ObserverMap {
             schema.getSchema(rootProperty) as JSONSchema,
             proxiedObject,
             target,
-            rootProperty
+            rootProperty,
         );
 
         return proxiedObject;
@@ -70,7 +70,7 @@ export class ObserverMap {
      */
     private defineChanged = (
         propertyName: string,
-        existingChangedMethod?: (prev: any, next: any) => void
+        existingChangedMethod?: (prev: any, next: any) => void,
     ): ((prev: any, next: any) => void) => {
         const getAndAssignObservablesAlias = this.getAndAssignObservables;
         const schema = this.schema;
@@ -92,7 +92,7 @@ export class ObserverMap {
                         this,
                         propertyName,
                         next,
-                        schema
+                        schema,
                     );
                 }
             } else if (!isObjectAssignment) {

--- a/packages/fast-html/src/components/schema.spec.ts
+++ b/packages/fast-html/src/components/schema.spec.ts
@@ -27,7 +27,9 @@ test.describe("Schema", async () => {
         const schemaA = schema.getSchema("a");
 
         expect(schemaA).not.toBe(null);
-        expect(schemaA!.$id).toEqual("https://fast.design/schemas/my-custom-element/a.json");
+        expect(schemaA!.$id).toEqual(
+            "https://fast.design/schemas/my-custom-element/a.json",
+        );
         expect(schemaA!.$schema).toEqual("https://json-schema.org/draft/2019-09/schema");
     });
     test("should add a property and cast the schema as type object if a nested path is given", async () => {
@@ -240,7 +242,7 @@ test.describe("Schema", async () => {
                 type: "repeat",
                 path: "user.posts",
                 currentContext: "post",
-                parentContext: "user"
+                parentContext: "user",
             },
             childrenMap: null,
         });
@@ -286,7 +288,7 @@ test.describe("Schema", async () => {
                 type: "repeat",
                 path: "user.posts",
                 currentContext: "post",
-                parentContext: "user"
+                parentContext: "user",
             },
             childrenMap: null,
         });
@@ -308,7 +310,7 @@ test.describe("Schema", async () => {
                 type: "repeat",
                 path: "post.meta.tags",
                 currentContext: "tag",
-                parentContext: "post"
+                parentContext: "post",
             },
             childrenMap: null,
         });
@@ -331,12 +333,22 @@ test.describe("Schema", async () => {
         expect(schemaA!.$defs?.["post"].properties["c"]).toBeDefined();
         expect(schemaA!.$defs?.["post"].properties["c"].properties["d"]).toBeDefined();
         expect(schemaA!.$defs?.["post"].properties["meta"]).toBeDefined();
-        expect(schemaA!.$defs?.["post"].properties["meta"].properties["tags"]).toBeDefined();
-        expect(schemaA!.$defs?.["post"].properties["meta"].properties["tags"].items).toBeDefined();
-        expect(schemaA!.$defs?.["post"].properties["meta"].properties["tags"].items.$ref).toEqual("#/$defs/tag");
+        expect(
+            schemaA!.$defs?.["post"].properties["meta"].properties["tags"],
+        ).toBeDefined();
+        expect(
+            schemaA!.$defs?.["post"].properties["meta"].properties["tags"].items,
+        ).toBeDefined();
+        expect(
+            schemaA!.$defs?.["post"].properties["meta"].properties["tags"].items.$ref,
+        ).toEqual("#/$defs/tag");
         expect(schemaA!.$defs?.["tag"]).toBeDefined();
         expect(schemaA!.$defs?.["tag"].$fast_context).toEqual("tags");
-        expect(schemaA!.$defs?.["tag"].$fast_parent_contexts).toEqual([null, "user", "post"]);
+        expect(schemaA!.$defs?.["tag"].$fast_parent_contexts).toEqual([
+            null,
+            "user",
+            "post",
+        ]);
     });
     test("should define an anyOf with a $ref to another schema", async () => {
         const schema = new Schema("my-custom-element");
@@ -358,11 +370,15 @@ test.describe("Schema", async () => {
         const schemaA = schema.getSchema("a");
 
         expect(schemaA).not.toBe(null);
-        expect(schemaA!.$id).toEqual("https://fast.design/schemas/my-custom-element/a.json");
+        expect(schemaA!.$id).toEqual(
+            "https://fast.design/schemas/my-custom-element/a.json",
+        );
         expect(schemaA!.$schema).toEqual("https://json-schema.org/draft/2019-09/schema");
         expect(schemaA!.anyOf).not.toBeUndefined();
         expect(schemaA!.anyOf).toHaveLength(1);
-        expect(schemaA!.anyOf?.[0].$ref).toEqual("https://fast.design/schemas/my-custom-element-2/b.json");
+        expect(schemaA!.anyOf?.[0].$ref).toEqual(
+            "https://fast.design/schemas/my-custom-element-2/b.json",
+        );
     });
     test("should define an anyOf with a $ref to multiple schemas", async () => {
         const schema = new Schema("my-custom-element");
@@ -397,12 +413,18 @@ test.describe("Schema", async () => {
         const schemaA = schema.getSchema("a");
 
         expect(schemaA).not.toBe(null);
-        expect(schemaA!.$id).toEqual("https://fast.design/schemas/my-custom-element/a.json");
+        expect(schemaA!.$id).toEqual(
+            "https://fast.design/schemas/my-custom-element/a.json",
+        );
         expect(schemaA!.$schema).toEqual("https://json-schema.org/draft/2019-09/schema");
         expect(schemaA!.anyOf).not.toBeUndefined();
         expect(schemaA!.anyOf).toHaveLength(2);
-        expect(schemaA!.anyOf?.[0].$ref).toEqual("https://fast.design/schemas/my-custom-element-2/b.json");
-        expect(schemaA!.anyOf?.[1].$ref).toEqual("https://fast.design/schemas/my-custom-element-3/c.json");
+        expect(schemaA!.anyOf?.[0].$ref).toEqual(
+            "https://fast.design/schemas/my-custom-element-2/b.json",
+        );
+        expect(schemaA!.anyOf?.[1].$ref).toEqual(
+            "https://fast.design/schemas/my-custom-element-3/c.json",
+        );
     });
     test("should define an anyOf with a $ref to another schema in a nested object", async () => {
         const schema = new Schema("my-custom-element");
@@ -430,7 +452,7 @@ test.describe("Schema", async () => {
             },
             childrenMap: {
                 customElementName: "my-custom-element-2",
-                attributeName: "test"
+                attributeName: "test",
             },
         });
 
@@ -438,7 +460,9 @@ test.describe("Schema", async () => {
 
         expect(schemaA!.properties.b.properties.c).toBeDefined();
         expect(schemaA!.properties.b.properties.c.anyOf).not.toBeUndefined();
-        expect(schemaA!.properties.b.properties.c.anyOf[0].$ref).toEqual("https://fast.design/schemas/my-custom-element-2/test.json");
+        expect(schemaA!.properties.b.properties.c.anyOf[0].$ref).toEqual(
+            "https://fast.design/schemas/my-custom-element-2/test.json",
+        );
     });
     test("should define an anyOf with a $ref to multiple schemas in a nested object", async () => {
         const schema = new Schema("my-custom-element");
@@ -466,7 +490,7 @@ test.describe("Schema", async () => {
             },
             childrenMap: {
                 customElementName: "my-custom-element-2",
-                attributeName: "test"
+                attributeName: "test",
             },
         });
 
@@ -480,7 +504,7 @@ test.describe("Schema", async () => {
             },
             childrenMap: {
                 customElementName: "my-custom-element-3",
-                attributeName: "test-2"
+                attributeName: "test-2",
             },
         });
 
@@ -488,8 +512,12 @@ test.describe("Schema", async () => {
 
         expect(schemaA!.properties.b.properties.c).toBeDefined();
         expect(schemaA!.properties.b.properties.c.anyOf).not.toBeUndefined();
-        expect(schemaA!.properties.b.properties.c.anyOf[0].$ref).toEqual("https://fast.design/schemas/my-custom-element-2/test.json");
-        expect(schemaA!.properties.b.properties.c.anyOf[1].$ref).toEqual("https://fast.design/schemas/my-custom-element-3/test-2.json");
+        expect(schemaA!.properties.b.properties.c.anyOf[0].$ref).toEqual(
+            "https://fast.design/schemas/my-custom-element-2/test.json",
+        );
+        expect(schemaA!.properties.b.properties.c.anyOf[1].$ref).toEqual(
+            "https://fast.design/schemas/my-custom-element-3/test-2.json",
+        );
     });
     test("should define an anyOf with a $ref in a nested object in a context", async () => {
         const schema = new Schema("my-custom-element");
@@ -515,7 +543,7 @@ test.describe("Schema", async () => {
             },
             childrenMap: {
                 customElementName: "my-custom-element-2",
-                attributeName: "c"
+                attributeName: "c",
             },
         });
 
@@ -529,7 +557,13 @@ test.describe("Schema", async () => {
         expect(schemaA!.$defs?.["user"].properties).toBeDefined();
         expect(schemaA!.$defs?.["user"].properties["a"]).toBeDefined();
         expect(schemaA!.$defs?.["user"].properties["a"].properties["b"]).toBeDefined();
-        expect(schemaA!.$defs?.["user"].properties["a"].properties["b"].anyOf).toHaveLength(1);
-        expect(schemaA!.$defs?.["user"].properties["a"].properties["b"].anyOf[0][refPropertyName]).toEqual("https://fast.design/schemas/my-custom-element-2/c.json");
+        expect(
+            schemaA!.$defs?.["user"].properties["a"].properties["b"].anyOf,
+        ).toHaveLength(1);
+        expect(
+            schemaA!.$defs?.["user"].properties["a"].properties["b"].anyOf[0][
+                refPropertyName
+            ],
+        ).toEqual("https://fast.design/schemas/my-custom-element-2/c.json");
     });
 });

--- a/packages/fast-html/src/components/schema.ts
+++ b/packages/fast-html/src/components/schema.ts
@@ -118,7 +118,7 @@ export class Schema {
         if (config.childrenMap) {
             childRef = this.getSchemaId(
                 config.childrenMap.customElementName,
-                config.childrenMap.attributeName
+                config.childrenMap.attributeName,
             );
 
             if (splitPath.length === 1) {
@@ -137,7 +137,7 @@ export class Schema {
                             schema,
                             splitPath.slice(1),
                             config.pathConfig.currentContext,
-                            childRef
+                            childRef,
                         );
                     } else {
                         if (!schema[defsPropertyName]?.[splitPath[0]]) {
@@ -150,7 +150,7 @@ export class Schema {
                             schema[defsPropertyName][splitPath[0]],
                             splitPath.slice(1),
                             config.pathConfig.currentContext as string,
-                            childRef
+                            childRef,
                         );
                     }
                 }
@@ -162,7 +162,7 @@ export class Schema {
                     schema,
                     splitPath.at(-1) as string, // example items
                     config.pathConfig.currentContext as string, // example item
-                    config.pathConfig.parentContext
+                    config.pathConfig.parentContext,
                 );
 
                 if (splitPath.length > 2) {
@@ -176,7 +176,7 @@ export class Schema {
                             ],
                             splitPath.slice(1, -1),
                             config.pathConfig.parentContext,
-                            childRef
+                            childRef,
                         );
                     }
 
@@ -185,7 +185,7 @@ export class Schema {
                         hasParentContext ? splitPath.slice(2) : splitPath.slice(1),
                         config.pathConfig.currentContext,
                         childRef,
-                        "array"
+                        "array",
                     );
                 } else if (splitPath.length > 1) {
                     let schemaDefinition;
@@ -201,12 +201,12 @@ export class Schema {
                         splitPath.slice(1),
                         config.pathConfig.currentContext,
                         childRef,
-                        "array"
+                        "array",
                     );
                 } else {
                     schema.type = "array";
                     schema[refPropertyName] = this.getDefsPath(
-                        config.pathConfig.currentContext as string
+                        config.pathConfig.currentContext as string,
                     );
                 }
 
@@ -280,7 +280,7 @@ export class Schema {
                 $schema: "https://json-schema.org/draft/2019-09/schema",
                 $id: this.getSchemaId(this.customElementName, propertyName),
                 [defsPropertyName]: {},
-            }
+            },
         );
     }
 
@@ -294,7 +294,7 @@ export class Schema {
         schema: any,
         splitPath: string[],
         context: string,
-        childRef: string | null
+        childRef: string | null,
     ) {
         schema.type = "object";
 
@@ -311,7 +311,7 @@ export class Schema {
                 schema.properties[splitPath[0]],
                 splitPath.slice(1),
                 context,
-                childRef
+                childRef,
             );
         } else if (childRef) {
             if (schema.properties[splitPath[0]].anyOf) {
@@ -336,7 +336,7 @@ export class Schema {
         splitPath: string[],
         context: string | null,
         childRef: string | null,
-        type: string = "object"
+        type: string = "object",
     ): any {
         schema.type = "object";
 
@@ -354,7 +354,7 @@ export class Schema {
                 splitPath.slice(1),
                 context,
                 childRef,
-                type
+                type,
             );
         } else if (type === "array") {
             if (splitPath.length > 1) {
@@ -363,12 +363,12 @@ export class Schema {
                     splitPath.slice(1),
                     context,
                     childRef,
-                    type
+                    type,
                 );
             } else {
                 return this.addArrayToAnObject(
                     schema.properties[splitPath[0]],
-                    context as string
+                    context as string,
                 );
             }
         }
@@ -408,7 +408,7 @@ export class Schema {
         schema: any,
         propertyName: string, // e.g items
         currentContext: string, // e.g. item
-        parentContext: string | null
+        parentContext: string | null,
     ): void {
         if (schema[defsPropertyName][currentContext]) {
             return;
@@ -430,7 +430,7 @@ export class Schema {
     private getParentContexts(
         schema: JSONSchema,
         parentContext: string | null,
-        contexts: Array<string | null> = []
+        contexts: Array<string | null> = [],
     ): Array<string | null> {
         if (parentContext === null) {
             return [null, ...contexts];
@@ -443,7 +443,7 @@ export class Schema {
         return this.getParentContexts(
             schema,
             parentParentContext.at(-1) as string | null,
-            [parentContext, ...contexts]
+            [parentContext, ...contexts],
         );
     }
 }

--- a/packages/fast-html/src/components/syntax.ts
+++ b/packages/fast-html/src/components/syntax.ts
@@ -14,6 +14,7 @@ interface Syntax {
     whenDirectiveOpen: string;
     whenDirectiveClose: string;
     attributeDirectivePrefix: string;
+    noneBindingModifier: string;
 }
 
 /**
@@ -25,6 +26,7 @@ export const {
     clientSideOpenExpression,
     closeExpression,
     executionContextAccessor,
+    noneBindingModifier,
     openExpression,
     repeatDirectiveClose,
     repeatDirectiveOpen,
@@ -38,6 +40,7 @@ export const {
     clientSideOpenExpression: "{",
     closeExpression: "}}",
     executionContextAccessor: "$c",
+    noneBindingModifier: "|binding:none",
     openExpression: "{{",
     unescapedCloseExpression: "}}}",
     unescapedOpenExpression: "{{{",

--- a/packages/fast-html/src/components/syntax.ts
+++ b/packages/fast-html/src/components/syntax.ts
@@ -14,7 +14,10 @@ interface Syntax {
     whenDirectiveOpen: string;
     whenDirectiveClose: string;
     attributeDirectivePrefix: string;
-    noneBindingModifier: string;
+    bindingArgSeparator: string;
+    bindingArgKeyValueSeparator: string;
+    bindingKey: string;
+    noneBinding: string;
 }
 
 /**
@@ -22,11 +25,14 @@ interface Syntax {
  */
 export const {
     attributeDirectivePrefix,
+    bindingArgKeyValueSeparator,
+    bindingArgSeparator,
+    bindingKey,
     clientSideCloseExpression,
     clientSideOpenExpression,
     closeExpression,
     executionContextAccessor,
-    noneBindingModifier,
+    noneBinding,
     openExpression,
     repeatDirectiveClose,
     repeatDirectiveOpen,
@@ -36,11 +42,14 @@ export const {
     whenDirectiveOpen,
 }: Syntax = {
     attributeDirectivePrefix: "f-",
+    bindingArgKeyValueSeparator: ":",
+    bindingArgSeparator: "|",
+    bindingKey: "binding",
     clientSideCloseExpression: "}",
     clientSideOpenExpression: "{",
     closeExpression: "}}",
     executionContextAccessor: "$c",
-    noneBindingModifier: "|binding:none",
+    noneBinding: "none",
     openExpression: "{{",
     unescapedCloseExpression: "}}}",
     unescapedOpenExpression: "{{{",

--- a/packages/fast-html/src/components/template.ts
+++ b/packages/fast-html/src/components/template.ts
@@ -7,11 +7,12 @@ import {
     FASTElementDefinition,
     fastElementRegistry,
     HydratableElementController,
-    HydrationControllerCallbacks,
+    type HydrationControllerCallbacks,
+    oneTime,
     ref,
     repeat,
     slotted,
-    TemplateLifecycleCallbacks,
+    type TemplateLifecycleCallbacks,
     ViewTemplate,
     when,
 } from "@microsoft/fast-element";
@@ -20,16 +21,18 @@ import { Message } from "../interfaces.js";
 import { ObserverMap } from "./observer-map.js";
 import { Schema } from "./schema.js";
 import {
-    AttributeDirective,
+    type AttributeDirective,
     bindingResolver,
-    ChainedExpression,
+    type ChainedExpression,
     contextPrefixDot,
-    DataBindingBehaviorConfig,
+    type DataBindingBehaviorConfig,
     getBooleanBinding,
     getExpressionChain,
     getNextBehavior,
     getRootPropertyName,
-    TemplateDirectiveBehaviorConfig,
+    hasNoneBindingModifier,
+    stripNoneBindingModifier,
+    type TemplateDirectiveBehaviorConfig,
     transformInnerHTML,
 } from "./utilities.js";
 
@@ -201,7 +204,7 @@ class TemplateElement extends FASTElement {
             if (TemplateElement.elementOptions[name]?.observerMap === "all") {
                 this.observerMap = new ObserverMap(
                     value.prototype,
-                    this.schema as Schema
+                    this.schema as Schema,
                 );
             }
 
@@ -223,7 +226,7 @@ class TemplateElement extends FASTElement {
                     null,
                     0,
                     this.schema as Schema,
-                    this.observerMap
+                    this.observerMap,
                 );
 
                 // Define the root properties cached in the observer map as observable (only if observerMap exists)
@@ -243,7 +246,7 @@ class TemplateElement extends FASTElement {
                     // This assignment triggers the Observable notification → callbacks fire
                     registeredFastElement.template = this.resolveTemplateOrBehavior(
                         strings,
-                        values
+                        values,
                     );
                 }
             } else {
@@ -265,7 +268,7 @@ class TemplateElement extends FASTElement {
         parentContext: string | null,
         level: number,
         schema: Schema,
-        observerMap?: ObserverMap
+        observerMap?: ObserverMap,
     ): Promise<ResolvedStringsAndValues> {
         const strings: any[] = [];
         const values: any[] = []; // these can be bindings, directives, etc.
@@ -278,7 +281,7 @@ class TemplateElement extends FASTElement {
             parentContext,
             level,
             schema,
-            observerMap
+            observerMap,
         );
 
         (strings as any).raw = strings.map(value => String.raw({ raw: value }));
@@ -296,7 +299,7 @@ class TemplateElement extends FASTElement {
      */
     private resolveTemplateOrBehavior(
         strings: Array<string>,
-        values: Array<any>
+        values: Array<any>,
     ): ViewTemplate<any, any> {
         return ViewTemplate.create(strings, values);
     }
@@ -318,7 +321,7 @@ class TemplateElement extends FASTElement {
         parentContext: string | null,
         level: number,
         schema: Schema,
-        observerMap?: ObserverMap
+        observerMap?: ObserverMap,
     ): Promise<void> {
         switch (behaviorConfig.name) {
             case "when": {
@@ -329,24 +332,24 @@ class TemplateElement extends FASTElement {
                     expressionChain as ChainedExpression,
                     parentContext,
                     level,
-                    schema
+                    schema,
                 );
 
                 const { strings, values } = await this.resolveStringsAndValues(
                     rootPropertyName,
                     innerHTML.slice(
                         behaviorConfig.openingTagEndIndex,
-                        behaviorConfig.closingTagStartIndex
+                        behaviorConfig.closingTagStartIndex,
                     ),
                     self,
                     parentContext,
                     level,
                     schema,
-                    observerMap
+                    observerMap,
                 );
 
                 externalValues.push(
-                    when(whenLogic, this.resolveTemplateOrBehavior(strings, values))
+                    when(whenLogic, this.resolveTemplateOrBehavior(strings, values)),
                 );
 
                 break;
@@ -359,7 +362,7 @@ class TemplateElement extends FASTElement {
                     rootPropertyName,
                     valueAttr[2],
                     parentContext,
-                    behaviorConfig.name
+                    behaviorConfig.name,
                 );
                 const binding = bindingResolver(
                     null,
@@ -369,27 +372,27 @@ class TemplateElement extends FASTElement {
                     behaviorConfig.name,
                     schema,
                     valueAttr[0],
-                    level
+                    level,
                 );
 
                 const { strings, values } = await this.resolveStringsAndValues(
                     rootPropertyName,
                     innerHTML.slice(
                         behaviorConfig.openingTagEndIndex,
-                        behaviorConfig.closingTagStartIndex
+                        behaviorConfig.closingTagStartIndex,
                     ),
                     true,
                     valueAttr[0],
                     updatedLevel,
                     schema,
-                    observerMap
+                    observerMap,
                 );
 
                 externalValues.push(
                     repeat(
                         (x, c) => binding(x, c),
-                        this.resolveTemplateOrBehavior(strings, values)
-                    )
+                        this.resolveTemplateOrBehavior(strings, values),
+                    ),
                 );
 
                 break;
@@ -406,7 +409,7 @@ class TemplateElement extends FASTElement {
     private async resolveAttributeDirective(
         name: AttributeDirective,
         propName: string,
-        externalValues: Array<any>
+        externalValues: Array<any>,
     ) {
         switch (name) {
             case "children": {
@@ -461,21 +464,25 @@ class TemplateElement extends FASTElement {
         parentContext: string | null,
         level: number,
         schema: Schema,
-        observerMap?: ObserverMap
+        observerMap?: ObserverMap,
     ): Promise<void> {
         switch (behaviorConfig.subtype) {
             case "content": {
                 strings.push(innerHTML.slice(0, behaviorConfig.openingStartIndex));
                 const type = "access";
-                const propName = innerHTML.slice(
+                const rawPropName = innerHTML.slice(
                     behaviorConfig.openingEndIndex,
-                    behaviorConfig.closingStartIndex
+                    behaviorConfig.closingStartIndex,
                 );
+                const isNoneBinding = hasNoneBindingModifier(rawPropName);
+                const propName = isNoneBinding
+                    ? stripNoneBindingModifier(rawPropName)
+                    : rawPropName;
                 rootPropertyName = getRootPropertyName(
                     rootPropertyName,
                     propName,
                     parentContext,
-                    type
+                    type,
                 );
                 const binding = bindingResolver(
                     strings.join(""),
@@ -485,10 +492,13 @@ class TemplateElement extends FASTElement {
                     type,
                     schema,
                     parentContext,
-                    level
+                    level,
                 );
-                const contentBinding = (x: any, c: any) => binding(x, c);
-                values.push(contentBinding);
+                values.push(
+                    isNoneBinding
+                        ? oneTime((x: any) => binding(x, null))
+                        : (x: any, c: any) => binding(x, c),
+                );
                 await this.resolveInnerHTML(
                     rootPropertyName,
                     innerHTML.slice(behaviorConfig.closingEndIndex, innerHTML.length),
@@ -498,7 +508,7 @@ class TemplateElement extends FASTElement {
                     parentContext,
                     level,
                     schema,
-                    observerMap
+                    observerMap,
                 );
 
                 break;
@@ -511,7 +521,7 @@ class TemplateElement extends FASTElement {
                     case "@": {
                         const bindingHTML = innerHTML.slice(
                             behaviorConfig.openingEndIndex,
-                            behaviorConfig.closingStartIndex
+                            behaviorConfig.closingStartIndex,
                         );
                         const openingParenthesis = bindingHTML.indexOf("(");
                         const closingParenthesis = bindingHTML.indexOf(")");
@@ -519,18 +529,18 @@ class TemplateElement extends FASTElement {
                             behaviorConfig.openingEndIndex,
                             behaviorConfig.closingStartIndex -
                                 (closingParenthesis - openingParenthesis) -
-                                1
+                                1,
                         );
                         const type = "event";
                         rootPropertyName = getRootPropertyName(
                             rootPropertyName,
                             propName,
                             parentContext,
-                            type
+                            type,
                         );
                         const arg = bindingHTML.slice(
                             openingParenthesis + 1,
-                            closingParenthesis
+                            closingParenthesis,
                         );
                         const binding = bindingResolver(
                             strings.join(""),
@@ -540,7 +550,7 @@ class TemplateElement extends FASTElement {
                             type,
                             schema,
                             parentContext,
-                            level
+                            level,
                         );
                         const isContextPath = propName.startsWith(contextPrefixDot);
                         const getOwner = isContextPath
@@ -548,7 +558,7 @@ class TemplateElement extends FASTElement {
                                   const ownerPath = propName.split(".").slice(1, -1);
                                   return ownerPath.reduce(
                                       (prev: any, item: string) => prev?.[item],
-                                      c
+                                      c,
                                   );
                               }
                             : (x: any, _c: any) => x;
@@ -565,10 +575,10 @@ class TemplateElement extends FASTElement {
                                               type,
                                               schema,
                                               parentContext,
-                                              level
+                                              level,
                                           )(x, c),
                                       ]
-                                    : [])
+                                    : []),
                             );
 
                         break;
@@ -576,7 +586,7 @@ class TemplateElement extends FASTElement {
                     case "?": {
                         const expression = innerHTML.slice(
                             behaviorConfig.openingEndIndex,
-                            behaviorConfig.closingStartIndex
+                            behaviorConfig.closingStartIndex,
                         );
                         const expressionChain = getExpressionChain(expression);
 
@@ -586,12 +596,12 @@ class TemplateElement extends FASTElement {
                                 expressionChain as ChainedExpression,
                                 parentContext,
                                 level,
-                                schema
+                                schema,
                             );
                         } else {
                             const propName = innerHTML.slice(
                                 behaviorConfig.openingEndIndex,
-                                behaviorConfig.closingStartIndex
+                                behaviorConfig.closingStartIndex,
                             );
                             const type = "access";
 
@@ -599,7 +609,7 @@ class TemplateElement extends FASTElement {
                                 rootPropertyName,
                                 propName,
                                 parentContext,
-                                type
+                                type,
                             );
 
                             const binding = bindingResolver(
@@ -610,7 +620,7 @@ class TemplateElement extends FASTElement {
                                 type,
                                 schema,
                                 parentContext,
-                                level
+                                level,
                             );
                             attributeBinding = (x: any, c: any) => binding(x, c);
                         }
@@ -620,7 +630,7 @@ class TemplateElement extends FASTElement {
                     default: {
                         const propName = innerHTML.slice(
                             behaviorConfig.openingEndIndex,
-                            behaviorConfig.closingStartIndex
+                            behaviorConfig.closingStartIndex,
                         );
                         const type = "access";
 
@@ -628,7 +638,7 @@ class TemplateElement extends FASTElement {
                             rootPropertyName,
                             propName,
                             parentContext,
-                            type
+                            type,
                         );
 
                         const binding = bindingResolver(
@@ -639,7 +649,7 @@ class TemplateElement extends FASTElement {
                             type,
                             schema,
                             parentContext,
-                            level
+                            level,
                         );
                         attributeBinding = (x: any, c: any) => binding(x, c);
                     }
@@ -656,7 +666,7 @@ class TemplateElement extends FASTElement {
                     parentContext,
                     level,
                     schema,
-                    observerMap
+                    observerMap,
                 );
 
                 break;
@@ -665,17 +675,17 @@ class TemplateElement extends FASTElement {
                 strings.push(
                     innerHTML.slice(
                         0,
-                        behaviorConfig.openingStartIndex - behaviorConfig.name.length - 4
-                    )
+                        behaviorConfig.openingStartIndex - behaviorConfig.name.length - 4,
+                    ),
                 );
                 const propName = innerHTML.slice(
                     behaviorConfig.openingEndIndex,
-                    behaviorConfig.closingStartIndex
+                    behaviorConfig.closingStartIndex,
                 );
                 await this.resolveAttributeDirective(
                     behaviorConfig.name,
                     propName,
-                    values
+                    values,
                 );
                 await this.resolveInnerHTML(
                     rootPropertyName,
@@ -686,7 +696,7 @@ class TemplateElement extends FASTElement {
                     parentContext,
                     level,
                     schema,
-                    observerMap
+                    observerMap,
                 );
 
                 break;
@@ -711,7 +721,7 @@ class TemplateElement extends FASTElement {
         parentContext: string | null,
         level: number,
         schema: Schema,
-        observerMap?: ObserverMap
+        observerMap?: ObserverMap,
     ): Promise<void> {
         const behaviorConfig = getNextBehavior(innerHTML);
 
@@ -730,7 +740,7 @@ class TemplateElement extends FASTElement {
                         parentContext,
                         level,
                         schema,
-                        observerMap
+                        observerMap,
                     );
 
                     break;
@@ -746,14 +756,14 @@ class TemplateElement extends FASTElement {
                         parentContext,
                         level,
                         schema,
-                        observerMap
+                        observerMap,
                     );
 
                     await this.resolveInnerHTML(
                         rootPropertyName,
                         innerHTML.slice(
                             behaviorConfig.closingTagEndIndex,
-                            innerHTML.length
+                            innerHTML.length,
                         ),
                         strings,
                         values,
@@ -761,7 +771,7 @@ class TemplateElement extends FASTElement {
                         parentContext,
                         level,
                         schema,
-                        observerMap
+                        observerMap,
                     );
 
                     break;

--- a/packages/fast-html/src/components/template.ts
+++ b/packages/fast-html/src/components/template.ts
@@ -20,6 +20,7 @@ import "@microsoft/fast-element/install-hydratable-view-templates.js";
 import { Message } from "../interfaces.js";
 import { ObserverMap } from "./observer-map.js";
 import { Schema } from "./schema.js";
+import { bindingKey, noneBinding } from "./syntax.js";
 import {
     type AttributeDirective,
     bindingResolver,
@@ -30,8 +31,7 @@ import {
     getExpressionChain,
     getNextBehavior,
     getRootPropertyName,
-    hasNoneBindingModifier,
-    stripNoneBindingModifier,
+    parseBindingExpression,
     type TemplateDirectiveBehaviorConfig,
     transformInnerHTML,
 } from "./utilities.js";
@@ -470,14 +470,13 @@ class TemplateElement extends FASTElement {
             case "content": {
                 strings.push(innerHTML.slice(0, behaviorConfig.openingStartIndex));
                 const type = "access";
-                const rawPropName = innerHTML.slice(
+                const rawExpression = innerHTML.slice(
                     behaviorConfig.openingEndIndex,
                     behaviorConfig.closingStartIndex,
                 );
-                const isNoneBinding = hasNoneBindingModifier(rawPropName);
-                const propName = isNoneBinding
-                    ? stripNoneBindingModifier(rawPropName)
-                    : rawPropName;
+                const { path: propName, modifiers } =
+                    parseBindingExpression(rawExpression);
+                const isNoneBinding = modifiers[bindingKey] === noneBinding;
                 rootPropertyName = getRootPropertyName(
                     rootPropertyName,
                     propName,

--- a/packages/fast-html/src/components/utilities.ts
+++ b/packages/fast-html/src/components/utilities.ts
@@ -9,11 +9,12 @@ import {
 } from "./schema.js";
 import {
     attributeDirectivePrefix,
+    bindingArgKeyValueSeparator,
+    bindingArgSeparator,
     clientSideCloseExpression,
     clientSideOpenExpression,
     closeExpression,
     executionContextAccessor,
-    noneBindingModifier,
     openExpression,
     repeatDirectiveClose,
     repeatDirectiveOpen,
@@ -90,21 +91,41 @@ interface ObservedTargetsAndProperties {
 export const contextPrefixDot: string = `${executionContextAccessor}.`;
 
 /**
- * Determines if the property name includes the none binding modifier
- * @param propName - The property name to check
- * @returns True if the property name includes the none binding modifier
+ * The result of parsing a binding expression that may include pipe-separated arguments.
  */
-export function hasNoneBindingModifier(propName: string): boolean {
-    return propName.endsWith(noneBindingModifier);
+export interface BindingExpression {
+    /** The property path (the part before any `|` separators). */
+    path: string;
+    /** Key/value modifiers parsed from the pipe-separated arguments, e.g. `{ binding: "none" }`. */
+    modifiers: Record<string, string>;
 }
 
 /**
- * Strips the none binding modifier from the property name
- * @param propName - The property name to strip
- * @returns The property name without the none binding modifier
+ * Parses a raw binding expression into its path and key/value modifiers.
+ *
+ * Syntax: `path|key1:value1|key2:value2`
+ *
+ * - The first segment (before the first `|`) is the property path.
+ * - Each subsequent segment is split on `:` into a key and value.
+ *
+ * @param rawExpression - The raw expression string from inside `{{...}}`.
+ * @returns A {@link BindingExpression} containing the path and any modifiers.
  */
-export function stripNoneBindingModifier(propName: string): string {
-    return propName.slice(0, propName.length - noneBindingModifier.length);
+export function parseBindingExpression(rawExpression: string): BindingExpression {
+    const parts = rawExpression.split(bindingArgSeparator);
+    const path = parts[0];
+    const modifiers: Record<string, string> = {};
+
+    for (let i = 1; i < parts.length; i++) {
+        const separatorIndex = parts[i].indexOf(bindingArgKeyValueSeparator);
+        if (separatorIndex !== -1) {
+            const key = parts[i].slice(0, separatorIndex);
+            const value = parts[i].slice(separatorIndex + 1);
+            modifiers[key] = value;
+        }
+    }
+
+    return { path, modifiers };
 }
 
 const startInnerHTMLDiv = `<div :innerHTML="{{`;

--- a/packages/fast-html/src/components/utilities.ts
+++ b/packages/fast-html/src/components/utilities.ts
@@ -13,6 +13,7 @@ import {
     clientSideOpenExpression,
     closeExpression,
     executionContextAccessor,
+    noneBindingModifier,
     openExpression,
     repeatDirectiveClose,
     repeatDirectiveOpen,
@@ -87,6 +88,24 @@ interface ObservedTargetsAndProperties {
 }
 
 export const contextPrefixDot: string = `${executionContextAccessor}.`;
+
+/**
+ * Determines if the property name includes the none binding modifier
+ * @param propName - The property name to check
+ * @returns True if the property name includes the none binding modifier
+ */
+export function hasNoneBindingModifier(propName: string): boolean {
+    return propName.endsWith(noneBindingModifier);
+}
+
+/**
+ * Strips the none binding modifier from the property name
+ * @param propName - The property name to strip
+ * @returns The property name without the none binding modifier
+ */
+export function stripNoneBindingModifier(propName: string): string {
+    return propName.slice(0, propName.length - noneBindingModifier.length);
+}
 
 const startInnerHTMLDiv = `<div :innerHTML="{{`;
 const startInnerHTMLDivLength = startInnerHTMLDiv.length;

--- a/packages/fast-html/src/index.ts
+++ b/packages/fast-html/src/index.ts
@@ -4,7 +4,7 @@ import { debugMessages } from "./debug.js";
 FAST.addMessages(debugMessages);
 
 export {
+    ObserverMap,
     RenderableFASTElement,
     TemplateElement,
-    ObserverMap,
 } from "./components/index.js";

--- a/packages/fast-html/test/fixtures/attribute/index.html
+++ b/packages/fast-html/test/fixtures/attribute/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title></title>
     </head>
     <body>

--- a/packages/fast-html/test/fixtures/children/index.html
+++ b/packages/fast-html/test/fixtures/children/index.html
@@ -1,21 +1,31 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title></title>
         <script type="module" src="./main.ts"></script>
     </head>
     <body>
         <f-template name="test-element">
-            <template><ul f-children="{listItems}"><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul></template>
+            <template
+                ><ul f-children="{listItems}">
+                    <f-repeat value="{{item in list}}"><li>{{ item }}</li></f-repeat>
+                </ul></template
+            >
         </f-template>
         <test-element>
             <template shadowrootmode="open">
                 <ul data-fe-b-0>
-                <!--fe-b$$start$$1$$t01oHhokPY$$fe-b-->
-                <!--fe-repeat$$start$$0$$fe-repeat--><li><!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->Foo<!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b--></li><!--fe-repeat$$end$$0$$fe-repeat-->
-                <!--fe-repeat$$start$$1$$fe-repeat--><li><!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->Bar<!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b--></li><!--fe-repeat$$end$$1$$fe-repeat-->
-                <!--fe-b$$end$$1$$t01oHhokPY$$fe-b-->
+                    <!--fe-b$$start$$1$$t01oHhokPY$$fe-b-->
+                    <!--fe-repeat$$start$$0$$fe-repeat-->
+                    <li>
+                        Foo<!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b-->
+                    </li><!--fe-repeat$$end$$0$$fe-repeat-->
+                    <!--fe-repeat$$start$$1$$fe-repeat-->
+                    <li>
+                        Bar<!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b-->
+                    </li><!--fe-repeat$$end$$1$$fe-repeat-->
+                    <!--fe-b$$end$$1$$t01oHhokPY$$fe-b-->
                 </ul>
             </template>
         </test-element>

--- a/packages/fast-html/test/fixtures/children/main.ts
+++ b/packages/fast-html/test/fixtures/children/main.ts
@@ -1,5 +1,5 @@
-import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 import { FASTElement, observable } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
 class TestElement extends FASTElement {
     @observable

--- a/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
@@ -13,8 +13,12 @@ test.describe("Deep Merge Test Fixture", () => {
         await expect(page.locator(".users h2")).toContainText("Users (2 total)");
 
         // Check first user details
-        await expect(page.locator(".user-card").first()).toContainText("Alice Johnson (ID: 1)");
-        await expect(page.locator(".user-card").first()).toContainText("alice@example.com");
+        await expect(page.locator(".user-card").first()).toContainText(
+            "Alice Johnson (ID: 1)",
+        );
+        await expect(page.locator(".user-card").first()).toContainText(
+            "alice@example.com",
+        );
         await expect(page.locator(".user-card").first()).toContainText("Age: 28");
         await expect(page.locator(".user-card").first()).toContainText("New York, USA");
         await expect(page.locator(".user-card").first()).toContainText("Theme: dark");
@@ -26,7 +30,9 @@ test.describe("Deep Merge Test Fixture", () => {
 
         // Check that nested properties were updated
         await expect(page.locator(".user-card").first()).toContainText("Age: 29");
-        await expect(page.locator(".user-card").first()).toContainText("San Francisco, USA");
+        await expect(page.locator(".user-card").first()).toContainText(
+            "San Francisco, USA",
+        );
         await expect(page.locator(".user-card").first()).toContainText("Theme: light");
 
         // Verify country wasn't changed (partial merge)
@@ -76,7 +82,6 @@ test.describe("Deep Merge Test Fixture", () => {
 
         await page.click('button:has-text("Update Product Tags")');
 
-
         // Check updated tags
         await expect(firstItem).toContainText("tech");
         await expect(firstItem).toContainText("premium");
@@ -93,7 +98,6 @@ test.describe("Deep Merge Test Fixture", () => {
 
         await page.click('button:has-text("Add New User")');
 
-
         await expect(page.locator(".users h2")).toContainText("Users (3 total)");
         await expect(page.locator(".user-card").nth(2)).toContainText("Charlie Davis");
         await expect(page.locator(".user-card").nth(2)).toContainText("Tokyo, Japan");
@@ -107,13 +111,11 @@ test.describe("Deep Merge Test Fixture", () => {
 
         await page.click('button:has-text("Toggle Details")');
 
-
         // Details should be hidden
         await expect(page.locator(".profile").first()).not.toBeVisible();
         await expect(page.locator(".metadata").first()).not.toBeVisible();
 
         await page.click('button:has-text("Toggle Details")');
-
 
         // Details should be visible again
         await expect(page.locator(".profile").first()).toBeVisible();
@@ -126,11 +128,9 @@ test.describe("Deep Merge Test Fixture", () => {
 
         await page.click('button:has-text("Increment Age")');
 
-
         await expect(page.locator(".user-card").first()).toContainText("Age: 29");
 
         await page.click('button:has-text("Increment Age")');
-
 
         await expect(page.locator(".user-card").first()).toContainText("Age: 30");
     });
@@ -141,7 +141,6 @@ test.describe("Deep Merge Test Fixture", () => {
         await expect(page.locator(".stats")).toContainText("Total Revenue: $425.5");
 
         await page.click('button:has-text("Update Stats")');
-
 
         await expect(page.locator(".stats")).toContainText("Total Orders: 4");
         await expect(page.locator(".stats")).toContainText("Total Revenue: $525.49");
@@ -156,7 +155,6 @@ test.describe("Deep Merge Test Fixture", () => {
         await expect(page.locator(".user-card").first()).toContainText("New York");
 
         await page.click('button:has-text("Test Undefined Merge")');
-
 
         // Age should remain unchanged (undefined skipped)
         await expect(page.locator(".user-card").first()).toContainText("Age: 28");
@@ -203,7 +201,6 @@ test.describe("Deep Merge Test Fixture", () => {
         // After updating, second item should be out of stock
         await page.click('button:has-text("Update Product Tags")');
 
-
         await expect(items.nth(1)).toContainText("✗ Out of Stock");
     });
 
@@ -211,13 +208,14 @@ test.describe("Deep Merge Test Fixture", () => {
         await page.goto("/fixtures/deep-merge/");
         await page.click('button:has-text("Add New User")');
 
-
         const newUser = page.locator(".user-card").nth(2);
         await expect(newUser).toContainText("Charlie Davis");
         await expect(newUser).toContainText("No orders yet");
     });
 
-    test("should preserve object identity for observable arrays when using deepMerge", async ({ page }) => {
+    test("should preserve object identity for observable arrays when using deepMerge", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/deep-merge/");
         // This test verifies that splice is used internally by checking
         // that updates work correctly multiple times (proving the array
@@ -225,13 +223,11 @@ test.describe("Deep Merge Test Fixture", () => {
 
         await page.click('button:has-text("Update Product Tags")');
 
-
         const firstItem = page.locator(".item").first();
         await expect(firstItem).toContainText("Views: 300");
 
         // Update again - if array identity wasn't preserved, this might fail
         await page.click('button:has-text("Update Product Tags")');
-
 
         // Should still work correctly
         await expect(firstItem).toContainText("Views: 300");

--- a/packages/fast-html/test/fixtures/deep-merge/index.html
+++ b/packages/fast-html/test/fixtures/deep-merge/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Deep Merge Test Fixture</title>
-    <style>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Deep Merge Test Fixture</title>
+        <style>
         body {
             font-family: system-ui, -apple-system, sans-serif;
             max-width: 1200px;
@@ -28,7 +28,7 @@
             background: white;
             padding: 20px;
             border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
 
         .stats {
@@ -148,300 +148,481 @@
         em {
             color: #999;
         }
-    </style>
-</head>
-<body>
-    <f-template name="deep-merge-test-element">
-        <template>
-            <div class="container">
-                <h1>Deep Merge Test Fixture</h1>
+        </style>
+    </head>
+    <body>
+        <f-template name="deep-merge-test-element">
+            <template>
+                <div class="container">
+                    <h1>Deep Merge Test Fixture</h1>
 
-                <!-- Stats Section with Deep Property Access -->
-                <div class="stats">
-                    <h2>Statistics</h2>
-                    <p>Total Orders: <strong>{{stats.totalOrders}}</strong></p>
-                    <p>Total Revenue: <strong>${{stats.totalRevenue}}</strong></p>
-                    <p>Active Users: <strong>{{stats.activeUsers}}</strong></p>
-                    <button @click="{updateStats()}">Update Stats</button>
-                </div>
+                    <!-- Stats Section with Deep Property Access -->
+                    <div class="stats">
+                        <h2>Statistics</h2>
+                        <p>Total Orders: <strong>{{ stats.totalOrders }}</strong></p>
+                        <p>Total Revenue: <strong>${{ stats.totalRevenue }}</strong></p>
+                        <p>Active Users: <strong>{{ stats.activeUsers }}</strong></p>
+                        <button @click="{updateStats()}">Update Stats</button>
+                    </div>
 
-                <!-- Control Buttons -->
-                <div class="controls">
-                    <h2>Test Actions</h2>
-                    <button @click="{updateUserProfile()}">Update User Profile</button>
-                    <button @click="{updateUserOrders()}">Replace Orders</button>
-                    <button @click="{removeOrderItems()}">Remove Order Items</button>
-                    <button @click="{updateProductTags()}">Update Product Tags</button>
-                    <button @click="{addNewUser()}">Add New User</button>
-                    <button @click="{toggleDetails()}">Toggle Details</button>
-                    <button @click="{incrementAge()}">Increment Age</button>
-                    <button @click="{testUndefinedMerge()}">Test Undefined Merge</button>
-                </div>
+                    <!-- Control Buttons -->
+                    <div class="controls">
+                        <h2>Test Actions</h2>
+                        <button @click="{updateUserProfile()}">
+                            Update User Profile
+                        </button>
+                        <button @click="{updateUserOrders()}">Replace Orders</button>
+                        <button @click="{removeOrderItems()}">Remove Order Items</button>
+                        <button @click="{updateProductTags()}">
+                            Update Product Tags
+                        </button>
+                        <button @click="{addNewUser()}">Add New User</button>
+                        <button @click="{toggleDetails()}">Toggle Details</button>
+                        <button @click="{incrementAge()}">Increment Age</button>
+                        <button @click="{testUndefinedMerge()}">
+                            Test Undefined Merge
+                        </button>
+                    </div>
 
-                <!-- Users List with Conditional Rendering -->
-                <div class="users">
-                    <h2>Users ({{users.length}} total)</h2>
+                    <!-- Users List with Conditional Rendering -->
+                    <div class="users">
+                        <h2>Users ({{ users.length }} total)</h2>
 
-                    <f-repeat value="{{user in users}}">
-                        <div class="user-card">
-                            <h3>{{user.name}} (ID: {{user.id}})</h3>
-                            <p>Email: {{user.email}}</p>
+                        <f-repeat value="{{user in users}}">
+                            <div class="user-card">
+                                <h3>{{ user.name }} (ID: {{ user.id }})</h3>
+                                <p>Email: {{ user.email }}</p>
 
-                            <!-- Conditional Details Section -->
-                            <f-when value="{{showDetails}}">
-                                <div class="profile">
-                                    <h4>Profile</h4>
-                                    <p>Age: {{user.profile.age}}</p>
-                                    <p>Location: {{user.profile.location.city}}, {{user.profile.location.country}}</p>
-                                    <p>Theme: {{user.profile.preferences.theme}}</p>
-                                    <p>Notifications: <f-when value="{{user.profile.preferences.notifications}}">Enabled</f-when><f-when value="{{!user.profile.preferences.notifications}}">Disabled</f-when></p>
-                                </div>
-                            </f-when>
+                                <!-- Conditional Details Section -->
+                                <f-when value="{{showDetails}}">
+                                    <div class="profile">
+                                        <h4>Profile</h4>
+                                        <p>Age: {{ user.profile.age }}</p>
+                                        <p>
+                                            Location: {{ user.profile.location.city }},
+                                            {{ user.profile.location.country }}
+                                        </p>
+                                        <p>Theme: {{ user.profile.preferences.theme }}</p>
+                                        <p>
+                                            Notifications:
+                                            <f-when
+                                                value="{{user.profile.preferences.notifications}}"
+                                                >Enabled</f-when
+                                            ><f-when
+                                                value="{{!user.profile.preferences.notifications}}"
+                                                >Disabled</f-when
+                                            >
+                                        </p>
+                                    </div>
+                                </f-when>
 
-                            <!-- Orders Section with Nested Repeats -->
-                            <div class="orders">
-                                <h4>Orders ({{user.orders.length}})</h4>
+                                <!-- Orders Section with Nested Repeats -->
+                                <div class="orders">
+                                    <h4>Orders ({{ user.orders.length }})</h4>
 
-                                <f-when value="{{user.orders.length > 0}}">
-                                    <f-repeat value="{{order in user.orders}}">
-                                        <div class="order">
-                                            <p><strong>Order #{{order.id}}</strong> - {{order.date}} - Total: ${{order.total}}</p>
+                                    <f-when value="{{user.orders.length > 0}}">
+                                        <f-repeat value="{{order in user.orders}}">
+                                            <div class="order">
+                                                <p>
+                                                    <strong>Order #{{ order.id }}</strong>
+                                                    - {{ order.date }} - Total: ${{ order.total }}
+                                                </p>
 
-                                            <!-- Items with Nested Array -->
-                                            <ul class="items">
-                                                <f-repeat value="{{item in order.items}}">
-                                                    <li class="item">
-                                                        <strong>{{item.name}}</strong> - ${{item.price}}
-                                                        <span class="stock"><f-when value="{{item.inStock}}">✓ In Stock</f-when><f-when value="{{!item.inStock}}">✗ Out of Stock</f-when></span>
+                                                <!-- Items with Nested Array -->
+                                                <ul class="items">
+                                                    <f-repeat
+                                                        value="{{item in order.items}}"
+                                                    >
+                                                        <li class="item">
+                                                            <strong
+                                                                >{{ item.name }}</strong
+                                                            >
+                                                            - ${{ item.price }}
+                                                            <span class="stock"
+                                                                ><f-when
+                                                                    value="{{item.inStock}}"
+                                                                    >✓ In Stock</f-when
+                                                                ><f-when
+                                                                    value="{{!item.inStock}}"
+                                                                    >✗ Out of Stock</f-when
+                                                                ></span
+                                                            >
 
-                                                        <!-- Tags Array -->
-                                                        <div class="tags">
-                                                            Tags: <f-repeat value="{{tag in item.tags}}"><span class="tag">{{tag}}</span></f-repeat>
-                                                        </div>
-
-                                                        <!-- Metadata -->
-                                                        <f-when value="{{showDetails}}">
-                                                            <div class="metadata">
-                                                                <small>Views: {{item.metadata.views}} | Rating: {{item.metadata.rating}}</small>
+                                                            <!-- Tags Array -->
+                                                            <div class="tags">
+                                                                Tags:
+                                                                <f-repeat
+                                                                    value="{{tag in item.tags}}"
+                                                                    ><span class="tag"
+                                                                        >{{ tag }}</span
+                                                                    ></f-repeat
+                                                                >
                                                             </div>
-                                                        </f-when>
-                                                    </li>
-                                                </f-repeat>
-                                            </ul>
-                                        </div>
-                                    </f-repeat>
-                                </f-when>
 
-                                <f-when value="{{user.orders.length == 0}}">
-                                    <p><em>No orders yet</em></p>
-                                </f-when>
+                                                            <!-- Metadata -->
+                                                            <f-when
+                                                                value="{{showDetails}}"
+                                                            >
+                                                                <div class="metadata">
+                                                                    <small
+                                                                        >Views:
+                                                                        {{ item.metadata.views }}
+                                                                        | Rating:
+                                                                        {{ item.metadata.rating }}</small
+                                                                    >
+                                                                </div>
+                                                            </f-when>
+                                                        </li>
+                                                    </f-repeat>
+                                                </ul>
+                                            </div>
+                                        </f-repeat>
+                                    </f-when>
+
+                                    <f-when value="{{user.orders.length == 0}}">
+                                        <p><em>No orders yet</em></p>
+                                    </f-when>
+                                </div>
                             </div>
-                        </div>
-                    </f-repeat>
+                        </f-repeat>
+                    </div>
                 </div>
-            </div>
-        </template>
-    </f-template>
-    <deep-merge-test-element>
-        <template shadowrootmode="open">
-            <div class="container">
-                <h1>Deep Merge Test Fixture</h1>
+            </template>
+        </f-template>
+        <deep-merge-test-element>
+            <template shadowrootmode="open">
+                <div class="container">
+                    <h1>Deep Merge Test Fixture</h1>
 
-                <!-- Stats Section with Deep Property Access -->
-                <div class="stats">
-                    <h2>Statistics</h2>
-                    <p>Total Orders: <strong><!--fe-b$$start$$0$$stats.totalOrders$$fe-b-->3<!--fe-b$$end$$0$$stats.totalOrders$$fe-b--></strong></p>
-                    <p>Total Revenue: <strong>$<!--fe-b$$start$$1$$stats.totalRevenue$$fe-b-->425.5<!--fe-b$$end$$1$$stats.totalRevenue$$fe-b--></strong></p>
-                    <p>Active Users: <strong><!--fe-b$$start$$2$$stats.activeUsers$$fe-b-->2<!--fe-b$$end$$2$$stats.activeUsers$$fe-b--></strong></p>
-                    <button data-fe-b-3>Update Stats</button>
-                </div>
+                    <!-- Stats Section with Deep Property Access -->
+                    <div class="stats">
+                        <h2>Statistics</h2>
+                        <p>
+                            Total Orders:
+                            <strong>3<!--fe-b$$end$$0$$stats.totalOrders$$fe-b--></strong>
+                        </p>
+                        <p>
+                            Total Revenue:
+                            <strong
+                                >$<!--fe-b$$start$$1$$stats.totalRevenue$$fe-b--> 425.5<!--fe-b$$end$$1$$stats.totalRevenue$$fe-b--></strong
+                            >
+                        </p>
+                        <p>
+                            Active Users:
+                            <strong>2<!--fe-b$$end$$2$$stats.activeUsers$$fe-b--></strong>
+                        </p>
+                        <button data-fe-b-3>Update Stats</button>
+                    </div>
 
-                <!-- Control Buttons -->
-                <div class="controls">
-                    <h2>Test Actions</h2>
-                    <button data-fe-b-4>Update User Profile</button>
-                    <button data-fe-b-5>Replace Orders</button>
-                    <button data-fe-b-6>Remove Order Items</button>
-                    <button data-fe-b-7>Update Product Tags</button>
-                    <button data-fe-b-8>Add New User</button>
-                    <button data-fe-b-9>Toggle Details</button>
-                    <button data-fe-b-10>Increment Age</button>
-                    <button data-fe-b-11>Test Undefined Merge</button>
-                </div>
+                    <!-- Control Buttons -->
+                    <div class="controls">
+                        <h2>Test Actions</h2>
+                        <button data-fe-b-4>Update User Profile</button>
+                        <button data-fe-b-5>Replace Orders</button>
+                        <button data-fe-b-6>Remove Order Items</button>
+                        <button data-fe-b-7>Update Product Tags</button>
+                        <button data-fe-b-8>Add New User</button>
+                        <button data-fe-b-9>Toggle Details</button>
+                        <button data-fe-b-10>Increment Age</button>
+                        <button data-fe-b-11>Test Undefined Merge</button>
+                    </div>
 
-                <!-- Users List with Conditional Rendering -->
-                <div class="users">
-                    <h2>Users (<!--fe-b$$start$$12$$users.length$$fe-b-->2<!--fe-b$$end$$12$$users.length$$fe-b--> total)</h2>
+                    <!-- Users List with Conditional Rendering -->
+                    <div class="users">
+                        <h2>
+                            Users (<!--fe-b$$start$$12$$users.length$$fe-b-->
+                            2<!--fe-b$$end$$12$$users.length$$fe-b--> total)
+                        </h2>
 
-                    <!--fe-b$$start$$13$$f-repeat-user-in-users$$fe-b-->
-                    <!--fe-repeat$$start$$0$$fe-repeat-->
+                        <!--fe-b$$start$$13$$f-repeat-user-in-users$$fe-b-->
+                        <!--fe-repeat$$start$$0$$fe-repeat-->
                         <div class="user-card">
-                            <h3><!--fe-b$$start$$0$$user.name$$fe-b-->Alice Johnson<!--fe-b$$end$$0$$user.name$$fe-b--> (ID: <!--fe-b$$start$$1$$user.id$$fe-b-->1<!--fe-b$$end$$1$$user.id$$fe-b-->)</h3>
-                            <p>Email: <!--fe-b$$start$$2$$user.email$$fe-b-->alice@example.com<!--fe-b$$end$$2$$user.email$$fe-b--></p>
+                            <h3>
+                                Alice Johnson<!--fe-b$$end$$0$$user.name$$fe-b--> (ID: <!--fe-b$$start$$1$$user.id$$fe-b-->1<!--fe-b$$end$$1$$user.id$$fe-b-->
+                                )
+                            </h3>
+                            <p>
+                                Email: <!--fe-b$$start$$2$$user.email$$fe-b-->alice@example.com<!--fe-b$$end$$2$$user.email$$fe-b-->
+                            </p>
 
                             <!-- Conditional Details Section -->
                             <!--fe-b$$start$$3$$when-showDetails$$fe-b-->
-                                <div class="profile">
-                                    <h4>Profile</h4>
-                                    <p>Age: <!--fe-b$$start$$0$$user.profile.age$$fe-b-->28<!--fe-b$$end$$0$$user.profile.age$$fe-b--></p>
-                                    <p>Location: <!--fe-b$$start$$1$$user.profile.location.city$$fe-b-->New York<!--fe-b$$end$$1$$user.profile.location.city$$fe-b-->, <!--fe-b$$start$$2$$user.profile.location.country$$fe-b-->USA<!--fe-b$$end$$2$$user.profile.location.country$$fe-b--></p>
-                                    <p>Theme: <!--fe-b$$start$$3$$user.profile.preferences.theme$$fe-b-->dark<!--fe-b$$end$$3$$user.profile.preferences.theme$$fe-b--></p>
-                                    <p>Notifications: <!--fe-b$$start$$4$$when-user.profile.preferences.notifications$$fe-b-->Enabled<!--fe-b$$end$$4$$when-user.profile.preferences.notifications$$fe-b--><!--fe-b$$start$$5$$when-!user.profile.preferences.notifications$$fe-b--><!--fe-b$$end$$5$$when-!user.profile.preferences.notifications$$fe-b--></p>
-                                </div>
+                            <div class="profile">
+                                <h4>Profile</h4>
+                                <p>
+                                    Age: <!--fe-b$$start$$0$$user.profile.age$$fe-b-->28<!--fe-b$$end$$0$$user.profile.age$$fe-b-->
+                                </p>
+                                <p>
+                                    Location: <!--fe-b$$start$$1$$user.profile.location.city$$fe-b-->New
+                                    York<!--fe-b$$end$$1$$user.profile.location.city$$fe-b-->, <!--fe-b$$start$$2$$user.profile.location.country$$fe-b-->USA<!--fe-b$$end$$2$$user.profile.location.country$$fe-b-->
+                                </p>
+                                <p>
+                                    Theme: <!--fe-b$$start$$3$$user.profile.preferences.theme$$fe-b-->dark<!--fe-b$$end$$3$$user.profile.preferences.theme$$fe-b-->
+                                </p>
+                                <p>
+                                    Notifications: <!--fe-b$$start$$4$$when-user.profile.preferences.notifications$$fe-b-->Enabled<!--fe-b$$end$$4$$when-user.profile.preferences.notifications$$fe-b--><!--fe-b$$start$$5$$when-!user.profile.preferences.notifications$$fe-b--><!--fe-b$$end$$5$$when-!user.profile.preferences.notifications$$fe-b-->
+                                </p>
+                            </div>
                             <!--fe-b$$end$$3$$when-showDetails$$fe-b-->
 
                             <!-- Orders Section with Nested Repeats -->
                             <div class="orders">
-                                <h4>Orders (<!--fe-b$$start$$4$$user.orders.length$$fe-b-->2<!--fe-b$$end$$4$$user.orders.length$$fe-b-->)</h4>
+                                <h4>
+                                    Orders
+                                    (<!--fe-b$$start$$4$$user.orders.length$$fe-b-->
+                                    2<!--fe-b$$end$$4$$user.orders.length$$fe-b--> )
+                                </h4>
 
                                 <!--fe-b$$start$$5$$when-user.orders.length > 0$$fe-b-->
-                                    <!--fe-b$$start$$0$$f-repeat-order-in-user.orders$$fe-b-->
-                                    <!--fe-repeat$$start$$0$$fe-repeat-->
-                                        <div class="order">
-                                            <p><strong>Order #<!--fe-b$$start$$0$$order.id$$fe-b-->101<!--fe-b$$end$$0$$order.id$$fe-b--></strong> - <!--fe-b$$start$$1$$order.date$$fe-b-->2024-01-15<!--fe-b$$end$$1$$order.date$$fe-b--> - Total: $<!--fe-b$$start$$2$$order.total$$fe-b-->150.5<!--fe-b$$end$$2$$order.total$$fe-b--></p>
+                                <!--fe-b$$start$$0$$f-repeat-order-in-user.orders$$fe-b-->
+                                <!--fe-repeat$$start$$0$$fe-repeat-->
+                                <div class="order">
+                                    <p>
+                                        <strong
+                                            >Order #<!--fe-b$$start$$0$$order.id$$fe-b-->
+                                            101<!--fe-b$$end$$0$$order.id$$fe-b--></strong
+                                        >
+                                        - <!--fe-b$$start$$1$$order.date$$fe-b-->2024-01-15<!--fe-b$$end$$1$$order.date$$fe-b--> -
+                                        Total: $<!--fe-b$$start$$2$$order.total$$fe-b-->
+                                        150.5<!--fe-b$$end$$2$$order.total$$fe-b-->
+                                    </p>
 
-                                            <!-- Items with Nested Array -->
-                                            <ul class="items">
-                                                <!--fe-b$$start$$3$$f-repeat-item-in-order.items$$fe-b-->
-                                                <!--fe-repeat$$start$$0$$fe-repeat-->
-                                                    <li class="item">
-                                                        <strong><!--fe-b$$start$$0$$item.name$$fe-b-->Laptop<!--fe-b$$end$$0$$item.name$$fe-b--></strong> - $<!--fe-b$$start$$1$$item.price$$fe-b-->100<!--fe-b$$end$$1$$item.price$$fe-b-->
-                                                        <span class="stock"><!--fe-b$$start$$2$$when-item.inStock$$fe-b-->✓ In Stock<!--fe-b$$end$$2$$when-item.inStock$$fe-b--><!--fe-b$$start$$3$$when-!item.inStock$$fe-b--><!--fe-b$$end$$3$$when-!item.inStock$$fe-b--></span>
+                                    <!-- Items with Nested Array -->
+                                    <ul class="items">
+                                        <!--fe-b$$start$$3$$f-repeat-item-in-order.items$$fe-b-->
+                                        <!--fe-repeat$$start$$0$$fe-repeat-->
+                                        <li class="item">
+                                            <strong
+                                                >Laptop<!--fe-b$$end$$0$$item.name$$fe-b--></strong
+                                            >
+                                            - $<!--fe-b$$start$$1$$item.price$$fe-b--> 100<!--fe-b$$end$$1$$item.price$$fe-b-->
+                                            <span class="stock"
+                                                >✓ In Stock<!--fe-b$$end$$2$$when-item.inStock$$fe-b--><!--fe-b$$start$$3$$when-!item.inStock$$fe-b--><!--fe-b$$end$$3$$when-!item.inStock$$fe-b--></span
+                                            >
 
-                                                        <!-- Tags Array -->
-                                                        <div class="tags">
-                                                            Tags: <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat--><span class="tag"><!--fe-b$$start$$0$$tag$$fe-b-->electronics<!--fe-b$$end$$0$$tag$$fe-b--></span><!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat--><span class="tag"><!--fe-b$$start$$0$$tag$$fe-b-->computers<!--fe-b$$end$$0$$tag$$fe-b--></span><!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$4$$f-repeat-tag-in-item.tags$$fe-b-->
-                                                        </div>
+                                            <!-- Tags Array -->
+                                            <div class="tags">
+                                                Tags: <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat--><!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat-->
+                                                <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat--> <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat--> <span
+                                                    class="tag"
+                                                    >electronics<!--fe-b$$end$$0$$tag$$fe-b--></span
+                                                    <!--fe-repeat$$end$$0$$fe-repeat--> <!--fe-repeat$$start$$1$$fe-repeat-->
+                                                ><span class="tag"
+                                                    >computers<!--fe-b$$end$$0$$tag$$fe-b--></span
+                                                ><!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$4$$f-repeat-tag-in-item.tags$$fe-b-->
+                                            </div>
 
-                                                        <!-- Metadata -->
-                                                        <!--fe-b$$start$$5$$when-showDetails$$fe-b-->
-                                                            <div class="metadata">
-                                                                <small>Views: <!--fe-b$$start$$0$$item.metadata.views$$fe-b-->250<!--fe-b$$end$$0$$item.metadata.views$$fe-b--> | Rating: <!--fe-b$$start$$1$$item.metadata.rating$$fe-b-->4.5<!--fe-b$$end$$1$$item.metadata.rating$$fe-b--></small>
-                                                            </div>
-                                                        <!--fe-b$$end$$5$$when-showDetails$$fe-b-->
-                                                    </li>
-                                                <!--fe-repeat$$end$$0$$fe-repeat-->
-                                                <!--fe-repeat$$start$$1$$fe-repeat-->
-                                                    <li class="item">
-                                                        <strong><!--fe-b$$start$$0$$item.name$$fe-b-->Mouse<!--fe-b$$end$$0$$item.name$$fe-b--></strong> - $<!--fe-b$$start$$1$$item.price$$fe-b-->50.5<!--fe-b$$end$$1$$item.price$$fe-b-->
-                                                        <span class="stock"><!--fe-b$$start$$2$$when-item.inStock$$fe-b-->✓ In Stock<!--fe-b$$end$$2$$when-item.inStock$$fe-b--><!--fe-b$$start$$3$$when-!item.inStock$$fe-b--><!--fe-b$$end$$3$$when-!item.inStock$$fe-b--></span>
+                                            <!-- Metadata -->
+                                            <!--fe-b$$start$$5$$when-showDetails$$fe-b-->
+                                            <div class="metadata">
+                                                <small
+                                                    >Views: <!--fe-b$$start$$0$$item.metadata.views$$fe-b-->250<!--fe-b$$end$$0$$item.metadata.views$$fe-b--> |
+                                                    Rating: <!--fe-b$$start$$1$$item.metadata.rating$$fe-b-->4.5<!--fe-b$$end$$1$$item.metadata.rating$$fe-b--></small
+                                                >
+                                            </div>
+                                            <!--fe-b$$end$$5$$when-showDetails$$fe-b-->
+                                        </li>
+                                        <!--fe-repeat$$end$$0$$fe-repeat-->
+                                        <!--fe-repeat$$start$$1$$fe-repeat-->
+                                        <li class="item">
+                                            <strong
+                                                >Mouse<!--fe-b$$end$$0$$item.name$$fe-b--></strong
+                                            >
+                                            - $<!--fe-b$$start$$1$$item.price$$fe-b-->
+                                            50.5<!--fe-b$$end$$1$$item.price$$fe-b-->
+                                            <span class="stock"
+                                                >✓ In Stock<!--fe-b$$end$$2$$when-item.inStock$$fe-b--><!--fe-b$$start$$3$$when-!item.inStock$$fe-b--><!--fe-b$$end$$3$$when-!item.inStock$$fe-b--></span
+                                            >
 
-                                                        <!-- Tags Array -->
-                                                        <div class="tags">
-                                                            Tags: <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat--><span class="tag"><!--fe-b$$start$$0$$tag$$fe-b-->electronics<!--fe-b$$end$$0$$tag$$fe-b--></span><!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat--><span class="tag"><!--fe-b$$start$$0$$tag$$fe-b-->accessories<!--fe-b$$end$$0$$tag$$fe-b--></span><!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$4$$f-repeat-tag-in-item.tags$$fe-b-->
-                                                        </div>
+                                            <!-- Tags Array -->
+                                            <div class="tags">
+                                                Tags: <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat--><!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat-->
+                                                <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat--> <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat--> <span
+                                                    class="tag"
+                                                    >electronics<!--fe-b$$end$$0$$tag$$fe-b--></span
+                                                    <!--fe-repeat$$end$$0$$fe-repeat--> <!--fe-repeat$$start$$1$$fe-repeat-->
+                                                ><span class="tag"
+                                                    >accessories<!--fe-b$$end$$0$$tag$$fe-b--></span
+                                                ><!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$4$$f-repeat-tag-in-item.tags$$fe-b-->
+                                            </div>
 
-                                                        <!-- Metadata -->
-                                                        <!--fe-b$$start$$5$$when-showDetails$$fe-b-->
-                                                            <div class="metadata">
-                                                                <small>Views: <!--fe-b$$start$$0$$item.metadata.views$$fe-b-->180<!--fe-b$$end$$0$$item.metadata.views$$fe-b--> | Rating: <!--fe-b$$start$$1$$item.metadata.rating$$fe-b-->4<!--fe-b$$end$$1$$item.metadata.rating$$fe-b--></small>
-                                                            </div>
-                                                        <!--fe-b$$end$$5$$when-showDetails$$fe-b-->
-                                                    </li>
-                                                <!--fe-repeat$$end$$1$$fe-repeat-->
-                                                <!--fe-b$$end$$3$$f-repeat-item-in-order.items$$fe-b-->
-                                            </ul>
-                                        </div>
-                                    <!--fe-repeat$$end$$0$$fe-repeat-->
-                                    <!--fe-repeat$$start$$1$$fe-repeat-->
-                                        <div class="order">
-                                            <p><strong>Order #<!--fe-b$$start$$0$$order.id$$fe-b-->102<!--fe-b$$end$$0$$order.id$$fe-b--></strong> - <!--fe-b$$start$$1$$order.date$$fe-b-->2024-02-20<!--fe-b$$end$$1$$order.date$$fe-b--> - Total: $<!--fe-b$$start$$2$$order.total$$fe-b-->75<!--fe-b$$end$$2$$order.total$$fe-b--></p>
+                                            <!-- Metadata -->
+                                            <!--fe-b$$start$$5$$when-showDetails$$fe-b-->
+                                            <div class="metadata">
+                                                <small
+                                                    >Views: <!--fe-b$$start$$0$$item.metadata.views$$fe-b-->180<!--fe-b$$end$$0$$item.metadata.views$$fe-b--> |
+                                                    Rating: <!--fe-b$$start$$1$$item.metadata.rating$$fe-b-->4<!--fe-b$$end$$1$$item.metadata.rating$$fe-b--></small
+                                                >
+                                            </div>
+                                            <!--fe-b$$end$$5$$when-showDetails$$fe-b-->
+                                        </li>
+                                        <!--fe-repeat$$end$$1$$fe-repeat-->
+                                        <!--fe-b$$end$$3$$f-repeat-item-in-order.items$$fe-b-->
+                                    </ul>
+                                </div>
+                                <!--fe-repeat$$end$$0$$fe-repeat-->
+                                <!--fe-repeat$$start$$1$$fe-repeat-->
+                                <div class="order">
+                                    <p>
+                                        <strong
+                                            >Order #<!--fe-b$$start$$0$$order.id$$fe-b-->
+                                            102<!--fe-b$$end$$0$$order.id$$fe-b--></strong
+                                        >
+                                        - <!--fe-b$$start$$1$$order.date$$fe-b-->2024-02-20<!--fe-b$$end$$1$$order.date$$fe-b--> -
+                                        Total: $<!--fe-b$$start$$2$$order.total$$fe-b-->
+                                        75<!--fe-b$$end$$2$$order.total$$fe-b-->
+                                    </p>
 
-                                            <!-- Items with Nested Array -->
-                                            <ul class="items">
-                                                <!--fe-b$$start$$3$$f-repeat-item-in-order.items$$fe-b-->
-                                                <!--fe-repeat$$start$$0$$fe-repeat-->
-                                                    <li class="item">
-                                                        <strong><!--fe-b$$start$$0$$item.name$$fe-b-->Keyboard<!--fe-b$$end$$0$$item.name$$fe-b--></strong> - $<!--fe-b$$start$$1$$item.price$$fe-b-->75<!--fe-b$$end$$1$$item.price$$fe-b-->
-                                                        <span class="stock"><!--fe-b$$start$$2$$when-item.inStock$$fe-b-->✓ In Stock<!--fe-b$$end$$2$$when-item.inStock$$fe-b--><!--fe-b$$start$$3$$when-!item.inStock$$fe-b--><!--fe-b$$end$$3$$when-!item.inStock$$fe-b--></span>
+                                    <!-- Items with Nested Array -->
+                                    <ul class="items">
+                                        <!--fe-b$$start$$3$$f-repeat-item-in-order.items$$fe-b-->
+                                        <!--fe-repeat$$start$$0$$fe-repeat-->
+                                        <li class="item">
+                                            <strong
+                                                >Keyboard<!--fe-b$$end$$0$$item.name$$fe-b--></strong
+                                            >
+                                            - $<!--fe-b$$start$$1$$item.price$$fe-b--> 75<!--fe-b$$end$$1$$item.price$$fe-b-->
+                                            <span class="stock"
+                                                >✓ In Stock<!--fe-b$$end$$2$$when-item.inStock$$fe-b--><!--fe-b$$start$$3$$when-!item.inStock$$fe-b--><!--fe-b$$end$$3$$when-!item.inStock$$fe-b--></span
+                                            >
 
-                                                        <!-- Tags Array -->
-                                                        <div class="tags">
-                                                            Tags: <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat--><span class="tag"><!--fe-b$$start$$0$$tag$$fe-b-->electronics<!--fe-b$$end$$0$$tag$$fe-b--></span><!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat--><span class="tag"><!--fe-b$$start$$0$$tag$$fe-b-->accessories<!--fe-b$$end$$0$$tag$$fe-b--></span><!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$4$$f-repeat-tag-in-item.tags$$fe-b-->
-                                                        </div>
+                                            <!-- Tags Array -->
+                                            <div class="tags">
+                                                Tags: <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat--><!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat-->
+                                                <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat--> <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat--> <span
+                                                    class="tag"
+                                                    >electronics<!--fe-b$$end$$0$$tag$$fe-b--></span
+                                                    <!--fe-repeat$$end$$0$$fe-repeat--> <!--fe-repeat$$start$$1$$fe-repeat-->
+                                                ><span class="tag"
+                                                    >accessories<!--fe-b$$end$$0$$tag$$fe-b--></span
+                                                ><!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$4$$f-repeat-tag-in-item.tags$$fe-b-->
+                                            </div>
 
-                                                        <!-- Metadata -->
-                                                        <!--fe-b$$start$$5$$when-showDetails$$fe-b-->
-                                                            <div class="metadata">
-                                                                <small>Views: <!--fe-b$$start$$0$$item.metadata.views$$fe-b-->120<!--fe-b$$end$$0$$item.metadata.views$$fe-b--> | Rating: <!--fe-b$$start$$1$$item.metadata.rating$$fe-b-->4.8<!--fe-b$$end$$1$$item.metadata.rating$$fe-b--></small>
-                                                            </div>
-                                                        <!--fe-b$$end$$5$$when-showDetails$$fe-b-->
-                                                    </li>
-                                                <!--fe-repeat$$end$$0$$fe-repeat-->
-                                                <!--fe-b$$end$$3$$f-repeat-item-in-order.items$$fe-b-->
-                                            </ul>
-                                        </div>
-                                    <!--fe-repeat$$end$$1$$fe-repeat-->
-                                    <!--fe-b$$end$$0$$f-repeat-order-in-user.orders$$fe-b-->
+                                            <!-- Metadata -->
+                                            <!--fe-b$$start$$5$$when-showDetails$$fe-b-->
+                                            <div class="metadata">
+                                                <small
+                                                    >Views: <!--fe-b$$start$$0$$item.metadata.views$$fe-b-->120<!--fe-b$$end$$0$$item.metadata.views$$fe-b--> |
+                                                    Rating: <!--fe-b$$start$$1$$item.metadata.rating$$fe-b-->4.8<!--fe-b$$end$$1$$item.metadata.rating$$fe-b--></small
+                                                >
+                                            </div>
+                                            <!--fe-b$$end$$5$$when-showDetails$$fe-b-->
+                                        </li>
+                                        <!--fe-repeat$$end$$0$$fe-repeat-->
+                                        <!--fe-b$$end$$3$$f-repeat-item-in-order.items$$fe-b-->
+                                    </ul>
+                                </div>
+                                <!--fe-repeat$$end$$1$$fe-repeat-->
+                                <!--fe-b$$end$$0$$f-repeat-order-in-user.orders$$fe-b-->
                                 <!--fe-b$$end$$5$$when-user.orders.length > 0$$fe-b-->
 
                                 <!--fe-b$$start$$6$$when-user.orders.length == 0$$fe-b--><!--fe-b$$end$$6$$when-user.orders.length == 0$$fe-b-->
                             </div>
                         </div>
-                    <!--fe-repeat$$end$$0$$fe-repeat-->
-                    <!--fe-repeat$$start$$1$$fe-repeat-->
+                        <!--fe-repeat$$end$$0$$fe-repeat-->
+                        <!--fe-repeat$$start$$1$$fe-repeat-->
                         <div class="user-card">
-                            <h3><!--fe-b$$start$$0$$user.name$$fe-b-->Bob Smith<!--fe-b$$end$$0$$user.name$$fe-b--> (ID: <!--fe-b$$start$$1$$user.id$$fe-b-->2<!--fe-b$$end$$1$$user.id$$fe-b-->)</h3>
-                            <p>Email: <!--fe-b$$start$$2$$user.email$$fe-b-->bob@example.com<!--fe-b$$end$$2$$user.email$$fe-b--></p>
+                            <h3>
+                                Bob Smith<!--fe-b$$end$$0$$user.name$$fe-b--> (ID: <!--fe-b$$start$$1$$user.id$$fe-b-->2<!--fe-b$$end$$1$$user.id$$fe-b-->
+                                )
+                            </h3>
+                            <p>
+                                Email: <!--fe-b$$start$$2$$user.email$$fe-b-->bob@example.com<!--fe-b$$end$$2$$user.email$$fe-b-->
+                            </p>
 
                             <!-- Conditional Details Section -->
                             <!--fe-b$$start$$3$$when-showDetails$$fe-b-->
-                                <div class="profile">
-                                    <h4>Profile</h4>
-                                    <p>Age: <!--fe-b$$start$$0$$user.profile.age$$fe-b-->35<!--fe-b$$end$$0$$user.profile.age$$fe-b--></p>
-                                    <p>Location: <!--fe-b$$start$$1$$user.profile.location.city$$fe-b-->London<!--fe-b$$end$$1$$user.profile.location.city$$fe-b-->, <!--fe-b$$start$$2$$user.profile.location.country$$fe-b-->UK<!--fe-b$$end$$2$$user.profile.location.country$$fe-b--></p>
-                                    <p>Theme: <!--fe-b$$start$$3$$user.profile.preferences.theme$$fe-b-->light<!--fe-b$$end$$3$$user.profile.preferences.theme$$fe-b--></p>
-                                    <p>Notifications: <!--fe-b$$start$$4$$when-user.profile.preferences.notifications$$fe-b--><!--fe-b$$end$$4$$when-user.profile.preferences.notifications$$fe-b--><!--fe-b$$start$$5$$when-!user.profile.preferences.notifications$$fe-b-->Disabled<!--fe-b$$end$$5$$when-!user.profile.preferences.notifications$$fe-b--></p>
-                                </div>
+                            <div class="profile">
+                                <h4>Profile</h4>
+                                <p>
+                                    Age: <!--fe-b$$start$$0$$user.profile.age$$fe-b-->35<!--fe-b$$end$$0$$user.profile.age$$fe-b-->
+                                </p>
+                                <p>
+                                    Location: <!--fe-b$$start$$1$$user.profile.location.city$$fe-b-->London<!--fe-b$$end$$1$$user.profile.location.city$$fe-b-->, <!--fe-b$$start$$2$$user.profile.location.country$$fe-b-->UK<!--fe-b$$end$$2$$user.profile.location.country$$fe-b-->
+                                </p>
+                                <p>
+                                    Theme: <!--fe-b$$start$$3$$user.profile.preferences.theme$$fe-b-->light<!--fe-b$$end$$3$$user.profile.preferences.theme$$fe-b-->
+                                </p>
+                                <p>
+                                    Notifications: <!--fe-b$$start$$4$$when-user.profile.preferences.notifications$$fe-b--><!--fe-b$$end$$4$$when-user.profile.preferences.notifications$$fe-b--><!--fe-b$$start$$5$$when-!user.profile.preferences.notifications$$fe-b-->Disabled<!--fe-b$$end$$5$$when-!user.profile.preferences.notifications$$fe-b-->
+                                </p>
+                            </div>
                             <!--fe-b$$end$$3$$when-showDetails$$fe-b-->
 
                             <!-- Orders Section with Nested Repeats -->
                             <div class="orders">
-                                <h4>Orders (<!--fe-b$$start$$4$$user.orders.length$$fe-b-->1<!--fe-b$$end$$4$$user.orders.length$$fe-b-->)</h4>
+                                <h4>
+                                    Orders
+                                    (<!--fe-b$$start$$4$$user.orders.length$$fe-b-->
+                                    1<!--fe-b$$end$$4$$user.orders.length$$fe-b--> )
+                                </h4>
 
                                 <!--fe-b$$start$$5$$when-user.orders.length > 0$$fe-b-->
-                                    <!--fe-b$$start$$0$$f-repeat-order-in-user.orders$$fe-b-->
-                                    <!--fe-repeat$$start$$0$$fe-repeat-->
-                                        <div class="order">
-                                            <p><strong>Order #<!--fe-b$$start$$0$$order.id$$fe-b-->201<!--fe-b$$end$$0$$order.id$$fe-b--></strong> - <!--fe-b$$start$$1$$order.date$$fe-b-->2024-03-10<!--fe-b$$end$$1$$order.date$$fe-b--> - Total: $<!--fe-b$$start$$2$$order.total$$fe-b-->200<!--fe-b$$end$$2$$order.total$$fe-b--></p>
+                                <!--fe-b$$start$$0$$f-repeat-order-in-user.orders$$fe-b-->
+                                <!--fe-repeat$$start$$0$$fe-repeat-->
+                                <div class="order">
+                                    <p>
+                                        <strong
+                                            >Order #<!--fe-b$$start$$0$$order.id$$fe-b-->
+                                            201<!--fe-b$$end$$0$$order.id$$fe-b--></strong
+                                        >
+                                        - <!--fe-b$$start$$1$$order.date$$fe-b-->2024-03-10<!--fe-b$$end$$1$$order.date$$fe-b--> -
+                                        Total: $<!--fe-b$$start$$2$$order.total$$fe-b-->
+                                        200<!--fe-b$$end$$2$$order.total$$fe-b-->
+                                    </p>
 
-                                            <!-- Items with Nested Array -->
-                                            <ul class="items">
-                                                <!--fe-b$$start$$3$$f-repeat-item-in-order.items$$fe-b-->
-                                                <!--fe-repeat$$start$$0$$fe-repeat-->
-                                                    <li class="item">
-                                                        <strong><!--fe-b$$start$$0$$item.name$$fe-b-->Headphones<!--fe-b$$end$$0$$item.name$$fe-b--></strong> - $<!--fe-b$$start$$1$$item.price$$fe-b-->200<!--fe-b$$end$$1$$item.price$$fe-b-->
-                                                        <span class="stock"><!--fe-b$$start$$2$$when-item.inStock$$fe-b--><!--fe-b$$end$$2$$when-item.inStock$$fe-b--><!--fe-b$$start$$3$$when-!item.inStock$$fe-b-->✗ Out of Stock<!--fe-b$$end$$3$$when-!item.inStock$$fe-b--></span>
+                                    <!-- Items with Nested Array -->
+                                    <ul class="items">
+                                        <!--fe-b$$start$$3$$f-repeat-item-in-order.items$$fe-b-->
+                                        <!--fe-repeat$$start$$0$$fe-repeat-->
+                                        <li class="item">
+                                            <strong
+                                                >Headphones<!--fe-b$$end$$0$$item.name$$fe-b--></strong
+                                            >
+                                            - $<!--fe-b$$start$$1$$item.price$$fe-b--> 200<!--fe-b$$end$$1$$item.price$$fe-b-->
+                                            <span class="stock"
+                                                >✗ Out of Stock<!--fe-b$$end$$3$$when-!item.inStock$$fe-b--></span
+                                            >
 
-                                                        <!-- Tags Array -->
-                                                        <div class="tags">
-                                                            Tags: <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat--><span class="tag"><!--fe-b$$start$$0$$tag$$fe-b-->electronics<!--fe-b$$end$$0$$tag$$fe-b--></span><!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat--><span class="tag"><!--fe-b$$start$$0$$tag$$fe-b-->audio<!--fe-b$$end$$0$$tag$$fe-b--></span><!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$4$$f-repeat-tag-in-item.tags$$fe-b-->
-                                                        </div>
+                                            <!-- Tags Array -->
+                                            <div class="tags">
+                                                Tags: <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat--><!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat-->
+                                                <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat--> <!--fe-b$$start$$4$$f-repeat-tag-in-item.tags$$fe-b--> <!--fe-repeat$$start$$0$$fe-repeat--> <span
+                                                    class="tag"
+                                                    >electronics<!--fe-b$$end$$0$$tag$$fe-b--></span
+                                                    <!--fe-repeat$$end$$0$$fe-repeat--> <!--fe-repeat$$start$$1$$fe-repeat-->
+                                                ><span class="tag"
+                                                    >audio<!--fe-b$$end$$0$$tag$$fe-b--></span
+                                                ><!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$4$$f-repeat-tag-in-item.tags$$fe-b-->
+                                            </div>
 
-                                                        <!-- Metadata -->
-                                                        <!--fe-b$$start$$5$$when-showDetails$$fe-b-->
-                                                            <div class="metadata">
-                                                                <small>Views: <!--fe-b$$start$$0$$item.metadata.views$$fe-b-->350<!--fe-b$$end$$0$$item.metadata.views$$fe-b--> | Rating: <!--fe-b$$start$$1$$item.metadata.rating$$fe-b-->4.7<!--fe-b$$end$$1$$item.metadata.rating$$fe-b--></small>
-                                                            </div>
-                                                        <!--fe-b$$end$$5$$when-showDetails$$fe-b-->
-                                                    </li>
-                                                <!--fe-repeat$$end$$0$$fe-repeat-->
-                                                <!--fe-b$$end$$3$$f-repeat-item-in-order.items$$fe-b-->
-                                            </ul>
-                                        </div>
-                                    <!--fe-repeat$$end$$0$$fe-repeat-->
-                                    <!--fe-b$$end$$0$$f-repeat-order-in-user.orders$$fe-b-->
+                                            <!-- Metadata -->
+                                            <!--fe-b$$start$$5$$when-showDetails$$fe-b-->
+                                            <div class="metadata">
+                                                <small
+                                                    >Views: <!--fe-b$$start$$0$$item.metadata.views$$fe-b-->350<!--fe-b$$end$$0$$item.metadata.views$$fe-b--> |
+                                                    Rating: <!--fe-b$$start$$1$$item.metadata.rating$$fe-b-->4.7<!--fe-b$$end$$1$$item.metadata.rating$$fe-b--></small
+                                                >
+                                            </div>
+                                            <!--fe-b$$end$$5$$when-showDetails$$fe-b-->
+                                        </li>
+                                        <!--fe-repeat$$end$$0$$fe-repeat-->
+                                        <!--fe-b$$end$$3$$f-repeat-item-in-order.items$$fe-b-->
+                                    </ul>
+                                </div>
+                                <!--fe-repeat$$end$$0$$fe-repeat-->
+                                <!--fe-b$$end$$0$$f-repeat-order-in-user.orders$$fe-b-->
                                 <!--fe-b$$end$$5$$when-user.orders.length > 0$$fe-b-->
 
                                 <!--fe-b$$start$$6$$when-user.orders.length == 0$$fe-b--><!--fe-b$$end$$6$$when-user.orders.length == 0$$fe-b-->
                             </div>
                         </div>
-                    <!--fe-repeat$$end$$1$$fe-repeat-->
-                    <!--fe-b$$end$$4$$f-repeat-user-in-users$$fe-b-->
+                        <!--fe-repeat$$end$$1$$fe-repeat-->
+                        <!--fe-b$$end$$4$$f-repeat-user-in-users$$fe-b-->
+                    </div>
                 </div>
-            </div>
-        </template>
-    </deep-merge-test-element>
-    <script type="module" src="./main.ts"></script>
-</body>
+            </template>
+        </deep-merge-test-element>
+        <script type="module" src="./main.ts"></script>
+    </body>
 </html>

--- a/packages/fast-html/test/fixtures/deep-merge/main.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/main.ts
@@ -1,6 +1,6 @@
 import { FASTElement, observable } from "@microsoft/fast-element";
-import { RenderableFASTElement, TemplateElement } from "../../../src/index.js";
 import { deepMerge } from "../../../src/components/utilities.js";
+import { RenderableFASTElement, TemplateElement } from "../../../src/index.js";
 
 interface Product {
     id: number;

--- a/packages/fast-html/test/fixtures/dot-syntax/dot-syntax.spec.ts
+++ b/packages/fast-html/test/fixtures/dot-syntax/dot-syntax.spec.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("f-template dot-syntax bindings", async () => {
-    test("create a object property reference using dot syntax in a binding", async ({ page }) => {
+    test("create a object property reference using dot syntax in a binding", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/dot-syntax/");
 
         const customElement = page.locator("test-element");
@@ -37,7 +39,9 @@ test.describe("f-template dot-syntax bindings", async () => {
         await expect(bSpan).toHaveText("Hello");
     });
 
-    test("should update object.a.b1 when 'Set a.b1' button is clicked", async ({ page }) => {
+    test("should update object.a.b1 when 'Set a.b1' button is clicked", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/dot-syntax/");
 
         const customElement = page.locator("test-element");
@@ -54,7 +58,9 @@ test.describe("f-template dot-syntax bindings", async () => {
         await expect(ab1Span).toHaveText("World");
     });
 
-    test("should update object.a.b2.c when 'Set a.b2.c' button is clicked", async ({ page }) => {
+    test("should update object.a.b2.c when 'Set a.b2.c' button is clicked", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/dot-syntax/");
 
         const customElement = page.locator("test-element");
@@ -156,7 +162,9 @@ test.describe("f-template dot-syntax bindings", async () => {
         await expect(bSpan).toHaveText("Hello", { timeout: 1000 });
     });
 
-    test("should observe changes to repeated items with missing nested properties", async ({ page }) => {
+    test("should observe changes to repeated items with missing nested properties", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/dot-syntax/");
 
         const customElement = page.locator("test-element");
@@ -176,7 +184,9 @@ test.describe("f-template dot-syntax bindings", async () => {
         await expect(customElement.locator("div").nth(2)).toHaveText("Item 3");
     });
 
-    test("should add new repeated items when nested properties are set", async ({ page }) => {
+    test("should add new repeated items when nested properties are set", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/dot-syntax/");
 
         const customElement = page.locator("test-element");
@@ -197,6 +207,5 @@ test.describe("f-template dot-syntax bindings", async () => {
         });
 
         await expect(divs).toHaveCount(2);
-
     });
 });

--- a/packages/fast-html/test/fixtures/dot-syntax/index.html
+++ b/packages/fast-html/test/fixtures/dot-syntax/index.html
@@ -1,23 +1,23 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title></title>
         <script type="module" src="./main.ts"></script>
     </head>
     <body>
         <f-template name="test-element">
             <template>
-                <span>{{object.b}}</span>
-                <span>{{object.a.b1}}</span>
-                <span>{{object.a.b2.c}}</span>
+                <span>{{ object.b }}</span>
+                <span>{{ object.a.b1 }}</span>
+                <span>{{ object.a.b2.c }}</span>
                 <button @click="{handleBClick()}">Set b</button>
                 <button @click="{handleAB1Click()}">Set a.b1</button>
                 <button @click="{handleAB2CClick()}">Set a.b2.c</button>
                 <f-when value="{{object.c}}">
                     <f-repeat value="{{item in object.c}}">
                         <f-when value="{{item.name && item.status == 'active'}}">
-                            <div>{{item.name}}</div>
+                            <div>{{ item.name }}</div>
                         </f-when>
                     </f-repeat>
                 </f-when>
@@ -25,9 +25,12 @@
         </f-template>
         <test-element>
             <template shadowrootmode="open">
-                <span><!--fe-b$$start$$0$$t01oHhokPY$$fe-b-->bar<!--fe-b$$end$$0$$t01oHhokPY$$fe-b--></span>
-                <span><!--fe-b$$start$$1$$t01oHhokPY$$fe-b--><!--fe-b$$end$$1$$t01oHhokPY$$fe-b--></span>
-                <span><!--fe-b$$start$$2$$t01oHhokPY$$fe-b-->FOO<!--fe-b$$end$$2$$t01oHhokPY$$fe-b--></span>
+                <span>bar<!--fe-b$$end$$0$$t01oHhokPY$$fe-b--></span>
+                <span>
+                    <!--fe-b$$start$$1$$t01oHhokPY$$fe-b-->
+                    <!--fe-b$$end$$1$$t01oHhokPY$$fe-b-->
+                </span>
+                <span>FOO<!--fe-b$$end$$2$$t01oHhokPY$$fe-b--></span>
                 <button data-fe-b-3>Set b</button>
                 <button data-fe-b-4>Set a.b1</button>
                 <button data-fe-b-5>Set a.b2.c</button>
@@ -35,12 +38,12 @@
                 <!--fe-b$$start$$0$$jklasdf$$fe-b-->
                 <!--fe-repeat$$start$$0$$fe-repeat-->
                 <!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->
-                <div><!--fe-b$$start$$0$$vEbKKUHmwU$$fe-b-->Item 1<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--></div>
+                <div>Item 1<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--></div>
                 <!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b-->
                 <!--fe-repeat$$end$$0$$fe-repeat-->
                 <!--fe-repeat$$start$$1$$fe-repeat-->
                 <!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->
-                <div><!--fe-b$$start$$0$$vEbKKUHmwU$$fe-b-->Item 2<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--></div>
+                <div>Item 2<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--></div>
                 <!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b-->
                 <!--fe-repeat$$end$$1$$fe-repeat-->
                 <!--fe-repeat$$start$$2$$fe-repeat-->

--- a/packages/fast-html/test/fixtures/event/event.spec.ts
+++ b/packages/fast-html/test/fixtures/event/event.spec.ts
@@ -7,7 +7,7 @@ test.describe("f-template", async () => {
         const customElement = page.locator("test-element");
 
         let message;
-        page.on("console", msg => message = msg.text());
+        page.on("console", msg => (message = msg.text()));
 
         await customElement.locator("button").nth(0).click();
 
@@ -19,7 +19,7 @@ test.describe("f-template", async () => {
         const customElement = page.locator("test-element");
 
         let message;
-        page.on("console", msg => message = msg.text());
+        page.on("console", msg => (message = msg.text()));
 
         await customElement.locator("button").nth(1).click();
 
@@ -31,7 +31,7 @@ test.describe("f-template", async () => {
         const customElement = page.locator("test-element");
 
         let message;
-        page.on("console", msg => message = msg.text());
+        page.on("console", msg => (message = msg.text()));
 
         await customElement.locator("button").nth(2).click();
 

--- a/packages/fast-html/test/fixtures/event/index.html
+++ b/packages/fast-html/test/fixtures/event/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title></title>
     </head>
     <body>
@@ -17,7 +17,9 @@
             <template>
                 <button @click="{handleNoArgsClick()}">No arguments</button>
                 <button @click="{handleEventArgClick(e)}">event argument</button>
-                <button @click="{handleAttributeArgClick(foo)}">attribute argument</button>
+                <button @click="{handleAttributeArgClick(foo)}">
+                    attribute argument
+                </button>
                 <button @click="{handleModifyAttributeClick()}">modify foo</button>
             </template>
         </f-template>

--- a/packages/fast-html/test/fixtures/event/main.ts
+++ b/packages/fast-html/test/fixtures/event/main.ts
@@ -1,5 +1,5 @@
-import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 import { attr, FASTElement } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
 class TestElement extends FASTElement {
     @attr

--- a/packages/fast-html/test/fixtures/host-bindings/host-bindings.spec.ts
+++ b/packages/fast-html/test/fixtures/host-bindings/host-bindings.spec.ts
@@ -2,9 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test.describe("Host Bindings Hydration", async () => {
     test.describe("should restart marker indexes inside the template after host bindings", () => {
-        test("single host event binding with content text binding", async ({
-            page,
-        }) => {
+        test("single host event binding with content text binding", async ({ page }) => {
             await page.goto("/fixtures/host-bindings/");
 
             const element = page.locator("host-event-element");
@@ -105,7 +103,7 @@ test.describe("Host Bindings Hydration", async () => {
             // Verify mouseenter event binding also works
             await element.hover();
             expect(messages.some(m => m.includes("host-events mouseenter: 1"))).toBe(
-                true
+                true,
             );
 
             // KEY TEST: Verify updating content binding works (proves correct offset with 2 host events)
@@ -136,7 +134,7 @@ test.describe("Host Bindings Hydration", async () => {
             await element.click();
 
             expect(messages.some(m => m.includes("host-multi-content clicked: 1"))).toBe(
-                true
+                true,
             );
 
             // KEY TEST: Update both attribute bindings to prove indexes 0,1 are correct
@@ -165,7 +163,7 @@ test.describe("Host Bindings Hydration", async () => {
             await element.click();
 
             expect(messages.some(m => m.includes("host-text-binding clicked: 1"))).toBe(
-                true
+                true,
             );
 
             // KEY TEST: Verify updating text binding works (proves correct index offset)
@@ -223,7 +221,7 @@ test.describe("Host Bindings Hydration", async () => {
             await element.click({ force: true }); // force because element is disabled
 
             expect(messages.some(m => m.includes("host-all-types clicked: 1"))).toBe(
-                true
+                true,
             );
 
             // KEY TEST: Verify updating content binding works regardless of host binding types/order
@@ -277,9 +275,9 @@ test.describe("Host Bindings Hydration", async () => {
 
                 await element.click({ force: true }); // force because element is disabled
 
-                expect(
-                    messages.some(m => m.includes(`${selector} clicked: 1`))
-                ).toBe(true);
+                expect(messages.some(m => m.includes(`${selector} clicked: 1`))).toBe(
+                    true,
+                );
 
                 // KEY TEST: Verify updating content binding works regardless of host binding order
                 await element.evaluate((el: any) => {
@@ -328,7 +326,7 @@ test.describe("Host Bindings Hydration", async () => {
                     (el: any, data: { prop: string; expected: string }) => {
                         el[data.prop] = data.expected;
                     },
-                    { prop, expected }
+                    { prop, expected },
                 );
 
                 // Verify the binding updated correctly

--- a/packages/fast-html/test/fixtures/host-bindings/index.html
+++ b/packages/fast-html/test/fixtures/host-bindings/index.html
@@ -1,52 +1,48 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title>Host Bindings Test</title>
         <style>
-            /* Ensure custom elements display as block to prevent overlap */
-            host-event-element,
-            host-multi-element,
-            host-static-element,
-            host-events-element,
-            host-multi-content-element,
-            host-text-binding-element,
-            host-property-element,
-            host-all-types-element,
-            host-perm-attr-first,
-            host-perm-bool-first,
-            host-perm-prop-first {
-                display: block;
-                margin: 10px 0;
-                padding: 10px;
-                border: 1px solid #ccc;
-            }
+        /* Ensure custom elements display as block to prevent overlap */
+        host-event-element,
+        host-multi-element,
+        host-static-element,
+        host-events-element,
+        host-multi-content-element,
+        host-text-binding-element,
+        host-property-element,
+        host-all-types-element,
+        host-perm-attr-first,
+        host-perm-bool-first,
+        host-perm-prop-first {
+            display: block;
+            margin: 10px 0;
+            padding: 10px;
+            border: 1px solid #ccc;
+        }
         </style>
     </head>
     <body>
         <!-- Test 1: Single host event binding with content attribute binding -->
         <!-- Verifies marker indexes restart at 0 inside content after host binding -->
         <host-event-element>
-            <template shadowrootmode="open">
-                <span data-fe-b-0>Hello</span>
-            </template>
+            <template shadowrootmode="open"> <span data-fe-b-0>Hello</span> </template>
         </host-event-element>
         <f-template name="host-event-element">
-            <template @click="{handleClick()}">
-                <span>{{greeting}}</span>
-            </template>
+            <template @click="{handleClick()}"> <span>{{ greeting }}</span> </template>
         </f-template>
 
         <!-- Test 2: Multiple host bindings (event + boolean attr) with content binding -->
         <!-- Verifies multiple host bindings don't affect content indexing -->
         <host-multi-element disabled>
             <template shadowrootmode="open">
-                <span><!--fe-b$$start$$0$$HostMulti$$fe-b-->World<!--fe-b$$end$$0$$HostMulti$$fe-b--></span>
+                <span>World<!--fe-b$$end$$0$$HostMulti$$fe-b--></span>
             </template>
         </host-multi-element>
         <f-template name="host-multi-element">
             <template @click="{handleClick()}" ?disabled="{{isDisabled}}">
-                <span>{{text}}</span>
+                <span>{{ text }}</span>
             </template>
         </f-template>
 
@@ -54,12 +50,14 @@
         <!-- Verifies static attributes on host + host event + content bindings work together -->
         <host-static-element id="static-host">
             <template shadowrootmode="open">
-                <span><!--fe-b$$start$$0$$StaticEl1$$fe-b-->first<!--fe-b$$end$$0$$StaticEl1$$fe-b--> <!--fe-b$$start$$1$$StaticEl1$$fe-b-->second<!--fe-b$$end$$1$$StaticEl1$$fe-b--></span>
+                <span
+                    >first<!--fe-b$$end$$0$$StaticEl1$$fe-b--> <!--fe-b$$start$$1$$StaticEl1$$fe-b-->second<!--fe-b$$end$$1$$StaticEl1$$fe-b--></span
+                >
             </template>
         </host-static-element>
         <f-template name="host-static-element">
             <template id="static-host" @click="{handleClick()}">
-                <span>{{first}} {{second}}</span>
+                <span>{{ first }} {{ second }}</span>
             </template>
         </f-template>
 
@@ -72,7 +70,7 @@
         </host-events-element>
         <f-template name="host-events-element">
             <template @click="{handleClick()}" @mouseenter="{handleMouseEnter()}">
-                {{text}}
+                {{ text }}
             </template>
         </f-template>
 
@@ -93,38 +91,39 @@
         <!-- Verifies host event + text binding in element -->
         <host-text-binding-element>
             <template shadowrootmode="open">
-                <span><!--fe-b$$start$$0$$TextBind1$$fe-b-->text content<!--fe-b$$end$$0$$TextBind1$$fe-b--></span>
+                <span>text content<!--fe-b$$end$$0$$TextBind1$$fe-b--></span>
             </template>
         </host-text-binding-element>
         <f-template name="host-text-binding-element">
-            <template @click="{handleClick()}">
-                <span>{{text}}</span>
-            </template>
+            <template @click="{handleClick()}"> <span>{{ text }}</span> </template>
         </f-template>
 
         <!-- Test 7: Host property binding with content binding -->
         <!-- Verifies property binding (:property) on host works correctly -->
         <host-property-element>
             <template shadowrootmode="open">
-                <span><!--fe-b$$start$$0$$PropEl1$$fe-b-->property test<!--fe-b$$end$$0$$PropEl1$$fe-b--></span>
+                <span>property test<!--fe-b$$end$$0$$PropEl1$$fe-b--></span>
             </template>
         </host-property-element>
         <f-template name="host-property-element">
-            <template :title="{hostTitle}">
-                <span>{{text}}</span>
-            </template>
+            <template :title="{hostTitle}"> <span>{{ text }}</span> </template>
         </f-template>
 
         <!-- Test 8: All host binding types (event + boolean + property + attribute) -->
         <!-- Verifies all binding types on host with content binding -->
         <host-all-types-element attr="value" disabled>
             <template shadowrootmode="open">
-                <span><!--fe-b$$start$$0$$AllTypes1$$fe-b-->all types<!--fe-b$$end$$0$$AllTypes1$$fe-b--></span>
+                <span>all types<!--fe-b$$end$$0$$AllTypes1$$fe-b--></span>
             </template>
         </host-all-types-element>
         <f-template name="host-all-types-element">
-            <template @click="{handleClick()}" ?disabled="{{isDisabled}}" :title="{hostTitle}" attr="{{hostAttr}}">
-                <span>{{text}}</span>
+            <template
+                @click="{handleClick()}"
+                ?disabled="{{isDisabled}}"
+                :title="{hostTitle}"
+                attr="{{hostAttr}}"
+            >
+                <span>{{ text }}</span>
             </template>
         </f-template>
 
@@ -132,12 +131,17 @@
         <!-- Order: attribute, property, boolean, event -->
         <host-perm-attr-first attr="value" disabled>
             <template shadowrootmode="open">
-                <span><!--fe-b$$start$$0$$PermAttr1$$fe-b-->perm attr first<!--fe-b$$end$$0$$PermAttr1$$fe-b--></span>
+                <span>perm attr first<!--fe-b$$end$$0$$PermAttr1$$fe-b--></span>
             </template>
         </host-perm-attr-first>
         <f-template name="host-perm-attr-first">
-            <template attr="{{hostAttr}}" :title="{hostTitle}" ?disabled="{{isDisabled}}" @click="{handleClick()}">
-                <span>{{text}}</span>
+            <template
+                attr="{{hostAttr}}"
+                :title="{hostTitle}"
+                ?disabled="{{isDisabled}}"
+                @click="{handleClick()}"
+            >
+                <span>{{ text }}</span>
             </template>
         </f-template>
 
@@ -145,12 +149,17 @@
         <!-- Order: boolean, event, attribute, property -->
         <host-perm-bool-first attr="value" disabled>
             <template shadowrootmode="open">
-                <span><!--fe-b$$start$$0$$PermBool1$$fe-b-->perm bool first<!--fe-b$$end$$0$$PermBool1$$fe-b--></span>
+                <span>perm bool first<!--fe-b$$end$$0$$PermBool1$$fe-b--></span>
             </template>
         </host-perm-bool-first>
         <f-template name="host-perm-bool-first">
-            <template ?disabled="{{isDisabled}}" @click="{handleClick()}" attr="{{hostAttr}}" :title="{hostTitle}">
-                <span>{{text}}</span>
+            <template
+                ?disabled="{{isDisabled}}"
+                @click="{handleClick()}"
+                attr="{{hostAttr}}"
+                :title="{hostTitle}"
+            >
+                <span>{{ text }}</span>
             </template>
         </f-template>
 
@@ -158,12 +167,17 @@
         <!-- Order: property, attribute, event, boolean -->
         <host-perm-prop-first attr="value" disabled>
             <template shadowrootmode="open">
-                <span><!--fe-b$$start$$0$$PermProp1$$fe-b-->perm prop first<!--fe-b$$end$$0$$PermProp1$$fe-b--></span>
+                <span>perm prop first<!--fe-b$$end$$0$$PermProp1$$fe-b--></span>
             </template>
         </host-perm-prop-first>
         <f-template name="host-perm-prop-first">
-            <template :title="{hostTitle}" attr="{{hostAttr}}" @click="{handleClick()}" ?disabled="{{isDisabled}}">
-                <span>{{text}}</span>
+            <template
+                :title="{hostTitle}"
+                attr="{{hostAttr}}"
+                @click="{handleClick()}"
+                ?disabled="{{isDisabled}}"
+            >
+                <span>{{ text }}</span>
             </template>
         </f-template>
 

--- a/packages/fast-html/test/fixtures/host-bindings/main.ts
+++ b/packages/fast-html/test/fixtures/host-bindings/main.ts
@@ -1,5 +1,5 @@
-import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
 // Test 1: Element with single host event binding and content attribute binding
 class HostEventElement extends FASTElement {

--- a/packages/fast-html/test/fixtures/lifecycle-callbacks/index.html
+++ b/packages/fast-html/test/fixtures/lifecycle-callbacks/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title>Lifecycle Callbacks Test</title>
     </head>
     <body>
@@ -16,11 +16,13 @@
         <complex-element needs-hydration title="Complex">
             <template shadowrootmode="open">
                 <div>
-                    <h2><!--fe-b$$start$$0$$title$$fe-b-->Complex<!--fe-b$$end$$0$$title$$fe-b--></h2>
-                    <p>Count: <!--fe-b$$start$$1$$count$$fe-b-->0<!--fe-b$$end$$1$$count$$fe-b--></p>
+                    <h2>Complex<!--fe-b$$end$$0$$title$$fe-b--></h2>
+                    <p>
+                        Count: <!--fe-b$$start$$1$$count$$fe-b-->0<!--fe-b$$end$$1$$count$$fe-b-->
+                    </p>
                     <nested-element needs-hydration data-fe-b-2 label="Complex">
                         <template shadowrootmode="open">
-                            <span><!--fe-b$$start$$0$$label$$fe-b-->Complex<!--fe-b$$end$$0$$label$$fe-b--></span>
+                            <span>Complex<!--fe-b$$end$$0$$label$$fe-b--></span>
                         </template>
                     </nested-element>
                 </div>
@@ -30,7 +32,9 @@
         <!-- Deferred element -->
         <deferred-element needs-hydration defer-hydration status="pending">
             <template shadowrootmode="open">
-                <p>Status: <!--fe-b$$start$$0$$status$$fe-b-->pending<!--fe-b$$end$$0$$status$$fe-b--></p>
+                <p>
+                    Status: <!--fe-b$$start$$0$$status$$fe-b-->pending<!--fe-b$$end$$0$$status$$fe-b-->
+                </p>
             </template>
         </deferred-element>
 
@@ -38,10 +42,15 @@
         <deferred-parent-element needs-hydration defer-hydration label="Parent">
             <template shadowrootmode="open">
                 <section>
-                    <p><!--fe-b$$start$$0$$label$$fe-b-->Parent<!--fe-b$$end$$0$$label$$fe-b--></p>
-                    <deferred-child-element needs-hydration defer-hydration label="Child" data-fe-b-1>
+                    <p>Parent<!--fe-b$$end$$0$$label$$fe-b--></p>
+                    <deferred-child-element
+                        needs-hydration
+                        defer-hydration
+                        label="Child"
+                        data-fe-b-1
+                    >
                         <template shadowrootmode="open">
-                            <span><!--fe-b$$start$$0$$label$$fe-b-->Child<!--fe-b$$end$$0$$label$$fe-b--></span>
+                            <span>Child<!--fe-b$$end$$0$$label$$fe-b--></span>
                         </template>
                     </deferred-child-element>
                 </section>
@@ -50,17 +59,17 @@
 
         <!-- Template definitions -->
         <f-template name="simple-element">
-            <template>{{message}} World</template>
+            <template>{{ message }} World</template>
         </f-template>
 
         <f-template name="complex-element">
             <template>
                 <div>
-                    <h2>{{title}}</h2>
-                    <p>Count: {{count}}</p>
+                    <h2>{{ title }}</h2>
+                    <p>Count: {{ count }}</p>
                     <nested-element label="{{title}}">
                         <template shadowrootmode="open">
-                            <span>{{label}}</span>
+                            <span>{{ label }}</span>
                         </template>
                     </nested-element>
                 </div>
@@ -68,24 +77,24 @@
         </f-template>
 
         <f-template name="nested-element">
-            <template><span>{{label}}</span></template>
+            <template><span>{{ label }}</span></template>
         </f-template>
 
         <f-template name="deferred-element">
-            <template><p>Status: {{status}}</p></template>
+            <template><p>Status: {{ status }}</p></template>
         </f-template>
 
         <f-template name="deferred-parent-element">
             <template>
                 <section>
-                    <p>{{label}}</p>
+                    <p>{{ label }}</p>
                     <deferred-child-element label="{{label}}"></deferred-child-element>
                 </section>
             </template>
         </f-template>
 
         <f-template name="deferred-child-element">
-            <template><span>{{label}}</span></template>
+            <template><span>{{ label }}</span></template>
         </f-template>
 
         <script type="module" src="./main.ts"></script>

--- a/packages/fast-html/test/fixtures/lifecycle-callbacks/lifecycle-callbacks.spec.ts
+++ b/packages/fast-html/test/fixtures/lifecycle-callbacks/lifecycle-callbacks.spec.ts
@@ -13,7 +13,7 @@ test.describe("Lifecycle Callbacks", async () => {
 
         // Verify callbacks for simple-element were called
         const simpleElementEvents = events.filter(
-            (e: any) => e.name === "simple-element"
+            (e: any) => e.name === "simple-element",
         );
 
         expect(simpleElementEvents.length).toBeGreaterThan(0);
@@ -66,16 +66,16 @@ test.describe("Lifecycle Callbacks", async () => {
         const events = await page.evaluate(() => (window as any).lifecycleEvents);
 
         const willHydrateEvents = events.filter(
-            (e: any) => e.callback === "elementWillHydrate"
+            (e: any) => e.callback === "elementWillHydrate",
         );
         const didHydrateEvents = events.filter(
-            (e: any) => e.callback === "elementDidHydrate"
+            (e: any) => e.callback === "elementDidHydrate",
         );
 
         // Every elementWillHydrate should be followed by elementDidHydrate for the same element
         willHydrateEvents.forEach((willEvent: any) => {
             const correspondingDidEvent = didHydrateEvents.find(
-                (e: any) => e.name === willEvent.name
+                (e: any) => e.name === willEvent.name,
             );
             expect(correspondingDidEvent).toBeDefined();
         });
@@ -88,7 +88,7 @@ test.describe("Lifecycle Callbacks", async () => {
 
         const hydrationComplete = await page.waitForFunction(
             () => (window as any).getHydrationCompleteStatus(),
-            { timeout: 5000 }
+            { timeout: 5000 },
         );
 
         expect(hydrationComplete).toBeTruthy();
@@ -97,7 +97,7 @@ test.describe("Lifecycle Callbacks", async () => {
 
         // Verify hydrationComplete callback was invoked
         const hydrationCompleteEvents = events.filter(
-            (e: any) => e.callback === "hydrationComplete"
+            (e: any) => e.callback === "hydrationComplete",
         );
         expect(hydrationCompleteEvents.length).toBe(1);
 
@@ -111,12 +111,15 @@ test.describe("Lifecycle Callbacks", async () => {
         await expect(nestedElement).not.toHaveAttribute("needs-hydration");
 
         // Verify hydrationComplete was called AFTER all individual element hydrations
-        const lastElementDidHydrateIndex = events.reduce((maxIndex: number, e: any, index: number) => {
-            return e.callback === "elementDidHydrate" ? index : maxIndex;
-        }, -1);
+        const lastElementDidHydrateIndex = events.reduce(
+            (maxIndex: number, e: any, index: number) => {
+                return e.callback === "elementDidHydrate" ? index : maxIndex;
+            },
+            -1,
+        );
 
         const hydrationCompleteIndex = events.findIndex(
-            (e: any) => e.callback === "hydrationComplete"
+            (e: any) => e.callback === "hydrationComplete",
         );
 
         expect(hydrationCompleteIndex).toBeGreaterThan(lastElementDidHydrateIndex);
@@ -139,7 +142,7 @@ test.describe("Lifecycle Callbacks", async () => {
         // Complex element should have all lifecycle callbacks
         expect(complexEvents.length).toBeGreaterThan(0);
         expect(complexEvents.some((e: any) => e.callback === "elementDidHydrate")).toBe(
-            true
+            true,
         );
     });
 
@@ -159,10 +162,10 @@ test.describe("Lifecycle Callbacks", async () => {
 
         // Both should have hydrated
         expect(complexEvents.some((e: any) => e.callback === "elementDidHydrate")).toBe(
-            true
+            true,
         );
         expect(nestedEvents.some((e: any) => e.callback === "elementDidHydrate")).toBe(
-            true
+            true,
         );
     });
 
@@ -179,10 +182,10 @@ test.describe("Lifecycle Callbacks", async () => {
 
         // Should have hydration callbacks
         expect(deferredEvents.some((e: any) => e.callback === "elementWillHydrate")).toBe(
-            true
+            true,
         );
         expect(deferredEvents.some((e: any) => e.callback === "elementDidHydrate")).toBe(
-            true
+            true,
         );
 
         const deferredElement = await page.locator("deferred-element");
@@ -190,32 +193,32 @@ test.describe("Lifecycle Callbacks", async () => {
         await expect(deferredElement).not.toHaveAttribute("defer-hydration");
     });
 
-        test("should defer child hydration until parent completes", async ({ page }) => {
-            await page.goto("/fixtures/lifecycle-callbacks/");
+    test("should defer child hydration until parent completes", async ({ page }) => {
+        await page.goto("/fixtures/lifecycle-callbacks/");
 
-            await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
-            const events = await page.evaluate(() => (window as any).lifecycleEvents);
+        const events = await page.evaluate(() => (window as any).lifecycleEvents);
 
-            const parentWillHydrateIndex = events.findIndex(
-                (e: any) =>
-                    e.name === "deferred-parent-element" &&
-                    e.callback === "elementWillHydrate"
-            );
+        const parentWillHydrateIndex = events.findIndex(
+            (e: any) =>
+                e.name === "deferred-parent-element" &&
+                e.callback === "elementWillHydrate",
+        );
 
-            const childWillHydrateIndex = events.findIndex(
-                (e: any) =>
-                    e.name === "deferred-child-element" &&
-                    e.callback === "elementWillHydrate"
-            );
+        const childWillHydrateIndex = events.findIndex(
+            (e: any) =>
+                e.name === "deferred-child-element" &&
+                e.callback === "elementWillHydrate",
+        );
 
-            expect(parentWillHydrateIndex).toBeGreaterThan(-1);
-            expect(childWillHydrateIndex).toBeGreaterThan(parentWillHydrateIndex);
+        expect(parentWillHydrateIndex).toBeGreaterThan(-1);
+        expect(childWillHydrateIndex).toBeGreaterThan(parentWillHydrateIndex);
 
-            const childElement = page.locator("deferred-child-element");
-            await expect(childElement).not.toHaveAttribute("needs-hydration");
-            await expect(childElement).not.toHaveAttribute("defer-hydration");
-        });
+        const childElement = page.locator("deferred-child-element");
+        await expect(childElement).not.toHaveAttribute("needs-hydration");
+        await expect(childElement).not.toHaveAttribute("defer-hydration");
+    });
 
     test("should verify template and hydration callbacks are invoked", async ({
         page,
@@ -276,9 +279,7 @@ test.describe("Lifecycle Callbacks", async () => {
         await expect(complexElement).toHaveText(/Complex/);
 
         // Verify elements are interactive after hydration
-        const currentCount = await complexElement.evaluate(
-            (el: any) => el.count
-        );
+        const currentCount = await complexElement.evaluate((el: any) => el.count);
         expect(currentCount).toBe(0);
 
         // Interact with the element

--- a/packages/fast-html/test/fixtures/lifecycle-callbacks/main.ts
+++ b/packages/fast-html/test/fixtures/lifecycle-callbacks/main.ts
@@ -1,5 +1,5 @@
-import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
 // Track lifecycle callbacks for testing
 export const lifecycleEvents: Array<{ callback: string; name?: string }> = [];

--- a/packages/fast-html/test/fixtures/nested-elements/index.html
+++ b/packages/fast-html/test/fixtures/nested-elements/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Nested Elements Hydration Tests</title>
         <script type="module" src="./main.ts"></script>
     </head>
@@ -133,15 +133,15 @@
         <f-template name="child-element">
             <template>
                 <div class="item">
-                    <span class="index">{{idx}}</span>
-                    <span class="text">{{text}}</span>
+                    <span class="index">{{ idx }}</span>
+                    <span class="text">{{ text }}</span>
                 </div>
             </template>
         </f-template>
         <f-template name="parent-element">
             <template>
                 <div class="list-container">
-                    <h2>{{title}}</h2>
+                    <h2>{{ title }}</h2>
                     <div class="items">
                         <f-repeat value="{{item in items}}" positioning="true">
                             <child-element

--- a/packages/fast-html/test/fixtures/nested-elements/main.ts
+++ b/packages/fast-html/test/fixtures/nested-elements/main.ts
@@ -83,10 +83,6 @@ export class Item extends RenderableElement {
     private static prepareCallCount = 0;
     private static instanceMap = new WeakMap<Item, number>();
 
-    constructor() {
-        super();
-    }
-
     async prepare() {
         // Assign instance number on first prepare() call for this instance
         if (!Item.instanceMap.has(this)) {
@@ -128,22 +124,22 @@ TemplateElement.options({
     .config({
         elementDidDefine(name: string) {
             (window as any).messages.push(
-                `Element did define: ${name} [${performance.now()}]`
+                `Element did define: ${name} [${performance.now()}]`,
             );
         },
         elementDidHydrate(source: HTMLElement) {
             (window as any).messages.push(
-                `Element did hydrate: ${source.localName} [${performance.now()}]`
+                `Element did hydrate: ${source.localName} [${performance.now()}]`,
             );
         },
         elementDidRegister(name: string) {
             (window as any).messages.push(
-                `Element did register: ${name} [${performance.now()}]`
+                `Element did register: ${name} [${performance.now()}]`,
             );
         },
         elementWillHydrate(source: HTMLElement) {
             (window as any).messages.push(
-                `Element will hydrate: ${source.localName} [${performance.now()}]`
+                `Element will hydrate: ${source.localName} [${performance.now()}]`,
             );
         },
         hydrationComplete() {
@@ -151,12 +147,12 @@ TemplateElement.options({
         },
         templateDidUpdate(name: string) {
             (window as any).messages.push(
-                `Template did update: ${name} [${performance.now()}]`
+                `Template did update: ${name} [${performance.now()}]`,
             );
         },
         templateWillUpdate(name: string) {
             (window as any).messages.push(
-                `Template will update: ${name} [${performance.now()}]`
+                `Template will update: ${name} [${performance.now()}]`,
             );
         },
     })

--- a/packages/fast-html/test/fixtures/nested-elements/nested-elements.spec.ts
+++ b/packages/fast-html/test/fixtures/nested-elements/nested-elements.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.describe("Nested Elements Hydration", () => {
     test("should hydrate parent elements before child elements", async ({ page }) => {
@@ -7,10 +7,10 @@ test.describe("Nested Elements Hydration", () => {
         const messages = (await page.evaluate("window.messages")) as string[];
 
         const parentDefinitionIndex = messages.findIndex(message =>
-            message.startsWith("Element did define: parent-element")
+            message.startsWith("Element did define: parent-element"),
         );
         const firstChildHydrationIndex = messages.findIndex(message =>
-            message.startsWith("Element will hydrate: child-element")
+            message.startsWith("Element will hydrate: child-element"),
         );
 
         expect(parentDefinitionIndex).toBeGreaterThan(-1);
@@ -18,10 +18,10 @@ test.describe("Nested Elements Hydration", () => {
         expect(parentDefinitionIndex).toBeLessThan(firstChildHydrationIndex);
 
         const childHydrationStarts = messages.filter(message =>
-            message.startsWith("Element will hydrate: child-element")
+            message.startsWith("Element will hydrate: child-element"),
         );
         const childHydrationCompletes = messages.filter(message =>
-            message.startsWith("Element did hydrate: child-element")
+            message.startsWith("Element did hydrate: child-element"),
         );
 
         // Non-zero proves the fixture actually exercised nested hydration.

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title></title>
         <script type="module" src="./main.ts"></script>
     </head>
     <body>
         <div class="container">
-            <observer-map-simple-array-test-element></observer-map-simple-array-test-element>
+            <observer-map-simple-array-test-element
+            ></observer-map-simple-array-test-element>
             <observer-map-test-element></observer-map-test-element>
             <observer-map-with-observables-test-element>
                 <template shadowrootmode="open">
@@ -28,13 +29,13 @@
                     <div class="stats">
                         <h2>Global Stats</h2>
                         <div class="nested-info">
-                            <strong>Total Users:</strong> {{stats.totalUsers}} |
-                            <strong>Active Users:</strong> {{stats.activeUsers}}
+                            <strong>Total Users:</strong> {{ stats.totalUsers }} |
+                            <strong>Active Users:</strong> {{ stats.activeUsers }}
                         </div>
                         <div class="nested-info">
                             <strong>Performance:</strong>
-                            Load: {{stats.metrics.performance.loadTime}}s,
-                            Render: {{stats.metrics.performance.renderTime}}s
+                            Load: {{ stats.metrics.performance.loadTime }}s, Render:
+                            {{ stats.metrics.performance.renderTime }}s
                         </div>
                         <div class="controls">
                             <button @click="{updateStats()}">Update Stats</button>
@@ -46,78 +47,134 @@
                         <h2>Users List</h2>
                         <f-repeat value="{{user in users}}">
                             <div class="user-card">
-                                <h3>{{user.name}} (ID: {{user.id}})
+                                <h3>
+                                    {{ user.name }}
+                                    (ID: {{ user.id }})
                                     <f-when value="{{user.id == selectedUserId}}">
                                         <span>⭐ SELECTED</span>
                                     </f-when>
                                 </h3>
 
                                 <div class="nested-info">
-                                    <strong>Age:</strong> {{user.details.personal.age}} years old
+                                    <strong>Age:</strong>
+                                    {{ user.details.personal.age }}
+                                    years old
                                 </div>
                                 <div class="nested-info">
-                                    <strong>Location:</strong> {{user.details.personal.location.city}}, {{user.details.personal.location.country}}
+                                    <strong>Location:</strong>
+                                    {{ user.details.personal.location.city }},
+                                    {{ user.details.personal.location.country }}
                                 </div>
                                 <div class="nested-info">
                                     <strong>Coordinates:</strong>
-                                    Lat: {{user.details.personal.location.coordinates.lat}},
-                                    Lng: {{user.details.personal.location.coordinates.lng}}
+                                    Lat:
+                                    {{ user.details.personal.location.coordinates.lat }},
+                                    Lng:
+                                    {{ user.details.personal.location.coordinates.lng }}
                                 </div>
 
                                 <div class="nested-info">
-                                    <strong>Theme:</strong> {{user.details.preferences.theme}} |
-                                    <strong>Email Notifications:</strong> {{user.details.preferences.notifications.email}} |
-                                    <strong>Push Notifications:</strong> {{user.details.preferences.notifications.push}}
+                                    <strong>Theme:</strong>
+                                    {{ user.details.preferences.theme }}
+                                    |
+                                    <strong>Email Notifications:</strong>
+                                    {{ user.details.preferences.notifications.email }}
+                                    |
+                                    <strong>Push Notifications:</strong>
+                                    {{ user.details.preferences.notifications.push }}
                                 </div>
                                 <div class="nested-info">
-                                    <strong>Notification Frequency:</strong> {{user.details.preferences.notifications.settings.frequency}}
+                                    <strong>Notification Frequency:</strong>
+                                    {{ user.details.preferences.notifications.settings.frequency }}
                                 </div>
                                 <div class="nested-info">
                                     <strong>Categories:</strong>
-                                    <f-repeat value="{{category in user.details.preferences.notifications.settings.categories}}">
-                                        <span class="tag">{{category}}</span>
+                                    <f-repeat
+                                        value="{{category in user.details.preferences.notifications.settings.categories}}"
+                                    >
+                                        <span class="tag">{{ category }}</span>
                                     </f-repeat>
                                 </div>
 
                                 <div class="controls">
-                                    <button @click="{selectUser(user.id)}">Select User</button>
-                                    <button @click="{updateUserAge(user.id)}">Age +1</button>
-                                    <button @click="{toggleUserTheme(user.id)}">Toggle Theme</button>
-                                    <button @click="{updateUserLocation(user.id)}">Change Location</button>
-                                    <button @click="{updateNotificationSettings(user.id)}">Update Notifications</button>
-                                    <button @click="{addNotificationCategory(user.id)}">Add Category</button>
-                                    <button @click="{removeNotificationCategory(user.id)}">Remove Tech Category</button>
-                                    <button @click="{removeUser(user.id)}">Remove User</button>
+                                    <button @click="{selectUser(user.id)}">
+                                        Select User
+                                    </button>
+                                    <button @click="{updateUserAge(user.id)}">
+                                        Age +1
+                                    </button>
+                                    <button @click="{toggleUserTheme(user.id)}">
+                                        Toggle Theme
+                                    </button>
+                                    <button @click="{updateUserLocation(user.id)}">
+                                        Change Location
+                                    </button>
+                                    <button
+                                        @click="{updateNotificationSettings(user.id)}"
+                                    >
+                                        Update Notifications
+                                    </button>
+                                    <button @click="{addNotificationCategory(user.id)}">
+                                        Add Category
+                                    </button>
+                                    <button
+                                        @click="{removeNotificationCategory(user.id)}"
+                                    >
+                                        Remove Tech Category
+                                    </button>
+                                    <button @click="{removeUser(user.id)}">
+                                        Remove User
+                                    </button>
                                 </div>
 
                                 <div>
-                                    <h4>Posts ({{user.posts.length}} posts)</h4>
+                                    <h4>Posts ({{ user.posts.length }} posts)</h4>
                                     <f-repeat value="{{post in user.posts}}">
                                         <div class="post-card">
-                                            <div><strong>{{post.title}}</strong> (ID: {{post.id}})</div>
-                                            <div class="nested-info">{{post.content}}</div>
+                                            <div>
+                                                <strong>{{ post.title }}</strong>
+                                                (ID: {{ post.id }})
+                                            </div>
                                             <div class="nested-info">
-                                                <strong>Author:</strong> {{post.metadata.author.name}}
-                                                <f-when value="{{post.metadata.author.verified}}">
+                                                {{ post.content }}
+                                            </div>
+                                            <div class="nested-info">
+                                                <strong>Author:</strong>
+                                                {{ post.metadata.author.name }}
+                                                <f-when
+                                                    value="{{post.metadata.author.verified}}"
+                                                >
                                                     <span>✓ Verified</span>
                                                 </f-when>
                                             </div>
                                             <div class="nested-info">
-                                                <strong>Stats:</strong> {{post.metadata.views}} views, {{post.metadata.likes}} likes
+                                                <strong>Stats:</strong>
+                                                {{ post.metadata.views }}
+                                                views,
+                                                {{ post.metadata.likes }}
+                                                likes
                                             </div>
                                             <div class="nested-info">
                                                 <strong>Tags:</strong>
-                                                <f-repeat value="{{tag in post.metadata.tags}}">
-                                                    <span class="tag">{{tag}}</span>
+                                                <f-repeat
+                                                    value="{{tag in post.metadata.tags}}"
+                                                >
+                                                    <span class="tag">{{ tag }}</span>
                                                 </f-repeat>
                                             </div>
                                             <div class="controls">
-                                                <button @click="{incrementPostLikes(post.id)}">Like Post</button>
+                                                <button
+                                                    @click="{incrementPostLikes(post.id)}"
+                                                >
+                                                    Like Post
+                                                </button>
                                             </div>
                                         </div>
                                     </f-repeat>
                                     <div class="controls">
-                                        <button @click="{addPostToUser(user.id)}">Add New Post</button>
+                                        <button @click="{addPostToUser(user.id)}">
+                                            Add New Post
+                                        </button>
                                     </div>
                                 </div>
                             </div>
@@ -127,36 +184,39 @@
             </f-template>
             <f-template name="observer-map-internal-test-element">
                 <template>
-                    selected user: {{selecteduserid}} <!-- because this is bound to an attribute property it must be lowercase -->
+                    selected user:
+                    {{ selecteduserid }}<!-- because this is bound to an attribute property it must be lowercase -->
                     <br>
-                    total users: {{totalusers}}
+                    total users: {{ totalusers }}
                     <br>
                     <div class="stats">
                         <div class="nested-info">
                             <strong>Engagement:</strong>
-                            Daily: {{metrics.engagement.daily}},
-                            Weekly: {{metrics.engagement.weekly}},
-                            Monthly: {{metrics.engagement.monthly}}
+                            Daily: {{ metrics.engagement.daily }}, Weekly:
+                            {{ metrics.engagement.weekly }}, Monthly:
+                            {{ metrics.engagement.monthly }}
                         </div>
                     </div>
                     <f-when value="{{a}}">
-                        <span class="nested-define">{{a.b.c}}</span>
+                        <span class="nested-define">{{ a.b.c }}</span>
                     </f-when>
                     <button @click="{defineB()}">Define B</button>
                     <button @click="{updateC()}">Update C</button>
                     <br>
                     <f-when value="{{x}}">
-                        <span class="nested-define-2">{{x.y.z}}</span>
+                        <span class="nested-define-2">{{ x.y.z }}</span>
                     </f-when>
                     <button @click="{defineY()}">Define Y</button>
                     <button @click="{updateZ()}">Update Z</button>
                     <div>
                         <f-repeat value="{{group in groups}}">
                             <f-repeat value="{{item in group.items}}">
-                                <div class="item">{{item.text}}</div>
+                                <div class="item">{{ item.text }}</div>
                                 <span>
                                     <f-repeat value="{{action in item.actions.trailing}}">
-                                        <span class="action-label">{{action.label}}</span>
+                                        <span class="action-label"
+                                            >{{ action.label }}</span
+                                        >
                                     </f-repeat>
                                 </span>
                             </f-repeat>
@@ -172,10 +232,10 @@
             </f-template>
             <f-template name="observer-map-with-observables-test-element">
                 <template>
-                    Level 3 Value: {{value1}}
+                    Level 3 Value: {{ value1 }}
                     <button @click="{updateValue1()}">Update Value1</button>
                     <br>
-                    Level 3 Value Observable: {{value2}}
+                    Level 3 Value Observable: {{ value2 }}
                     <button @click="{updateValue2()}">Update Value2</button>
                 </template>
             </f-template>
@@ -183,7 +243,7 @@
                 <template>
                     <ul>
                         <f-repeat value="{{item in items}}">
-                            <li class="simple-item">{{item}}</li>
+                            <li class="simple-item">{{ item }}</li>
                         </f-repeat>
                     </ul>
                     <button @click="{updateFirstItem()}">Update First Item</button>

--- a/packages/fast-html/test/fixtures/performance-metrics/index.html
+++ b/packages/fast-html/test/fixtures/performance-metrics/index.html
@@ -1,247 +1,247 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title>Performance Metrics Test</title>
-        <link rel="preload" as="style" href="./fast-card.css" />
+        <link rel="preload" as="style" href="./fast-card.css">
     </head>
     <body>
         <fast-card needs-hydration defer-hydration defer-delay="0">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="0">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="0">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="0">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="0">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="150">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="150">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="150">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="150">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="300">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="300">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="300">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="300">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <fast-card needs-hydration defer-hydration defer-delay="300">
             <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
+                    <dd>300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
+                    <dd>0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
                 </dl>
             </template>
         </fast-card>
 
         <f-template name="fast-card">
             <template>
-                <link rel="stylesheet" href="./fast-card.css" />
+                <link rel="stylesheet" href="./fast-card.css">
                 <dl>
                     <dt>Configured Delay</dt>
-                    <dd>{{displayDelay}}</dd>
+                    <dd>{{ displayDelay }}</dd>
                     <dt>Element Will Hydrate</dt>
-                    <dd>{{willHydrate}}</dd>
+                    <dd>{{ willHydrate }}</dd>
                     <dt>Element Did Hydrate</dt>
-                    <dd>{{didHydrate}}</dd>
+                    <dd>{{ didHydrate }}</dd>
                     <dt>Element Hydration Duration</dt>
-                    <dd>{{hydrationDuration}}</dd>
+                    <dd>{{ hydrationDuration }}</dd>
                 </dl>
             </template>
         </f-template>

--- a/packages/fast-html/test/fixtures/performance-metrics/main.ts
+++ b/packages/fast-html/test/fixtures/performance-metrics/main.ts
@@ -100,13 +100,13 @@ TemplateElement.config({
         if (markName) {
             const measure = performance.measure(
                 `hydration:${source.localName}`,
-                markName
+                markName,
             );
             hydrationMarks.delete(source);
 
             if (source instanceof FastCard) {
                 source.didHydrate = `${(measure.startTime + measure.duration).toPrecision(
-                    4
+                    4,
                 )}ms`;
                 source.hydrationDuration = `${measure.duration.toPrecision(4)}ms`;
             }

--- a/packages/fast-html/test/fixtures/performance-metrics/performance-metrics.spec.ts
+++ b/packages/fast-html/test/fixtures/performance-metrics/performance-metrics.spec.ts
@@ -12,7 +12,7 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
         const measures = await page.evaluate(() =>
             performance
                 .getEntriesByType("measure")
-                .filter(m => m.name === "hydration:fast-card")
+                .filter(m => m.name === "hydration:fast-card"),
         );
 
         const cards = page.locator("fast-card");
@@ -25,7 +25,7 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
         const measure = await page.evaluate(() =>
             performance
                 .getEntriesByType("measure")
-                .filter(m => m.name === "hydration:complete")
+                .filter(m => m.name === "hydration:complete"),
         );
 
         expect(measure).toHaveLength(1);
@@ -35,9 +35,7 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
         const { regTime, tmplTime, regSeq, tmplSeq } = await page.evaluate(() => {
             const entries = performance.getEntriesByType("mark") as PerformanceMark[];
             const reg = entries.find(m => m.name === "element-register:fast-card");
-            const tmpl = entries.find(m =>
-                m.name === "template-update:fast-card:start"
-            );
+            const tmpl = entries.find(m => m.name === "template-update:fast-card:start");
             return {
                 regTime: reg?.startTime,
                 tmplTime: tmpl?.startTime,
@@ -60,30 +58,23 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
     test("template-update should precede element-define", async ({ page }) => {
         const { templateEnd, defineTime, templateEndSeq, defineSeq } =
             await page.evaluate(() => {
-                const marks =
-                    performance.getEntriesByType("mark") as PerformanceMark[];
+                const marks = performance.getEntriesByType("mark") as PerformanceMark[];
                 const measures = performance.getEntriesByType("measure");
-                const tmpl = measures.find(
-                    m => m.name === "template-update:fast-card"
-                );
-                const def = marks.find(
-                    m => m.name === "element-define:fast-card"
-                );
+                const tmpl = measures.find(m => m.name === "template-update:fast-card");
+                const def = marks.find(m => m.name === "element-define:fast-card");
                 // template-update:start fires before template-update (the
                 // measure), and element-define fires after.  Compare the
                 // start-mark sequence against the define-mark sequence.
                 const startMark = marks.find(
-                    m => m.name === "template-update:fast-card:start"
+                    m => m.name === "template-update:fast-card:start",
                 );
                 return {
-                    templateEnd: tmpl
-                        ? tmpl.startTime + tmpl.duration
-                        : undefined,
+                    templateEnd: tmpl ? tmpl.startTime + tmpl.duration : undefined,
                     defineTime: def?.startTime,
-                    templateEndSeq: (startMark?.detail as any)
-                        ?.sequence as number | undefined,
-                    defineSeq: (def?.detail as any)
-                        ?.sequence as number | undefined,
+                    templateEndSeq: (startMark?.detail as any)?.sequence as
+                        | number
+                        | undefined,
+                    defineSeq: (def?.detail as any)?.sequence as number | undefined,
                 };
             });
 
@@ -97,24 +88,17 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
     });
 
     test("element-define should precede hydration:started", async ({ page }) => {
-        const { defineTime, hsTime, defineSeq, hsSeq } = await page.evaluate(
-            () => {
-                const marks =
-                    performance.getEntriesByType("mark") as PerformanceMark[];
-                const def = marks.find(
-                    m => m.name === "element-define:fast-card"
-                );
-                const hs = marks.find(m => m.name === "hydration:started");
-                return {
-                    defineTime: def?.startTime,
-                    hsTime: hs?.startTime,
-                    defineSeq: (def?.detail as any)
-                        ?.sequence as number | undefined,
-                    hsSeq: (hs?.detail as any)
-                        ?.sequence as number | undefined,
-                };
-            }
-        );
+        const { defineTime, hsTime, defineSeq, hsSeq } = await page.evaluate(() => {
+            const marks = performance.getEntriesByType("mark") as PerformanceMark[];
+            const def = marks.find(m => m.name === "element-define:fast-card");
+            const hs = marks.find(m => m.name === "hydration:started");
+            return {
+                defineTime: def?.startTime,
+                hsTime: hs?.startTime,
+                defineSeq: (def?.detail as any)?.sequence as number | undefined,
+                hsSeq: (hs?.detail as any)?.sequence as number | undefined,
+            };
+        });
 
         expect(defineTime).toBeDefined();
         expect(hsTime).toBeDefined();
@@ -132,9 +116,7 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
             const marks = performance.getEntriesByType("mark");
             const measures = performance.getEntriesByType("measure");
             const hs = marks.find(m => m.name === "hydration:started");
-            const cardMeasures = measures.filter(
-                m => m.name === "hydration:fast-card"
-            );
+            const cardMeasures = measures.filter(m => m.name === "hydration:fast-card");
             const earliest = Math.min(...cardMeasures.map(m => m.startTime));
             return { hydrationStarted: hs?.startTime, firstCardHydration: earliest };
         });
@@ -148,14 +130,10 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
     }) => {
         const { lastCardEnd, completeEnd } = await page.evaluate(() => {
             const measures = performance.getEntriesByType("measure");
-            const cardMeasures = measures.filter(
-                m => m.name === "hydration:fast-card"
-            );
+            const cardMeasures = measures.filter(m => m.name === "hydration:fast-card");
             const complete = measures.find(m => m.name === "hydration:complete");
             return {
-                lastCardEnd: Math.max(
-                    ...cardMeasures.map(m => m.startTime + m.duration)
-                ),
+                lastCardEnd: Math.max(...cardMeasures.map(m => m.startTime + m.duration)),
                 completeEnd: complete
                     ? complete.startTime + complete.duration
                     : undefined,
@@ -169,10 +147,11 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
     test("should create an element-prepared measure for each element", async ({
         page,
     }) => {
-        const count = await page.evaluate(() =>
-            performance
-                .getEntriesByType("measure")
-                .filter(m => m.name.startsWith("element-prepared:fast-card:")).length
+        const count = await page.evaluate(
+            () =>
+                performance
+                    .getEntriesByType("measure")
+                    .filter(m => m.name.startsWith("element-prepared:fast-card:")).length,
         );
 
         expect(count).toBe(14);
@@ -185,12 +164,12 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
             const marks = performance.getEntriesByType("mark");
             const measures = performance.getEntriesByType("measure");
             const prepared = measures.filter(m =>
-                m.name.startsWith("element-prepared:fast-card:")
+                m.name.startsWith("element-prepared:fast-card:"),
             );
             const hs = marks.find(m => m.name === "hydration:started");
             return {
                 earliestPreparedEnd: Math.min(
-                    ...prepared.map(m => m.startTime + m.duration)
+                    ...prepared.map(m => m.startTime + m.duration),
                 ),
                 hydrationStarted: hs?.startTime,
             };
@@ -205,10 +184,10 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
     }) => {
         const { zeroDurations, delayedDurations } = await page.evaluate(() => {
             const measures = performance.getEntriesByType(
-                "measure"
+                "measure",
             ) as PerformanceMeasure[];
             const prepared = measures.filter(m =>
-                m.name.startsWith("element-prepared:fast-card:")
+                m.name.startsWith("element-prepared:fast-card:"),
             );
 
             const zero: number[] = [];
@@ -243,12 +222,8 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
 
         for (let i = 0; i < count; i++) {
             const card = cards.nth(i);
-            const willHydrate = await card.evaluate(
-                (el: any) => el.willHydrate
-            );
-            const didHydrate = await card.evaluate(
-                (el: any) => el.didHydrate
-            );
+            const willHydrate = await card.evaluate((el: any) => el.willHydrate);
+            const didHydrate = await card.evaluate((el: any) => el.didHydrate);
 
             expect(willHydrate, `card ${i} willHydrate`).toBeTruthy();
             expect(didHydrate, `card ${i} didHydrate`).toBeTruthy();

--- a/packages/fast-html/test/fixtures/ref/index.html
+++ b/packages/fast-html/test/fixtures/ref/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title></title>
         <script type="module" src="./main.ts"></script>
     </head>

--- a/packages/fast-html/test/fixtures/repeat-event/index.html
+++ b/packages/fast-html/test/fixtures/repeat-event/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title></title>
         <script type="module" src="./main.ts"></script>
     </head>
@@ -11,7 +11,9 @@
                 <ul>
                     <f-repeat value="{{item in items}}">
                         <li>
-                            <button @click="{$c.parent.handleItemClick($c.event)}">{{item.name}}</button>
+                            <button @click="{$c.parent.handleItemClick($c.event)}">
+                                {{ item.name }}
+                            </button>
                         </li>
                     </f-repeat>
                 </ul>
@@ -20,7 +22,8 @@
         <test-element-repeat-event>
             <template shadowrootmode="open">
                 <ul>
-                    <!--fe-b$$start$$0$$item-in-items$$fe-b--><!--fe-b$$end$$0$$item-in-items$$fe-b-->
+                    <!--fe-b$$start$$0$$item-in-items$$fe-b-->
+                    <!--fe-b$$end$$0$$item-in-items$$fe-b-->
                 </ul>
             </template>
         </test-element-repeat-event>
@@ -32,7 +35,12 @@
                     <f-repeat value="{{item in items}}">
                         <li>
                             <f-when value="{{$c.parent.showNames}}">
-                                <button class="name" @click="{$c.parent.handleItemClick(e)}">{{item.name}}</button>
+                                <button
+                                    class="name"
+                                    @click="{$c.parent.handleItemClick(e)}"
+                                >
+                                    {{ item.name }}
+                                </button>
                             </f-when>
                         </li>
                     </f-repeat>
@@ -46,14 +54,18 @@
                     <!--fe-repeat$$start$$0$$fe-repeat-->
                     <li>
                         <!--fe-b$$start$$0$$WhenRepWhen$$fe-b-->
-                        <button class="name" data-fe-b-0><!--fe-b$$start$$1$$WhenRepName$$fe-b-->Alpha<!--fe-b$$end$$1$$WhenRepName$$fe-b--></button>
+                        <button class="name" data-fe-b-0>
+                            Alpha<!--fe-b$$end$$1$$WhenRepName$$fe-b-->
+                        </button>
                         <!--fe-b$$end$$0$$WhenRepWhen$$fe-b-->
                     </li>
                     <!--fe-repeat$$end$$0$$fe-repeat-->
                     <!--fe-repeat$$start$$1$$fe-repeat-->
                     <li>
                         <!--fe-b$$start$$0$$WhenRepWhen$$fe-b-->
-                        <button class="name" data-fe-b-0><!--fe-b$$start$$1$$WhenRepName$$fe-b-->Beta<!--fe-b$$end$$1$$WhenRepName$$fe-b--></button>
+                        <button class="name" data-fe-b-0>
+                            Beta<!--fe-b$$end$$1$$WhenRepName$$fe-b-->
+                        </button>
                         <!--fe-b$$end$$0$$WhenRepWhen$$fe-b-->
                     </li>
                     <!--fe-repeat$$end$$1$$fe-repeat-->

--- a/packages/fast-html/test/fixtures/repeat-event/main.ts
+++ b/packages/fast-html/test/fixtures/repeat-event/main.ts
@@ -1,5 +1,5 @@
-import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 import { FASTElement, observable } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
 export interface ItemType {
     name: string;

--- a/packages/fast-html/test/fixtures/repeat-event/repeat-event.spec.ts
+++ b/packages/fast-html/test/fixtures/repeat-event/repeat-event.spec.ts
@@ -26,10 +26,7 @@ test.describe("f-repeat event binding", async () => {
         // set on the host element.
         await buttons.nth(0).click();
 
-        await expect(customElement).toHaveJSProperty(
-            "clickedItemName",
-            "Alpha"
-        );
+        await expect(customElement).toHaveJSProperty("clickedItemName", "Alpha");
     });
 
     test("f-when with c.parent condition inside f-repeat", async ({ page }) => {

--- a/packages/fast-html/test/fixtures/repeat/index.html
+++ b/packages/fast-html/test/fixtures/repeat/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title></title>
         <script type="module" src="./main.ts"></script>
     </head>
@@ -10,7 +10,7 @@
             <template>
                 <ul>
                     <f-repeat value="{{item in list}}">
-                        <li>{{item}} - {{item_parent}}</li>
+                        <li>{{ item }} - {{ item_parent }}</li>
                     </f-repeat>
                 </ul>
             </template>
@@ -19,9 +19,7 @@
             <template>
                 <ul>
                     <f-repeat value="{{item in list}}">
-                        <f-when value="{{item.show}}">
-                            <li>{{item.text}}</li>
-                        </f-when>
+                        <f-when value="{{item.show}}"> <li>{{ item.text }}</li> </f-when>
                     </f-repeat>
                 </ul>
             </template>
@@ -31,10 +29,14 @@
                 <ul>
                     <!--fe-b$$start$$0$$EVAQBRnUUH$$fe-b-->
                     <!--fe-repeat$$start$$0$$fe-repeat-->
-                    <li><!--fe-b$$start$$0$$vEbKKUHmwU$$fe-b-->Foo<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--> - <!--fe-b$$start$$1$$vEbKKUHmwU$$fe-b-->Bat<!--fe-b$$end$$1$$vEbKKUHmwU$$fe-b--></li>
+                    <li>
+                        Foo<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--> - <!--fe-b$$start$$1$$vEbKKUHmwU$$fe-b-->Bat<!--fe-b$$end$$1$$vEbKKUHmwU$$fe-b-->
+                    </li>
                     <!--fe-repeat$$end$$0$$fe-repeat-->
                     <!--fe-repeat$$start$$1$$fe-repeat-->
-                    <li><!--fe-b$$start$$0$$vEbKKUHmwU$$fe-b-->Bar<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--> - <!--fe-b$$start$$1$$vEbKKUHmwU$$fe-b-->Bat<!--fe-b$$end$$1$$vEbKKUHmwU$$fe-b--></li>
+                    <li>
+                        Bar<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--> - <!--fe-b$$start$$1$$vEbKKUHmwU$$fe-b-->Bat<!--fe-b$$end$$1$$vEbKKUHmwU$$fe-b-->
+                    </li>
                     <!--fe-repeat$$end$$1$$fe-repeat-->
                     <!--fe-b$$end$$0$$EVAQBRnUUH$$fe-b-->
                 </ul>
@@ -44,7 +46,7 @@
             <template>
                 <ul>
                     <f-repeat value="{{item in list}}">
-                        <li>{{item}} - {{item_parent}}</li>
+                        <li>{{ item }} - {{ item_parent }}</li>
                     </f-repeat>
                 </ul>
             </template>
@@ -54,10 +56,14 @@
                 <ul>
                     <!--fe-b$$start$$0$$EVAQBRnUUH$$fe-b-->
                     <!--fe-repeat$$start$$0$$fe-repeat-->
-                    <li><!--fe-b$$start$$0$$vEbKKUHmwU$$fe-b-->Foo<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--> - <!--fe-b$$start$$1$$vEbKKUHmwU$$fe-b-->Bat<!--fe-b$$end$$1$$vEbKKUHmwU$$fe-b--></li>
+                    <li>
+                        Foo<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--> - <!--fe-b$$start$$1$$vEbKKUHmwU$$fe-b-->Bat<!--fe-b$$end$$1$$vEbKKUHmwU$$fe-b-->
+                    </li>
                     <!--fe-repeat$$end$$0$$fe-repeat-->
                     <!--fe-repeat$$start$$1$$fe-repeat-->
-                    <li><!--fe-b$$start$$0$$vEbKKUHmwU$$fe-b-->Bar<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--> - <!--fe-b$$start$$1$$vEbKKUHmwU$$fe-b-->Bat<!--fe-b$$end$$1$$vEbKKUHmwU$$fe-b--></li>
+                    <li>
+                        Bar<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--> - <!--fe-b$$start$$1$$vEbKKUHmwU$$fe-b-->Bat<!--fe-b$$end$$1$$vEbKKUHmwU$$fe-b-->
+                    </li>
                     <!--fe-repeat$$end$$1$$fe-repeat-->
                     <!--fe-b$$end$$0$$EVAQBRnUUH$$fe-b-->
                 </ul>
@@ -69,7 +75,7 @@
                     <!--fe-b$$start$$0$$EVAQBRnUUH$$fe-b-->
                     <!--fe-repeat$$start$$0$$fe-repeat-->
                     <!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->
-                    <li><!--fe-b$$start$$0$$vEbKKUHmwU$$fe-b-->Foo<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--></li>
+                    <li>Foo<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--></li>
                     <!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b-->
                     <!--fe-repeat$$end$$0$$fe-repeat-->
                     <!--fe-b$$end$$0$$EVAQBRnUUH$$fe-b-->
@@ -128,16 +134,15 @@
         <test-element-no-item-repeat-binding>
             <template shadowrootmode="open">
                 <ul>
-                    <!--fe-b$$start$$0$$item-in-list$$fe-b--><!--fe-b$$end$$0$$item-in-list$$fe-b-->
+                    <!--fe-b$$start$$0$$item-in-list$$fe-b-->
+                    <!--fe-b$$end$$0$$item-in-list$$fe-b-->
                 </ul>
             </template>
         </test-element-no-item-repeat-binding>
         <f-template name="test-element-no-item-repeat-binding">
             <template>
                 <ul>
-                    <f-repeat value="{{item in list}}">
-                        <li>{{item}}</li>
-                    </f-repeat>
+                    <f-repeat value="{{item in list}}"> <li>{{ item }}</li> </f-repeat>
                 </ul>
             </template>
         </f-template>

--- a/packages/fast-html/test/fixtures/slotted/index.html
+++ b/packages/fast-html/test/fixtures/slotted/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title></title>
         <script type="module" src="./main.ts"></script>
     </head>
@@ -10,7 +10,10 @@
             <template>
                 <slot f-slotted="{slottedNodes filter elements()}"></slot>
                 <slot name="foo" f-slotted="{slottedFooNodes}"></slot>
-                <slot name="bar" f-slotted="{slottedBarNodes filter elements(p, ol)}"></slot>
+                <slot
+                    name="bar"
+                    f-slotted="{slottedBarNodes filter elements(p, ol)}"
+                ></slot>
             </template>
         </f-template>
         <test-element>
@@ -21,7 +24,10 @@
             </template>
             <div>Slotted</div>
             Not slotted
-            <ul slot="foo"><li>Item 1</li><li>Item 2</li></ul>
+            <ul slot="foo">
+                <li>Item 1</li>
+                <li>Item 2</li>
+            </ul>
             <div slot="bar"></div>
             <p slot="bar"></p>
         </test-element>

--- a/packages/fast-html/test/fixtures/slotted/main.ts
+++ b/packages/fast-html/test/fixtures/slotted/main.ts
@@ -1,5 +1,5 @@
-import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 import { FASTElement, observable } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
 class TestElement extends FASTElement {
     @observable

--- a/packages/fast-html/test/fixtures/slotted/slotted.spec.ts
+++ b/packages/fast-html/test/fixtures/slotted/slotted.spec.ts
@@ -10,7 +10,7 @@ test.describe("f-template", () => {
     test("create a slotted directive", async () => {
         await expect(element).toHaveJSProperty("classList.length", 2);
 
-        await element.evaluate((node) => {
+        await element.evaluate(node => {
             const newElement = document.createElement("button");
             newElement.slot = "foo";
             node.append(newElement);

--- a/packages/fast-html/test/fixtures/static-accessor/index.html
+++ b/packages/fast-html/test/fixtures/static-accessor/index.html
@@ -10,14 +10,8 @@
                 <!--fe-b$$start$$0$$ZJEYduCZlM$$fe-b-->Hello world<!--fe-b$$end$$0$$ZJEYduCZlM$$fe-b-->
             </template>
         </test-element>
-        <test-element-unescaped>
-            <template shadowrootmode="open">
-                <div><p>Hello world<!--fe-b$$end$$0$$ZJEYduCZlM$$fe-b--></p></div>
-            </template>
-        </test-element-unescaped>
-        <f-template name="test-element"> <template>{{ text }}</template> </f-template>
-        <f-template name="test-element-unescaped">
-            <template>{{ {html }}}</template>
+        <f-template name="test-element">
+            <template>{{ text|binding:none }}</template>
         </f-template>
         <script type="module" src="./main.ts"></script>
     </body>

--- a/packages/fast-html/test/fixtures/static-accessor/main.ts
+++ b/packages/fast-html/test/fixtures/static-accessor/main.ts
@@ -10,14 +10,6 @@ RenderableFASTElement(TestElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementUnescaped extends FASTElement {
-    public html = `<p>Hello world</p>`;
-}
-RenderableFASTElement(TestElementUnescaped).defineAsync({
-    name: "test-element-unescaped",
-    templateOptions: "defer-and-hydrate",
-});
-
 TemplateElement.define({
     name: "f-template",
 });

--- a/packages/fast-html/test/fixtures/static-accessor/static-accessor.spec.ts
+++ b/packages/fast-html/test/fixtures/static-accessor/static-accessor.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("f-template", async () => {
+    test("create a static accessor (non-reactive binding)", async ({ page }) => {
+        await page.goto("/fixtures/static-accessor/");
+
+        const customElement = page.locator("test-element");
+
+        await expect(await customElement.getAttribute("text")).toEqual("Hello world");
+        await expect(customElement).toHaveText("Hello world");
+
+        await page.evaluate(() => {
+            const customElement = document.getElementsByTagName("test-element");
+            customElement.item(0)?.setAttribute("text", "Hello pluto");
+        });
+
+        await expect(await customElement.getAttribute("text")).toEqual("Hello pluto");
+        // Content should NOT update since |binding:none creates a non-reactive accessor
+        await expect(customElement).toHaveText("Hello world");
+    });
+});

--- a/packages/fast-html/test/fixtures/when/index.html
+++ b/packages/fast-html/test/fixtures/when/index.html
@@ -1,160 +1,242 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title></title>
         <script type="module" src="./main.ts"></script>
     </head>
     <body>
         <!-- multiple -->
-         <f-template name="test-element-multiple">
-            <template>Hello <f-when value="{{planet == 'earth'}}">world</f-when><f-when value="{{planet == 'pluto'}}">pluto</f-when><f-when value="{{planet == 'mars'}}">mars</f-when></template>
+        <f-template name="test-element-multiple">
+            <template
+                >Hello <f-when value="{{planet == 'earth'}}">world</f-when
+                ><f-when value="{{planet == 'pluto'}}">pluto</f-when
+                ><f-when value="{{planet == 'mars'}}">mars</f-when></template
+            >
         </f-template>
         <test-element-multiple id="multiple1" planet="earth">
-            <template shadowrootmode="open">Hello <!--fe-b$$start$$0$$a$$fe-b-->world<!--fe-b$$end$$0$$a$$fe-b--><!--fe-b$$start$$1$$b$$fe-b--><!--fe-b$$end$$1$$b$$fe-b--><!--fe-b$$start$$2$$c$$fe-b--><!--fe-b$$end$$2$$c$$fe-b--></template>
+            <template shadowrootmode="open"
+                >Hello <!--fe-b$$start$$0$$a$$fe-b-->world<!--fe-b$$end$$0$$a$$fe-b--><!--fe-b$$start$$1$$b$$fe-b--><!--fe-b$$end$$1$$b$$fe-b--><!--fe-b$$start$$2$$c$$fe-b--><!--fe-b$$end$$2$$c$$fe-b--></template
+            >
         </test-element-multiple>
         <test-element-multiple id="multiple2" planet="pluto">
-            <template shadowrootmode="open">Hello <!--fe-b$$start$$0$$a$$fe-b--><!--fe-b$$end$$0$$a$$fe-b--><!--fe-b$$start$$1$$b$$fe-b-->pluto<!--fe-b$$end$$1$$b$$fe-b--><!--fe-b$$start$$2$$c$$fe-b--><!--fe-b$$end$$2$$c$$fe-b--></template>
+            <template shadowrootmode="open"
+                >Hello <!--fe-b$$start$$0$$a$$fe-b--><!--fe-b$$end$$0$$a$$fe-b--><!--fe-b$$start$$1$$b$$fe-b-->pluto<!--fe-b$$end$$1$$b$$fe-b--><!--fe-b$$start$$2$$c$$fe-b--><!--fe-b$$end$$2$$c$$fe-b--></template
+            >
         </test-element-multiple>
         <test-element-multiple id="multiple3" planet="mars">
-            <template shadowrootmode="open">Hello <!--fe-b$$start$$0$$a$$fe-b--><!--fe-b$$end$$0$$a$$fe-b--><!--fe-b$$start$$1$$b$$fe-b--><!--fe-b$$end$$1$$b$$fe-b--><!--fe-b$$start$$2$$c$$fe-b-->mars<!--fe-b$$end$$2$$c$$fe-b--></template>
+            <template shadowrootmode="open"
+                >Hello <!--fe-b$$start$$0$$a$$fe-b--><!--fe-b$$end$$0$$a$$fe-b--><!--fe-b$$start$$1$$b$$fe-b--><!--fe-b$$end$$1$$b$$fe-b--><!--fe-b$$start$$2$$c$$fe-b-->mars<!--fe-b$$end$$2$$c$$fe-b--></template
+            >
         </test-element-multiple>
         <!-- boolean -->
         <f-template name="test-element">
             <template><f-when value="{{show}}">Hello world</f-when></template>
         </f-template>
         <test-element id="show" show>
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Hello world<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open"
+                >Hello world<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template
+            >
         </test-element>
         <test-element id="hide">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->
+                <!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b-->
+            </template>
         </test-element>
         <!-- not -->
         <f-template name="test-element-not">
             <template><f-when value="{{!hide}}">Hello world</f-when></template>
         </f-template>
         <test-element-not id="show-not">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Hello world<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open"
+                >Hello world<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template
+            >
         </test-element-not>
         <test-element-not id="hide-not" hide>
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->
+                <!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b-->
+            </template>
         </test-element-not>
         <!-- equals -->
         <f-template name="test-element-equals">
             <template><f-when value="{{varA == 3}}">Equals 3</f-when></template>
         </f-template>
         <test-element-equals id="equals-true" var-a="3">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Equals 3<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open"
+                >Equals 3<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template
+            >
         </test-element-equals>
         <test-element-equals id="equals-false" var-a="4">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->
+                <!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b-->
+            </template>
         </test-element-equals>
         <!-- not equals -->
         <f-template name="test-element-not-equals">
             <template><f-when value="{{varA != 3}}">Not equals 3</f-when></template>
         </f-template>
         <test-element-not-equals id="not-equals-true" var-a="4">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Not equals 3<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open"
+                >Not equals 3<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template
+            >
         </test-element-not-equals>
         <test-element-not-equals id="not-equals-false" var-a="3">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->
+                <!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b-->
+            </template>
         </test-element-not-equals>
         <!-- greater than or equals -->
         <f-template name="test-element-ge">
             <template><f-when value="{{varA >= 2}}">Two and Over</f-when></template>
         </f-template>
         <test-element-ge id="ge-true" var-a="3">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Two and Over<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open"
+                >Two and Over<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template
+            >
         </test-element-ge>
         <test-element-ge id="ge-false" var-a="0">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->
+                <!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b-->
+            </template>
         </test-element-ge>
         <!-- greater than -->
         <f-template name="test-element-gt">
             <template><f-when value="{{varA > 2}}">Over two</f-when></template>
         </f-template>
         <test-element-gt id="gt-true" var-a="3">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Over two<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open"
+                >Over two<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template
+            >
         </test-element-gt>
         <test-element-gt id="gt-false" var-a="0">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->
+                <!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b-->
+            </template>
         </test-element-gt>
         <!-- less than or equals -->
         <f-template name="test-element-le">
             <template><f-when value="{{varA <= 2}}">Two and Under</f-when></template>
         </f-template>
         <test-element-le id="le-true" var-a="2">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Two and Under<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open"
+                >Two and Under<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template
+            >
         </test-element-le>
         <test-element-le id="le-false" var-a="4">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->
+                <!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b-->
+            </template>
         </test-element-le>
         <!-- less than -->
         <f-template name="test-element-lt">
             <template><f-when value="{{varA < 2}}">Under two</f-when></template>
         </f-template>
         <test-element-lt id="lt-true" var-a="1">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Under two<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open"
+                >Under two<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template
+            >
         </test-element-lt>
         <test-element-lt id="lt-false" var-a="3">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->
+                <!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b-->
+            </template>
         </test-element-lt>
         <!-- or -->
         <f-template name="test-element-or">
-            <template><f-when value="{{thisVar || thatVar}}">This or That</f-when></template>
+            <template
+                ><f-when value="{{thisVar || thatVar}}">This or That</f-when></template
+            >
         </f-template>
         <test-element-or id="or-true" this-var="3">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->This or That<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open"
+                >This or That<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template
+            >
         </test-element-or>
         <test-element-or id="or-false">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->
+                <!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b-->
+            </template>
         </test-element-or>
         <!-- and -->
         <f-template name="test-element-and">
-            <template><f-when value="{{thisVar && thatVar}}">This and That</f-when></template>
+            <template
+                ><f-when value="{{thisVar && thatVar}}">This and That</f-when></template
+            >
         </f-template>
         <test-element-and id="and-true" this-var that-var>
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->This and That<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open"
+                >This and That<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template
+            >
         </test-element-and>
         <test-element-and id="and-false" this-var>
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->
+                <!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b-->
+            </template>
         </test-element-and>
 
         <!-- nested when -->
         <f-template name="nested-when">
             <template>
                 <f-when value="{{error}}">
-                    <div class="error" role="alert">{{strings.errorMessage}}</div>
+                    <div class="error" role="alert">{{ strings.errorMessage }}</div>
                 </f-when>
                 <div class="buttons">
                     <f-when value="{{!error}}">
-                        <f-when value="{{showProgress}}">
-                            <progress></progress>
-                        </f-when>
+                        <f-when value="{{showProgress}}"> <progress></progress> </f-when>
                         <f-when value="{{!showProgress}}">
-                            <button ?disabled="{{!enableContinue}}" @click="{handleClick()}">
-                                {{strings.continueButtonText}}
+                            <button
+                                ?disabled="{{!enableContinue}}"
+                                @click="{handleClick()}"
+                            >
+                                {{ strings.continueButtonText }}
                             </button>
                         </f-when>
                     </f-when>
                     <f-when value="{{error}}">
-                        <button>{{strings.retryButtonText}}</button>
+                        <button>{{ strings.retryButtonText }}</button>
                     </f-when>
                 </div>
             </template>
         </f-template>
         <nested-when id="nested-when">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$nW0x5kp2Qm$$fe-b--><!--fe-b$$end$$0$$nW0x5kp2Qm$$fe-b--><div class="buttons"><!--fe-b$$start$$1$$nW0x5kp2Qm$$fe-b--><!--fe-b$$start$$0$$bX9mL3kR7v$$fe-b--><progress></progress><!--fe-b$$end$$0$$bX9mL3kR7v$$fe-b--><!--fe-b$$start$$1$$bX9mL3kR7v$$fe-b--><!--fe-b$$end$$1$$bX9mL3kR7v$$fe-b--><!--fe-b$$end$$1$$nW0x5kp2Qm$$fe-b--><!--fe-b$$start$$2$$nW0x5kp2Qm$$fe-b--><!--fe-b$$end$$2$$nW0x5kp2Qm$$fe-b--></div></template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$nW0x5kp2Qm$$fe-b-->
+                <!--fe-b$$end$$0$$nW0x5kp2Qm$$fe-b-->
+                <div class="buttons">
+                    <!--fe-b$$start$$1$$nW0x5kp2Qm$$fe-b--> <!--fe-b$$start$$0$$bX9mL3kR7v$$fe-b--> <progress
+                    ></progress><!--fe-b$$end$$0$$bX9mL3kR7v$$fe-b--><!--fe-b$$start$$1$$bX9mL3kR7v$$fe-b--><!--fe-b$$end$$1$$bX9mL3kR7v$$fe-b--><!--fe-b$$end$$1$$nW0x5kp2Qm$$fe-b--><!--fe-b$$start$$2$$nW0x5kp2Qm$$fe-b--><!--fe-b$$end$$2$$nW0x5kp2Qm$$fe-b-->
+                </div></template
+            >
         </nested-when>
         <!-- event -->
         <f-template name="test-element-event">
-            <template><f-when value="{{show}}"><button @click="{handleClick()}">Click me</button></f-when></template>
+            <template
+                ><f-when value="{{show}}"
+                    ><button @click="{handleClick()}">Click me</button></f-when
+                ></template
+            >
         </f-template>
         <test-element-event id="event-show" show>
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><button data-fe-b-0>Click me</button><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--> <button data-fe-b-0>
+                    Click me
+                </button><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template
+            >
         </test-element-event>
         <test-element-event id="event-hide">
-            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->
+                <!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b-->
+            </template>
         </test-element-event>
     </body>
 </html>

--- a/packages/fast-html/test/index.html
+++ b/packages/fast-html/test/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>FAST HTML Test Suite</title>
     </head>
     <body>

--- a/packages/fast-html/test/tsconfig.json
+++ b/packages/fast-html/test/tsconfig.json
@@ -2,12 +2,8 @@
     "extends": "../tsconfig.json",
     "compilerOptions": {
         "paths": {
-            "@microsoft/fast-html": [
-                "../src"
-            ]
+            "@microsoft/fast-html": ["../src"]
         }
     },
-    "include": [
-        "**/*.ts"
-    ]
+    "include": ["**/*.ts"]
 }

--- a/packages/fast-html/tsconfig.json
+++ b/packages/fast-html/tsconfig.json
@@ -1,24 +1,19 @@
 {
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "outDir": "dist/esm",
-    "declaration": true,
-    "declarationDir": "dist/dts",
-    "target": "ES2019",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "importHelpers": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "noEmitOnError": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "lib": [
-      "dom",
-      "esnext"
-    ],
-  },
-  "include": [
-    "src"
-  ]
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "outDir": "dist/esm",
+        "declaration": true,
+        "declarationDir": "dist/dts",
+        "target": "ES2019",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "importHelpers": true,
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
+        "noEmitOnError": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "lib": ["dom", "esnext"]
+    },
+    "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Adds support for `{{foo|binding:none}}` syntax in `@microsoft/fast-html` templates. This creates a one-time (non-reactive) static accessor instead of a reactive binding.

## Motivation

All current `{{}}` bindings are reactive — they set up observers so the DOM updates whenever the bound property changes. This PR adds a way to opt out of reactivity for cases where a value only needs to be read once on element connect.

## Changes

### `packages/fast-html`

- **`src/components/syntax.ts`**: Add `noneBindingModifier = "|binding:none"` constant
- **`src/components/utilities.ts`**: Add `hasNoneBindingModifier` and `stripNoneBindingModifier` helper functions
- **`src/components/template.ts`**: Import `oneTime` from `@microsoft/fast-element`; detect `|binding:none` modifier in content bindings and use `oneTime()` instead of a reactive function
- **`test/fixtures/static-accessor/`**: New test fixture verifying non-reactive rendering
- **`README.md`**: Document the new `Static accessor` syntax

## Behavior

| Syntax | Equivalent | Reactive? |
|--------|-----------|-----------|
| `{{text}}` | `${x => x.text}` | ✅ Yes |
| `{{text\|binding:none}}` | `${x.text}` (one-time) | ❌ No |

## Test

New test in `test/fixtures/static-accessor/static-accessor.spec.ts` verifies:
1. The initial value is rendered correctly
2. After changing the attribute, the DOM content does **not** update (no reactivity)