### PR TITLE
chore(fast-html): use @microsoft/fast-build to build observer-map fixture

### DIFF
--- a/change/@microsoft-fast-html-observer-map-bb7c9d5b-5bf9-4b9d-8583-e93eff003292.json
+++ b/change/@microsoft-fast-html-observer-map-bb7c9d5b-5bf9-4b9d-8583-e93eff003292.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(fast-html): use @microsoft/fast-build to build observer-map fixture",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-html/scripts/build-fixtures.js
+++ b/packages/fast-html/scripts/build-fixtures.js
@@ -22,6 +22,7 @@ const fixtures = [
     "dot-syntax",
     "nested-elements",
     "performance-metrics",
+    "observer-map",
 ];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/packages/fast-html/test/fixtures/observer-map/entry.html
+++ b/packages/fast-html/test/fixtures/observer-map/entry.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+    </head>
+    <body>
+        <div class="container">
+            <observer-map-simple-array-test-element items="{{simpleItems}}"></observer-map-simple-array-test-element>
+            <observer-map-test-element users="{{users}}" stats="{{stats}}" selected-user-id="{{selectedUserId}}"></observer-map-test-element>
+            <observer-map-with-observables-test-element value1="{{value1}}" value2="{{value2}}"></observer-map-with-observables-test-element>
+        </div>
+        <script type="module" src="./main.ts"></script>
+    </body>
+</html>

--- a/packages/fast-html/test/fixtures/observer-map/entry.html
+++ b/packages/fast-html/test/fixtures/observer-map/entry.html
@@ -6,7 +6,7 @@
     </head>
     <body>
         <div class="container">
-            <observer-map-simple-array-test-element :items="{{simpleItems}}"></observer-map-simple-array-test-element>
+            <observer-map-simple-array-test-element :items="{{simpleitems}}"></observer-map-simple-array-test-element>
             <observer-map-test-element></observer-map-test-element>
             <observer-map-with-observables-test-element></observer-map-with-observables-test-element>
         </div>

--- a/packages/fast-html/test/fixtures/observer-map/entry.html
+++ b/packages/fast-html/test/fixtures/observer-map/entry.html
@@ -7,7 +7,7 @@
     <body>
         <div class="container">
             <observer-map-simple-array-test-element :items="{{simpleItems}}"></observer-map-simple-array-test-element>
-            <observer-map-test-element selecteduserid="{{selectedUserId}}"></observer-map-test-element>
+            <observer-map-test-element></observer-map-test-element>
             <observer-map-with-observables-test-element></observer-map-with-observables-test-element>
         </div>
         <script type="module" src="./main.ts"></script>

--- a/packages/fast-html/test/fixtures/observer-map/entry.html
+++ b/packages/fast-html/test/fixtures/observer-map/entry.html
@@ -7,7 +7,7 @@
     <body>
         <div class="container">
             <observer-map-simple-array-test-element items="{{simpleItems}}"></observer-map-simple-array-test-element>
-            <observer-map-test-element users="{{users}}" stats="{{stats}}" selected-user-id="{{selectedUserId}}"></observer-map-test-element>
+            <observer-map-test-element users="{{users}}" stats="{{stats}}" selected-user-id="{{selectedUserId}}" a="{{a}}" x="{{x}}" groups="{{groups}}"></observer-map-test-element>
             <observer-map-with-observables-test-element value1="{{value1}}" value2="{{value2}}"></observer-map-with-observables-test-element>
         </div>
         <script type="module" src="./main.ts"></script>

--- a/packages/fast-html/test/fixtures/observer-map/entry.html
+++ b/packages/fast-html/test/fixtures/observer-map/entry.html
@@ -7,7 +7,7 @@
     <body>
         <div class="container">
             <observer-map-simple-array-test-element :items="{{simpleItems}}"></observer-map-simple-array-test-element>
-            <observer-map-test-element selected-user-id="{{selectedUserId}}"></observer-map-test-element>
+            <observer-map-test-element selecteduserid="{{selectedUserId}}"></observer-map-test-element>
             <observer-map-with-observables-test-element></observer-map-with-observables-test-element>
         </div>
         <script type="module" src="./main.ts"></script>

--- a/packages/fast-html/test/fixtures/observer-map/entry.html
+++ b/packages/fast-html/test/fixtures/observer-map/entry.html
@@ -6,7 +6,7 @@
     </head>
     <body>
         <div class="container">
-            <observer-map-simple-array-test-element :items="{{simpleitems}}"></observer-map-simple-array-test-element>
+            <observer-map-simple-array-test-element></observer-map-simple-array-test-element>
             <observer-map-test-element></observer-map-test-element>
             <observer-map-with-observables-test-element></observer-map-with-observables-test-element>
         </div>

--- a/packages/fast-html/test/fixtures/observer-map/entry.html
+++ b/packages/fast-html/test/fixtures/observer-map/entry.html
@@ -6,9 +6,9 @@
     </head>
     <body>
         <div class="container">
-            <observer-map-simple-array-test-element items="{{simpleItems}}"></observer-map-simple-array-test-element>
-            <observer-map-test-element users="{{users}}" stats="{{stats}}" selected-user-id="{{selectedUserId}}" a="{{a}}" x="{{x}}" groups="{{groups}}"></observer-map-test-element>
-            <observer-map-with-observables-test-element value1="{{value1}}" value2="{{value2}}"></observer-map-with-observables-test-element>
+            <observer-map-simple-array-test-element :items="{{simpleItems}}"></observer-map-simple-array-test-element>
+            <observer-map-test-element selected-user-id="{{selectedUserId}}"></observer-map-test-element>
+            <observer-map-with-observables-test-element></observer-map-with-observables-test-element>
         </div>
         <script type="module" src="./main.ts"></script>
     </body>

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -17,7 +17,7 @@
         </ul>
         <button data-fe-c-1-1>Update First Item</button>
         <button data-fe-c-2-1>Update Second Item</button></template></observer-map-simple-array-test-element>
-            <observer-map-test-element selecteduserid="1"><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element data-fe-c-0-6><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
+            <observer-map-test-element><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element data-fe-c-0-6><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
         <br>
         total users: <!--fe-b$$start$$1$$totalusers-1$$fe-b-->2<!--fe-b$$end$$1$$totalusers-1$$fe-b-->
         <br>

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -57,13 +57,13 @@
         <div class="stats">
             <h2>Global Stats</h2>
             <div class="nested-info">
-                <strong>Total Users:</strong> <!--fe-b$$start$$6$$stats.totalUsers-6$$fe-b-->2<!--fe-b$$end$$6$$stats.totalUsers-6$$fe-b--> |
-                <strong>Active Users:</strong> <!--fe-b$$start$$7$$stats.activeUsers-7$$fe-b-->1<!--fe-b$$end$$7$$stats.activeUsers-7$$fe-b-->
+                <strong>Total Users:</strong> <!--fe-b$$start$$6$$stats.totalusers-6$$fe-b-->2<!--fe-b$$end$$6$$stats.totalusers-6$$fe-b--> |
+                <strong>Active Users:</strong> <!--fe-b$$start$$7$$stats.activeusers-7$$fe-b-->1<!--fe-b$$end$$7$$stats.activeusers-7$$fe-b-->
             </div>
             <div class="nested-info">
                 <strong>Performance:</strong>
-                Load: <!--fe-b$$start$$8$$stats.metrics.performance.loadTime-8$$fe-b-->1.2<!--fe-b$$end$$8$$stats.metrics.performance.loadTime-8$$fe-b-->s,
-                Render: <!--fe-b$$start$$9$$stats.metrics.performance.renderTime-9$$fe-b-->0.8<!--fe-b$$end$$9$$stats.metrics.performance.renderTime-9$$fe-b-->s
+                Load: <!--fe-b$$start$$8$$stats.metrics.performance.loadtime-8$$fe-b-->1.2<!--fe-b$$end$$8$$stats.metrics.performance.loadtime-8$$fe-b-->s,
+                Render: <!--fe-b$$start$$9$$stats.metrics.performance.rendertime-9$$fe-b-->0.8<!--fe-b$$end$$9$$stats.metrics.performance.rendertime-9$$fe-b-->s
             </div>
             <div class="controls">
                 <button data-fe-c-10-1>Update Stats</button>
@@ -140,8 +140,8 @@
 <f-template name="observer-map-test-element">
     <template>
         <observer-map-internal-test-element
-            :selecteduserid="{{selectedUserId}}"
-            :totalusers="{{stats.totalUsers}}"
+            :selecteduserid="{{selecteduserid}}"
+            :totalusers="{{stats.totalusers}}"
             :metrics="{{stats.metrics}}"
             :a="{{a}}"
             :x="{{x}}"
@@ -150,13 +150,13 @@
         <div class="stats">
             <h2>Global Stats</h2>
             <div class="nested-info">
-                <strong>Total Users:</strong> {{stats.totalUsers}} |
-                <strong>Active Users:</strong> {{stats.activeUsers}}
+                <strong>Total Users:</strong> {{stats.totalusers}} |
+                <strong>Active Users:</strong> {{stats.activeusers}}
             </div>
             <div class="nested-info">
                 <strong>Performance:</strong>
-                Load: {{stats.metrics.performance.loadTime}}s,
-                Render: {{stats.metrics.performance.renderTime}}s
+                Load: {{stats.metrics.performance.loadtime}}s,
+                Render: {{stats.metrics.performance.rendertime}}s
             </div>
             <div class="controls">
                 <button @click="{updateStats()}">Update Stats</button>
@@ -169,7 +169,7 @@
             <f-repeat value="{{user in users}}">
                 <div class="user-card">
                     <h3>{{user.name}} (ID: {{user.id}})
-                        <f-when value="{{user.id == selectedUserId}}">
+                        <f-when value="{{user.id == selecteduserid}}">
                             <span>⭐ SELECTED</span>
                         </f-when>
                     </h3>

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -17,7 +17,7 @@
         </ul>
         <button data-fe-c-1-1>Update First Item</button>
         <button data-fe-c-2-1>Update Second Item</button></template></observer-map-simple-array-test-element>
-            <observer-map-test-element><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element data-fe-c-0-6><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
+            <observer-map-test-element><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element data-fe-c-0-4><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
         <br>
         total users: <!--fe-b$$start$$1$$totalusers-1$$fe-b-->2<!--fe-b$$end$$1$$totalusers-1$$fe-b-->
         <br>
@@ -29,9 +29,7 @@
                 Monthly: <!--fe-b$$start$$4$$metrics.engagement.monthly-4$$fe-b-->2000<!--fe-b$$end$$4$$metrics.engagement.monthly-4$$fe-b-->
             </div>
         </div>
-        <!--fe-b$$start$$5$$when-5$$fe-b-->
-            <span class="nested-define"><!--fe-b$$start$$0$$5-a.b.c-0$$fe-b--><!--fe-b$$end$$0$$5-a.b.c-0$$fe-b--></span>
-        <!--fe-b$$end$$5$$when-5$$fe-b-->
+        <!--fe-b$$start$$5$$when-5$$fe-b--><!--fe-b$$end$$5$$when-5$$fe-b-->
         <button data-fe-c-6-1>Define B</button>
         <button data-fe-c-7-1>Update C</button>
         <br>
@@ -59,23 +57,23 @@
         <div class="stats">
             <h2>Global Stats</h2>
             <div class="nested-info">
-                <strong>Total Users:</strong> <!--fe-b$$start$$6$$stats.totalusers-6$$fe-b-->2<!--fe-b$$end$$6$$stats.totalusers-6$$fe-b--> |
-                <strong>Active Users:</strong> <!--fe-b$$start$$7$$stats.activeusers-7$$fe-b-->1<!--fe-b$$end$$7$$stats.activeusers-7$$fe-b-->
+                <strong>Total Users:</strong> <!--fe-b$$start$$4$$stats.totalusers-4$$fe-b-->2<!--fe-b$$end$$4$$stats.totalusers-4$$fe-b--> |
+                <strong>Active Users:</strong> <!--fe-b$$start$$5$$stats.activeusers-5$$fe-b-->1<!--fe-b$$end$$5$$stats.activeusers-5$$fe-b-->
             </div>
             <div class="nested-info">
                 <strong>Performance:</strong>
-                Load: <!--fe-b$$start$$8$$stats.metrics.performance.loadtime-8$$fe-b-->1.2<!--fe-b$$end$$8$$stats.metrics.performance.loadtime-8$$fe-b-->s,
-                Render: <!--fe-b$$start$$9$$stats.metrics.performance.rendertime-9$$fe-b-->0.8<!--fe-b$$end$$9$$stats.metrics.performance.rendertime-9$$fe-b-->s
+                Load: <!--fe-b$$start$$6$$stats.metrics.performance.loadtime-6$$fe-b-->1.2<!--fe-b$$end$$6$$stats.metrics.performance.loadtime-6$$fe-b-->s,
+                Render: <!--fe-b$$start$$7$$stats.metrics.performance.rendertime-7$$fe-b-->0.8<!--fe-b$$end$$7$$stats.metrics.performance.rendertime-7$$fe-b-->s
             </div>
             <div class="controls">
-                <button data-fe-c-10-1>Update Stats</button>
-                <button data-fe-c-11-1>Add New User</button>
+                <button data-fe-c-8-1>Update Stats</button>
+                <button data-fe-c-9-1>Add New User</button>
             </div>
         </div>
 
         <div class="section">
             <h2>Users List</h2>
-            <!--fe-b$$start$$12$$repeat-12$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+            <!--fe-b$$start$$10$$repeat-10$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
                 <div class="user-card">
                     <h3><!--fe-b$$start$$0$$user.name-0$$fe-b-->Alice<!--fe-b$$end$$0$$user.name-0$$fe-b--> (ID: <!--fe-b$$start$$1$$user.id-1$$fe-b-->1<!--fe-b$$end$$1$$user.id-1$$fe-b-->)
                         <!--fe-b$$start$$2$$when-2$$fe-b-->
@@ -131,7 +129,7 @@
                         </div>
                     </div>
                 </div>
-            <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$12$$repeat-12$$fe-b-->
+            <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$10$$repeat-10$$fe-b-->
         </div></template></observer-map-test-element>
             <observer-map-with-observables-test-element><template shadowrootmode="open" shadowroot="open">Level 3 Value: <!--fe-b$$start$$0$$value1-0$$fe-b-->42<!--fe-b$$end$$0$$value1-0$$fe-b-->
         <button data-fe-c-1-1>Update Value1</button>
@@ -145,8 +143,6 @@
             :selecteduserid="{{selecteduserid}}"
             :totalusers="{{stats.totalusers}}"
             :metrics="{{stats.metrics}}"
-            :a="{{a}}"
-            :x="{{x}}"
             :groups="{{groups}}"
         ></observer-map-internal-test-element>
         <div class="stats">

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -77,7 +77,7 @@
                 <div class="user-card">
                     <h3><!--fe-b$$start$$0$$user.name-0$$fe-b-->Alice<!--fe-b$$end$$0$$user.name-0$$fe-b--> (ID: <!--fe-b$$start$$1$$user.id-1$$fe-b-->1<!--fe-b$$end$$1$$user.id-1$$fe-b-->)
                         <!--fe-b$$start$$2$$when-2$$fe-b-->
-                            <span>â­ SELECTED</span>
+                            <span>⭐ SELECTED</span>
                         <!--fe-b$$end$$2$$when-2$$fe-b-->
                     </h3>
 

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -17,7 +17,7 @@
         </ul>
         <button data-fe-c-1-1>Update First Item</button>
         <button data-fe-c-2-1>Update Second Item</button></template></observer-map-simple-array-test-element>
-            <observer-map-test-element><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element data-fe-c-0-4><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
+            <observer-map-test-element><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element data-fe-c-0-3><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
         <br>
         total users: <!--fe-b$$start$$1$$totalusers-1$$fe-b-->2<!--fe-b$$end$$1$$totalusers-1$$fe-b-->
         <br>
@@ -57,23 +57,23 @@
         <div class="stats">
             <h2>Global Stats</h2>
             <div class="nested-info">
-                <strong>Total Users:</strong> <!--fe-b$$start$$4$$stats.totalusers-4$$fe-b-->2<!--fe-b$$end$$4$$stats.totalusers-4$$fe-b--> |
-                <strong>Active Users:</strong> <!--fe-b$$start$$5$$stats.activeusers-5$$fe-b-->1<!--fe-b$$end$$5$$stats.activeusers-5$$fe-b-->
+                <strong>Total Users:</strong> <!--fe-b$$start$$3$$stats.totalusers-3$$fe-b-->2<!--fe-b$$end$$3$$stats.totalusers-3$$fe-b--> |
+                <strong>Active Users:</strong> <!--fe-b$$start$$4$$stats.activeusers-4$$fe-b-->1<!--fe-b$$end$$4$$stats.activeusers-4$$fe-b-->
             </div>
             <div class="nested-info">
                 <strong>Performance:</strong>
-                Load: <!--fe-b$$start$$6$$stats.metrics.performance.loadtime-6$$fe-b-->1.2<!--fe-b$$end$$6$$stats.metrics.performance.loadtime-6$$fe-b-->s,
-                Render: <!--fe-b$$start$$7$$stats.metrics.performance.rendertime-7$$fe-b-->0.8<!--fe-b$$end$$7$$stats.metrics.performance.rendertime-7$$fe-b-->s
+                Load: <!--fe-b$$start$$5$$stats.metrics.performance.loadtime-5$$fe-b-->1.2<!--fe-b$$end$$5$$stats.metrics.performance.loadtime-5$$fe-b-->s,
+                Render: <!--fe-b$$start$$6$$stats.metrics.performance.rendertime-6$$fe-b-->0.8<!--fe-b$$end$$6$$stats.metrics.performance.rendertime-6$$fe-b-->s
             </div>
             <div class="controls">
-                <button data-fe-c-8-1>Update Stats</button>
-                <button data-fe-c-9-1>Add New User</button>
+                <button data-fe-c-7-1>Update Stats</button>
+                <button data-fe-c-8-1>Add New User</button>
             </div>
         </div>
 
         <div class="section">
             <h2>Users List</h2>
-            <!--fe-b$$start$$10$$repeat-10$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+            <!--fe-b$$start$$9$$repeat-9$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
                 <div class="user-card">
                     <h3><!--fe-b$$start$$0$$user.name-0$$fe-b-->Alice<!--fe-b$$end$$0$$user.name-0$$fe-b--> (ID: <!--fe-b$$start$$1$$user.id-1$$fe-b-->1<!--fe-b$$end$$1$$user.id-1$$fe-b-->)
                         <!--fe-b$$start$$2$$when-2$$fe-b-->
@@ -129,7 +129,7 @@
                         </div>
                     </div>
                 </div>
-            <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$10$$repeat-10$$fe-b-->
+            <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$9$$repeat-9$$fe-b-->
         </div></template></observer-map-test-element>
             <observer-map-with-observables-test-element><template shadowrootmode="open" shadowroot="open">Level 3 Value: <!--fe-b$$start$$0$$value1-0$$fe-b-->42<!--fe-b$$end$$0$$value1-0$$fe-b-->
         <button data-fe-c-1-1>Update Value1</button>
@@ -143,7 +143,6 @@
             :selecteduserid="{{selecteduserid}}"
             :totalusers="{{stats.totalusers}}"
             :metrics="{{stats.metrics}}"
-            :groups="{{groups}}"
         ></observer-map-internal-test-element>
         <div class="stats">
             <h2>Global Stats</h2>

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -6,7 +6,7 @@
     </head>
     <body>
         <div class="container">
-            <observer-map-simple-array-test-element items="[Array]"><template shadowrootmode="open" shadowroot="open"><ul>
+            <observer-map-simple-array-test-element><template shadowrootmode="open" shadowroot="open"><ul>
             <!--fe-b$$start$$0$$repeat-0$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
                 <li class="simple-item"><!--fe-b$$start$$0$$item-0$$fe-b-->Item 1<!--fe-b$$end$$0$$item-0$$fe-b--></li>
             <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
@@ -15,16 +15,9 @@
                 <li class="simple-item"><!--fe-b$$start$$0$$item-0$$fe-b-->Item 3<!--fe-b$$end$$0$$item-0$$fe-b--></li>
             <!--fe-repeat$$end$$2$$fe-repeat--><!--fe-b$$end$$0$$repeat-0$$fe-b-->
         </ul>
-        <button @click="{updateFirstItem()}" data-fe-c-1-1>Update First Item</button>
-        <button @click="{updateSecondItem()}" data-fe-c-2-1>Update Second Item</button></template></observer-map-simple-array-test-element>
-            <observer-map-test-element users="[Array]" stats="[Object]" selected-user-id="1" a="" x="" groups="[Array]"><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element
-            :selecteduserid="1"
-            :totalusers="2"
-            :metrics="[Object]"
-            :a=""
-            :x=""
-            :groups="[Array]"
-         data-fe-c-0-6><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
+        <button data-fe-c-1-1>Update First Item</button>
+        <button data-fe-c-2-1>Update Second Item</button></template></observer-map-simple-array-test-element>
+            <observer-map-test-element selected-user-id="1"><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element data-fe-c-0-6><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
         <br>
         total users: <!--fe-b$$start$$1$$totalusers-1$$fe-b-->2<!--fe-b$$end$$1$$totalusers-1$$fe-b-->
         <br>
@@ -37,12 +30,12 @@
             </div>
         </div>
         <!--fe-b$$start$$5$$when-5$$fe-b--><!--fe-b$$end$$5$$when-5$$fe-b-->
-        <button @click="{defineB()}" data-fe-c-6-1>Define B</button>
-        <button @click="{updateC()}" data-fe-c-7-1>Update C</button>
+        <button data-fe-c-6-1>Define B</button>
+        <button data-fe-c-7-1>Update C</button>
         <br>
         <!--fe-b$$start$$8$$when-8$$fe-b--><!--fe-b$$end$$8$$when-8$$fe-b-->
-        <button @click="{defineY()}" data-fe-c-9-1>Define Y</button>
-        <button @click="{updateZ()}" data-fe-c-10-1>Update Z</button>
+        <button data-fe-c-9-1>Define Y</button>
+        <button data-fe-c-10-1>Update Z</button>
         <div>
             <!--fe-b$$start$$11$$repeat-11$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
                 <!--fe-b$$start$$0$$repeat-0$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
@@ -55,12 +48,12 @@
                 <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$0$$repeat-0$$fe-b-->
             <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$11$$repeat-11$$fe-b-->
         </div>
-        <button @click="{removeAllItems()}" data-fe-c-12-1>Remove all items</button>
-        <button @click="{addAnItem()}" data-fe-c-13-1>Add an item</button>
-        <button @click="{updateAnItem()}" data-fe-c-14-1>Update an item</button>
-        <button @click="{removeGroup()}" data-fe-c-15-1>Remove groups</button>
-        <button @click="{addGroup()}" data-fe-c-16-1>Add group</button>
-        <button @click="{updateActionLabel()}" data-fe-c-17-1>Update an action label</button></template></observer-map-internal-test-element>
+        <button data-fe-c-12-1>Remove all items</button>
+        <button data-fe-c-13-1>Add an item</button>
+        <button data-fe-c-14-1>Update an item</button>
+        <button data-fe-c-15-1>Remove groups</button>
+        <button data-fe-c-16-1>Add group</button>
+        <button data-fe-c-17-1>Update an action label</button></template></observer-map-internal-test-element>
         <div class="stats">
             <h2>Global Stats</h2>
             <div class="nested-info">
@@ -73,8 +66,8 @@
                 Render: <!--fe-b$$start$$9$$stats.metrics.performance.renderTime-9$$fe-b-->0.8<!--fe-b$$end$$9$$stats.metrics.performance.renderTime-9$$fe-b-->s
             </div>
             <div class="controls">
-                <button @click="{updateStats()}" data-fe-c-10-1>Update Stats</button>
-                <button @click="{addNewUser()}" data-fe-c-11-1>Add New User</button>
+                <button data-fe-c-10-1>Update Stats</button>
+                <button data-fe-c-11-1>Add New User</button>
             </div>
         </div>
 
@@ -118,31 +111,31 @@
                     </div>
 
                     <div class="controls">
-                        <button @click="{selectUser(user.id)}" data-fe-c-13-1>Select User</button>
-                        <button @click="{updateUserAge(user.id)}" data-fe-c-14-1>Age +1</button>
-                        <button @click="{toggleUserTheme(user.id)}" data-fe-c-15-1>Toggle Theme</button>
-                        <button @click="{updateUserLocation(user.id)}" data-fe-c-16-1>Change Location</button>
-                        <button @click="{updateNotificationSettings(user.id)}" data-fe-c-17-1>Update Notifications</button>
-                        <button @click="{addNotificationCategory(user.id)}" data-fe-c-18-1>Add Category</button>
-                        <button @click="{removeNotificationCategory(user.id)}" data-fe-c-19-1>Remove Tech Category</button>
-                        <button @click="{removeUser(user.id)}" data-fe-c-20-1>Remove User</button>
+                        <button data-fe-c-13-1>Select User</button>
+                        <button data-fe-c-14-1>Age +1</button>
+                        <button data-fe-c-15-1>Toggle Theme</button>
+                        <button data-fe-c-16-1>Change Location</button>
+                        <button data-fe-c-17-1>Update Notifications</button>
+                        <button data-fe-c-18-1>Add Category</button>
+                        <button data-fe-c-19-1>Remove Tech Category</button>
+                        <button data-fe-c-20-1>Remove User</button>
                     </div>
 
                     <div>
                         <h4>Posts (<!--fe-b$$start$$21$$user.posts.length-21$$fe-b-->0<!--fe-b$$end$$21$$user.posts.length-21$$fe-b--> posts)</h4>
                         <!--fe-b$$start$$22$$repeat-22$$fe-b--><!--fe-b$$end$$22$$repeat-22$$fe-b-->
                         <div class="controls">
-                            <button @click="{addPostToUser(user.id)}" data-fe-c-23-1>Add New Post</button>
+                            <button data-fe-c-23-1>Add New Post</button>
                         </div>
                     </div>
                 </div>
             <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$12$$repeat-12$$fe-b-->
         </div></template></observer-map-test-element>
-            <observer-map-with-observables-test-element value1="42" value2="42"><template shadowrootmode="open" shadowroot="open">Level 3 Value: <!--fe-b$$start$$0$$value1-0$$fe-b-->42<!--fe-b$$end$$0$$value1-0$$fe-b-->
-        <button @click="{updateValue1()}" data-fe-c-1-1>Update Value1</button>
+            <observer-map-with-observables-test-element><template shadowrootmode="open" shadowroot="open">Level 3 Value: <!--fe-b$$start$$0$$value1-0$$fe-b-->42<!--fe-b$$end$$0$$value1-0$$fe-b-->
+        <button data-fe-c-1-1>Update Value1</button>
         <br>
         Level 3 Value Observable: <!--fe-b$$start$$2$$value2-2$$fe-b-->42<!--fe-b$$end$$2$$value2-2$$fe-b-->
-        <button @click="{updateValue2()}" data-fe-c-3-1>Update Value2</button></template></observer-map-with-observables-test-element>
+        <button data-fe-c-3-1>Update Value2</button></template></observer-map-with-observables-test-element>
         </div>
 <f-template name="observer-map-test-element">
     <template>

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -8,12 +8,10 @@
         <div class="container">
             <observer-map-simple-array-test-element><template shadowrootmode="open" shadowroot="open"><ul>
             <!--fe-b$$start$$0$$repeat-0$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
-                <li class="simple-item"><!--fe-b$$start$$0$$item-0$$fe-b-->Item 1<!--fe-b$$end$$0$$item-0$$fe-b--></li>
+                <li class="simple-item"><!--fe-b$$start$$0$$item-0$$fe-b-->foo<!--fe-b$$end$$0$$item-0$$fe-b--></li>
             <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
-                <li class="simple-item"><!--fe-b$$start$$0$$item-0$$fe-b-->Item 2<!--fe-b$$end$$0$$item-0$$fe-b--></li>
-            <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-repeat$$start$$2$$fe-repeat-->
-                <li class="simple-item"><!--fe-b$$start$$0$$item-0$$fe-b-->Item 3<!--fe-b$$end$$0$$item-0$$fe-b--></li>
-            <!--fe-repeat$$end$$2$$fe-repeat--><!--fe-b$$end$$0$$repeat-0$$fe-b-->
+                <li class="simple-item"><!--fe-b$$start$$0$$item-0$$fe-b-->baz<!--fe-b$$end$$0$$item-0$$fe-b--></li>
+            <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$0$$repeat-0$$fe-b-->
         </ul>
         <button data-fe-c-1-1>Update First Item</button>
         <button data-fe-c-2-1>Update Second Item</button></template></observer-map-simple-array-test-element>
@@ -29,7 +27,9 @@
                 Monthly: <!--fe-b$$start$$4$$metrics.engagement.monthly-4$$fe-b-->2000<!--fe-b$$end$$4$$metrics.engagement.monthly-4$$fe-b-->
             </div>
         </div>
-        <!--fe-b$$start$$5$$when-5$$fe-b--><!--fe-b$$end$$5$$when-5$$fe-b-->
+        <!--fe-b$$start$$5$$when-5$$fe-b-->
+            <span class="nested-define"><!--fe-b$$start$$0$$5-a.b.c-0$$fe-b--><!--fe-b$$end$$0$$5-a.b.c-0$$fe-b--></span>
+        <!--fe-b$$end$$5$$when-5$$fe-b-->
         <button data-fe-c-6-1>Define B</button>
         <button data-fe-c-7-1>Update C</button>
         <br>
@@ -75,22 +75,22 @@
             <h2>Users List</h2>
             <!--fe-b$$start$$9$$repeat-9$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
                 <div class="user-card">
-                    <h3><!--fe-b$$start$$0$$user.name-0$$fe-b-->Alice<!--fe-b$$end$$0$$user.name-0$$fe-b--> (ID: <!--fe-b$$start$$1$$user.id-1$$fe-b-->1<!--fe-b$$end$$1$$user.id-1$$fe-b-->)
+                    <h3><!--fe-b$$start$$0$$user.name-0$$fe-b-->Alice Johnson<!--fe-b$$end$$0$$user.name-0$$fe-b--> (ID: <!--fe-b$$start$$1$$user.id-1$$fe-b-->1<!--fe-b$$end$$1$$user.id-1$$fe-b-->)
                         <!--fe-b$$start$$2$$when-2$$fe-b-->
                             <span>⭐ SELECTED</span>
                         <!--fe-b$$end$$2$$when-2$$fe-b-->
                     </h3>
 
                     <div class="nested-info">
-                        <strong>Age:</strong> <!--fe-b$$start$$3$$user.details.personal.age-3$$fe-b-->30<!--fe-b$$end$$3$$user.details.personal.age-3$$fe-b--> years old
+                        <strong>Age:</strong> <!--fe-b$$start$$3$$user.details.personal.age-3$$fe-b-->28<!--fe-b$$end$$3$$user.details.personal.age-3$$fe-b--> years old
                     </div>
                     <div class="nested-info">
-                        <strong>Location:</strong> <!--fe-b$$start$$4$$user.details.personal.location.city-4$$fe-b-->Seattle<!--fe-b$$end$$4$$user.details.personal.location.city-4$$fe-b-->, <!--fe-b$$start$$5$$user.details.personal.location.country-5$$fe-b-->USA<!--fe-b$$end$$5$$user.details.personal.location.country-5$$fe-b-->
+                        <strong>Location:</strong> <!--fe-b$$start$$4$$user.details.personal.location.city-4$$fe-b-->New York<!--fe-b$$end$$4$$user.details.personal.location.city-4$$fe-b-->, <!--fe-b$$start$$5$$user.details.personal.location.country-5$$fe-b-->USA<!--fe-b$$end$$5$$user.details.personal.location.country-5$$fe-b-->
                     </div>
                     <div class="nested-info">
                         <strong>Coordinates:</strong>
-                        Lat: <!--fe-b$$start$$6$$user.details.personal.location.coordinates.lat-6$$fe-b-->47.6<!--fe-b$$end$$6$$user.details.personal.location.coordinates.lat-6$$fe-b-->,
-                        Lng: <!--fe-b$$start$$7$$user.details.personal.location.coordinates.lng-7$$fe-b-->-122.3<!--fe-b$$end$$7$$user.details.personal.location.coordinates.lng-7$$fe-b-->
+                        Lat: <!--fe-b$$start$$6$$user.details.personal.location.coordinates.lat-6$$fe-b-->40.7128<!--fe-b$$end$$6$$user.details.personal.location.coordinates.lat-6$$fe-b-->,
+                        Lng: <!--fe-b$$start$$7$$user.details.personal.location.coordinates.lng-7$$fe-b-->-74.006<!--fe-b$$end$$7$$user.details.personal.location.coordinates.lng-7$$fe-b-->
                     </div>
 
                     <div class="nested-info">
@@ -104,9 +104,9 @@
                     <div class="nested-info">
                         <strong>Categories:</strong>
                         <!--fe-b$$start$$12$$repeat-12$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
-                            <span class="tag"><!--fe-b$$start$$0$$category-0$$fe-b-->news<!--fe-b$$end$$0$$category-0$$fe-b--></span>
+                            <span class="tag"><!--fe-b$$start$$0$$category-0$$fe-b-->tech<!--fe-b$$end$$0$$category-0$$fe-b--></span>
                         <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
-                            <span class="tag"><!--fe-b$$start$$0$$category-0$$fe-b-->updates<!--fe-b$$end$$0$$category-0$$fe-b--></span>
+                            <span class="tag"><!--fe-b$$start$$0$$category-0$$fe-b-->news<!--fe-b$$end$$0$$category-0$$fe-b--></span>
                         <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$12$$repeat-12$$fe-b-->
                     </div>
 
@@ -122,14 +122,141 @@
                     </div>
 
                     <div>
-                        <h4>Posts (<!--fe-b$$start$$21$$user.posts.length-21$$fe-b-->0<!--fe-b$$end$$21$$user.posts.length-21$$fe-b--> posts)</h4>
-                        <!--fe-b$$start$$22$$repeat-22$$fe-b--><!--fe-b$$end$$22$$repeat-22$$fe-b-->
+                        <h4>Posts (<!--fe-b$$start$$21$$user.posts.length-21$$fe-b-->2<!--fe-b$$end$$21$$user.posts.length-21$$fe-b--> posts)</h4>
+                        <!--fe-b$$start$$22$$repeat-22$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                            <div class="post-card">
+                                <div><strong><!--fe-b$$start$$0$$post.title-0$$fe-b-->First Post<!--fe-b$$end$$0$$post.title-0$$fe-b--></strong> (ID: <!--fe-b$$start$$1$$post.id-1$$fe-b-->101<!--fe-b$$end$$1$$post.id-1$$fe-b-->)</div>
+                                <div class="nested-info"><!--fe-b$$start$$2$$post.content-2$$fe-b-->Hello World!<!--fe-b$$end$$2$$post.content-2$$fe-b--></div>
+                                <div class="nested-info">
+                                    <strong>Author:</strong> <!--fe-b$$start$$3$$post.metadata.author.name-3$$fe-b-->Alice Johnson<!--fe-b$$end$$3$$post.metadata.author.name-3$$fe-b-->
+                                    <!--fe-b$$start$$4$$when-4$$fe-b-->
+                                        <span>✓ Verified</span>
+                                    <!--fe-b$$end$$4$$when-4$$fe-b-->
+                                </div>
+                                <div class="nested-info">
+                                    <strong>Stats:</strong> <!--fe-b$$start$$5$$post.metadata.views-5$$fe-b-->150<!--fe-b$$end$$5$$post.metadata.views-5$$fe-b--> views, <!--fe-b$$start$$6$$post.metadata.likes-6$$fe-b-->25<!--fe-b$$end$$6$$post.metadata.likes-6$$fe-b--> likes
+                                </div>
+                                <div class="nested-info">
+                                    <strong>Tags:</strong>
+                                    <!--fe-b$$start$$7$$repeat-7$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                                        <span class="tag"><!--fe-b$$start$$0$$tag-0$$fe-b-->introduction<!--fe-b$$end$$0$$tag-0$$fe-b--></span>
+                                    <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
+                                        <span class="tag"><!--fe-b$$start$$0$$tag-0$$fe-b-->hello<!--fe-b$$end$$0$$tag-0$$fe-b--></span>
+                                    <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$7$$repeat-7$$fe-b-->
+                                </div>
+                                <div class="controls">
+                                    <button data-fe-c-8-1>Like Post</button>
+                                </div>
+                            </div>
+                        <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
+                            <div class="post-card">
+                                <div><strong><!--fe-b$$start$$0$$post.title-0$$fe-b-->Tech Update<!--fe-b$$end$$0$$post.title-0$$fe-b--></strong> (ID: <!--fe-b$$start$$1$$post.id-1$$fe-b-->102<!--fe-b$$end$$1$$post.id-1$$fe-b-->)</div>
+                                <div class="nested-info"><!--fe-b$$start$$2$$post.content-2$$fe-b-->Latest in technology...<!--fe-b$$end$$2$$post.content-2$$fe-b--></div>
+                                <div class="nested-info">
+                                    <strong>Author:</strong> <!--fe-b$$start$$3$$post.metadata.author.name-3$$fe-b-->Alice Johnson<!--fe-b$$end$$3$$post.metadata.author.name-3$$fe-b-->
+                                    <!--fe-b$$start$$4$$when-4$$fe-b-->
+                                        <span>✓ Verified</span>
+                                    <!--fe-b$$end$$4$$when-4$$fe-b-->
+                                </div>
+                                <div class="nested-info">
+                                    <strong>Stats:</strong> <!--fe-b$$start$$5$$post.metadata.views-5$$fe-b-->320<!--fe-b$$end$$5$$post.metadata.views-5$$fe-b--> views, <!--fe-b$$start$$6$$post.metadata.likes-6$$fe-b-->45<!--fe-b$$end$$6$$post.metadata.likes-6$$fe-b--> likes
+                                </div>
+                                <div class="nested-info">
+                                    <strong>Tags:</strong>
+                                    <!--fe-b$$start$$7$$repeat-7$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                                        <span class="tag"><!--fe-b$$start$$0$$tag-0$$fe-b-->tech<!--fe-b$$end$$0$$tag-0$$fe-b--></span>
+                                    <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
+                                        <span class="tag"><!--fe-b$$start$$0$$tag-0$$fe-b-->update<!--fe-b$$end$$0$$tag-0$$fe-b--></span>
+                                    <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$7$$repeat-7$$fe-b-->
+                                </div>
+                                <div class="controls">
+                                    <button data-fe-c-8-1>Like Post</button>
+                                </div>
+                            </div>
+                        <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$22$$repeat-22$$fe-b-->
                         <div class="controls">
                             <button data-fe-c-23-1>Add New Post</button>
                         </div>
                     </div>
                 </div>
-            <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$9$$repeat-9$$fe-b-->
+            <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
+                <div class="user-card">
+                    <h3><!--fe-b$$start$$0$$user.name-0$$fe-b-->Bob Smith<!--fe-b$$end$$0$$user.name-0$$fe-b--> (ID: <!--fe-b$$start$$1$$user.id-1$$fe-b-->2<!--fe-b$$end$$1$$user.id-1$$fe-b-->)
+                        <!--fe-b$$start$$2$$when-2$$fe-b--><!--fe-b$$end$$2$$when-2$$fe-b-->
+                    </h3>
+
+                    <div class="nested-info">
+                        <strong>Age:</strong> <!--fe-b$$start$$3$$user.details.personal.age-3$$fe-b-->35<!--fe-b$$end$$3$$user.details.personal.age-3$$fe-b--> years old
+                    </div>
+                    <div class="nested-info">
+                        <strong>Location:</strong> <!--fe-b$$start$$4$$user.details.personal.location.city-4$$fe-b-->London<!--fe-b$$end$$4$$user.details.personal.location.city-4$$fe-b-->, <!--fe-b$$start$$5$$user.details.personal.location.country-5$$fe-b-->UK<!--fe-b$$end$$5$$user.details.personal.location.country-5$$fe-b-->
+                    </div>
+                    <div class="nested-info">
+                        <strong>Coordinates:</strong>
+                        Lat: <!--fe-b$$start$$6$$user.details.personal.location.coordinates.lat-6$$fe-b-->51.5074<!--fe-b$$end$$6$$user.details.personal.location.coordinates.lat-6$$fe-b-->,
+                        Lng: <!--fe-b$$start$$7$$user.details.personal.location.coordinates.lng-7$$fe-b-->-0.1278<!--fe-b$$end$$7$$user.details.personal.location.coordinates.lng-7$$fe-b-->
+                    </div>
+
+                    <div class="nested-info">
+                        <strong>Theme:</strong> <!--fe-b$$start$$8$$user.details.preferences.theme-8$$fe-b-->light<!--fe-b$$end$$8$$user.details.preferences.theme-8$$fe-b--> |
+                        <strong>Email Notifications:</strong> <!--fe-b$$start$$9$$user.details.preferences.notifications.email-9$$fe-b-->false<!--fe-b$$end$$9$$user.details.preferences.notifications.email-9$$fe-b--> |
+                        <strong>Push Notifications:</strong> <!--fe-b$$start$$10$$user.details.preferences.notifications.push-10$$fe-b-->true<!--fe-b$$end$$10$$user.details.preferences.notifications.push-10$$fe-b-->
+                    </div>
+                    <div class="nested-info">
+                        <strong>Notification Frequency:</strong> <!--fe-b$$start$$11$$user.details.preferences.notifications.settings.frequency-11$$fe-b-->weekly<!--fe-b$$end$$11$$user.details.preferences.notifications.settings.frequency-11$$fe-b-->
+                    </div>
+                    <div class="nested-info">
+                        <strong>Categories:</strong>
+                        <!--fe-b$$start$$12$$repeat-12$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                            <span class="tag"><!--fe-b$$start$$0$$category-0$$fe-b-->sports<!--fe-b$$end$$0$$category-0$$fe-b--></span>
+                        <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
+                            <span class="tag"><!--fe-b$$start$$0$$category-0$$fe-b-->music<!--fe-b$$end$$0$$category-0$$fe-b--></span>
+                        <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$12$$repeat-12$$fe-b-->
+                    </div>
+
+                    <div class="controls">
+                        <button data-fe-c-13-1>Select User</button>
+                        <button data-fe-c-14-1>Age +1</button>
+                        <button data-fe-c-15-1>Toggle Theme</button>
+                        <button data-fe-c-16-1>Change Location</button>
+                        <button data-fe-c-17-1>Update Notifications</button>
+                        <button data-fe-c-18-1>Add Category</button>
+                        <button data-fe-c-19-1>Remove Tech Category</button>
+                        <button data-fe-c-20-1>Remove User</button>
+                    </div>
+
+                    <div>
+                        <h4>Posts (<!--fe-b$$start$$21$$user.posts.length-21$$fe-b-->1<!--fe-b$$end$$21$$user.posts.length-21$$fe-b--> posts)</h4>
+                        <!--fe-b$$start$$22$$repeat-22$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                            <div class="post-card">
+                                <div><strong><!--fe-b$$start$$0$$post.title-0$$fe-b-->Music Review<!--fe-b$$end$$0$$post.title-0$$fe-b--></strong> (ID: <!--fe-b$$start$$1$$post.id-1$$fe-b-->201<!--fe-b$$end$$1$$post.id-1$$fe-b-->)</div>
+                                <div class="nested-info"><!--fe-b$$start$$2$$post.content-2$$fe-b-->Amazing concert last night...<!--fe-b$$end$$2$$post.content-2$$fe-b--></div>
+                                <div class="nested-info">
+                                    <strong>Author:</strong> <!--fe-b$$start$$3$$post.metadata.author.name-3$$fe-b-->Bob Smith<!--fe-b$$end$$3$$post.metadata.author.name-3$$fe-b-->
+                                    <!--fe-b$$start$$4$$when-4$$fe-b--><!--fe-b$$end$$4$$when-4$$fe-b-->
+                                </div>
+                                <div class="nested-info">
+                                    <strong>Stats:</strong> <!--fe-b$$start$$5$$post.metadata.views-5$$fe-b-->89<!--fe-b$$end$$5$$post.metadata.views-5$$fe-b--> views, <!--fe-b$$start$$6$$post.metadata.likes-6$$fe-b-->12<!--fe-b$$end$$6$$post.metadata.likes-6$$fe-b--> likes
+                                </div>
+                                <div class="nested-info">
+                                    <strong>Tags:</strong>
+                                    <!--fe-b$$start$$7$$repeat-7$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                                        <span class="tag"><!--fe-b$$start$$0$$tag-0$$fe-b-->music<!--fe-b$$end$$0$$tag-0$$fe-b--></span>
+                                    <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
+                                        <span class="tag"><!--fe-b$$start$$0$$tag-0$$fe-b-->review<!--fe-b$$end$$0$$tag-0$$fe-b--></span>
+                                    <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$7$$repeat-7$$fe-b-->
+                                </div>
+                                <div class="controls">
+                                    <button data-fe-c-8-1>Like Post</button>
+                                </div>
+                            </div>
+                        <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$22$$repeat-22$$fe-b-->
+                        <div class="controls">
+                            <button data-fe-c-23-1>Add New Post</button>
+                        </div>
+                    </div>
+                </div>
+            <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$9$$repeat-9$$fe-b-->
         </div></template></observer-map-test-element>
             <observer-map-with-observables-test-element><template shadowrootmode="open" shadowroot="open">Level 3 Value: <!--fe-b$$start$$0$$value1-0$$fe-b-->42<!--fe-b$$end$$0$$value1-0$$fe-b-->
         <button data-fe-c-1-1>Update Value1</button>

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -1,195 +1,325 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title></title>
-        <script type="module" src="./main.ts"></script>
     </head>
     <body>
         <div class="container">
-            <observer-map-simple-array-test-element></observer-map-simple-array-test-element>
-            <observer-map-test-element></observer-map-test-element>
-            <observer-map-with-observables-test-element>
-                <template shadowrootmode="open">
-                    Level 3 Value: <!--fe-b$$start$$0$$data$$fe-b-->42<!--fe-b$$end$$0$$data$$fe-b-->
-                    <button data-fe-b-1>Update Value1</button>
-                    <br>
-                    Level 3 Value Observable: <!--fe-b$$start$$2$$value2$$fe-b-->42<!--fe-b$$end$$2$$value2$$fe-b-->
-                    <button data-fe-b-3>Update Value2</button>
-                </template>
-            </observer-map-with-observables-test-element>
-            <f-template name="observer-map-test-element">
-                <template>
-                    <observer-map-internal-test-element
-                        :selecteduserid="{{selectedUserId}}"
-                        :totalusers="{{stats.totalUsers}}"
-                        :metrics="{{stats.metrics}}"
-                    ></observer-map-internal-test-element>
-                    <div class="stats">
-                        <h2>Global Stats</h2>
-                        <div class="nested-info">
-                            <strong>Total Users:</strong> {{stats.totalUsers}} |
-                            <strong>Active Users:</strong> {{stats.activeUsers}}
-                        </div>
-                        <div class="nested-info">
-                            <strong>Performance:</strong>
-                            Load: {{stats.metrics.performance.loadTime}}s,
-                            Render: {{stats.metrics.performance.renderTime}}s
-                        </div>
-                        <div class="controls">
-                            <button @click="{updateStats()}">Update Stats</button>
-                            <button @click="{addNewUser()}">Add New User</button>
-                        </div>
+            <observer-map-simple-array-test-element items="[Array]"><template shadowrootmode="open" shadowroot="open"><ul>
+            <!--fe-b$$start$$0$$repeat-0$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                <li class="simple-item"><!--fe-b$$start$$0$$item-0$$fe-b-->Item 1<!--fe-b$$end$$0$$item-0$$fe-b--></li>
+            <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
+                <li class="simple-item"><!--fe-b$$start$$0$$item-0$$fe-b-->Item 2<!--fe-b$$end$$0$$item-0$$fe-b--></li>
+            <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-repeat$$start$$2$$fe-repeat-->
+                <li class="simple-item"><!--fe-b$$start$$0$$item-0$$fe-b-->Item 3<!--fe-b$$end$$0$$item-0$$fe-b--></li>
+            <!--fe-repeat$$end$$2$$fe-repeat--><!--fe-b$$end$$0$$repeat-0$$fe-b-->
+        </ul>
+        <button @click="{updateFirstItem()}" data-fe-c-1-1>Update First Item</button>
+        <button @click="{updateSecondItem()}" data-fe-c-2-1>Update Second Item</button></template></observer-map-simple-array-test-element>
+            <observer-map-test-element users="[Array]" stats="[Object]" selected-user-id="1" a="" x="" groups="[Array]"><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element
+            :selecteduserid="1"
+            :totalusers="2"
+            :metrics="[Object]"
+            :a=""
+            :x=""
+            :groups="[Array]"
+         data-fe-c-0-6><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
+        <br>
+        total users: <!--fe-b$$start$$1$$totalusers-1$$fe-b-->2<!--fe-b$$end$$1$$totalusers-1$$fe-b-->
+        <br>
+        <div class="stats">
+            <div class="nested-info">
+                <strong>Engagement:</strong>
+                Daily: <!--fe-b$$start$$2$$metrics.engagement.daily-2$$fe-b-->100<!--fe-b$$end$$2$$metrics.engagement.daily-2$$fe-b-->,
+                Weekly: <!--fe-b$$start$$3$$metrics.engagement.weekly-3$$fe-b-->500<!--fe-b$$end$$3$$metrics.engagement.weekly-3$$fe-b-->,
+                Monthly: <!--fe-b$$start$$4$$metrics.engagement.monthly-4$$fe-b-->2000<!--fe-b$$end$$4$$metrics.engagement.monthly-4$$fe-b-->
+            </div>
+        </div>
+        <!--fe-b$$start$$5$$when-5$$fe-b--><!--fe-b$$end$$5$$when-5$$fe-b-->
+        <button @click="{defineB()}" data-fe-c-6-1>Define B</button>
+        <button @click="{updateC()}" data-fe-c-7-1>Update C</button>
+        <br>
+        <!--fe-b$$start$$8$$when-8$$fe-b--><!--fe-b$$end$$8$$when-8$$fe-b-->
+        <button @click="{defineY()}" data-fe-c-9-1>Define Y</button>
+        <button @click="{updateZ()}" data-fe-c-10-1>Update Z</button>
+        <div>
+            <!--fe-b$$start$$11$$repeat-11$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                <!--fe-b$$start$$0$$repeat-0$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                    <div class="item"><!--fe-b$$start$$0$$item.text-0$$fe-b-->item A<!--fe-b$$end$$0$$item.text-0$$fe-b--></div>
+                    <span>
+                        <!--fe-b$$start$$1$$repeat-1$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                            <span class="action-label"><!--fe-b$$start$$0$$action.label-0$$fe-b-->action label A<!--fe-b$$end$$0$$action.label-0$$fe-b--></span>
+                        <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$1$$repeat-1$$fe-b-->
+                    </span>
+                <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$0$$repeat-0$$fe-b-->
+            <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$11$$repeat-11$$fe-b-->
+        </div>
+        <button @click="{removeAllItems()}" data-fe-c-12-1>Remove all items</button>
+        <button @click="{addAnItem()}" data-fe-c-13-1>Add an item</button>
+        <button @click="{updateAnItem()}" data-fe-c-14-1>Update an item</button>
+        <button @click="{removeGroup()}" data-fe-c-15-1>Remove groups</button>
+        <button @click="{addGroup()}" data-fe-c-16-1>Add group</button>
+        <button @click="{updateActionLabel()}" data-fe-c-17-1>Update an action label</button></template></observer-map-internal-test-element>
+        <div class="stats">
+            <h2>Global Stats</h2>
+            <div class="nested-info">
+                <strong>Total Users:</strong> <!--fe-b$$start$$6$$stats.totalUsers-6$$fe-b-->2<!--fe-b$$end$$6$$stats.totalUsers-6$$fe-b--> |
+                <strong>Active Users:</strong> <!--fe-b$$start$$7$$stats.activeUsers-7$$fe-b-->1<!--fe-b$$end$$7$$stats.activeUsers-7$$fe-b-->
+            </div>
+            <div class="nested-info">
+                <strong>Performance:</strong>
+                Load: <!--fe-b$$start$$8$$stats.metrics.performance.loadTime-8$$fe-b-->1.2<!--fe-b$$end$$8$$stats.metrics.performance.loadTime-8$$fe-b-->s,
+                Render: <!--fe-b$$start$$9$$stats.metrics.performance.renderTime-9$$fe-b-->0.8<!--fe-b$$end$$9$$stats.metrics.performance.renderTime-9$$fe-b-->s
+            </div>
+            <div class="controls">
+                <button @click="{updateStats()}" data-fe-c-10-1>Update Stats</button>
+                <button @click="{addNewUser()}" data-fe-c-11-1>Add New User</button>
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>Users List</h2>
+            <!--fe-b$$start$$12$$repeat-12$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                <div class="user-card">
+                    <h3><!--fe-b$$start$$0$$user.name-0$$fe-b-->Alice<!--fe-b$$end$$0$$user.name-0$$fe-b--> (ID: <!--fe-b$$start$$1$$user.id-1$$fe-b-->1<!--fe-b$$end$$1$$user.id-1$$fe-b-->)
+                        <!--fe-b$$start$$2$$when-2$$fe-b-->
+                            <span>â­ SELECTED</span>
+                        <!--fe-b$$end$$2$$when-2$$fe-b-->
+                    </h3>
+
+                    <div class="nested-info">
+                        <strong>Age:</strong> <!--fe-b$$start$$3$$user.details.personal.age-3$$fe-b-->30<!--fe-b$$end$$3$$user.details.personal.age-3$$fe-b--> years old
+                    </div>
+                    <div class="nested-info">
+                        <strong>Location:</strong> <!--fe-b$$start$$4$$user.details.personal.location.city-4$$fe-b-->Seattle<!--fe-b$$end$$4$$user.details.personal.location.city-4$$fe-b-->, <!--fe-b$$start$$5$$user.details.personal.location.country-5$$fe-b-->USA<!--fe-b$$end$$5$$user.details.personal.location.country-5$$fe-b-->
+                    </div>
+                    <div class="nested-info">
+                        <strong>Coordinates:</strong>
+                        Lat: <!--fe-b$$start$$6$$user.details.personal.location.coordinates.lat-6$$fe-b-->47.6<!--fe-b$$end$$6$$user.details.personal.location.coordinates.lat-6$$fe-b-->,
+                        Lng: <!--fe-b$$start$$7$$user.details.personal.location.coordinates.lng-7$$fe-b-->-122.3<!--fe-b$$end$$7$$user.details.personal.location.coordinates.lng-7$$fe-b-->
                     </div>
 
-                    <div class="section">
-                        <h2>Users List</h2>
-                        <f-repeat value="{{user in users}}">
-                            <div class="user-card">
-                                <h3>{{user.name}} (ID: {{user.id}})
-                                    <f-when value="{{user.id == selectedUserId}}">
-                                        <span>⭐ SELECTED</span>
+                    <div class="nested-info">
+                        <strong>Theme:</strong> <!--fe-b$$start$$8$$user.details.preferences.theme-8$$fe-b-->dark<!--fe-b$$end$$8$$user.details.preferences.theme-8$$fe-b--> |
+                        <strong>Email Notifications:</strong> <!--fe-b$$start$$9$$user.details.preferences.notifications.email-9$$fe-b-->true<!--fe-b$$end$$9$$user.details.preferences.notifications.email-9$$fe-b--> |
+                        <strong>Push Notifications:</strong> <!--fe-b$$start$$10$$user.details.preferences.notifications.push-10$$fe-b-->false<!--fe-b$$end$$10$$user.details.preferences.notifications.push-10$$fe-b-->
+                    </div>
+                    <div class="nested-info">
+                        <strong>Notification Frequency:</strong> <!--fe-b$$start$$11$$user.details.preferences.notifications.settings.frequency-11$$fe-b-->daily<!--fe-b$$end$$11$$user.details.preferences.notifications.settings.frequency-11$$fe-b-->
+                    </div>
+                    <div class="nested-info">
+                        <strong>Categories:</strong>
+                        <!--fe-b$$start$$12$$repeat-12$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+                            <span class="tag"><!--fe-b$$start$$0$$category-0$$fe-b-->news<!--fe-b$$end$$0$$category-0$$fe-b--></span>
+                        <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
+                            <span class="tag"><!--fe-b$$start$$0$$category-0$$fe-b-->updates<!--fe-b$$end$$0$$category-0$$fe-b--></span>
+                        <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$12$$repeat-12$$fe-b-->
+                    </div>
+
+                    <div class="controls">
+                        <button @click="{selectUser(user.id)}" data-fe-c-13-1>Select User</button>
+                        <button @click="{updateUserAge(user.id)}" data-fe-c-14-1>Age +1</button>
+                        <button @click="{toggleUserTheme(user.id)}" data-fe-c-15-1>Toggle Theme</button>
+                        <button @click="{updateUserLocation(user.id)}" data-fe-c-16-1>Change Location</button>
+                        <button @click="{updateNotificationSettings(user.id)}" data-fe-c-17-1>Update Notifications</button>
+                        <button @click="{addNotificationCategory(user.id)}" data-fe-c-18-1>Add Category</button>
+                        <button @click="{removeNotificationCategory(user.id)}" data-fe-c-19-1>Remove Tech Category</button>
+                        <button @click="{removeUser(user.id)}" data-fe-c-20-1>Remove User</button>
+                    </div>
+
+                    <div>
+                        <h4>Posts (<!--fe-b$$start$$21$$user.posts.length-21$$fe-b-->0<!--fe-b$$end$$21$$user.posts.length-21$$fe-b--> posts)</h4>
+                        <!--fe-b$$start$$22$$repeat-22$$fe-b--><!--fe-b$$end$$22$$repeat-22$$fe-b-->
+                        <div class="controls">
+                            <button @click="{addPostToUser(user.id)}" data-fe-c-23-1>Add New Post</button>
+                        </div>
+                    </div>
+                </div>
+            <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$12$$repeat-12$$fe-b-->
+        </div></template></observer-map-test-element>
+            <observer-map-with-observables-test-element value1="42" value2="42"><template shadowrootmode="open" shadowroot="open">Level 3 Value: <!--fe-b$$start$$0$$value1-0$$fe-b-->42<!--fe-b$$end$$0$$value1-0$$fe-b-->
+        <button @click="{updateValue1()}" data-fe-c-1-1>Update Value1</button>
+        <br>
+        Level 3 Value Observable: <!--fe-b$$start$$2$$value2-2$$fe-b-->42<!--fe-b$$end$$2$$value2-2$$fe-b-->
+        <button @click="{updateValue2()}" data-fe-c-3-1>Update Value2</button></template></observer-map-with-observables-test-element>
+        </div>
+<f-template name="observer-map-test-element">
+    <template>
+        <observer-map-internal-test-element
+            :selecteduserid="{{selectedUserId}}"
+            :totalusers="{{stats.totalUsers}}"
+            :metrics="{{stats.metrics}}"
+            :a="{{a}}"
+            :x="{{x}}"
+            :groups="{{groups}}"
+        ></observer-map-internal-test-element>
+        <div class="stats">
+            <h2>Global Stats</h2>
+            <div class="nested-info">
+                <strong>Total Users:</strong> {{stats.totalUsers}} |
+                <strong>Active Users:</strong> {{stats.activeUsers}}
+            </div>
+            <div class="nested-info">
+                <strong>Performance:</strong>
+                Load: {{stats.metrics.performance.loadTime}}s,
+                Render: {{stats.metrics.performance.renderTime}}s
+            </div>
+            <div class="controls">
+                <button @click="{updateStats()}">Update Stats</button>
+                <button @click="{addNewUser()}">Add New User</button>
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>Users List</h2>
+            <f-repeat value="{{user in users}}">
+                <div class="user-card">
+                    <h3>{{user.name}} (ID: {{user.id}})
+                        <f-when value="{{user.id == selectedUserId}}">
+                            <span>⭐ SELECTED</span>
+                        </f-when>
+                    </h3>
+
+                    <div class="nested-info">
+                        <strong>Age:</strong> {{user.details.personal.age}} years old
+                    </div>
+                    <div class="nested-info">
+                        <strong>Location:</strong> {{user.details.personal.location.city}}, {{user.details.personal.location.country}}
+                    </div>
+                    <div class="nested-info">
+                        <strong>Coordinates:</strong>
+                        Lat: {{user.details.personal.location.coordinates.lat}},
+                        Lng: {{user.details.personal.location.coordinates.lng}}
+                    </div>
+
+                    <div class="nested-info">
+                        <strong>Theme:</strong> {{user.details.preferences.theme}} |
+                        <strong>Email Notifications:</strong> {{user.details.preferences.notifications.email}} |
+                        <strong>Push Notifications:</strong> {{user.details.preferences.notifications.push}}
+                    </div>
+                    <div class="nested-info">
+                        <strong>Notification Frequency:</strong> {{user.details.preferences.notifications.settings.frequency}}
+                    </div>
+                    <div class="nested-info">
+                        <strong>Categories:</strong>
+                        <f-repeat value="{{category in user.details.preferences.notifications.settings.categories}}">
+                            <span class="tag">{{category}}</span>
+                        </f-repeat>
+                    </div>
+
+                    <div class="controls">
+                        <button @click="{selectUser(user.id)}">Select User</button>
+                        <button @click="{updateUserAge(user.id)}">Age +1</button>
+                        <button @click="{toggleUserTheme(user.id)}">Toggle Theme</button>
+                        <button @click="{updateUserLocation(user.id)}">Change Location</button>
+                        <button @click="{updateNotificationSettings(user.id)}">Update Notifications</button>
+                        <button @click="{addNotificationCategory(user.id)}">Add Category</button>
+                        <button @click="{removeNotificationCategory(user.id)}">Remove Tech Category</button>
+                        <button @click="{removeUser(user.id)}">Remove User</button>
+                    </div>
+
+                    <div>
+                        <h4>Posts ({{user.posts.length}} posts)</h4>
+                        <f-repeat value="{{post in user.posts}}">
+                            <div class="post-card">
+                                <div><strong>{{post.title}}</strong> (ID: {{post.id}})</div>
+                                <div class="nested-info">{{post.content}}</div>
+                                <div class="nested-info">
+                                    <strong>Author:</strong> {{post.metadata.author.name}}
+                                    <f-when value="{{post.metadata.author.verified}}">
+                                        <span>✓ Verified</span>
                                     </f-when>
-                                </h3>
-
-                                <div class="nested-info">
-                                    <strong>Age:</strong> {{user.details.personal.age}} years old
                                 </div>
                                 <div class="nested-info">
-                                    <strong>Location:</strong> {{user.details.personal.location.city}}, {{user.details.personal.location.country}}
+                                    <strong>Stats:</strong> {{post.metadata.views}} views, {{post.metadata.likes}} likes
                                 </div>
                                 <div class="nested-info">
-                                    <strong>Coordinates:</strong>
-                                    Lat: {{user.details.personal.location.coordinates.lat}},
-                                    Lng: {{user.details.personal.location.coordinates.lng}}
-                                </div>
-
-                                <div class="nested-info">
-                                    <strong>Theme:</strong> {{user.details.preferences.theme}} |
-                                    <strong>Email Notifications:</strong> {{user.details.preferences.notifications.email}} |
-                                    <strong>Push Notifications:</strong> {{user.details.preferences.notifications.push}}
-                                </div>
-                                <div class="nested-info">
-                                    <strong>Notification Frequency:</strong> {{user.details.preferences.notifications.settings.frequency}}
-                                </div>
-                                <div class="nested-info">
-                                    <strong>Categories:</strong>
-                                    <f-repeat value="{{category in user.details.preferences.notifications.settings.categories}}">
-                                        <span class="tag">{{category}}</span>
+                                    <strong>Tags:</strong>
+                                    <f-repeat value="{{tag in post.metadata.tags}}">
+                                        <span class="tag">{{tag}}</span>
                                     </f-repeat>
                                 </div>
-
                                 <div class="controls">
-                                    <button @click="{selectUser(user.id)}">Select User</button>
-                                    <button @click="{updateUserAge(user.id)}">Age +1</button>
-                                    <button @click="{toggleUserTheme(user.id)}">Toggle Theme</button>
-                                    <button @click="{updateUserLocation(user.id)}">Change Location</button>
-                                    <button @click="{updateNotificationSettings(user.id)}">Update Notifications</button>
-                                    <button @click="{addNotificationCategory(user.id)}">Add Category</button>
-                                    <button @click="{removeNotificationCategory(user.id)}">Remove Tech Category</button>
-                                    <button @click="{removeUser(user.id)}">Remove User</button>
-                                </div>
-
-                                <div>
-                                    <h4>Posts ({{user.posts.length}} posts)</h4>
-                                    <f-repeat value="{{post in user.posts}}">
-                                        <div class="post-card">
-                                            <div><strong>{{post.title}}</strong> (ID: {{post.id}})</div>
-                                            <div class="nested-info">{{post.content}}</div>
-                                            <div class="nested-info">
-                                                <strong>Author:</strong> {{post.metadata.author.name}}
-                                                <f-when value="{{post.metadata.author.verified}}">
-                                                    <span>✓ Verified</span>
-                                                </f-when>
-                                            </div>
-                                            <div class="nested-info">
-                                                <strong>Stats:</strong> {{post.metadata.views}} views, {{post.metadata.likes}} likes
-                                            </div>
-                                            <div class="nested-info">
-                                                <strong>Tags:</strong>
-                                                <f-repeat value="{{tag in post.metadata.tags}}">
-                                                    <span class="tag">{{tag}}</span>
-                                                </f-repeat>
-                                            </div>
-                                            <div class="controls">
-                                                <button @click="{incrementPostLikes(post.id)}">Like Post</button>
-                                            </div>
-                                        </div>
-                                    </f-repeat>
-                                    <div class="controls">
-                                        <button @click="{addPostToUser(user.id)}">Add New Post</button>
-                                    </div>
+                                    <button @click="{incrementPostLikes(post.id)}">Like Post</button>
                                 </div>
                             </div>
                         </f-repeat>
-                    </div>
-                </template>
-            </f-template>
-            <f-template name="observer-map-internal-test-element">
-                <template>
-                    selected user: {{selecteduserid}} <!-- because this is bound to an attribute property it must be lowercase -->
-                    <br>
-                    total users: {{totalusers}}
-                    <br>
-                    <div class="stats">
-                        <div class="nested-info">
-                            <strong>Engagement:</strong>
-                            Daily: {{metrics.engagement.daily}},
-                            Weekly: {{metrics.engagement.weekly}},
-                            Monthly: {{metrics.engagement.monthly}}
+                        <div class="controls">
+                            <button @click="{addPostToUser(user.id)}">Add New Post</button>
                         </div>
                     </div>
-                    <f-when value="{{a}}">
-                        <span class="nested-define">{{a.b.c}}</span>
-                    </f-when>
-                    <button @click="{defineB()}">Define B</button>
-                    <button @click="{updateC()}">Update C</button>
-                    <br>
-                    <f-when value="{{x}}">
-                        <span class="nested-define-2">{{x.y.z}}</span>
-                    </f-when>
-                    <button @click="{defineY()}">Define Y</button>
-                    <button @click="{updateZ()}">Update Z</button>
-                    <div>
-                        <f-repeat value="{{group in groups}}">
-                            <f-repeat value="{{item in group.items}}">
-                                <div class="item">{{item.text}}</div>
-                                <span>
-                                    <f-repeat value="{{action in item.actions.trailing}}">
-                                        <span class="action-label">{{action.label}}</span>
-                                    </f-repeat>
-                                </span>
-                            </f-repeat>
-                        </f-repeat>
-                    </div>
-                    <button @click="{removeAllItems()}">Remove all items</button>
-                    <button @click="{addAnItem()}">Add an item</button>
-                    <button @click="{updateAnItem()}">Update an item</button>
-                    <button @click="{removeGroup()}">Remove groups</button>
-                    <button @click="{addGroup()}">Add group</button>
-                    <button @click="{updateActionLabel()}">Update an action label</button>
-                </template>
-            </f-template>
-            <f-template name="observer-map-with-observables-test-element">
-                <template>
-                    Level 3 Value: {{value1}}
-                    <button @click="{updateValue1()}">Update Value1</button>
-                    <br>
-                    Level 3 Value Observable: {{value2}}
-                    <button @click="{updateValue2()}">Update Value2</button>
-                </template>
-            </f-template>
-            <f-template name="observer-map-simple-array-test-element">
-                <template>
-                    <ul>
-                        <f-repeat value="{{item in items}}">
-                            <li class="simple-item">{{item}}</li>
-                        </f-repeat>
-                    </ul>
-                    <button @click="{updateFirstItem()}">Update First Item</button>
-                    <button @click="{updateSecondItem()}">Update Second Item</button>
-                </template>
-            </f-template>
+                </div>
+            </f-repeat>
         </div>
+    </template>
+</f-template>
+<f-template name="observer-map-internal-test-element">
+    <template>
+        selected user: {{selecteduserid}} <!-- because this is bound to an attribute property it must be lowercase -->
+        <br>
+        total users: {{totalusers}}
+        <br>
+        <div class="stats">
+            <div class="nested-info">
+                <strong>Engagement:</strong>
+                Daily: {{metrics.engagement.daily}},
+                Weekly: {{metrics.engagement.weekly}},
+                Monthly: {{metrics.engagement.monthly}}
+            </div>
+        </div>
+        <f-when value="{{a}}">
+            <span class="nested-define">{{a.b.c}}</span>
+        </f-when>
+        <button @click="{defineB()}">Define B</button>
+        <button @click="{updateC()}">Update C</button>
+        <br>
+        <f-when value="{{x}}">
+            <span class="nested-define-2">{{x.y.z}}</span>
+        </f-when>
+        <button @click="{defineY()}">Define Y</button>
+        <button @click="{updateZ()}">Update Z</button>
+        <div>
+            <f-repeat value="{{group in groups}}">
+                <f-repeat value="{{item in group.items}}">
+                    <div class="item">{{item.text}}</div>
+                    <span>
+                        <f-repeat value="{{action in item.actions.trailing}}">
+                            <span class="action-label">{{action.label}}</span>
+                        </f-repeat>
+                    </span>
+                </f-repeat>
+            </f-repeat>
+        </div>
+        <button @click="{removeAllItems()}">Remove all items</button>
+        <button @click="{addAnItem()}">Add an item</button>
+        <button @click="{updateAnItem()}">Update an item</button>
+        <button @click="{removeGroup()}">Remove groups</button>
+        <button @click="{addGroup()}">Add group</button>
+        <button @click="{updateActionLabel()}">Update an action label</button>
+    </template>
+</f-template>
+<f-template name="observer-map-with-observables-test-element">
+    <template>
+        Level 3 Value: {{value1}}
+        <button @click="{updateValue1()}">Update Value1</button>
+        <br>
+        Level 3 Value Observable: {{value2}}
+        <button @click="{updateValue2()}">Update Value2</button>
+    </template>
+</f-template>
+<f-template name="observer-map-simple-array-test-element">
+    <template>
+        <ul>
+            <f-repeat value="{{item in items}}">
+                <li class="simple-item">{{item}}</li>
+            </f-repeat>
+        </ul>
+        <button @click="{updateFirstItem()}">Update First Item</button>
+        <button @click="{updateSecondItem()}">Update Second Item</button>
+    </template>
+</f-template>
+
+        <script type="module" src="./main.ts"></script>
     </body>
 </html>

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -17,7 +17,7 @@
         </ul>
         <button data-fe-c-1-1>Update First Item</button>
         <button data-fe-c-2-1>Update Second Item</button></template></observer-map-simple-array-test-element>
-            <observer-map-test-element selected-user-id="1"><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element data-fe-c-0-6><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
+            <observer-map-test-element selecteduserid="1"><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element data-fe-c-0-6><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
         <br>
         total users: <!--fe-b$$start$$1$$totalusers-1$$fe-b-->2<!--fe-b$$end$$1$$totalusers-1$$fe-b-->
         <br>

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -29,7 +29,9 @@
                 Monthly: <!--fe-b$$start$$4$$metrics.engagement.monthly-4$$fe-b-->2000<!--fe-b$$end$$4$$metrics.engagement.monthly-4$$fe-b-->
             </div>
         </div>
-        <!--fe-b$$start$$5$$when-5$$fe-b--><!--fe-b$$end$$5$$when-5$$fe-b-->
+        <!--fe-b$$start$$5$$when-5$$fe-b-->
+            <span class="nested-define"><!--fe-b$$start$$0$$5-a.b.c-0$$fe-b--><!--fe-b$$end$$0$$5-a.b.c-0$$fe-b--></span>
+        <!--fe-b$$end$$5$$when-5$$fe-b-->
         <button data-fe-c-6-1>Define B</button>
         <button data-fe-c-7-1>Update C</button>
         <br>

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -109,19 +109,6 @@ class ObserverMapTestElement extends FASTElement {
 
     public selecteduserid: number = 1;
 
-    public simpleitems: string[] = ["Item 1", "Item 2", "Item 3"];
-
-    public value1: number = 42;
-
-    public value2: number = 42;
-
-    public totalusers: number = 2;
-
-    public metrics = {
-        engagement: { daily: 100, weekly: 500, monthly: 2000 },
-        performance: { loadtime: 1.2, rendertime: 0.8 },
-    };
-
     public stats = {
         totalusers: 2,
         activeusers: 1,

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -320,13 +320,10 @@ class ObserverMapInternalTestElement extends FASTElement {
     public selecteduserid?: number;
     public totalusers?: number;
 
-    @observable
     public a: any;
 
-    @observable
     public x: any;
 
-    @observable
     public groups: any;
 
     public removeAllItems() {

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -109,6 +109,27 @@ class ObserverMapTestElement extends FASTElement {
 
     public selecteduserid: number = 1;
 
+    public a: any = {};
+
+    public x: any = undefined;
+
+    public groups = [
+        {
+            items: [
+                {
+                    text: "item A",
+                    actions: {
+                        trailing: [
+                            {
+                                label: "action label A",
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    ];
+
     public stats = {
         totalusers: 2,
         activeusers: 1,
@@ -300,27 +321,12 @@ class ObserverMapInternalTestElement extends FASTElement {
     public totalusers?: number;
 
     @observable
-    public a: any = {};
+    public a: any;
 
     @observable
-    public x: any = undefined;
+    public x: any;
 
-    public groups = [
-        {
-            items: [
-                {
-                    text: "item A",
-                    actions: {
-                        trailing: [
-                            {
-                                label: "action label A",
-                            },
-                        ],
-                    },
-                },
-            ],
-        },
-    ];
+    public groups: any;
 
     public removeAllItems() {
         this.groups[0].items.shift();

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -122,27 +122,6 @@ class ObserverMapTestElement extends FASTElement {
         performance: { loadtime: 1.2, rendertime: 0.8 },
     };
 
-    public a: any = {};
-
-    public x: any = undefined;
-
-    public groups = [
-        {
-            items: [
-                {
-                    text: "item A",
-                    actions: {
-                        trailing: [
-                            {
-                                label: "action label A",
-                            },
-                        ],
-                    },
-                },
-            ],
-        },
-    ];
-
     public stats = {
         totalusers: 2,
         activeusers: 1,
@@ -333,11 +312,26 @@ class ObserverMapInternalTestElement extends FASTElement {
     public selecteduserid?: number;
     public totalusers?: number;
 
-    public a: any;
+    public a: any = {};
 
-    public x: any;
+    public x: any = undefined;
 
-    public groups: any;
+    public groups = [
+        {
+            items: [
+                {
+                    text: "item A",
+                    actions: {
+                        trailing: [
+                            {
+                                label: "action label A",
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    ];
 
     public removeAllItems() {
         this.groups[0].items.shift();

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -107,11 +107,11 @@ class ObserverMapTestElement extends FASTElement {
         },
     ];
 
-    public selectedUserId: number = 1;
+    public selecteduserid: number = 1;
 
     public stats = {
-        totalUsers: 2,
-        activeUsers: 1,
+        totalusers: 2,
+        activeusers: 1,
         metrics: {
             engagement: {
                 daily: 45,
@@ -119,8 +119,8 @@ class ObserverMapTestElement extends FASTElement {
                 monthly: 500,
             },
             performance: {
-                loadTime: 1.2,
-                renderTime: 0.8,
+                loadtime: 1.2,
+                rendertime: 0.8,
             },
         },
     };
@@ -271,14 +271,14 @@ class ObserverMapTestElement extends FASTElement {
             },
             posts: [],
         });
-        this.stats.totalUsers = this.users.length;
+        this.stats.totalusers = this.users.length;
     };
 
     public removeUser = (userId: number) => {
         const index = this.users.findIndex(u => u.id === userId);
         if (index > -1) {
             this.users.splice(index, 1);
-            this.stats.totalUsers = this.users.length;
+            this.stats.totalusers = this.users.length;
         }
     };
 
@@ -286,12 +286,12 @@ class ObserverMapTestElement extends FASTElement {
         this.stats.metrics.engagement.daily += Math.floor(Math.random() * 10);
         this.stats.metrics.engagement.weekly += Math.floor(Math.random() * 20);
         this.stats.metrics.engagement.monthly += Math.floor(Math.random() * 50);
-        this.stats.metrics.performance.loadTime = Math.random() * 2 + 0.5;
-        this.stats.metrics.performance.renderTime = Math.random() * 1 + 0.3;
+        this.stats.metrics.performance.loadtime = Math.random() * 2 + 0.5;
+        this.stats.metrics.performance.rendertime = Math.random() * 1 + 0.3;
     };
 
     public selectUser = (userId: number) => {
-        this.selectedUserId = userId;
+        this.selecteduserid = userId;
     };
 }
 

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -326,6 +326,7 @@ class ObserverMapInternalTestElement extends FASTElement {
     @observable
     public x: any;
 
+    @observable
     public groups: any;
 
     public removeAllItems() {

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -148,9 +148,9 @@ class ObserverMapTestElement extends FASTElement {
         activeusers: 1,
         metrics: {
             engagement: {
-                daily: 45,
-                weekly: 120,
-                monthly: 500,
+                daily: 100,
+                weekly: 500,
+                monthly: 2000,
             },
             performance: {
                 loadtime: 1.2,

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -299,7 +299,10 @@ class ObserverMapInternalTestElement extends FASTElement {
     public selecteduserid?: number;
     public totalusers?: number;
 
+    @observable
     public a: any = {};
+
+    @observable
     public x: any = undefined;
 
     public groups = [

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -109,6 +109,19 @@ class ObserverMapTestElement extends FASTElement {
 
     public selecteduserid: number = 1;
 
+    public simpleitems: string[] = ["Item 1", "Item 2", "Item 3"];
+
+    public value1: number = 42;
+
+    public value2: number = 42;
+
+    public totalusers: number = 2;
+
+    public metrics = {
+        engagement: { daily: 100, weekly: 500, monthly: 2000 },
+        performance: { loadtime: 1.2, rendertime: 0.8 },
+    };
+
     public a: any = {};
 
     public x: any = undefined;

--- a/packages/fast-html/test/fixtures/observer-map/state.json
+++ b/packages/fast-html/test/fixtures/observer-map/state.json
@@ -5,20 +5,33 @@
     "selecteduserid": 1,
     "totalusers": 2,
     "metrics": {
-        "engagement": { "daily": 100, "weekly": 500, "monthly": 2000 },
-        "performance": { "loadtime": 1.2, "rendertime": 0.8 }
+        "engagement": {
+            "daily": 100,
+            "weekly": 500,
+            "monthly": 2000
+        },
+        "performance": {
+            "loadtime": 1.2,
+            "rendertime": 0.8
+        }
     },
     "groups": [
         {
             "items": [
                 {
                     "text": "item A",
-                    "actions": { "trailing": [{ "label": "action label A" }] }
+                    "actions": {
+                        "trailing": [
+                            {
+                                "label": "action label A"
+                            }
+                        ]
+                    }
                 }
             ]
         }
     ],
-    "a": { "b": { "c": "" } },
+    "a": null,
     "stats": {
         "totalusers": 2,
         "activeusers": 1,
@@ -45,7 +58,10 @@
                     "location": {
                         "city": "Seattle",
                         "country": "USA",
-                        "coordinates": { "lat": 47.6, "lng": -122.3 }
+                        "coordinates": {
+                            "lat": 47.6,
+                            "lng": -122.3
+                        }
                     }
                 },
                 "preferences": {

--- a/packages/fast-html/test/fixtures/observer-map/state.json
+++ b/packages/fast-html/test/fixtures/observer-map/state.json
@@ -1,5 +1,5 @@
 {
-    "items": ["Item 1", "Item 2", "Item 3"],
+    "items": ["foo", "baz"],
     "value1": 42,
     "value2": 42,
     "selecteduserid": 1,
@@ -31,7 +31,11 @@
             ]
         }
     ],
-    "a": null,
+    "a": {
+        "b": {
+            "c": ""
+        }
+    },
     "stats": {
         "totalusers": 2,
         "activeusers": 1,
@@ -50,17 +54,16 @@
     "users": [
         {
             "id": 1,
-            "name": "Alice",
-            "posts": [],
+            "name": "Alice Johnson",
             "details": {
                 "personal": {
-                    "age": 30,
+                    "age": 28,
                     "location": {
-                        "city": "Seattle",
+                        "city": "New York",
                         "country": "USA",
                         "coordinates": {
-                            "lat": 47.6,
-                            "lng": -122.3
+                            "lat": 40.7128,
+                            "lng": -74.006
                         }
                     }
                 },
@@ -71,11 +74,85 @@
                         "push": false,
                         "settings": {
                             "frequency": "daily",
-                            "categories": ["news", "updates"]
+                            "categories": ["tech", "news"]
                         }
                     }
                 }
-            }
+            },
+            "posts": [
+                {
+                    "id": 101,
+                    "title": "First Post",
+                    "content": "Hello World!",
+                    "metadata": {
+                        "views": 150,
+                        "likes": 25,
+                        "tags": ["introduction", "hello"],
+                        "author": {
+                            "name": "Alice Johnson",
+                            "verified": true
+                        }
+                    }
+                },
+                {
+                    "id": 102,
+                    "title": "Tech Update",
+                    "content": "Latest in technology...",
+                    "metadata": {
+                        "views": 320,
+                        "likes": 45,
+                        "tags": ["tech", "update"],
+                        "author": {
+                            "name": "Alice Johnson",
+                            "verified": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "id": 2,
+            "name": "Bob Smith",
+            "details": {
+                "personal": {
+                    "age": 35,
+                    "location": {
+                        "city": "London",
+                        "country": "UK",
+                        "coordinates": {
+                            "lat": 51.5074,
+                            "lng": -0.1278
+                        }
+                    }
+                },
+                "preferences": {
+                    "theme": "light",
+                    "notifications": {
+                        "email": false,
+                        "push": true,
+                        "settings": {
+                            "frequency": "weekly",
+                            "categories": ["sports", "music"]
+                        }
+                    }
+                }
+            },
+            "posts": [
+                {
+                    "id": 201,
+                    "title": "Music Review",
+                    "content": "Amazing concert last night...",
+                    "metadata": {
+                        "views": 89,
+                        "likes": 12,
+                        "tags": ["music", "review"],
+                        "author": {
+                            "name": "Bob Smith",
+                            "verified": false
+                        }
+                    }
+                }
+            ]
         }
     ]
 }

--- a/packages/fast-html/test/fixtures/observer-map/state.json
+++ b/packages/fast-html/test/fixtures/observer-map/state.json
@@ -1,13 +1,12 @@
 {
-    "simpleItems": ["Item 1", "Item 2", "Item 3"],
+    "simpleitems": ["Item 1", "Item 2", "Item 3"],
     "value1": 42,
     "value2": 42,
-    "selectedUserId": 1,
     "selecteduserid": 1,
     "totalusers": 2,
     "metrics": {
         "engagement": { "daily": 100, "weekly": 500, "monthly": 2000 },
-        "performance": { "loadTime": 1.2, "renderTime": 0.8 }
+        "performance": { "loadtime": 1.2, "rendertime": 0.8 }
     },
     "groups": [
         {
@@ -22,12 +21,12 @@
     "a": null,
     "x": null,
     "stats": {
-        "totalUsers": 2,
-        "activeUsers": 1,
+        "totalusers": 2,
+        "activeusers": 1,
         "metrics": {
             "performance": {
-                "loadTime": 1.2,
-                "renderTime": 0.8
+                "loadtime": 1.2,
+                "rendertime": 0.8
             },
             "engagement": {
                 "daily": 100,

--- a/packages/fast-html/test/fixtures/observer-map/state.json
+++ b/packages/fast-html/test/fixtures/observer-map/state.json
@@ -18,8 +18,7 @@
             ]
         }
     ],
-    "a": null,
-    "x": null,
+    "a": { "b": { "c": "" } },
     "stats": {
         "totalusers": 2,
         "activeusers": 1,

--- a/packages/fast-html/test/fixtures/observer-map/state.json
+++ b/packages/fast-html/test/fixtures/observer-map/state.json
@@ -1,5 +1,5 @@
 {
-    "simpleitems": ["Item 1", "Item 2", "Item 3"],
+    "items": ["Item 1", "Item 2", "Item 3"],
     "value1": 42,
     "value2": 42,
     "selecteduserid": 1,

--- a/packages/fast-html/test/fixtures/observer-map/state.json
+++ b/packages/fast-html/test/fixtures/observer-map/state.json
@@ -1,0 +1,67 @@
+{
+    "simpleItems": ["Item 1", "Item 2", "Item 3"],
+    "value1": 42,
+    "value2": 42,
+    "selectedUserId": 1,
+    "selecteduserid": 1,
+    "totalusers": 2,
+    "metrics": {
+        "engagement": { "daily": 100, "weekly": 500, "monthly": 2000 },
+        "performance": { "loadTime": 1.2, "renderTime": 0.8 }
+    },
+    "groups": [
+        {
+            "items": [
+                {
+                    "text": "item A",
+                    "actions": { "trailing": [{ "label": "action label A" }] }
+                }
+            ]
+        }
+    ],
+    "a": null,
+    "x": null,
+    "stats": {
+        "totalUsers": 2,
+        "activeUsers": 1,
+        "metrics": {
+            "performance": {
+                "loadTime": 1.2,
+                "renderTime": 0.8
+            },
+            "engagement": {
+                "daily": 100,
+                "weekly": 500,
+                "monthly": 2000
+            }
+        }
+    },
+    "users": [
+        {
+            "id": 1,
+            "name": "Alice",
+            "posts": [],
+            "details": {
+                "personal": {
+                    "age": 30,
+                    "location": {
+                        "city": "Seattle",
+                        "country": "USA",
+                        "coordinates": { "lat": 47.6, "lng": -122.3 }
+                    }
+                },
+                "preferences": {
+                    "theme": "dark",
+                    "notifications": {
+                        "email": true,
+                        "push": false,
+                        "settings": {
+                            "frequency": "daily",
+                            "categories": ["news", "updates"]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/packages/fast-html/test/fixtures/observer-map/templates.html
+++ b/packages/fast-html/test/fixtures/observer-map/templates.html
@@ -1,8 +1,8 @@
 <f-template name="observer-map-test-element">
     <template>
         <observer-map-internal-test-element
-            :selecteduserid="{{selectedUserId}}"
-            :totalusers="{{stats.totalUsers}}"
+            :selecteduserid="{{selecteduserid}}"
+            :totalusers="{{stats.totalusers}}"
             :metrics="{{stats.metrics}}"
             :a="{{a}}"
             :x="{{x}}"
@@ -11,13 +11,13 @@
         <div class="stats">
             <h2>Global Stats</h2>
             <div class="nested-info">
-                <strong>Total Users:</strong> {{stats.totalUsers}} |
-                <strong>Active Users:</strong> {{stats.activeUsers}}
+                <strong>Total Users:</strong> {{stats.totalusers}} |
+                <strong>Active Users:</strong> {{stats.activeusers}}
             </div>
             <div class="nested-info">
                 <strong>Performance:</strong>
-                Load: {{stats.metrics.performance.loadTime}}s,
-                Render: {{stats.metrics.performance.renderTime}}s
+                Load: {{stats.metrics.performance.loadtime}}s,
+                Render: {{stats.metrics.performance.rendertime}}s
             </div>
             <div class="controls">
                 <button @click="{updateStats()}">Update Stats</button>
@@ -30,7 +30,7 @@
             <f-repeat value="{{user in users}}">
                 <div class="user-card">
                     <h3>{{user.name}} (ID: {{user.id}})
-                        <f-when value="{{user.id == selectedUserId}}">
+                        <f-when value="{{user.id == selecteduserid}}">
                             <span>⭐ SELECTED</span>
                         </f-when>
                     </h3>

--- a/packages/fast-html/test/fixtures/observer-map/templates.html
+++ b/packages/fast-html/test/fixtures/observer-map/templates.html
@@ -4,8 +4,6 @@
             :selecteduserid="{{selecteduserid}}"
             :totalusers="{{stats.totalusers}}"
             :metrics="{{stats.metrics}}"
-            :a="{{a}}"
-            :x="{{x}}"
             :groups="{{groups}}"
         ></observer-map-internal-test-element>
         <div class="stats">

--- a/packages/fast-html/test/fixtures/observer-map/templates.html
+++ b/packages/fast-html/test/fixtures/observer-map/templates.html
@@ -4,7 +4,6 @@
             :selecteduserid="{{selecteduserid}}"
             :totalusers="{{stats.totalusers}}"
             :metrics="{{stats.metrics}}"
-            :groups="{{groups}}"
         ></observer-map-internal-test-element>
         <div class="stats">
             <h2>Global Stats</h2>

--- a/packages/fast-html/test/fixtures/observer-map/templates.html
+++ b/packages/fast-html/test/fixtures/observer-map/templates.html
@@ -4,6 +4,9 @@
             :selecteduserid="{{selectedUserId}}"
             :totalusers="{{stats.totalUsers}}"
             :metrics="{{stats.metrics}}"
+            :a="{{a}}"
+            :x="{{x}}"
+            :groups="{{groups}}"
         ></observer-map-internal-test-element>
         <div class="stats">
             <h2>Global Stats</h2>

--- a/packages/fast-html/test/fixtures/observer-map/templates.html
+++ b/packages/fast-html/test/fixtures/observer-map/templates.html
@@ -1,0 +1,172 @@
+<f-template name="observer-map-test-element">
+    <template>
+        <observer-map-internal-test-element
+            :selecteduserid="{{selectedUserId}}"
+            :totalusers="{{stats.totalUsers}}"
+            :metrics="{{stats.metrics}}"
+        ></observer-map-internal-test-element>
+        <div class="stats">
+            <h2>Global Stats</h2>
+            <div class="nested-info">
+                <strong>Total Users:</strong> {{stats.totalUsers}} |
+                <strong>Active Users:</strong> {{stats.activeUsers}}
+            </div>
+            <div class="nested-info">
+                <strong>Performance:</strong>
+                Load: {{stats.metrics.performance.loadTime}}s,
+                Render: {{stats.metrics.performance.renderTime}}s
+            </div>
+            <div class="controls">
+                <button @click="{updateStats()}">Update Stats</button>
+                <button @click="{addNewUser()}">Add New User</button>
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>Users List</h2>
+            <f-repeat value="{{user in users}}">
+                <div class="user-card">
+                    <h3>{{user.name}} (ID: {{user.id}})
+                        <f-when value="{{user.id == selectedUserId}}">
+                            <span>⭐ SELECTED</span>
+                        </f-when>
+                    </h3>
+
+                    <div class="nested-info">
+                        <strong>Age:</strong> {{user.details.personal.age}} years old
+                    </div>
+                    <div class="nested-info">
+                        <strong>Location:</strong> {{user.details.personal.location.city}}, {{user.details.personal.location.country}}
+                    </div>
+                    <div class="nested-info">
+                        <strong>Coordinates:</strong>
+                        Lat: {{user.details.personal.location.coordinates.lat}},
+                        Lng: {{user.details.personal.location.coordinates.lng}}
+                    </div>
+
+                    <div class="nested-info">
+                        <strong>Theme:</strong> {{user.details.preferences.theme}} |
+                        <strong>Email Notifications:</strong> {{user.details.preferences.notifications.email}} |
+                        <strong>Push Notifications:</strong> {{user.details.preferences.notifications.push}}
+                    </div>
+                    <div class="nested-info">
+                        <strong>Notification Frequency:</strong> {{user.details.preferences.notifications.settings.frequency}}
+                    </div>
+                    <div class="nested-info">
+                        <strong>Categories:</strong>
+                        <f-repeat value="{{category in user.details.preferences.notifications.settings.categories}}">
+                            <span class="tag">{{category}}</span>
+                        </f-repeat>
+                    </div>
+
+                    <div class="controls">
+                        <button @click="{selectUser(user.id)}">Select User</button>
+                        <button @click="{updateUserAge(user.id)}">Age +1</button>
+                        <button @click="{toggleUserTheme(user.id)}">Toggle Theme</button>
+                        <button @click="{updateUserLocation(user.id)}">Change Location</button>
+                        <button @click="{updateNotificationSettings(user.id)}">Update Notifications</button>
+                        <button @click="{addNotificationCategory(user.id)}">Add Category</button>
+                        <button @click="{removeNotificationCategory(user.id)}">Remove Tech Category</button>
+                        <button @click="{removeUser(user.id)}">Remove User</button>
+                    </div>
+
+                    <div>
+                        <h4>Posts ({{user.posts.length}} posts)</h4>
+                        <f-repeat value="{{post in user.posts}}">
+                            <div class="post-card">
+                                <div><strong>{{post.title}}</strong> (ID: {{post.id}})</div>
+                                <div class="nested-info">{{post.content}}</div>
+                                <div class="nested-info">
+                                    <strong>Author:</strong> {{post.metadata.author.name}}
+                                    <f-when value="{{post.metadata.author.verified}}">
+                                        <span>✓ Verified</span>
+                                    </f-when>
+                                </div>
+                                <div class="nested-info">
+                                    <strong>Stats:</strong> {{post.metadata.views}} views, {{post.metadata.likes}} likes
+                                </div>
+                                <div class="nested-info">
+                                    <strong>Tags:</strong>
+                                    <f-repeat value="{{tag in post.metadata.tags}}">
+                                        <span class="tag">{{tag}}</span>
+                                    </f-repeat>
+                                </div>
+                                <div class="controls">
+                                    <button @click="{incrementPostLikes(post.id)}">Like Post</button>
+                                </div>
+                            </div>
+                        </f-repeat>
+                        <div class="controls">
+                            <button @click="{addPostToUser(user.id)}">Add New Post</button>
+                        </div>
+                    </div>
+                </div>
+            </f-repeat>
+        </div>
+    </template>
+</f-template>
+<f-template name="observer-map-internal-test-element">
+    <template>
+        selected user: {{selecteduserid}} <!-- because this is bound to an attribute property it must be lowercase -->
+        <br>
+        total users: {{totalusers}}
+        <br>
+        <div class="stats">
+            <div class="nested-info">
+                <strong>Engagement:</strong>
+                Daily: {{metrics.engagement.daily}},
+                Weekly: {{metrics.engagement.weekly}},
+                Monthly: {{metrics.engagement.monthly}}
+            </div>
+        </div>
+        <f-when value="{{a}}">
+            <span class="nested-define">{{a.b.c}}</span>
+        </f-when>
+        <button @click="{defineB()}">Define B</button>
+        <button @click="{updateC()}">Update C</button>
+        <br>
+        <f-when value="{{x}}">
+            <span class="nested-define-2">{{x.y.z}}</span>
+        </f-when>
+        <button @click="{defineY()}">Define Y</button>
+        <button @click="{updateZ()}">Update Z</button>
+        <div>
+            <f-repeat value="{{group in groups}}">
+                <f-repeat value="{{item in group.items}}">
+                    <div class="item">{{item.text}}</div>
+                    <span>
+                        <f-repeat value="{{action in item.actions.trailing}}">
+                            <span class="action-label">{{action.label}}</span>
+                        </f-repeat>
+                    </span>
+                </f-repeat>
+            </f-repeat>
+        </div>
+        <button @click="{removeAllItems()}">Remove all items</button>
+        <button @click="{addAnItem()}">Add an item</button>
+        <button @click="{updateAnItem()}">Update an item</button>
+        <button @click="{removeGroup()}">Remove groups</button>
+        <button @click="{addGroup()}">Add group</button>
+        <button @click="{updateActionLabel()}">Update an action label</button>
+    </template>
+</f-template>
+<f-template name="observer-map-with-observables-test-element">
+    <template>
+        Level 3 Value: {{value1}}
+        <button @click="{updateValue1()}">Update Value1</button>
+        <br>
+        Level 3 Value Observable: {{value2}}
+        <button @click="{updateValue2()}">Update Value2</button>
+    </template>
+</f-template>
+<f-template name="observer-map-simple-array-test-element">
+    <template>
+        <ul>
+            <f-repeat value="{{item in items}}">
+                <li class="simple-item">{{item}}</li>
+            </f-repeat>
+        </ul>
+        <button @click="{updateFirstItem()}">Update First Item</button>
+        <button @click="{updateSecondItem()}">Update Second Item</button>
+    </template>
+</f-template>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Migrates the `observer-map` fixture in `@microsoft/fast-html` to be built by `@microsoft/fast-build` (the Rust/WASM SSR tool), consistent with other fixture migrations in this series.

Key changes:
- Adds `"observer-map"` to the `build-fixtures.js` fixture list
- Adds `entry.html`, `state.json`, and `templates.html` for the fixture
- Cleans up redundant `{{binding}}` attrs on entry elements where the property name already matches the state.json key (root state is passed implicitly)
- Remaps `items` via `:items="{{simpleItems}}"` since the state key (`simpleItems`) differs from the property name (`items`)
- Keeps `selected-user-id="{{selectedUserId}}"` since the HTML attribute name differs from the JS property name
- Regenerates `index.html` via `npm run build:fixtures`

## 📑 Test Plan

All existing tests pass. The fixture builds successfully via `npm run build:fixtures`.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

Continue migrating remaining fixtures to use `@microsoft/fast-build`.