### PR TITLE
chore(microsoft-fast-build): fix clippy warnings and remove duplicate function

### DIFF
--- a/crates/microsoft-fast-build/src/directive.rs
+++ b/crates/microsoft-fast-build/src/directive.rs
@@ -354,22 +354,6 @@ pub fn render_custom_element(
     Ok((output, after))
 }
 
-fn kebab_to_camel(s: &str) -> String {
-    let mut result = String::new();
-    let mut capitalize_next = false;
-    for c in s.chars() {
-        if c == '-' {
-            capitalize_next = true;
-        } else if capitalize_next {
-            result.extend(c.to_uppercase());
-            capitalize_next = false;
-        } else {
-            result.push(c);
-        }
-    }
-    result
-}
-
 fn attribute_to_json_value(value: Option<&String>, root: &JsonValue, loop_vars: &[(String, JsonValue)]) -> JsonValue {
     let v = match value {
         None => return JsonValue::Bool(true), // boolean attribute (no value)

--- a/crates/microsoft-fast-build/src/expression.rs
+++ b/crates/microsoft-fast-build/src/expression.rs
@@ -55,12 +55,14 @@ fn find_comparison_op(expr: &str, op: &str) -> Option<usize> {
     let mut i = 0;
     while i + op_bytes.len() <= bytes.len() {
         if &bytes[i..i + op_bytes.len()] == op_bytes {
-            // For single-char < or >, make sure next char isn't = (to avoid matching part of <= or >=)
-            if op_bytes.len() == 1 && (op_bytes[0] == b'>' || op_bytes[0] == b'<') {
-                if bytes.get(i + 1) == Some(&b'=') {
-                    i += 1;
-                    continue;
-                }
+            // For single-char < or >, ensure the next char is not `=` to avoid
+            // matching the first character of `<=` / `>=`.
+            if op_bytes.len() == 1
+                && (op_bytes[0] == b'>' || op_bytes[0] == b'<')
+                && bytes.get(i + 1) == Some(&b'=')
+            {
+                i += 1;
+                continue;
             }
             return Some(i);
         }

--- a/crates/microsoft-fast-build/src/json.rs
+++ b/crates/microsoft-fast-build/src/json.rs
@@ -76,22 +76,22 @@ fn parse_value(input: &str) -> Result<(JsonValue, &str), JsonError> {
             Ok((JsonValue::String(s), rest))
         }
         't' => {
-            if input.starts_with("true") {
-                Ok((JsonValue::Bool(true), &input[4..]))
+            if let Some(rest) = input.strip_prefix("true") {
+                Ok((JsonValue::Bool(true), rest))
             } else {
                 Err(JsonError { message: format!("Invalid token: {}", &input[..input.len().min(10)]) })
             }
         }
         'f' => {
-            if input.starts_with("false") {
-                Ok((JsonValue::Bool(false), &input[5..]))
+            if let Some(rest) = input.strip_prefix("false") {
+                Ok((JsonValue::Bool(false), rest))
             } else {
                 Err(JsonError { message: format!("Invalid token: {}", &input[..input.len().min(10)]) })
             }
         }
         'n' => {
-            if input.starts_with("null") {
-                Ok((JsonValue::Null, &input[4..]))
+            if let Some(rest) = input.strip_prefix("null") {
+                Ok((JsonValue::Null, rest))
             } else {
                 Err(JsonError { message: format!("Invalid token: {}", &input[..input.len().min(10)]) })
             }

--- a/crates/microsoft-fast-build/src/locator.rs
+++ b/crates/microsoft-fast-build/src/locator.rs
@@ -179,7 +179,7 @@ fn normalize_path(path: &str) -> String {
 /// Return the static directory prefix before the first wildcard in `pattern`.
 fn static_prefix_dir(pattern: &str) -> String {
     let first_wild = pattern.find(|c: char| c == '*' || c == '?');
-    let base = match first_wild {
+    match first_wild {
         None => match pattern.rfind('/') {
             Some(i) => pattern[..=i].to_string(),
             None => ".".to_string(),
@@ -191,8 +191,7 @@ fn static_prefix_dir(pattern: &str) -> String {
                 None => ".".to_string(),
             }
         }
-    };
-    base
+    }
 }
 
 /// Recursively walk `dir` and collect all `.html` files.


### PR DESCRIPTION
# Pull Request

## 📖 Description

Addresses clippy warnings and removes a dead duplicate function from the `microsoft-fast-build` crate:

- `json.rs` — replace `.starts_with("true")` + manual byte offset with `strip_prefix("true")` for the `true`, `false`, and `null` literal parsers. More idiomatic and avoids hard-coded character offsets.
- `expression.rs` — collapse two nested `if` statements in `find_comparison_op` into a single condition with `&&`.
- `locator.rs` — remove intermediate `base` binding in `static_prefix_dir` and return the `match` expression directly (let-and-return).
- `directive.rs` — remove dead `kebab_to_camel` function. An identical implementation already exists in `attribute.rs`; the one in `directive.rs` was never called.

## 📑 Test Plan

All existing tests pass. No behaviour change.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.