### PR TITLE
fix(fast-build): :prop bindings forward typed state to child without rendering as HTML attribute

### DIFF
--- a/crates/microsoft-fast-build/DESIGN.md
+++ b/crates/microsoft-fast-build/DESIGN.md
@@ -210,15 +210,16 @@ A custom element is any opening tag whose name contains a hyphen, excluding `f-w
 2. **Detect self-closing** — if the character before `>` (ignoring whitespace) is `/`, the element is self-closing. The output always uses non-self-closing form.
 3. **Parse attributes** — `parse_element_attributes` walks the opening tag string and extracts `(name, Option<value>)` pairs.
 4. **Build child state** from the attributes:
-   - Attributes starting with `@` (event handlers), `:` (property bindings), or named `f-ref`, `f-slotted`, `f-children` (attribute directives) are **skipped** — all are resolved entirely by the FAST client runtime and have no meaning in server-side rendering state.
+   - Attributes starting with `@` (event handlers) or named `f-ref`, `f-slotted`, `f-children` (attribute directives) are **skipped** — all are resolved entirely by the FAST client runtime and have no meaning in server-side rendering state.
+   - Attributes starting with `:` (property bindings) are **stripped from rendered HTML** but their resolved value **is added to the child state** under the lowercased property name (without the `:` prefix). This lets structured data (arrays, objects) be passed to the SSR template without appearing as a visible HTML attribute.
    - **HTML attribute keys are lowercased** — HTML attribute names are case-insensitive and browsers always store them lowercase. `isEnabled` becomes `isenabled`; hyphens are preserved: `selected-user-id` stays `selected-user-id`.
    - `data-*` attributes (e.g. `data-date-of-birth`) are **grouped under a nested `"dataset"` key** using the `attribute::data_attr_to_dataset_key` helper, which returns the full dot-notation path (`data-date-of-birth` → `"dataset.dateOfBirth"`). The caller splits on `.` and inserts into the nested map. This means `{{dataset.dateOfBirth}}` in the shadow template resolves via ordinary dot-notation.
    - No value (boolean attribute) → `Bool(true)`
-   - `"{{binding}}"` → resolve from parent state (can be any `JsonValue` type)
-   - Anything else → `String` (attribute values are always strings; booleans and numbers must be passed via `{{binding}}` expressions)
+   - `"{{binding}}"` → resolve from parent state (can be any `JsonValue` type, including arrays and objects)
+   - Anything else → `String` (attribute values are always strings; arrays, objects, booleans, and numbers must be passed via `:prop="{{binding}}"` or `prop="{{binding}}"` so the resolved value from parent state is used)
 5. **Render the shadow template** by calling `render_node` recursively with the child state as root and a **fresh `HydrationScope`** (always active). The `Locator` is threaded through so nested custom elements are expanded too.
 6. **Extract light DOM children** via `extract_directive_content` (reuses the same nesting-aware scanner as directives).
-7. **Strip client-only binding attributes** (`@attr` event bindings, `:attr` property bindings, and `f-ref`/`f-slotted`/`f-children` attribute directives) from both the outer element's opening tag and from all tags inside the rendered shadow template. These are skipped in step 4 (not added to child state) and also removed from the rendered HTML — they are resolved entirely by the FAST client runtime. The `data-fe-c` binding count is preserved — these bindings are still counted so the FAST client runtime allocates the correct number of binding slots.
+7. **Strip client-only binding attributes** (`@attr` event bindings, `:attr` property bindings, and `f-ref`/`f-slotted`/`f-children` attribute directives) from both the outer element's opening tag and from all tags inside the rendered shadow template. `@attr` and `f-ref`/`f-slotted`/`f-children` are skipped entirely in step 4. `:attr` bindings contribute to child state in step 4 but are still removed from the rendered HTML — they are resolved by the FAST client runtime. The `data-fe-c` binding count is preserved — these bindings are still counted so the FAST client runtime allocates the correct number of binding slots.
 8. **Emit Declarative Shadow DOM** with hydration attributes:
    ```html
    <my-button label="Hi">

--- a/crates/microsoft-fast-build/README.md
+++ b/crates/microsoft-fast-build/README.md
@@ -282,12 +282,14 @@ Attributes on a custom element become the state passed to its template:
 | `disabled` (boolean, no value) | `{"disabled": true}` |
 | `label="Click me"` | `{"label": "Click me"}` |
 | `count="42"` | `{"count": "42"}` |
+| `items="{{items}}"` | `{"items": <value of items from parent state>}` (array, object, or any type) |
+| `:items="{{items}}"` | `{"items": <value of items from parent state>}` — same as above but **not rendered as an HTML attribute** |
 | `foo="{{bar}}"` | `{"foo": <value of bar from parent state>}` |
 | `selected-user-id="42"` | `{"selected-user-id": "42"}` |
 | `isEnabled="{{isEnabled}}"` | `{"isenabled": <resolved value>}` |
 | `data-date-of-birth="1990-01-01"` | `{"dataset": {"dateOfBirth": "1990-01-01"}}` |
 | `data-date-of-birth="{{dob}}"` | `{"dataset": {"dateOfBirth": <value of dob from parent state>}}` |
-| `:myProp="{{expr}}"` | *(skipped — client-side only)* |
+| `:myProp="{{expr}}"` | `{"myprop": <resolved value>}` — **not rendered as an HTML attribute** |
 | `@click="{handler()}"` | *(skipped — client-side only)* |
 | `f-ref="{video}"` | *(skipped — client-side only)* |
 | `f-slotted="{nodes}"` | *(skipped — client-side only)* |
@@ -295,11 +297,13 @@ Attributes on a custom element become the state passed to its template:
 
 **HTML attribute keys are lowercased** — HTML attribute names are case-insensitive and browsers always store them lowercase. `isEnabled` becomes `isenabled`; hyphens are preserved so `selected-user-id` stays `selected-user-id`. Templates must reference the lowercase form.
 
-**Attribute values are always strings** — except for boolean attributes (no value), which become `true`. Booleans and numbers must be passed via `{{binding}}` expressions so the resolved value from parent state (which can be any type) is used.
+**Attribute values are always strings** — except for boolean attributes (no value), which become `true`, and `{{binding}}` expressions, which resolve to whatever type the value holds in the parent state (string, number, boolean, array, or object). A literal string like `count="42"` yields `{"count": "42"}`; use `count="{{count}}"` with `count: 42` in state to get a number.
+
+**Use `:prop="{{binding}}"` to pass arrays and objects without polluting HTML attributes** — the `:` prefix causes the attribute to be stripped from the rendered HTML while still forwarding the resolved value (which can be an array or object) into the child element's rendering state. This is the recommended way to pass structured data to custom elements for use with `f-repeat` and similar directives.
 
 **`data-*` attributes** are always grouped under a nested `"dataset"` key. `data_attr_to_dataset_key` returns the full dot-notation path (e.g. `"dataset.dateOfBirth"`), which is split on `.` when building the nested state, making `{{dataset.X}}` bindings work naturally in shadow templates.
 
-**Client-only bindings stripped from HTML and skipped from state**: `@attr` event bindings, `:attr` property bindings, and `f-ref`/`f-slotted`/`f-children` attribute directives are removed from the rendered HTML output and are not added to the child element's rendering scope — they are resolved entirely by the FAST client runtime. The `data-fe-c` binding count still includes them so the FAST runtime allocates the correct number of binding slots.
+**`@event` bindings and `f-ref`/`f-slotted`/`f-children` directives are skipped entirely** — not added to child state and removed from rendered HTML. They are resolved purely by the FAST client runtime. The `data-fe-c` binding count still includes them so the FAST runtime allocates the correct number of binding slots.
 
 ### Output Format
 

--- a/crates/microsoft-fast-build/src/directive.rs
+++ b/crates/microsoft-fast-build/src/directive.rs
@@ -256,15 +256,24 @@ pub fn render_custom_element(
     let attrs = parse_element_attributes(open_tag_content);
     let mut state_map = std::collections::HashMap::new();
     for (attr_name, value) in &attrs {
-        // Skip client-side-only bindings: @event handlers, :property bindings,
-        // and f-ref/f-slotted/f-children attribute directives.
-        // All are resolved entirely by the FAST client runtime and have no meaning
-        // in server-side rendering state.
-        if attr_name.starts_with('@') || attr_name.starts_with(':')
+        // Skip @event handlers — they are client-side only and have no meaning in SSR state.
+        // Also skip f-ref, f-slotted, and f-children attribute directives — all are resolved
+        // entirely by the FAST client runtime.
+        if attr_name.starts_with('@')
             || attr_name.eq_ignore_ascii_case("f-ref")
             || attr_name.eq_ignore_ascii_case("f-slotted")
             || attr_name.eq_ignore_ascii_case("f-children")
         {
+            continue;
+        }
+        // :prop bindings are stripped from rendered HTML but their resolved value IS
+        // forwarded to the child element's rendering state. This lets structured data
+        // (arrays, objects) be passed to SSR templates without appearing as visible
+        // attributes in the rendered HTML.
+        if let Some(prop_name) = attr_name.strip_prefix(':') {
+            let json_val = attribute_to_json_value(value.as_ref(), root, loop_vars);
+            let key = prop_name.to_lowercase();
+            state_map.insert(key, json_val);
             continue;
         }
         let json_val = attribute_to_json_value(value.as_ref(), root, loop_vars);

--- a/crates/microsoft-fast-build/tests/custom_elements.rs
+++ b/crates/microsoft-fast-build/tests/custom_elements.rs
@@ -231,18 +231,18 @@ fn test_custom_element_multi_word_kebab_attrs() {
 // ── colon-prefixed property bindings ─────────────────────────────────────────
 
 #[test]
-fn test_custom_element_colon_property_binding_skipped() {
-    // `:prop` bindings are client-side only and are NOT added to the child rendering scope.
-    // They are stripped from the rendered HTML just like @event bindings.
-    let locator = make_locator(&[("my-btn", "<button>{{label}}</button>")]);
+fn test_custom_element_colon_property_in_state_not_html() {
+    // `:prop` bindings are NOT rendered as HTML attributes but their resolved value
+    // IS added to the child element's rendering state.
+    let locator = make_locator(&[("my-btn", "<button>{{label}}</button><span>{{myprop}}</span>")]);
     let result = render_template_with_locator(
         r#"<my-btn label="OK" :myProp="{{value}}"></my-btn>"#,
-        r#"{"value": "ignored"}"#,
+        r#"{"value": "passed"}"#,
         &locator,
     ).unwrap();
     assert!(result.contains("OK"), "label: {result}");
-    assert!(!result.contains(":myProp"), "colon attr stripped: {result}");
-    assert!(!result.contains("ignored"), "prop value not in output: {result}");
+    assert!(!result.contains(":myProp"), "colon attr stripped from HTML: {result}");
+    assert!(result.contains("passed"), "prop value in child state: {result}");
 }
 
 #[test]
@@ -256,4 +256,54 @@ fn test_custom_element_event_binding_skipped() {
     ).unwrap();
     assert!(result.contains("OK"), "label: {result}");
     // The @click binding should not appear in element state or cause an error
+}
+
+// ── f-repeat resolves arrays from :prop bindings ─────────────────────────────
+
+#[test]
+fn test_custom_element_repeat_from_colon_binding() {
+    // Arrays are passed to child elements via :prop={{binding}} so the typed array
+    // reaches the child state without appearing as a rendered HTML attribute.
+    // f-repeat then resolves the named array from the child element's state.
+    let locator = make_locator(&[(
+        "item-list",
+        r#"<f-repeat value="{{item in items}}"><span>{{item}}</span></f-repeat>"#,
+    )]);
+    let result = render_template_with_locator(
+        r#"<item-list :items="{{items}}"></item-list>"#,
+        r#"{"items":["a","b","c"]}"#,
+        &locator,
+    ).unwrap();
+    assert!(!result.contains(":items"), "colon attr not in HTML: {result}");
+    assert!(result.contains(">a<"), "rendered a: {result}");
+    assert!(result.contains(">b<"), "rendered b: {result}");
+    assert!(result.contains(">c<"), "rendered c: {result}");
+}
+
+#[test]
+fn test_custom_element_repeat_empty_array_from_colon_binding() {
+    let locator = make_locator(&[(
+        "item-list",
+        r#"<f-repeat value="{{item in items}}"><span>{{item}}</span></f-repeat>"#,
+    )]);
+    let result = render_template_with_locator(
+        r#"<item-list :items="{{items}}"></item-list>"#,
+        r#"{"items":[]}"#,
+        &locator,
+    ).unwrap();
+    assert!(!result.contains("<span>"), "no items: {result}");
+}
+
+#[test]
+fn test_custom_element_object_from_colon_binding() {
+    // Object values passed via :prop={{binding}} are resolved from the parent state
+    // and forwarded to the child element's rendering scope without appearing in HTML.
+    let locator = make_locator(&[("my-card", r#"<div>{{config.title}}</div>"#)]);
+    let result = render_template_with_locator(
+        r#"<my-card :config="{{config}}"></my-card>"#,
+        r#"{"config":{"title":"Hello"}}"#,
+        &locator,
+    ).unwrap();
+    assert!(!result.contains(":config"), "colon attr not in HTML: {result}");
+    assert!(result.contains("Hello"), "rendered: {result}");
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Attributes with a `:` prefix (FAST property bindings) are now forwarded to the child element's SSR rendering state but are **stripped from the rendered HTML output**. Previously, `:prop` bindings were skipped entirely — not added to child state and not rendered in HTML.

This change enables structured data (arrays, objects) to be passed from the parent state to a custom element's SSR template — for use with `f-repeat` and similar directives — without the value appearing as a visible string attribute (e.g. `[Object]`) in the rendered HTML.

| Attribute form | In rendered HTML | In child state |
|---|---|---|
| `:items="{{items}}"` | ❌ stripped | ✅ `{"items": <array from parent state>}` |
| `items="{{items}}"` | ✅ rendered | ✅ `{"items": <array from parent state>}` |
| `@click="{handler()}"` | ❌ stripped | ❌ skipped |
| `f-ref`, `f-slotted`, `f-children` | ❌ stripped | ❌ skipped |

### Example

```html
<!-- entry.html -->
<item-list :items="{{items}}"></item-list>

<!-- templates.html -->
<f-template name="item-list">
  <template>
    <f-repeat value="{{item in items}}"><li>{{item}}</li></f-repeat>
  </template>
</f-template>
```

`state.json` supplies `{"items": ["a", "b", "c"]}`. The `:items` binding resolves the typed array from the parent state and places it in the child state without rendering it as an HTML attribute.

## 📑 Test Plan

- `test_custom_element_colon_property_in_state_not_html` — verifies `:prop` resolves into child state and is absent from rendered HTML
- `test_custom_element_repeat_from_colon_binding` — verifies `f-repeat` iterates an array passed via `:prop`
- `test_custom_element_repeat_empty_array_from_colon_binding` — empty array case
- `test_custom_element_object_from_colon_binding` — object passed via `:prop` resolves in child template

All existing tests pass (`cargo test` in `crates/microsoft-fast-build`).

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
