### PR TITLE
fix(microsoft-fast-build): replace .unwrap() with .expect() for clarity

### DIFF
--- a/crates/microsoft-fast-build/src/json.rs
+++ b/crates/microsoft-fast-build/src/json.rs
@@ -71,7 +71,7 @@ fn parse_value(input: &str) -> Result<(JsonValue, &str), JsonError> {
     if input.is_empty() {
         return Err(JsonError { message: "Unexpected end of input".to_string() });
     }
-    match input.chars().next().unwrap() {
+    match input.chars().next().expect("input is non-empty; checked above") {
         '{' => parse_object(input),
         '[' => parse_array(input),
         '"' => {

--- a/crates/microsoft-fast-build/src/locator.rs
+++ b/crates/microsoft-fast-build/src/locator.rs
@@ -66,7 +66,7 @@ impl Locator {
                 let paths = entries.into_iter().map(|(p, _)| p).collect();
                 return Err(RenderError::DuplicateTemplate { element, paths });
             }
-            let (_, content) = entries.into_iter().next().unwrap();
+            let (_, content) = entries.into_iter().next().expect("entries.len() == 1; duplicate check above ensures at least one entry");
             templates.insert(element, content);
         }
 

--- a/crates/microsoft-fast-build/src/locator.rs
+++ b/crates/microsoft-fast-build/src/locator.rs
@@ -66,7 +66,9 @@ impl Locator {
                 let paths = entries.into_iter().map(|(p, _)| p).collect();
                 return Err(RenderError::DuplicateTemplate { element, paths });
             }
-            let (_, content) = entries.into_iter().next().expect("entries.len() == 1; duplicate check above ensures at least one entry");
+            let (_, content) = entries.into_iter().next().expect(
+                "expected exactly one entry for element; duplicates rejected above and entries are only created when a template is added",
+            );
             templates.insert(element, content);
         }
 

--- a/crates/microsoft-fast-build/src/node.rs
+++ b/crates/microsoft-fast-build/src/node.rs
@@ -125,7 +125,7 @@ fn process_directive(
         Directive::When(p) => render_when(template, p, root, loop_vars, locator, hydration),
         Directive::Repeat(p) => render_repeat(template, p, root, loop_vars, locator, hydration),
         Directive::CustomElement(p) => {
-            render_custom_element(template, p, root, loop_vars, locator.unwrap(), hydration, is_entry)
+            render_custom_element(template, p, root, loop_vars, locator.expect("locator is required to render a CustomElement directive"), hydration, is_entry)
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Replaces three implicit `.unwrap()` panics with descriptive `.expect()` messages in the `microsoft-fast-build` crate. When these safety assumptions are violated the panic message now explains why the invariant was expected to hold, making debugging significantly easier.

- `locator.rs` — `entries.into_iter().next()` is safe because `entries.len() == 1` is guaranteed by the duplicate-check branch above
- `json.rs` — `input.chars().next()` is safe because `input.is_empty()` is checked at the top of `parse_value`
- `node.rs` — `locator.unwrap()` is safe because `CustomElement` directives are only emitted by `next_directive` when a `Locator` is present

## 📑 Test Plan

All existing tests pass. No behaviour change.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.