### PR TITLE
chore(fast-html): use @microsoft/fast-build to build performance-metrics fixture

### DIFF
--- a/change/@microsoft-fast-html-performance-metrics-599a5431-68aa-4a89-843e-6df26cfd6f59.json
+++ b/change/@microsoft-fast-html-performance-metrics-599a5431-68aa-4a89-843e-6df26cfd6f59.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(fast-html): use @microsoft/fast-build to build performance-metrics fixture",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-html/scripts/build-fixtures.js
+++ b/packages/fast-html/scripts/build-fixtures.js
@@ -7,7 +7,22 @@ import { fileURLToPath } from "node:url";
 
 // Builds test fixtures using @microsoft/fast-build. Add fixture names here
 // incrementally as each one is verified to work with the fast-build CLI.
-const fixtures = ["attribute", "binding", "event", "ref", "slotted", "when", "repeat", "repeat-event", "children", "host-bindings", "lifecycle-callbacks", "dot-syntax", "nested-elements"];
+const fixtures = [
+    "attribute",
+    "binding",
+    "event",
+    "ref",
+    "slotted",
+    "when",
+    "repeat",
+    "repeat-event",
+    "children",
+    "host-bindings",
+    "lifecycle-callbacks",
+    "dot-syntax",
+    "nested-elements",
+    "performance-metrics",
+];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);

--- a/packages/fast-html/test/fixtures/performance-metrics/entry.html
+++ b/packages/fast-html/test/fixtures/performance-metrics/entry.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <head>
+        <meta charset="utf-8">
+        <title>Performance Metrics Test</title>
+        <link rel="preload" as="style" href="./fast-card.css" />
+    </head>
+    <body>
+        <fast-card needs-hydration defer-hydration defer-delay="0" displayDelay="0ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="0" displayDelay="0ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="0" displayDelay="0ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="0" displayDelay="0ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="0" displayDelay="0ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="150" displayDelay="150ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="150" displayDelay="150ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="150" displayDelay="150ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="150" displayDelay="150ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="300" displayDelay="300ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="300" displayDelay="300ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="300" displayDelay="300ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="300" displayDelay="300ms"></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="300" displayDelay="300ms"></fast-card>
+        <script type="module" src="./main.ts"></script>
+    </body>
+</html>

--- a/packages/fast-html/test/fixtures/performance-metrics/index.html
+++ b/packages/fast-html/test/fixtures/performance-metrics/index.html
@@ -1,250 +1,180 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title>Performance Metrics Test</title>
         <link rel="preload" as="style" href="./fast-card.css" />
     </head>
     <body>
-        <fast-card needs-hydration defer-hydration defer-delay="0">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="0">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="0">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="0">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="0">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="150">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="150">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="150">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="150">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->150ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="300">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="300">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="300">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="300">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <fast-card needs-hydration defer-hydration defer-delay="300">
-            <template shadowrootmode="open">
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd><!--fe-b$$start$$0$$displayDelay$$fe-b-->300ms<!--fe-b$$end$$0$$displayDelay$$fe-b--></dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd><!--fe-b$$start$$1$$willhydrate$$fe-b-->0ms<!--fe-b$$end$$1$$willhydrate$$fe-b--></dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd><!--fe-b$$start$$2$$didhydrate$$fe-b-->0ms<!--fe-b$$end$$2$$didhydrate$$fe-b--></dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd><!--fe-b$$start$$3$$hydrationduration$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationduration$$fe-b--></dd>
-                </dl>
-            </template>
-        </fast-card>
-
-        <f-template name="fast-card">
-            <template>
-                <link rel="stylesheet" href="./fast-card.css" />
-                <dl>
-                    <dt>Configured Delay</dt>
-                    <dd>{{displayDelay}}</dd>
-                    <dt>Element Will Hydrate</dt>
-                    <dd>{{willHydrate}}</dd>
-                    <dt>Element Did Hydrate</dt>
-                    <dd>{{didHydrate}}</dd>
-                    <dt>Element Hydration Duration</dt>
-                    <dd>{{hydrationDuration}}</dd>
-                </dl>
-            </template>
-        </f-template>
+        <fast-card needs-hydration defer-hydration defer-delay="0" displayDelay="0ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="0" displayDelay="0ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="0" displayDelay="0ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="0" displayDelay="0ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="0" displayDelay="0ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="150" displayDelay="150ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="150" displayDelay="150ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="150" displayDelay="150ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="150" displayDelay="150ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="300" displayDelay="300ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="300" displayDelay="300ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="300" displayDelay="300ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="300" displayDelay="300ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+        <fast-card needs-hydration defer-hydration defer-delay="300" displayDelay="300ms"><template shadowrootmode="open" shadowroot="open"><link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd><!--fe-b$$start$$0$$displayDelay-0$$fe-b-->0ms<!--fe-b$$end$$0$$displayDelay-0$$fe-b--></dd>
+            <dt>Element Will Hydrate</dt>
+            <dd><!--fe-b$$start$$1$$willHydrate-1$$fe-b-->0ms<!--fe-b$$end$$1$$willHydrate-1$$fe-b--></dd>
+            <dt>Element Did Hydrate</dt>
+            <dd><!--fe-b$$start$$2$$didHydrate-2$$fe-b-->0ms<!--fe-b$$end$$2$$didHydrate-2$$fe-b--></dd>
+            <dt>Element Hydration Duration</dt>
+            <dd><!--fe-b$$start$$3$$hydrationDuration-3$$fe-b-->0ms<!--fe-b$$end$$3$$hydrationDuration-3$$fe-b--></dd>
+        </dl></template></fast-card>
+<f-template name="fast-card">
+    <template>
+        <link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd>{{displayDelay}}</dd>
+            <dt>Element Will Hydrate</dt>
+            <dd>{{willHydrate}}</dd>
+            <dt>Element Did Hydrate</dt>
+            <dd>{{didHydrate}}</dd>
+            <dt>Element Hydration Duration</dt>
+            <dd>{{hydrationDuration}}</dd>
+        </dl>
+    </template>
+</f-template>
 
         <script type="module" src="./main.ts"></script>
     </body>

--- a/packages/fast-html/test/fixtures/performance-metrics/state.json
+++ b/packages/fast-html/test/fixtures/performance-metrics/state.json
@@ -1,0 +1,6 @@
+{
+    "displayDelay": "0ms",
+    "willHydrate": "0ms",
+    "didHydrate": "0ms",
+    "hydrationDuration": "0ms"
+}

--- a/packages/fast-html/test/fixtures/performance-metrics/templates.html
+++ b/packages/fast-html/test/fixtures/performance-metrics/templates.html
@@ -1,0 +1,15 @@
+<f-template name="fast-card">
+    <template>
+        <link rel="stylesheet" href="./fast-card.css" />
+        <dl>
+            <dt>Configured Delay</dt>
+            <dd>{{displayDelay}}</dd>
+            <dt>Element Will Hydrate</dt>
+            <dd>{{willHydrate}}</dd>
+            <dt>Element Did Hydrate</dt>
+            <dd>{{didHydrate}}</dd>
+            <dt>Element Hydration Duration</dt>
+            <dd>{{hydrationDuration}}</dd>
+        </dl>
+    </template>
+</f-template>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds the `performance-metrics` test fixture to `@microsoft/fast-html` and generates its `index.html` using `@microsoft/fast-build`, consistent with the other fixtures.

The `performance-metrics` fixture covers deferred hydration with configurable delays (`defer-delay`). It renders 14 `fast-card` elements across three delay groups (0ms, 150ms, 300ms) and verifies that `@microsoft/fast-build` correctly pre-renders their shadow DOM content.

Redundant `{{binding}}` attrs (`willHydrate`, `didHydrate`, `hydrationDuration`) have been removed from entry elements — their property names match the root `state.json` keys so they are passed implicitly. Static attrs (`needs-hydration`, `defer-hydration`, `defer-delay`, `displayDelay`) are preserved. The duplicate changefile from the original two commits has also been removed.

### 🎫 Issues

No open issues directly addressed.

## 📑 Test Plan

- `npm run build:fixtures` in `packages/fast-html` runs cleanly and regenerates `performance-metrics/index.html` with all 14 `fast-card` elements correctly rendered from root state.
- All other fixture outputs are unchanged.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.