### PR TITLE
chore: add when-false-with-repeat fixture to when tests

### DIFF
--- a/change/@microsoft-fast-html-8effa3be-3d65-4307-b8d9-a65580ac097c.json
+++ b/change/@microsoft-fast-html-8effa3be-3d65-4307-b8d9-a65580ac097c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add when-false-with-repeat fixture to when tests",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-html/test/fixtures/when/entry.html
+++ b/packages/fast-html/test/fixtures/when/entry.html
@@ -41,6 +41,8 @@
         <test-element-and id="and-false" thisvar></test-element-and>
         <!-- nested when -->
         <nested-when id="nested-when" error="{{error}}"></nested-when>
+        <!-- when false with repeat -->
+        <test-element-when-false-repeat id="when-false-repeat"></test-element-when-false-repeat>
         <!-- event -->
         <test-element-event id="event-show" show></test-element-event>
         <test-element-event id="event-hide"></test-element-event>

--- a/packages/fast-html/test/fixtures/when/index.html
+++ b/packages/fast-html/test/fixtures/when/index.html
@@ -50,6 +50,8 @@
             <!--fe-b$$end$$1$$when-1$$fe-b-->
             <!--fe-b$$start$$2$$when-2$$fe-b--><!--fe-b$$end$$2$$when-2$$fe-b-->
         </div></template></nested-when>
+        <!-- when false with repeat -->
+        <test-element-when-false-repeat id="when-false-repeat"><template shadowrootmode="open" shadowroot="open"><!--fe-b$$start$$0$$when-0$$fe-b--><!--fe-b$$end$$0$$when-0$$fe-b--></template></test-element-when-false-repeat>
         <!-- event -->
         <test-element-event id="event-show" show><template shadowrootmode="open" shadowroot="open"><!--fe-b$$start$$0$$when-0$$fe-b--><button data-fe-c-0-1>Click me</button><!--fe-b$$end$$0$$when-0$$fe-b--></template></test-element-event>
         <test-element-event id="event-hide"><template shadowrootmode="open" shadowroot="open"><!--fe-b$$start$$0$$when-0$$fe-b--><!--fe-b$$end$$0$$when-0$$fe-b--></template></test-element-event>
@@ -119,6 +121,10 @@
             </f-when>
         </div>
     </template>
+</f-template>
+<!-- when false with repeat -->
+<f-template name="test-element-when-false-repeat">
+    <template><f-when value="{{show}}"><ul><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul></f-when></template>
 </f-template>
 <!-- event -->
 <f-template name="test-element-event">

--- a/packages/fast-html/test/fixtures/when/main.ts
+++ b/packages/fast-html/test/fixtures/when/main.ts
@@ -106,6 +106,18 @@ RenderableFASTElement(TestElementAnd).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
+export class TestElementWhenFalseRepeat extends FASTElement {
+    @attr({ mode: "boolean" })
+    show: boolean = false;
+
+    @observable
+    list: Array<string> = ["Alpha", "Beta", "Gamma"];
+}
+RenderableFASTElement(TestElementWhenFalseRepeat).defineAsync({
+    name: "test-element-when-false-repeat",
+    templateOptions: "defer-and-hydrate",
+});
+
 export class TestElementEvent extends FASTElement {
     @attr({ mode: "boolean" })
     show: boolean = false;

--- a/packages/fast-html/test/fixtures/when/templates.html
+++ b/packages/fast-html/test/fixtures/when/templates.html
@@ -65,6 +65,10 @@
         </div>
     </template>
 </f-template>
+<!-- when false with repeat -->
+<f-template name="test-element-when-false-repeat">
+    <template><f-when value="{{show}}"><ul><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul></f-when></template>
+</f-template>
 <!-- event -->
 <f-template name="test-element-event">
     <template><f-when value="{{show}}"><button @click="{handleClick()}">Click me</button></f-when></template>

--- a/packages/fast-html/test/fixtures/when/when.spec.ts
+++ b/packages/fast-html/test/fixtures/when/when.spec.ts
@@ -132,6 +132,50 @@ test.describe("f-template", async () => {
         await expect(customElementHide).not.toHaveText("This and That");
     });
 
+    test("when false with repeat: initially hidden, shows items when toggled to true, and items can be updated", async ({
+        page,
+    }) => {
+        await page.goto("/fixtures/when/");
+        const element = page.locator("#when-false-repeat");
+        const listItems = element.locator("li");
+
+        // Initially the when condition is false, so no list items should be visible
+        await expect(listItems).toHaveCount(0);
+        await expect(element.locator("ul")).toHaveCount(0);
+
+        // Flip the when condition to true
+        await page.evaluate(() => {
+            document.getElementById("when-false-repeat")?.setAttribute("show", "");
+        });
+
+        // Now the repeated items should be visible
+        await expect(listItems).toHaveCount(3);
+        await expect(listItems).toContainText(["Alpha", "Beta", "Gamma"]);
+
+        // Update the list to verify repeat reactivity inside when
+        await page.evaluate(() => {
+            (document.getElementById("when-false-repeat") as any).list = ["One", "Two"];
+        });
+
+        await expect(listItems).toHaveCount(2);
+        await expect(listItems).toContainText(["One", "Two"]);
+
+        // Toggle when back to false
+        await page.evaluate(() => {
+            document.getElementById("when-false-repeat")?.removeAttribute("show");
+        });
+
+        await expect(listItems).toHaveCount(0);
+
+        // Toggle when back to true again to verify items persist
+        await page.evaluate(() => {
+            document.getElementById("when-false-repeat")?.setAttribute("show", "");
+        });
+
+        await expect(listItems).toHaveCount(2);
+        await expect(listItems).toContainText(["One", "Two"]);
+    });
+
     test("should fire events inside a when directive", async ({ page }) => {
         await page.goto("/fixtures/when/");
         const element = page.locator("#event-show");


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add a new test fixture to the `when` fixture suite in `@microsoft/fast-html` that verifies the behavior of an `f-when` directive starting with a `false` condition that contains an `f-repeat` directive with elements.

This covers the scenario where a conditional block containing repeated items is initially hidden and later toggled to visible, ensuring that the repeat directive works correctly when the when condition transitions from false to true.

## 👩‍💻 Reviewer Notes

The fixture adds a `test-element-when-false-repeat` component with a boolean `show` attribute (default `false`) and an observable `list` array. The template wraps an `f-repeat` inside an `f-when`, and the Playwright test exercises toggling and list updates.

## 📑 Test Plan

The new Playwright test verifies:
- Items are hidden when the `f-when` condition is false
- Toggling the condition to true renders the repeated items
- Updating the list array reflects in the rendered output
- Toggling back to false hides items, and back to true shows them again with the updated list

All 237 existing Chromium tests continue to pass.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.