### PR TITLE
chore: ensure hydrationComplete is awaited before test assertions in fast-html fixtures

### DIFF
--- a/change/@microsoft-fast-html-ff8acfff-ec30-4970-a58c-a2d310940e91.json
+++ b/change/@microsoft-fast-html-ff8acfff-ec30-4970-a58c-a2d310940e91.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Ensure hydrationComplete is awaited in all fixture tests to fix flaky test failures",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -461,6 +461,10 @@ A separate integration test suite validates that `@microsoft/webui` can build an
 
 Run locally with `npm run test:webui-integration` or via the `ci-webui-integration.yml` GitHub Action on PRs and pushes to `main`.
 
+### Hydration readiness
+
+Every fixture must wait for hydration to complete before running assertions. Each `main.ts` registers a `hydrationComplete()` callback via `TemplateElement.config()` that sets a global flag, and each spec file calls `page.waitForFunction()` after `page.goto()` to block until the flag is set. See [test/fixtures/README.md](./test/fixtures/README.md) for the implementation pattern.
+
 See [test/fixtures/README.md](./test/fixtures/README.md) for the full fixture authoring guide, and [test/fixtures/deep-merge/README.md](./test/fixtures/deep-merge/README.md) for an example of a complex multi-feature fixture.
 
 ---

--- a/packages/fast-html/test/fixtures/README.md
+++ b/packages/fast-html/test/fixtures/README.md
@@ -18,15 +18,12 @@ Fixtures are auto-discovered by the Vite config in `../vite.config.ts`. To add a
 
 Each fixture's `main.ts` must track when hydration completes so that Playwright tests can wait for the element to be fully interactive before asserting. The standard pattern is:
 
-1. **In `main.ts`**, declare a boolean flag and expose a global getter, then set the flag inside the `hydrationComplete()` lifecycle callback:
+1. **In `main.ts`**, set a global flag inside the `hydrationComplete()` lifecycle callback:
 
     ```ts
-    let hydrationCompleteEmitted = false;
-    (window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
     TemplateElement.config({
         hydrationComplete() {
-            hydrationCompleteEmitted = true;
+            (window as any).hydrationCompleted = true;
         },
     }).define({
         name: "f-template",
@@ -35,16 +32,17 @@ Each fixture's `main.ts` must track when hydration completes so that Playwright 
 
     If the fixture already uses `.options()` or `.config()`, chain `.config()` after `.options()` and include `hydrationComplete` in the callback object.
 
-2. **In the spec file**, wait for the flag immediately after navigation:
+2. **In the spec file**, create the wait **before** navigation so the listener is registered before the page starts loading:
 
     ```ts
-    await page.goto("/fixtures/<fixture-name>/");
-    await page.waitForFunction(() =>
-        (window as any).getHydrationCompleteStatus(),
+    const hydrationCompleted = page.waitForFunction(
+        () => (window as any).hydrationCompleted === true,
     );
+    await page.goto("/fixtures/<fixture-name>/");
+    await hydrationCompleted;
     ```
 
-    Place this after every `page.goto()` call — including inside `test.beforeEach` hooks — to prevent assertions from running before hydration finishes.
+    Place this around every `page.goto()` call — including inside `test.beforeEach` hooks — to prevent assertions from running before hydration finishes.
 
 ## Entry HTML attribute guidelines
 

--- a/packages/fast-html/test/fixtures/README.md
+++ b/packages/fast-html/test/fixtures/README.md
@@ -14,6 +14,38 @@ Each fixture contains the following contents:
 
 Fixtures are auto-discovered by the Vite config in `../vite.config.ts`. To add a new fixture, create a new directory with the files above — no other changes are needed.
 
+## Hydration readiness
+
+Each fixture's `main.ts` must track when hydration completes so that Playwright tests can wait for the element to be fully interactive before asserting. The standard pattern is:
+
+1. **In `main.ts`**, declare a boolean flag and expose a global getter, then set the flag inside the `hydrationComplete()` lifecycle callback:
+
+    ```ts
+    let hydrationCompleteEmitted = false;
+    (window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
+    TemplateElement.config({
+        hydrationComplete() {
+            hydrationCompleteEmitted = true;
+        },
+    }).define({
+        name: "f-template",
+    });
+    ```
+
+    If the fixture already uses `.options()` or `.config()`, chain `.config()` after `.options()` and include `hydrationComplete` in the callback object.
+
+2. **In the spec file**, wait for the flag immediately after navigation:
+
+    ```ts
+    await page.goto("/fixtures/<fixture-name>/");
+    await page.waitForFunction(() =>
+        (window as any).getHydrationCompleteStatus(),
+    );
+    ```
+
+    Place this after every `page.goto()` call — including inside `test.beforeEach` hooks — to prevent assertions from running before hydration finishes.
+
 ## Entry HTML attribute guidelines
 
 The `entry.html` file defines the root custom elements that the server-side renderer processes. When writing attribute bindings on root elements, follow these conventions:

--- a/packages/fast-html/test/fixtures/attribute/attribute.spec.ts
+++ b/packages/fast-html/test/fixtures/attribute/attribute.spec.ts
@@ -2,16 +2,22 @@ import { expect, test } from "@playwright/test";
 
 test.describe("f-template", async () => {
     test("create a non-binding attribute", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/attribute/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
         const customElementInput = customElement.locator("input");
         await expect(customElementInput).toHaveAttribute("disabled");
     });
     test("create an attribute binding", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/attribute/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -27,8 +33,11 @@ test.describe("f-template", async () => {
         await expect(customElement.locator("input[type='radio']")).toHaveCount(1);
     });
     test("create a property to attribute binding", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/attribute/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element-property");
 
@@ -42,8 +51,11 @@ test.describe("f-template", async () => {
         await expect(customElement.locator("input[disabled]")).toHaveCount(0);
     });
     test("create an attribute binding with an expression", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/attribute/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = await page.locator("test-element-expression");
         const customElementInput = await customElement.locator("input");

--- a/packages/fast-html/test/fixtures/attribute/attribute.spec.ts
+++ b/packages/fast-html/test/fixtures/attribute/attribute.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 test.describe("f-template", async () => {
     test("create a non-binding attribute", async ({ page }) => {
         await page.goto("/fixtures/attribute/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
         const customElementInput = customElement.locator("input");
@@ -10,6 +11,7 @@ test.describe("f-template", async () => {
     });
     test("create an attribute binding", async ({ page }) => {
         await page.goto("/fixtures/attribute/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -26,6 +28,7 @@ test.describe("f-template", async () => {
     });
     test("create a property to attribute binding", async ({ page }) => {
         await page.goto("/fixtures/attribute/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element-property");
 
@@ -40,6 +43,7 @@ test.describe("f-template", async () => {
     });
     test("create an attribute binding with an expression", async ({ page }) => {
         await page.goto("/fixtures/attribute/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = await page.locator("test-element-expression");
         const customElementInput = await customElement.locator("input");

--- a/packages/fast-html/test/fixtures/attribute/main.ts
+++ b/packages/fast-html/test/fixtures/attribute/main.ts
@@ -31,6 +31,13 @@ RenderableFASTElement(TestElementExpression).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-TemplateElement.define({
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
+TemplateElement.config({
+    hydrationComplete() {
+        hydrationCompleteEmitted = true;
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/fast-html/test/fixtures/attribute/main.ts
+++ b/packages/fast-html/test/fixtures/attribute/main.ts
@@ -31,12 +31,9 @@ RenderableFASTElement(TestElementExpression).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.config({
     hydrationComplete() {
-        hydrationCompleteEmitted = true;
+        (window as any).hydrationCompleted = true;
     },
 }).define({
     name: "f-template",

--- a/packages/fast-html/test/fixtures/binding/binding.spec.ts
+++ b/packages/fast-html/test/fixtures/binding/binding.spec.ts
@@ -2,8 +2,11 @@ import { expect, test } from "@playwright/test";
 
 test.describe("f-template", async () => {
     test("create a binding", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/binding/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -19,8 +22,11 @@ test.describe("f-template", async () => {
         await expect(customElement).toHaveText("Hello pluto");
     });
     test("create an unescaped binding", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/binding/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element-unescaped");
 

--- a/packages/fast-html/test/fixtures/binding/binding.spec.ts
+++ b/packages/fast-html/test/fixtures/binding/binding.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 test.describe("f-template", async () => {
     test("create a binding", async ({ page }) => {
         await page.goto("/fixtures/binding/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -19,6 +20,7 @@ test.describe("f-template", async () => {
     });
     test("create an unescaped binding", async ({ page }) => {
         await page.goto("/fixtures/binding/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element-unescaped");
 

--- a/packages/fast-html/test/fixtures/binding/main.ts
+++ b/packages/fast-html/test/fixtures/binding/main.ts
@@ -1,5 +1,5 @@
-import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 import { attr, FASTElement } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
 class TestElement extends FASTElement {
     @attr
@@ -18,6 +18,13 @@ RenderableFASTElement(TestElementUnescaped).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-TemplateElement.define({
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
+TemplateElement.config({
+    hydrationComplete() {
+        hydrationCompleteEmitted = true;
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/fast-html/test/fixtures/binding/main.ts
+++ b/packages/fast-html/test/fixtures/binding/main.ts
@@ -18,12 +18,9 @@ RenderableFASTElement(TestElementUnescaped).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.config({
     hydrationComplete() {
-        hydrationCompleteEmitted = true;
+        (window as any).hydrationCompleted = true;
     },
 }).define({
     name: "f-template",

--- a/packages/fast-html/test/fixtures/children/children.spec.ts
+++ b/packages/fast-html/test/fixtures/children/children.spec.ts
@@ -4,8 +4,11 @@ test.describe("f-template", async () => {
     test("create a children directive", async ({ page }) => {
         test.slow();
 
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/children/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const element = page.locator("test-element");
         const listItems = element.locator("li");

--- a/packages/fast-html/test/fixtures/children/children.spec.ts
+++ b/packages/fast-html/test/fixtures/children/children.spec.ts
@@ -5,6 +5,7 @@ test.describe("f-template", async () => {
         test.slow();
 
         await page.goto("/fixtures/children/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const element = page.locator("test-element");
         const listItems = element.locator("li");

--- a/packages/fast-html/test/fixtures/children/main.ts
+++ b/packages/fast-html/test/fixtures/children/main.ts
@@ -13,12 +13,9 @@ RenderableFASTElement(TestElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.config({
     hydrationComplete() {
-        hydrationCompleteEmitted = true;
+        (window as any).hydrationCompleted = true;
     },
 }).define({
     name: "f-template",

--- a/packages/fast-html/test/fixtures/children/main.ts
+++ b/packages/fast-html/test/fixtures/children/main.ts
@@ -1,5 +1,5 @@
-import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 import { FASTElement, observable } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
 class TestElement extends FASTElement {
     @observable
@@ -13,6 +13,13 @@ RenderableFASTElement(TestElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-TemplateElement.define({
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
+TemplateElement.config({
+    hydrationComplete() {
+        hydrationCompleteEmitted = true;
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
@@ -2,8 +2,11 @@ import { expect, test } from "@playwright/test";
 
 test.describe("Deep Merge Test Fixture", () => {
     test("should render initial state correctly", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         // Check stats
         await expect(page.locator(".stats")).toContainText("Total Orders: 3");
@@ -26,8 +29,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should update user profile via deepMerge", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         await page.click('button:has-text("Update User Profile")');
 
         // Check that nested properties were updated
@@ -42,8 +48,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should replace orders array via deepMerge", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         // Initially has 2 orders
         await expect(page.locator(".user-card").first()).toContainText("Orders (2)");
 
@@ -56,8 +65,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should remove array items via deepMerge", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         // First order initially has 2 items
         const firstOrder = page.locator(".order").first();
         const itemsCount = await firstOrder.locator(".item").count();
@@ -77,8 +89,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should update nested array tags via deepMerge", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         const firstItem = page.locator(".item").first();
 
         // Check initial tags
@@ -98,8 +113,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should add new user to array", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         await expect(page.locator(".users h2")).toContainText("Users (2 total)");
 
         await page.click('button:has-text("Add New User")');
@@ -110,8 +128,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should toggle conditional rendering", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         // Details should be visible initially
         await expect(page.locator(".profile").first()).toBeVisible();
         await expect(page.locator(".metadata").first()).toBeVisible();
@@ -130,8 +151,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should increment age directly", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         await expect(page.locator(".user-card").first()).toContainText("Age: 28");
 
         await page.click('button:has-text("Increment Age")');
@@ -144,8 +168,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should update stats via deepMerge", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         await expect(page.locator(".stats")).toContainText("Total Orders: 3");
         await expect(page.locator(".stats")).toContainText("Total Revenue: $425.5");
 
@@ -159,8 +186,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should handle undefined values in deepMerge", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         await expect(page.locator(".user-card").first()).toContainText("Age: 28");
         await expect(page.locator(".user-card").first()).toContainText("New York");
 
@@ -174,8 +204,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should display nested repeats correctly", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         // Check nested structure: users -> orders -> items -> tags
         const firstUser = page.locator(".user-card").first();
         const firstOrder = firstUser.locator(".order").first();
@@ -191,8 +224,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should handle conditional with comparison operators", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         const secondUser = page.locator(".user-card").nth(1);
 
         // Bob has 1 order
@@ -204,8 +240,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should display in-stock and out-of-stock items correctly", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         const items = page.locator(".item");
 
         // First two items should be in stock
@@ -218,8 +257,11 @@ test.describe("Deep Merge Test Fixture", () => {
     });
 
     test("should handle empty orders array", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         await page.click('button:has-text("Add New User")');
 
         const newUser = page.locator(".user-card").nth(2);
@@ -230,8 +272,11 @@ test.describe("Deep Merge Test Fixture", () => {
     test("should preserve object identity for observable arrays when using deepMerge", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/deep-merge/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         // This test verifies that splice is used internally by checking
         // that updates work correctly multiple times (proving the array
         // reference is maintained)

--- a/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 test.describe("Deep Merge Test Fixture", () => {
     test("should render initial state correctly", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         // Check stats
         await expect(page.locator(".stats")).toContainText("Total Orders: 3");
@@ -13,8 +14,12 @@ test.describe("Deep Merge Test Fixture", () => {
         await expect(page.locator(".users h2")).toContainText("Users (2 total)");
 
         // Check first user details
-        await expect(page.locator(".user-card").first()).toContainText("Alice Johnson (ID: 1)");
-        await expect(page.locator(".user-card").first()).toContainText("alice@example.com");
+        await expect(page.locator(".user-card").first()).toContainText(
+            "Alice Johnson (ID: 1)",
+        );
+        await expect(page.locator(".user-card").first()).toContainText(
+            "alice@example.com",
+        );
         await expect(page.locator(".user-card").first()).toContainText("Age: 28");
         await expect(page.locator(".user-card").first()).toContainText("New York, USA");
         await expect(page.locator(".user-card").first()).toContainText("Theme: dark");
@@ -22,11 +27,14 @@ test.describe("Deep Merge Test Fixture", () => {
 
     test("should update user profile via deepMerge", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         await page.click('button:has-text("Update User Profile")');
 
         // Check that nested properties were updated
         await expect(page.locator(".user-card").first()).toContainText("Age: 29");
-        await expect(page.locator(".user-card").first()).toContainText("San Francisco, USA");
+        await expect(page.locator(".user-card").first()).toContainText(
+            "San Francisco, USA",
+        );
         await expect(page.locator(".user-card").first()).toContainText("Theme: light");
 
         // Verify country wasn't changed (partial merge)
@@ -35,6 +43,7 @@ test.describe("Deep Merge Test Fixture", () => {
 
     test("should replace orders array via deepMerge", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         // Initially has 2 orders
         await expect(page.locator(".user-card").first()).toContainText("Orders (2)");
 
@@ -48,6 +57,7 @@ test.describe("Deep Merge Test Fixture", () => {
 
     test("should remove array items via deepMerge", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         // First order initially has 2 items
         const firstOrder = page.locator(".order").first();
         const itemsCount = await firstOrder.locator(".item").count();
@@ -68,6 +78,7 @@ test.describe("Deep Merge Test Fixture", () => {
 
     test("should update nested array tags via deepMerge", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         const firstItem = page.locator(".item").first();
 
         // Check initial tags
@@ -75,7 +86,6 @@ test.describe("Deep Merge Test Fixture", () => {
         await expect(firstItem).toContainText("computers");
 
         await page.click('button:has-text("Update Product Tags")');
-
 
         // Check updated tags
         await expect(firstItem).toContainText("tech");
@@ -89,10 +99,10 @@ test.describe("Deep Merge Test Fixture", () => {
 
     test("should add new user to array", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         await expect(page.locator(".users h2")).toContainText("Users (2 total)");
 
         await page.click('button:has-text("Add New User")');
-
 
         await expect(page.locator(".users h2")).toContainText("Users (3 total)");
         await expect(page.locator(".user-card").nth(2)).toContainText("Charlie Davis");
@@ -101,19 +111,18 @@ test.describe("Deep Merge Test Fixture", () => {
 
     test("should toggle conditional rendering", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         // Details should be visible initially
         await expect(page.locator(".profile").first()).toBeVisible();
         await expect(page.locator(".metadata").first()).toBeVisible();
 
         await page.click('button:has-text("Toggle Details")');
 
-
         // Details should be hidden
         await expect(page.locator(".profile").first()).not.toBeVisible();
         await expect(page.locator(".metadata").first()).not.toBeVisible();
 
         await page.click('button:has-text("Toggle Details")');
-
 
         // Details should be visible again
         await expect(page.locator(".profile").first()).toBeVisible();
@@ -122,26 +131,25 @@ test.describe("Deep Merge Test Fixture", () => {
 
     test("should increment age directly", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         await expect(page.locator(".user-card").first()).toContainText("Age: 28");
 
         await page.click('button:has-text("Increment Age")');
 
-
         await expect(page.locator(".user-card").first()).toContainText("Age: 29");
 
         await page.click('button:has-text("Increment Age")');
-
 
         await expect(page.locator(".user-card").first()).toContainText("Age: 30");
     });
 
     test("should update stats via deepMerge", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         await expect(page.locator(".stats")).toContainText("Total Orders: 3");
         await expect(page.locator(".stats")).toContainText("Total Revenue: $425.5");
 
         await page.click('button:has-text("Update Stats")');
-
 
         await expect(page.locator(".stats")).toContainText("Total Orders: 4");
         await expect(page.locator(".stats")).toContainText("Total Revenue: $525.49");
@@ -152,11 +160,11 @@ test.describe("Deep Merge Test Fixture", () => {
 
     test("should handle undefined values in deepMerge", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         await expect(page.locator(".user-card").first()).toContainText("Age: 28");
         await expect(page.locator(".user-card").first()).toContainText("New York");
 
         await page.click('button:has-text("Test Undefined Merge")');
-
 
         // Age should remain unchanged (undefined skipped)
         await expect(page.locator(".user-card").first()).toContainText("Age: 28");
@@ -167,6 +175,7 @@ test.describe("Deep Merge Test Fixture", () => {
 
     test("should display nested repeats correctly", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         // Check nested structure: users -> orders -> items -> tags
         const firstUser = page.locator(".user-card").first();
         const firstOrder = firstUser.locator(".order").first();
@@ -183,6 +192,7 @@ test.describe("Deep Merge Test Fixture", () => {
 
     test("should handle conditional with comparison operators", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         const secondUser = page.locator(".user-card").nth(1);
 
         // Bob has 1 order
@@ -195,6 +205,7 @@ test.describe("Deep Merge Test Fixture", () => {
 
     test("should display in-stock and out-of-stock items correctly", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         const items = page.locator(".item");
 
         // First two items should be in stock
@@ -203,35 +214,35 @@ test.describe("Deep Merge Test Fixture", () => {
         // After updating, second item should be out of stock
         await page.click('button:has-text("Update Product Tags")');
 
-
         await expect(items.nth(1)).toContainText("✗ Out of Stock");
     });
 
     test("should handle empty orders array", async ({ page }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         await page.click('button:has-text("Add New User")');
-
 
         const newUser = page.locator(".user-card").nth(2);
         await expect(newUser).toContainText("Charlie Davis");
         await expect(newUser).toContainText("No orders yet");
     });
 
-    test("should preserve object identity for observable arrays when using deepMerge", async ({ page }) => {
+    test("should preserve object identity for observable arrays when using deepMerge", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/deep-merge/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         // This test verifies that splice is used internally by checking
         // that updates work correctly multiple times (proving the array
         // reference is maintained)
 
         await page.click('button:has-text("Update Product Tags")');
 
-
         const firstItem = page.locator(".item").first();
         await expect(firstItem).toContainText("Views: 300");
 
         // Update again - if array identity wasn't preserved, this might fail
         await page.click('button:has-text("Update Product Tags")');
-
 
         // Should still work correctly
         await expect(firstItem).toContainText("Views: 300");

--- a/packages/fast-html/test/fixtures/deep-merge/main.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/main.ts
@@ -348,9 +348,6 @@ class DeepMergeTestElement extends FASTElement {
     }
 }
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.options({
     "deep-merge-test-element": {
         observerMap: "all",
@@ -358,7 +355,7 @@ TemplateElement.options({
 })
     .config({
         hydrationComplete() {
-            hydrationCompleteEmitted = true;
+            (window as any).hydrationCompleted = true;
         },
     })
     .define({

--- a/packages/fast-html/test/fixtures/deep-merge/main.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/main.ts
@@ -1,6 +1,6 @@
 import { FASTElement, observable } from "@microsoft/fast-element";
-import { RenderableFASTElement, TemplateElement } from "../../../src/index.js";
 import { deepMerge } from "../../../src/components/utilities.js";
+import { RenderableFASTElement, TemplateElement } from "../../../src/index.js";
 
 interface Product {
     id: number;
@@ -348,13 +348,22 @@ class DeepMergeTestElement extends FASTElement {
     }
 }
 
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
 TemplateElement.options({
     "deep-merge-test-element": {
         observerMap: "all",
     },
-}).define({
-    name: "f-template",
-});
+})
+    .config({
+        hydrationComplete() {
+            hydrationCompleteEmitted = true;
+        },
+    })
+    .define({
+        name: "f-template",
+    });
 
 RenderableFASTElement(DeepMergeTestElement).defineAsync({
     name: "deep-merge-test-element",

--- a/packages/fast-html/test/fixtures/dot-syntax/dot-syntax.spec.ts
+++ b/packages/fast-html/test/fixtures/dot-syntax/dot-syntax.spec.ts
@@ -4,8 +4,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     test("create a object property reference using dot syntax in a binding", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -13,8 +16,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     });
 
     test("should display initial property values correctly", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -25,8 +31,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     });
 
     test("should update object.b when 'Set b' button is clicked", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
         const setBButton = customElement.locator("button").nth(0);
@@ -45,8 +54,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     test("should update object.a.b1 when 'Set a.b1' button is clicked", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
         const setAB1Button = customElement.locator("button").nth(1);
@@ -65,8 +77,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     test("should update object.a.b2.c when 'Set a.b2.c' button is clicked", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
         const setAB2CButton = customElement.locator("button").nth(2);
@@ -80,8 +95,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     });
 
     test("should handle multiple property updates independently", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
         const setBButton = customElement.locator("button").nth(0);
@@ -104,8 +122,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     });
 
     test("should maintain property values after multiple clicks", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
         const setBButton = customElement.locator("button").nth(0);
@@ -123,8 +144,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     });
 
     test("should update nested properties correctly", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
         const setAB1Button = customElement.locator("button").nth(1);
@@ -146,8 +170,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     });
 
     test("should have correct button labels", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -158,8 +185,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     });
 
     test("should reflect property changes in DOM immediately", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
         const setBButton = customElement.locator("button").nth(0);
@@ -175,8 +205,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     test("should observe changes to repeated items with missing nested properties", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -198,8 +231,11 @@ test.describe("f-template dot-syntax bindings", async () => {
     test("should add new repeated items when nested properties are set", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/dot-syntax/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 

--- a/packages/fast-html/test/fixtures/dot-syntax/dot-syntax.spec.ts
+++ b/packages/fast-html/test/fixtures/dot-syntax/dot-syntax.spec.ts
@@ -1,8 +1,11 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("f-template dot-syntax bindings", async () => {
-    test("create a object property reference using dot syntax in a binding", async ({ page }) => {
+    test("create a object property reference using dot syntax in a binding", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -11,6 +14,7 @@ test.describe("f-template dot-syntax bindings", async () => {
 
     test("should display initial property values correctly", async ({ page }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -22,6 +26,7 @@ test.describe("f-template dot-syntax bindings", async () => {
 
     test("should update object.b when 'Set b' button is clicked", async ({ page }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
         const setBButton = customElement.locator("button").nth(0);
@@ -37,8 +42,11 @@ test.describe("f-template dot-syntax bindings", async () => {
         await expect(bSpan).toHaveText("Hello");
     });
 
-    test("should update object.a.b1 when 'Set a.b1' button is clicked", async ({ page }) => {
+    test("should update object.a.b1 when 'Set a.b1' button is clicked", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
         const setAB1Button = customElement.locator("button").nth(1);
@@ -54,8 +62,11 @@ test.describe("f-template dot-syntax bindings", async () => {
         await expect(ab1Span).toHaveText("World");
     });
 
-    test("should update object.a.b2.c when 'Set a.b2.c' button is clicked", async ({ page }) => {
+    test("should update object.a.b2.c when 'Set a.b2.c' button is clicked", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
         const setAB2CButton = customElement.locator("button").nth(2);
@@ -70,6 +81,7 @@ test.describe("f-template dot-syntax bindings", async () => {
 
     test("should handle multiple property updates independently", async ({ page }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
         const setBButton = customElement.locator("button").nth(0);
@@ -93,6 +105,7 @@ test.describe("f-template dot-syntax bindings", async () => {
 
     test("should maintain property values after multiple clicks", async ({ page }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
         const setBButton = customElement.locator("button").nth(0);
@@ -111,6 +124,7 @@ test.describe("f-template dot-syntax bindings", async () => {
 
     test("should update nested properties correctly", async ({ page }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
         const setAB1Button = customElement.locator("button").nth(1);
@@ -133,6 +147,7 @@ test.describe("f-template dot-syntax bindings", async () => {
 
     test("should have correct button labels", async ({ page }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -144,6 +159,7 @@ test.describe("f-template dot-syntax bindings", async () => {
 
     test("should reflect property changes in DOM immediately", async ({ page }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
         const setBButton = customElement.locator("button").nth(0);
@@ -156,8 +172,11 @@ test.describe("f-template dot-syntax bindings", async () => {
         await expect(bSpan).toHaveText("Hello", { timeout: 1000 });
     });
 
-    test("should observe changes to repeated items with missing nested properties", async ({ page }) => {
+    test("should observe changes to repeated items with missing nested properties", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -176,8 +195,11 @@ test.describe("f-template dot-syntax bindings", async () => {
         await expect(customElement.locator("div").nth(2)).toHaveText("Item 3");
     });
 
-    test("should add new repeated items when nested properties are set", async ({ page }) => {
+    test("should add new repeated items when nested properties are set", async ({
+        page,
+    }) => {
         await page.goto("/fixtures/dot-syntax/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -197,6 +219,5 @@ test.describe("f-template dot-syntax bindings", async () => {
         });
 
         await expect(divs).toHaveCount(2);
-
     });
 });

--- a/packages/fast-html/test/fixtures/dot-syntax/main.ts
+++ b/packages/fast-html/test/fixtures/dot-syntax/main.ts
@@ -47,10 +47,19 @@ RenderableFASTElement(TestElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
 TemplateElement.options({
     "test-element": {
         observerMap: "all",
     },
-}).define({
-    name: "f-template",
-});
+})
+    .config({
+        hydrationComplete() {
+            hydrationCompleteEmitted = true;
+        },
+    })
+    .define({
+        name: "f-template",
+    });

--- a/packages/fast-html/test/fixtures/dot-syntax/main.ts
+++ b/packages/fast-html/test/fixtures/dot-syntax/main.ts
@@ -47,9 +47,6 @@ RenderableFASTElement(TestElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.options({
     "test-element": {
         observerMap: "all",
@@ -57,7 +54,7 @@ TemplateElement.options({
 })
     .config({
         hydrationComplete() {
-            hydrationCompleteEmitted = true;
+            (window as any).hydrationCompleted = true;
         },
     })
     .define({

--- a/packages/fast-html/test/fixtures/event/event.spec.ts
+++ b/packages/fast-html/test/fixtures/event/event.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 test.describe("f-template", async () => {
     test("create an event attribute without arguments", async ({ page }) => {
         await page.goto("/fixtures/event/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -17,6 +18,7 @@ test.describe("f-template", async () => {
         page,
     }) => {
         await page.goto("/fixtures/event/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -29,6 +31,7 @@ test.describe("f-template", async () => {
     });
     test("should properly bind events with `this`", async ({ page }) => {
         await page.goto("/fixtures/event/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -40,6 +43,7 @@ test.describe("f-template", async () => {
     });
     test("create an event attribute with $e argument", async ({ page }) => {
         await page.goto("/fixtures/event/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -52,6 +56,7 @@ test.describe("f-template", async () => {
     });
     test("create an event attribute with $c (context) argument", async ({ page }) => {
         await page.goto("/fixtures/event/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -66,6 +71,7 @@ test.describe("f-template", async () => {
         page,
     }) => {
         await page.goto("/fixtures/event/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 
@@ -78,6 +84,7 @@ test.describe("f-template", async () => {
     });
     test("create an event attribute with $c.event argument", async ({ page }) => {
         await page.goto("/fixtures/event/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
 

--- a/packages/fast-html/test/fixtures/event/event.spec.ts
+++ b/packages/fast-html/test/fixtures/event/event.spec.ts
@@ -2,8 +2,11 @@ import { expect, test } from "@playwright/test";
 
 test.describe("f-template", async () => {
     test("create an event attribute without arguments", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/event/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -17,8 +20,11 @@ test.describe("f-template", async () => {
     test("create an event attribute with an event argument (deprecated e)", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/event/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -30,8 +36,11 @@ test.describe("f-template", async () => {
         expect(message).toEqual("click");
     });
     test("should properly bind events with `this`", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/event/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -42,8 +51,11 @@ test.describe("f-template", async () => {
         await expect(customElement).toHaveJSProperty("foo", "modified-by-click");
     });
     test("create an event attribute with $e argument", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/event/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -55,8 +67,11 @@ test.describe("f-template", async () => {
         expect(message).toEqual("click");
     });
     test("create an event attribute with $c (context) argument", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/event/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -70,8 +85,11 @@ test.describe("f-template", async () => {
     test("create an event attribute with multiple arguments ($e, $c)", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/event/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 
@@ -83,8 +101,11 @@ test.describe("f-template", async () => {
         expect(message).toEqual("click,click");
     });
     test("create an event attribute with $c.event argument", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/event/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
 

--- a/packages/fast-html/test/fixtures/event/main.ts
+++ b/packages/fast-html/test/fixtures/event/main.ts
@@ -39,6 +39,13 @@ RenderableFASTElement(TestElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-TemplateElement.define({
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
+TemplateElement.config({
+    hydrationComplete() {
+        hydrationCompleteEmitted = true;
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/fast-html/test/fixtures/event/main.ts
+++ b/packages/fast-html/test/fixtures/event/main.ts
@@ -39,12 +39,9 @@ RenderableFASTElement(TestElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.config({
     hydrationComplete() {
-        hydrationCompleteEmitted = true;
+        (window as any).hydrationCompleted = true;
     },
 }).define({
     name: "f-template",

--- a/packages/fast-html/test/fixtures/host-bindings/host-bindings.spec.ts
+++ b/packages/fast-html/test/fixtures/host-bindings/host-bindings.spec.ts
@@ -3,10 +3,11 @@ import { expect, test } from "@playwright/test";
 test.describe("Host Bindings Hydration", async () => {
     test.describe("should restart marker indexes inside the template after host bindings", () => {
         test("single host event binding with content text binding", async ({ page }) => {
-            await page.goto("/fixtures/host-bindings/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/host-bindings/");
+            await hydrationCompleted;
 
             const element = page.locator("host-event-element");
 
@@ -32,10 +33,11 @@ test.describe("Host Bindings Hydration", async () => {
         test("multiple host bindings (event + boolean attr) with content text binding", async ({
             page,
         }) => {
-            await page.goto("/fixtures/host-bindings/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/host-bindings/");
+            await hydrationCompleted;
 
             const element = page.locator("host-multi-element");
 
@@ -62,10 +64,11 @@ test.describe("Host Bindings Hydration", async () => {
         test("host bindings with static attribute and multiple content text bindings", async ({
             page,
         }) => {
-            await page.goto("/fixtures/host-bindings/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/host-bindings/");
+            await hydrationCompleted;
 
             const element = page.locator("host-static-element");
 
@@ -95,10 +98,11 @@ test.describe("Host Bindings Hydration", async () => {
         });
 
         test("multiple host events with content text binding", async ({ page }) => {
-            await page.goto("/fixtures/host-bindings/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/host-bindings/");
+            await hydrationCompleted;
 
             const element = page.locator("host-events-element");
 
@@ -130,10 +134,11 @@ test.describe("Host Bindings Hydration", async () => {
         test("host event with multiple content attribute bindings on same element", async ({
             page,
         }) => {
-            await page.goto("/fixtures/host-bindings/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/host-bindings/");
+            await hydrationCompleted;
 
             const element = page.locator("host-multi-content-element");
             const span = element.locator("span");
@@ -163,10 +168,11 @@ test.describe("Host Bindings Hydration", async () => {
         });
 
         test("host event with content text binding in element", async ({ page }) => {
-            await page.goto("/fixtures/host-bindings/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/host-bindings/");
+            await hydrationCompleted;
 
             const element = page.locator("host-text-binding-element");
             const span = element.locator("span");
@@ -195,10 +201,11 @@ test.describe("Host Bindings Hydration", async () => {
 
     test.describe("should restart marker indexes after host bindings of different types", () => {
         test("host property binding with content text binding", async ({ page }) => {
-            await page.goto("/fixtures/host-bindings/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/host-bindings/");
+            await hydrationCompleted;
 
             const element = page.locator("host-property-element");
             const span = element.locator("span");
@@ -221,10 +228,11 @@ test.describe("Host Bindings Hydration", async () => {
         test("all host binding types (event + boolean + property + attribute) with content binding", async ({
             page,
         }) => {
-            await page.goto("/fixtures/host-bindings/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/host-bindings/");
+            await hydrationCompleted;
 
             const element = page.locator("host-all-types-element");
             const span = element.locator("span");
@@ -279,10 +287,11 @@ test.describe("Host Bindings Hydration", async () => {
 
         for (const { name, selector, initialText } of permutations) {
             test(`host binding permutation: ${name}`, async ({ page }) => {
-                await page.goto("/fixtures/host-bindings/");
-                await page.waitForFunction(() =>
-                    (window as any).getHydrationCompleteStatus(),
+                const hydrationCompleted = page.waitForFunction(
+                    () => (window as any).hydrationCompleted === true,
                 );
+                await page.goto("/fixtures/host-bindings/");
+                await hydrationCompleted;
 
                 const element = page.locator(selector);
                 const span = element.locator("span");
@@ -320,10 +329,11 @@ test.describe("Host Bindings Hydration", async () => {
         test("updating content bindings after hydration proves correct index offset", async ({
             page,
         }) => {
-            await page.goto("/fixtures/host-bindings/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/host-bindings/");
+            await hydrationCompleted;
 
             // Test across multiple elements to verify the fix works consistently
             const elements = [

--- a/packages/fast-html/test/fixtures/host-bindings/host-bindings.spec.ts
+++ b/packages/fast-html/test/fixtures/host-bindings/host-bindings.spec.ts
@@ -2,10 +2,11 @@ import { expect, test } from "@playwright/test";
 
 test.describe("Host Bindings Hydration", async () => {
     test.describe("should restart marker indexes inside the template after host bindings", () => {
-        test("single host event binding with content text binding", async ({
-            page,
-        }) => {
+        test("single host event binding with content text binding", async ({ page }) => {
             await page.goto("/fixtures/host-bindings/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
 
             const element = page.locator("host-event-element");
 
@@ -32,6 +33,9 @@ test.describe("Host Bindings Hydration", async () => {
             page,
         }) => {
             await page.goto("/fixtures/host-bindings/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
 
             const element = page.locator("host-multi-element");
 
@@ -59,6 +63,9 @@ test.describe("Host Bindings Hydration", async () => {
             page,
         }) => {
             await page.goto("/fixtures/host-bindings/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
 
             const element = page.locator("host-static-element");
 
@@ -89,6 +96,9 @@ test.describe("Host Bindings Hydration", async () => {
 
         test("multiple host events with content text binding", async ({ page }) => {
             await page.goto("/fixtures/host-bindings/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
 
             const element = page.locator("host-events-element");
 
@@ -105,7 +115,7 @@ test.describe("Host Bindings Hydration", async () => {
             // Verify mouseenter event binding also works
             await element.hover();
             expect(messages.some(m => m.includes("host-events mouseenter: 1"))).toBe(
-                true
+                true,
             );
 
             // KEY TEST: Verify updating content binding works (proves correct offset with 2 host events)
@@ -121,6 +131,9 @@ test.describe("Host Bindings Hydration", async () => {
             page,
         }) => {
             await page.goto("/fixtures/host-bindings/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
 
             const element = page.locator("host-multi-content-element");
             const span = element.locator("span");
@@ -136,7 +149,7 @@ test.describe("Host Bindings Hydration", async () => {
             await element.click();
 
             expect(messages.some(m => m.includes("host-multi-content clicked: 1"))).toBe(
-                true
+                true,
             );
 
             // KEY TEST: Update both attribute bindings to prove indexes 0,1 are correct
@@ -151,6 +164,9 @@ test.describe("Host Bindings Hydration", async () => {
 
         test("host event with content text binding in element", async ({ page }) => {
             await page.goto("/fixtures/host-bindings/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
 
             const element = page.locator("host-text-binding-element");
             const span = element.locator("span");
@@ -165,7 +181,7 @@ test.describe("Host Bindings Hydration", async () => {
             await element.click();
 
             expect(messages.some(m => m.includes("host-text-binding clicked: 1"))).toBe(
-                true
+                true,
             );
 
             // KEY TEST: Verify updating text binding works (proves correct index offset)
@@ -180,6 +196,9 @@ test.describe("Host Bindings Hydration", async () => {
     test.describe("should restart marker indexes after host bindings of different types", () => {
         test("host property binding with content text binding", async ({ page }) => {
             await page.goto("/fixtures/host-bindings/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
 
             const element = page.locator("host-property-element");
             const span = element.locator("span");
@@ -203,6 +222,9 @@ test.describe("Host Bindings Hydration", async () => {
             page,
         }) => {
             await page.goto("/fixtures/host-bindings/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
 
             const element = page.locator("host-all-types-element");
             const span = element.locator("span");
@@ -223,7 +245,7 @@ test.describe("Host Bindings Hydration", async () => {
             await element.click({ force: true }); // force because element is disabled
 
             expect(messages.some(m => m.includes("host-all-types clicked: 1"))).toBe(
-                true
+                true,
             );
 
             // KEY TEST: Verify updating content binding works regardless of host binding types/order
@@ -258,6 +280,9 @@ test.describe("Host Bindings Hydration", async () => {
         for (const { name, selector, initialText } of permutations) {
             test(`host binding permutation: ${name}`, async ({ page }) => {
                 await page.goto("/fixtures/host-bindings/");
+                await page.waitForFunction(() =>
+                    (window as any).getHydrationCompleteStatus(),
+                );
 
                 const element = page.locator(selector);
                 const span = element.locator("span");
@@ -277,9 +302,9 @@ test.describe("Host Bindings Hydration", async () => {
 
                 await element.click({ force: true }); // force because element is disabled
 
-                expect(
-                    messages.some(m => m.includes(`${selector} clicked: 1`))
-                ).toBe(true);
+                expect(messages.some(m => m.includes(`${selector} clicked: 1`))).toBe(
+                    true,
+                );
 
                 // KEY TEST: Verify updating content binding works regardless of host binding order
                 await element.evaluate((el: any) => {
@@ -296,6 +321,9 @@ test.describe("Host Bindings Hydration", async () => {
             page,
         }) => {
             await page.goto("/fixtures/host-bindings/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
 
             // Test across multiple elements to verify the fix works consistently
             const elements = [
@@ -328,7 +356,7 @@ test.describe("Host Bindings Hydration", async () => {
                     (el: any, data: { prop: string; expected: string }) => {
                         el[data.prop] = data.expected;
                     },
-                    { prop, expected }
+                    { prop, expected },
                 );
 
                 // Verify the binding updated correctly

--- a/packages/fast-html/test/fixtures/host-bindings/main.ts
+++ b/packages/fast-html/test/fixtures/host-bindings/main.ts
@@ -212,12 +212,9 @@ RenderableFASTElement(HostPermPropFirst).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.config({
     hydrationComplete() {
-        hydrationCompleteEmitted = true;
+        (window as any).hydrationCompleted = true;
     },
 }).define({
     name: "f-template",

--- a/packages/fast-html/test/fixtures/host-bindings/main.ts
+++ b/packages/fast-html/test/fixtures/host-bindings/main.ts
@@ -212,6 +212,13 @@ RenderableFASTElement(HostPermPropFirst).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-TemplateElement.define({
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
+TemplateElement.config({
+    hydrationComplete() {
+        hydrationCompleteEmitted = true;
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/fast-html/test/fixtures/lifecycle-callbacks/lifecycle-callbacks.spec.ts
+++ b/packages/fast-html/test/fixtures/lifecycle-callbacks/lifecycle-callbacks.spec.ts
@@ -4,16 +4,17 @@ test.describe("Lifecycle Callbacks", async () => {
     test("should invoke all lifecycle callbacks in correct order for simple element", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/lifecycle-callbacks/");
-
-        // Wait for hydration to complete
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const events = await page.evaluate(() => (window as any).lifecycleEvents);
 
         // Verify callbacks for simple-element were called
         const simpleElementEvents = events.filter(
-            (e: any) => e.name === "simple-element"
+            (e: any) => e.name === "simple-element",
         );
 
         expect(simpleElementEvents.length).toBeGreaterThan(0);
@@ -44,9 +45,11 @@ test.describe("Lifecycle Callbacks", async () => {
     });
 
     test("should invoke callbacks for multiple elements", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/lifecycle-callbacks/");
-
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const events = await page.evaluate(() => (window as any).lifecycleEvents);
 
@@ -59,23 +62,25 @@ test.describe("Lifecycle Callbacks", async () => {
     });
 
     test("should invoke elementWillHydrate before hydration", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/lifecycle-callbacks/");
-
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const events = await page.evaluate(() => (window as any).lifecycleEvents);
 
         const willHydrateEvents = events.filter(
-            (e: any) => e.callback === "elementWillHydrate"
+            (e: any) => e.callback === "elementWillHydrate",
         );
         const didHydrateEvents = events.filter(
-            (e: any) => e.callback === "elementDidHydrate"
+            (e: any) => e.callback === "elementDidHydrate",
         );
 
         // Every elementWillHydrate should be followed by elementDidHydrate for the same element
         willHydrateEvents.forEach((willEvent: any) => {
             const correspondingDidEvent = didHydrateEvents.find(
-                (e: any) => e.name === willEvent.name
+                (e: any) => e.name === willEvent.name,
             );
             expect(correspondingDidEvent).toBeDefined();
         });
@@ -84,12 +89,11 @@ test.describe("Lifecycle Callbacks", async () => {
     test("should invoke hydrationComplete callback after all elements hydrate", async ({
         page,
     }) => {
-        await page.goto("/fixtures/lifecycle-callbacks/");
-
-        const hydrationComplete = await page.waitForFunction(
-            () => (window as any).getHydrationCompleteStatus(),
-            { timeout: 5000 }
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
         );
+        await page.goto("/fixtures/lifecycle-callbacks/");
+        const hydrationComplete = await hydrationCompleted;
 
         expect(hydrationComplete).toBeTruthy();
 
@@ -97,7 +101,7 @@ test.describe("Lifecycle Callbacks", async () => {
 
         // Verify hydrationComplete callback was invoked
         const hydrationCompleteEvents = events.filter(
-            (e: any) => e.callback === "hydrationComplete"
+            (e: any) => e.callback === "hydrationComplete",
         );
         expect(hydrationCompleteEvents.length).toBe(1);
 
@@ -111,21 +115,26 @@ test.describe("Lifecycle Callbacks", async () => {
         await expect(nestedElement).not.toHaveAttribute("needs-hydration");
 
         // Verify hydrationComplete was called AFTER all individual element hydrations
-        const lastElementDidHydrateIndex = events.reduce((maxIndex: number, e: any, index: number) => {
-            return e.callback === "elementDidHydrate" ? index : maxIndex;
-        }, -1);
+        const lastElementDidHydrateIndex = events.reduce(
+            (maxIndex: number, e: any, index: number) => {
+                return e.callback === "elementDidHydrate" ? index : maxIndex;
+            },
+            -1,
+        );
 
         const hydrationCompleteIndex = events.findIndex(
-            (e: any) => e.callback === "hydrationComplete"
+            (e: any) => e.callback === "hydrationComplete",
         );
 
         expect(hydrationCompleteIndex).toBeGreaterThan(lastElementDidHydrateIndex);
     });
 
     test("should handle complex element with observer map", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/lifecycle-callbacks/");
-
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const complexElement = await page.locator("complex-element");
 
@@ -139,14 +148,16 @@ test.describe("Lifecycle Callbacks", async () => {
         // Complex element should have all lifecycle callbacks
         expect(complexEvents.length).toBeGreaterThan(0);
         expect(complexEvents.some((e: any) => e.callback === "elementDidHydrate")).toBe(
-            true
+            true,
         );
     });
 
     test("should handle nested elements correctly", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/lifecycle-callbacks/");
-
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const events = await page.evaluate(() => (window as any).lifecycleEvents);
 
@@ -159,30 +170,30 @@ test.describe("Lifecycle Callbacks", async () => {
 
         // Both should have hydrated
         expect(complexEvents.some((e: any) => e.callback === "elementDidHydrate")).toBe(
-            true
+            true,
         );
         expect(nestedEvents.some((e: any) => e.callback === "elementDidHydrate")).toBe(
-            true
+            true,
         );
     });
 
     test("should handle deferred hydration element", async ({ page }) => {
-        await page.goto("/fixtures/lifecycle-callbacks/");
-
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         // The deferred element has a prepare() method that delays hydration
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus(), {
-            timeout: 5000,
-        });
+        await page.goto("/fixtures/lifecycle-callbacks/");
+        await hydrationCompleted;
 
         const events = await page.evaluate(() => (window as any).lifecycleEvents);
         const deferredEvents = events.filter((e: any) => e.name === "deferred-element");
 
         // Should have hydration callbacks
         expect(deferredEvents.some((e: any) => e.callback === "elementWillHydrate")).toBe(
-            true
+            true,
         );
         expect(deferredEvents.some((e: any) => e.callback === "elementDidHydrate")).toBe(
-            true
+            true,
         );
 
         const deferredElement = await page.locator("deferred-element");
@@ -190,39 +201,43 @@ test.describe("Lifecycle Callbacks", async () => {
         await expect(deferredElement).not.toHaveAttribute("defer-hydration");
     });
 
-        test("should defer child hydration until parent completes", async ({ page }) => {
-            await page.goto("/fixtures/lifecycle-callbacks/");
+    test("should defer child hydration until parent completes", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/lifecycle-callbacks/");
+        await hydrationCompleted;
 
-            await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        const events = await page.evaluate(() => (window as any).lifecycleEvents);
 
-            const events = await page.evaluate(() => (window as any).lifecycleEvents);
+        const parentWillHydrateIndex = events.findIndex(
+            (e: any) =>
+                e.name === "deferred-parent-element" &&
+                e.callback === "elementWillHydrate",
+        );
 
-            const parentWillHydrateIndex = events.findIndex(
-                (e: any) =>
-                    e.name === "deferred-parent-element" &&
-                    e.callback === "elementWillHydrate"
-            );
+        const childWillHydrateIndex = events.findIndex(
+            (e: any) =>
+                e.name === "deferred-child-element" &&
+                e.callback === "elementWillHydrate",
+        );
 
-            const childWillHydrateIndex = events.findIndex(
-                (e: any) =>
-                    e.name === "deferred-child-element" &&
-                    e.callback === "elementWillHydrate"
-            );
+        expect(parentWillHydrateIndex).toBeGreaterThan(-1);
+        expect(childWillHydrateIndex).toBeGreaterThan(parentWillHydrateIndex);
 
-            expect(parentWillHydrateIndex).toBeGreaterThan(-1);
-            expect(childWillHydrateIndex).toBeGreaterThan(parentWillHydrateIndex);
-
-            const childElement = page.locator("deferred-child-element");
-            await expect(childElement).not.toHaveAttribute("needs-hydration");
-            await expect(childElement).not.toHaveAttribute("defer-hydration");
-        });
+        const childElement = page.locator("deferred-child-element");
+        await expect(childElement).not.toHaveAttribute("needs-hydration");
+        await expect(childElement).not.toHaveAttribute("defer-hydration");
+    });
 
     test("should verify template and hydration callbacks are invoked", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/lifecycle-callbacks/");
-
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const events = await page.evaluate(() => (window as any).lifecycleEvents);
 
@@ -262,9 +277,11 @@ test.describe("Lifecycle Callbacks", async () => {
     test("should properly hydrate elements and maintain functionality", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/lifecycle-callbacks/");
-
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const simpleElement = await page.locator("simple-element");
         const complexElement = await page.locator("complex-element");
@@ -276,9 +293,7 @@ test.describe("Lifecycle Callbacks", async () => {
         await expect(complexElement).toHaveText(/Complex/);
 
         // Verify elements are interactive after hydration
-        const currentCount = await complexElement.evaluate(
-            (el: any) => el.count
-        );
+        const currentCount = await complexElement.evaluate((el: any) => el.count);
         expect(currentCount).toBe(0);
 
         // Interact with the element

--- a/packages/fast-html/test/fixtures/lifecycle-callbacks/main.ts
+++ b/packages/fast-html/test/fixtures/lifecycle-callbacks/main.ts
@@ -1,11 +1,8 @@
-import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
 // Track lifecycle callbacks for testing
 export const lifecycleEvents: Array<{ callback: string; name?: string }> = [];
-
-// Track hydration complete
-export let hydrationCompleteEmitted = false;
 
 // Configure lifecycle callbacks
 TemplateElement.config({
@@ -29,7 +26,7 @@ TemplateElement.config({
     },
     hydrationComplete(): void {
         lifecycleEvents.push({ callback: "hydrationComplete" });
-        hydrationCompleteEmitted = true;
+        (window as any).hydrationCompleted = true;
     },
 });
 
@@ -137,4 +134,3 @@ TemplateElement.options({
 
 // Make lifecycleEvents available globally for testing
 (window as any).lifecycleEvents = lifecycleEvents;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;

--- a/packages/fast-html/test/fixtures/nested-elements/main.ts
+++ b/packages/fast-html/test/fixtures/nested-elements/main.ts
@@ -128,6 +128,9 @@ RenderableFASTElement(GrandChildItem).defineAsync({
 });
 
 (window as any).messages = [];
+(window as any).hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () =>
+    (window as any).hydrationCompleteEmitted;
 
 TemplateElement.options({
     "parent-element": {
@@ -163,6 +166,7 @@ TemplateElement.options({
         },
         hydrationComplete() {
             (window as any).messages.push(`Hydration complete [${performance.now()}]`);
+            (window as any).hydrationCompleteEmitted = true;
         },
         templateDidUpdate(name: string) {
             (window as any).messages.push(

--- a/packages/fast-html/test/fixtures/nested-elements/main.ts
+++ b/packages/fast-html/test/fixtures/nested-elements/main.ts
@@ -128,9 +128,6 @@ RenderableFASTElement(GrandChildItem).defineAsync({
 });
 
 (window as any).messages = [];
-(window as any).hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () =>
-    (window as any).hydrationCompleteEmitted;
 
 TemplateElement.options({
     "parent-element": {
@@ -166,7 +163,7 @@ TemplateElement.options({
         },
         hydrationComplete() {
             (window as any).messages.push(`Hydration complete [${performance.now()}]`);
-            (window as any).hydrationCompleteEmitted = true;
+            (window as any).hydrationCompleted = true;
         },
         templateDidUpdate(name: string) {
             (window as any).messages.push(

--- a/packages/fast-html/test/fixtures/nested-elements/nested-elements.spec.ts
+++ b/packages/fast-html/test/fixtures/nested-elements/nested-elements.spec.ts
@@ -3,8 +3,11 @@ import type { ItemList } from "./main.js";
 
 test.describe("Nested Elements Hydration", () => {
     test("should hydrate parent elements before child elements", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/nested-elements/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const messages = (await page.evaluate("window.messages")) as string[];
 
@@ -34,8 +37,11 @@ test.describe("Nested Elements Hydration", () => {
     });
 
     test("should pass parent attribute to child elements", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/nested-elements/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const parentElements = page.locator("parent-element");
         const firstParent = parentElements.nth(0);

--- a/packages/fast-html/test/fixtures/nested-elements/nested-elements.spec.ts
+++ b/packages/fast-html/test/fixtures/nested-elements/nested-elements.spec.ts
@@ -4,6 +4,7 @@ import type { ItemList } from "./main.js";
 test.describe("Nested Elements Hydration", () => {
     test("should hydrate parent elements before child elements", async ({ page }) => {
         await page.goto("/fixtures/nested-elements/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const messages = (await page.evaluate("window.messages")) as string[];
 
@@ -34,6 +35,7 @@ test.describe("Nested Elements Hydration", () => {
 
     test("should pass parent attribute to child elements", async ({ page }) => {
         await page.goto("/fixtures/nested-elements/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const parentElements = page.locator("parent-element");
         const firstParent = parentElements.nth(0);

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -454,6 +454,9 @@ ObserverMapSimpleArrayTestElement.defineAsync({
     name: "observer-map-simple-array-test-element",
 });
 
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
 // Configure TemplateElement with observerMap enabled for this test
 TemplateElement.options({
     "observer-map-test-element": {
@@ -468,8 +471,14 @@ TemplateElement.options({
     "observer-map-simple-array-test-element": {
         observerMap: "all",
     },
-}).define({
-    name: "f-template",
-});
+})
+    .config({
+        hydrationComplete() {
+            hydrationCompleteEmitted = true;
+        },
+    })
+    .define({
+        name: "f-template",
+    });
 
 (window as any).Observable = Observable;

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -454,9 +454,6 @@ ObserverMapSimpleArrayTestElement.defineAsync({
     name: "observer-map-simple-array-test-element",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 // Configure TemplateElement with observerMap enabled for this test
 TemplateElement.options({
     "observer-map-test-element": {
@@ -474,7 +471,7 @@ TemplateElement.options({
 })
     .config({
         hydrationComplete() {
-            hydrationCompleteEmitted = true;
+            (window as any).hydrationCompleted = true;
         },
     })
     .define({

--- a/packages/fast-html/test/fixtures/observer-map/observer-map.spec.ts
+++ b/packages/fast-html/test/fixtures/observer-map/observer-map.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 test.describe("ObserverMap", async () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/fixtures/observer-map/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         await page.waitForSelector("observer-map-test-element");
     });
 

--- a/packages/fast-html/test/fixtures/observer-map/observer-map.spec.ts
+++ b/packages/fast-html/test/fixtures/observer-map/observer-map.spec.ts
@@ -2,8 +2,11 @@ import { expect, test } from "@playwright/test";
 
 test.describe("ObserverMap", async () => {
     test.beforeEach(async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/observer-map/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         await page.waitForSelector("observer-map-test-element");
     });
 

--- a/packages/fast-html/test/fixtures/performance-metrics/main.ts
+++ b/packages/fast-html/test/fixtures/performance-metrics/main.ts
@@ -100,13 +100,13 @@ TemplateElement.config({
         if (markName) {
             const measure = performance.measure(
                 `hydration:${source.localName}`,
-                markName
+                markName,
             );
             hydrationMarks.delete(source);
 
             if (source instanceof FastCard) {
                 source.didHydrate = `${(measure.startTime + measure.duration).toPrecision(
-                    4
+                    4,
                 )}ms`;
                 source.hydrationDuration = `${measure.duration.toPrecision(4)}ms`;
             }
@@ -115,8 +115,6 @@ TemplateElement.config({
 
     hydrationComplete(): void {
         performance.measure("hydration:complete", "hydration:started");
+        (window as any).hydrationCompleted = true;
     },
 }).define({ name: "f-template" });
-
-(window as any).getHydrationComplete = () =>
-    performance.getEntriesByName("hydration:complete", "measure").length > 0;

--- a/packages/fast-html/test/fixtures/performance-metrics/performance-metrics.spec.ts
+++ b/packages/fast-html/test/fixtures/performance-metrics/performance-metrics.spec.ts
@@ -2,8 +2,11 @@ import { expect, test } from "@playwright/test";
 
 test.describe("Performance Metrics via Lifecycle Callbacks", () => {
     test.beforeEach(async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/performance-metrics/");
-        await page.waitForFunction(() => (window as any).getHydrationComplete());
+        await hydrationCompleted;
     });
 
     test("should create a performance measure for each hydrated element", async ({
@@ -12,7 +15,7 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
         const measures = await page.evaluate(() =>
             performance
                 .getEntriesByType("measure")
-                .filter(m => m.name === "hydration:fast-card")
+                .filter(m => m.name === "hydration:fast-card"),
         );
 
         const cards = page.locator("fast-card");
@@ -25,7 +28,7 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
         const measure = await page.evaluate(() =>
             performance
                 .getEntriesByType("measure")
-                .filter(m => m.name === "hydration:complete")
+                .filter(m => m.name === "hydration:complete"),
         );
 
         expect(measure).toHaveLength(1);
@@ -35,9 +38,7 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
         const { regTime, tmplTime, regSeq, tmplSeq } = await page.evaluate(() => {
             const entries = performance.getEntriesByType("mark") as PerformanceMark[];
             const reg = entries.find(m => m.name === "element-register:fast-card");
-            const tmpl = entries.find(m =>
-                m.name === "template-update:fast-card:start"
-            );
+            const tmpl = entries.find(m => m.name === "template-update:fast-card:start");
             return {
                 regTime: reg?.startTime,
                 tmplTime: tmpl?.startTime,
@@ -60,30 +61,23 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
     test("template-update should precede element-define", async ({ page }) => {
         const { templateEnd, defineTime, templateEndSeq, defineSeq } =
             await page.evaluate(() => {
-                const marks =
-                    performance.getEntriesByType("mark") as PerformanceMark[];
+                const marks = performance.getEntriesByType("mark") as PerformanceMark[];
                 const measures = performance.getEntriesByType("measure");
-                const tmpl = measures.find(
-                    m => m.name === "template-update:fast-card"
-                );
-                const def = marks.find(
-                    m => m.name === "element-define:fast-card"
-                );
+                const tmpl = measures.find(m => m.name === "template-update:fast-card");
+                const def = marks.find(m => m.name === "element-define:fast-card");
                 // template-update:start fires before template-update (the
                 // measure), and element-define fires after.  Compare the
                 // start-mark sequence against the define-mark sequence.
                 const startMark = marks.find(
-                    m => m.name === "template-update:fast-card:start"
+                    m => m.name === "template-update:fast-card:start",
                 );
                 return {
-                    templateEnd: tmpl
-                        ? tmpl.startTime + tmpl.duration
-                        : undefined,
+                    templateEnd: tmpl ? tmpl.startTime + tmpl.duration : undefined,
                     defineTime: def?.startTime,
-                    templateEndSeq: (startMark?.detail as any)
-                        ?.sequence as number | undefined,
-                    defineSeq: (def?.detail as any)
-                        ?.sequence as number | undefined,
+                    templateEndSeq: (startMark?.detail as any)?.sequence as
+                        | number
+                        | undefined,
+                    defineSeq: (def?.detail as any)?.sequence as number | undefined,
                 };
             });
 
@@ -97,24 +91,17 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
     });
 
     test("element-define should precede hydration:started", async ({ page }) => {
-        const { defineTime, hsTime, defineSeq, hsSeq } = await page.evaluate(
-            () => {
-                const marks =
-                    performance.getEntriesByType("mark") as PerformanceMark[];
-                const def = marks.find(
-                    m => m.name === "element-define:fast-card"
-                );
-                const hs = marks.find(m => m.name === "hydration:started");
-                return {
-                    defineTime: def?.startTime,
-                    hsTime: hs?.startTime,
-                    defineSeq: (def?.detail as any)
-                        ?.sequence as number | undefined,
-                    hsSeq: (hs?.detail as any)
-                        ?.sequence as number | undefined,
-                };
-            }
-        );
+        const { defineTime, hsTime, defineSeq, hsSeq } = await page.evaluate(() => {
+            const marks = performance.getEntriesByType("mark") as PerformanceMark[];
+            const def = marks.find(m => m.name === "element-define:fast-card");
+            const hs = marks.find(m => m.name === "hydration:started");
+            return {
+                defineTime: def?.startTime,
+                hsTime: hs?.startTime,
+                defineSeq: (def?.detail as any)?.sequence as number | undefined,
+                hsSeq: (hs?.detail as any)?.sequence as number | undefined,
+            };
+        });
 
         expect(defineTime).toBeDefined();
         expect(hsTime).toBeDefined();
@@ -132,9 +119,7 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
             const marks = performance.getEntriesByType("mark");
             const measures = performance.getEntriesByType("measure");
             const hs = marks.find(m => m.name === "hydration:started");
-            const cardMeasures = measures.filter(
-                m => m.name === "hydration:fast-card"
-            );
+            const cardMeasures = measures.filter(m => m.name === "hydration:fast-card");
             const earliest = Math.min(...cardMeasures.map(m => m.startTime));
             return { hydrationStarted: hs?.startTime, firstCardHydration: earliest };
         });
@@ -148,14 +133,10 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
     }) => {
         const { lastCardEnd, completeEnd } = await page.evaluate(() => {
             const measures = performance.getEntriesByType("measure");
-            const cardMeasures = measures.filter(
-                m => m.name === "hydration:fast-card"
-            );
+            const cardMeasures = measures.filter(m => m.name === "hydration:fast-card");
             const complete = measures.find(m => m.name === "hydration:complete");
             return {
-                lastCardEnd: Math.max(
-                    ...cardMeasures.map(m => m.startTime + m.duration)
-                ),
+                lastCardEnd: Math.max(...cardMeasures.map(m => m.startTime + m.duration)),
                 completeEnd: complete
                     ? complete.startTime + complete.duration
                     : undefined,
@@ -169,10 +150,11 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
     test("should create an element-prepared measure for each element", async ({
         page,
     }) => {
-        const count = await page.evaluate(() =>
-            performance
-                .getEntriesByType("measure")
-                .filter(m => m.name.startsWith("element-prepared:fast-card:")).length
+        const count = await page.evaluate(
+            () =>
+                performance
+                    .getEntriesByType("measure")
+                    .filter(m => m.name.startsWith("element-prepared:fast-card:")).length,
         );
 
         expect(count).toBe(14);
@@ -185,12 +167,12 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
             const marks = performance.getEntriesByType("mark");
             const measures = performance.getEntriesByType("measure");
             const prepared = measures.filter(m =>
-                m.name.startsWith("element-prepared:fast-card:")
+                m.name.startsWith("element-prepared:fast-card:"),
             );
             const hs = marks.find(m => m.name === "hydration:started");
             return {
                 earliestPreparedEnd: Math.min(
-                    ...prepared.map(m => m.startTime + m.duration)
+                    ...prepared.map(m => m.startTime + m.duration),
                 ),
                 hydrationStarted: hs?.startTime,
             };
@@ -205,10 +187,10 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
     }) => {
         const { zeroDurations, delayedDurations } = await page.evaluate(() => {
             const measures = performance.getEntriesByType(
-                "measure"
+                "measure",
             ) as PerformanceMeasure[];
             const prepared = measures.filter(m =>
-                m.name.startsWith("element-prepared:fast-card:")
+                m.name.startsWith("element-prepared:fast-card:"),
             );
 
             const zero: number[] = [];
@@ -243,12 +225,8 @@ test.describe("Performance Metrics via Lifecycle Callbacks", () => {
 
         for (let i = 0; i < count; i++) {
             const card = cards.nth(i);
-            const willHydrate = await card.evaluate(
-                (el: any) => el.willHydrate
-            );
-            const didHydrate = await card.evaluate(
-                (el: any) => el.didHydrate
-            );
+            const willHydrate = await card.evaluate((el: any) => el.willHydrate);
+            const didHydrate = await card.evaluate((el: any) => el.didHydrate);
 
             expect(willHydrate, `card ${i} willHydrate`).toBeTruthy();
             expect(didHydrate, `card ${i} didHydrate`).toBeTruthy();

--- a/packages/fast-html/test/fixtures/ref/main.ts
+++ b/packages/fast-html/test/fixtures/ref/main.ts
@@ -9,12 +9,9 @@ RenderableFASTElement(TestElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.config({
     hydrationComplete() {
-        hydrationCompleteEmitted = true;
+        (window as any).hydrationCompleted = true;
     },
 }).define({
     name: "f-template",

--- a/packages/fast-html/test/fixtures/ref/main.ts
+++ b/packages/fast-html/test/fixtures/ref/main.ts
@@ -9,6 +9,13 @@ RenderableFASTElement(TestElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-TemplateElement.define({
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
+TemplateElement.config({
+    hydrationComplete() {
+        hydrationCompleteEmitted = true;
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/fast-html/test/fixtures/ref/ref.spec.ts
+++ b/packages/fast-html/test/fixtures/ref/ref.spec.ts
@@ -2,8 +2,11 @@ import { expect, test } from "@playwright/test";
 
 test.describe("f-template", async () => {
     test("create a ref directive", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/ref/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const element = page.locator("test-element");
 

--- a/packages/fast-html/test/fixtures/ref/ref.spec.ts
+++ b/packages/fast-html/test/fixtures/ref/ref.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 test.describe("f-template", async () => {
     test("create a ref directive", async ({ page }) => {
         await page.goto("/fixtures/ref/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const element = page.locator("test-element");
 

--- a/packages/fast-html/test/fixtures/repeat-event/main.ts
+++ b/packages/fast-html/test/fixtures/repeat-event/main.ts
@@ -39,9 +39,6 @@ RenderableFASTElement(TestWhenInRepeat).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.options({
     "test-when-in-repeat": {
         observerMap: "all",
@@ -49,7 +46,7 @@ TemplateElement.options({
 })
     .config({
         hydrationComplete() {
-            hydrationCompleteEmitted = true;
+            (window as any).hydrationCompleted = true;
         },
     })
     .define({

--- a/packages/fast-html/test/fixtures/repeat-event/main.ts
+++ b/packages/fast-html/test/fixtures/repeat-event/main.ts
@@ -39,10 +39,19 @@ RenderableFASTElement(TestWhenInRepeat).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
 TemplateElement.options({
     "test-when-in-repeat": {
         observerMap: "all",
     },
-}).define({
-    name: "f-template",
-});
+})
+    .config({
+        hydrationComplete() {
+            hydrationCompleteEmitted = true;
+        },
+    })
+    .define({
+        name: "f-template",
+    });

--- a/packages/fast-html/test/fixtures/repeat-event/repeat-event.spec.ts
+++ b/packages/fast-html/test/fixtures/repeat-event/repeat-event.spec.ts
@@ -5,8 +5,11 @@ test.describe("f-repeat event binding", async () => {
     test("event handler inside f-repeat should have host element as this", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/repeat-event/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element-repeat-event");
         const buttons = customElement.locator("button");
@@ -31,8 +34,11 @@ test.describe("f-repeat event binding", async () => {
     });
 
     test("f-when with c.parent condition inside f-repeat", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/repeat-event/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const el = page.locator("test-when-in-repeat");
         const buttons = el.locator("button.name");

--- a/packages/fast-html/test/fixtures/repeat-event/repeat-event.spec.ts
+++ b/packages/fast-html/test/fixtures/repeat-event/repeat-event.spec.ts
@@ -6,6 +6,7 @@ test.describe("f-repeat event binding", async () => {
         page,
     }) => {
         await page.goto("/fixtures/repeat-event/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element-repeat-event");
         const buttons = customElement.locator("button");
@@ -31,6 +32,7 @@ test.describe("f-repeat event binding", async () => {
 
     test("f-when with c.parent condition inside f-repeat", async ({ page }) => {
         await page.goto("/fixtures/repeat-event/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const el = page.locator("test-when-in-repeat");
         const buttons = el.locator("button.name");

--- a/packages/fast-html/test/fixtures/repeat/main.ts
+++ b/packages/fast-html/test/fixtures/repeat/main.ts
@@ -93,6 +93,9 @@ RenderableFASTElement(TestElementWithObserverMap).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
 TemplateElement.options({
     "test-element-interval-updates": {
         observerMap: "all",
@@ -100,6 +103,12 @@ TemplateElement.options({
     "test-element-with-observer-map": {
         observerMap: "all",
     },
-}).define({
-    name: "f-template",
-});
+})
+    .config({
+        hydrationComplete() {
+            hydrationCompleteEmitted = true;
+        },
+    })
+    .define({
+        name: "f-template",
+    });

--- a/packages/fast-html/test/fixtures/repeat/main.ts
+++ b/packages/fast-html/test/fixtures/repeat/main.ts
@@ -93,9 +93,6 @@ RenderableFASTElement(TestElementWithObserverMap).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.options({
     "test-element-interval-updates": {
         observerMap: "all",
@@ -106,7 +103,7 @@ TemplateElement.options({
 })
     .config({
         hydrationComplete() {
-            hydrationCompleteEmitted = true;
+            (window as any).hydrationCompleted = true;
         },
     })
     .define({

--- a/packages/fast-html/test/fixtures/repeat/repeat.spec.ts
+++ b/packages/fast-html/test/fixtures/repeat/repeat.spec.ts
@@ -11,6 +11,7 @@ test.describe("f-template", async () => {
         page,
     }) => {
         await page.goto("/fixtures/repeat/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element");
         const customElementListItems = customElement.locator("li");
@@ -33,6 +34,7 @@ test.describe("f-template", async () => {
         page,
     }) => {
         await page.goto("/fixtures/repeat/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element-with-observer-map");
         const customElementListItems = customElement.locator("li");
@@ -53,6 +55,7 @@ test.describe("f-template", async () => {
     });
     test("create a repeat directive with an inner when", async ({ page }) => {
         await page.goto("/fixtures/repeat/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElement = page.locator("test-element-inner-when");
         const customElementListItems = customElement.locator("li");
@@ -65,6 +68,7 @@ test.describe("f-template", async () => {
         page,
     }) => {
         await page.goto("/fixtures/repeat/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const element = page.locator("test-element-interval-updates");
 
@@ -102,6 +106,7 @@ test.describe("f-template", async () => {
         page,
     }) => {
         await page.goto("/fixtures/repeat/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const element = page.locator("test-element-interval-updates");
 
@@ -138,6 +143,7 @@ test.describe("f-template", async () => {
 
     test("repeat directive with no item binding should not error", async ({ page }) => {
         await page.goto("/fixtures/repeat/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const element = page.locator("test-element-no-item-repeat-binding");
         const listItems = element.locator("li");
@@ -172,6 +178,7 @@ test.describe("f-template", async () => {
 
     test("should fire events inside a repeat directive", async ({ page }) => {
         await page.goto("/fixtures/repeat/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         const element = page.locator("test-element-event");
         const buttons = element.locator("button");
 
@@ -193,6 +200,7 @@ test.describe("f-template", async () => {
         page,
     }) => {
         await page.goto("/fixtures/repeat/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const element = page.locator("test-element-empty-array");
         const listItems = element.locator("li");

--- a/packages/fast-html/test/fixtures/repeat/repeat.spec.ts
+++ b/packages/fast-html/test/fixtures/repeat/repeat.spec.ts
@@ -10,8 +10,11 @@ test.describe("f-template", async () => {
     test("create a repeat directive over an array of strings with an observable decorator", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/repeat/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element");
         const customElementListItems = customElement.locator("li");
@@ -33,8 +36,11 @@ test.describe("f-template", async () => {
     test("create a repeat directive over an array of strings with observer map", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/repeat/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element-with-observer-map");
         const customElementListItems = customElement.locator("li");
@@ -54,8 +60,11 @@ test.describe("f-template", async () => {
         ]);
     });
     test("create a repeat directive with an inner when", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/repeat/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElement = page.locator("test-element-inner-when");
         const customElementListItems = customElement.locator("li");
@@ -67,8 +76,11 @@ test.describe("f-template", async () => {
     test("should NOT trigger updates when data is deeply merged with same values", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/repeat/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const element = page.locator("test-element-interval-updates");
 
@@ -105,8 +117,11 @@ test.describe("f-template", async () => {
     test("should trigger updates when data is deeply merged with different values", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/repeat/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const element = page.locator("test-element-interval-updates");
 
@@ -142,8 +157,11 @@ test.describe("f-template", async () => {
     });
 
     test("repeat directive with no item binding should not error", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/repeat/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const element = page.locator("test-element-no-item-repeat-binding");
         const listItems = element.locator("li");
@@ -177,8 +195,11 @@ test.describe("f-template", async () => {
     });
 
     test("should fire events inside a repeat directive", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/repeat/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         const element = page.locator("test-element-event");
         const buttons = element.locator("button");
 
@@ -199,8 +220,11 @@ test.describe("f-template", async () => {
     test("repeat directive with an empty array should render no items", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/repeat/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const element = page.locator("test-element-empty-array");
         const listItems = element.locator("li");

--- a/packages/fast-html/test/fixtures/slotted/main.ts
+++ b/packages/fast-html/test/fixtures/slotted/main.ts
@@ -1,5 +1,5 @@
-import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 import { FASTElement, observable } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
 class TestElement extends FASTElement {
     @observable
@@ -20,6 +20,13 @@ RenderableFASTElement(TestElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-TemplateElement.define({
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
+TemplateElement.config({
+    hydrationComplete() {
+        hydrationCompleteEmitted = true;
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/fast-html/test/fixtures/slotted/main.ts
+++ b/packages/fast-html/test/fixtures/slotted/main.ts
@@ -20,12 +20,9 @@ RenderableFASTElement(TestElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.config({
     hydrationComplete() {
-        hydrationCompleteEmitted = true;
+        (window as any).hydrationCompleted = true;
     },
 }).define({
     name: "f-template",

--- a/packages/fast-html/test/fixtures/slotted/slotted.spec.ts
+++ b/packages/fast-html/test/fixtures/slotted/slotted.spec.ts
@@ -3,8 +3,11 @@ import { expect, type Locator, test } from "@playwright/test";
 test.describe("f-template", () => {
     let element: Locator;
     test.beforeEach(async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/slotted/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         element = page.locator("test-element");
     });
 

--- a/packages/fast-html/test/fixtures/slotted/slotted.spec.ts
+++ b/packages/fast-html/test/fixtures/slotted/slotted.spec.ts
@@ -4,13 +4,14 @@ test.describe("f-template", () => {
     let element: Locator;
     test.beforeEach(async ({ page }) => {
         await page.goto("/fixtures/slotted/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         element = page.locator("test-element");
     });
 
     test("create a slotted directive", async () => {
         await expect(element).toHaveJSProperty("classList.length", 2);
 
-        await element.evaluate((node) => {
+        await element.evaluate(node => {
             const newElement = document.createElement("button");
             newElement.slot = "foo";
             node.append(newElement);

--- a/packages/fast-html/test/fixtures/when/main.ts
+++ b/packages/fast-html/test/fixtures/when/main.ts
@@ -162,6 +162,13 @@ RenderableFASTElement(NestedWhenElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-TemplateElement.define({
+let hydrationCompleteEmitted = false;
+(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
+
+TemplateElement.config({
+    hydrationComplete() {
+        hydrationCompleteEmitted = true;
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/fast-html/test/fixtures/when/main.ts
+++ b/packages/fast-html/test/fixtures/when/main.ts
@@ -162,12 +162,9 @@ RenderableFASTElement(NestedWhenElement).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
-let hydrationCompleteEmitted = false;
-(window as any).getHydrationCompleteStatus = () => hydrationCompleteEmitted;
-
 TemplateElement.config({
     hydrationComplete() {
-        hydrationCompleteEmitted = true;
+        (window as any).hydrationCompleted = true;
     },
 }).define({
     name: "f-template",

--- a/packages/fast-html/test/fixtures/when/when.spec.ts
+++ b/packages/fast-html/test/fixtures/when/when.spec.ts
@@ -2,8 +2,11 @@ import { expect, test } from "@playwright/test";
 
 test.describe("f-template", async () => {
     test("create a when directive for a boolean: true", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElementShow = await page.locator("#show");
         const customElementHide = await page.locator("#hide");
@@ -22,8 +25,11 @@ test.describe("f-template", async () => {
         await expect(customElementHide).toHaveText("Hello world");
     });
     test("create a when directive for multiple string cases", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElementWorld = await page.locator("#multiple1");
         const customElementPluto = await page.locator("#multiple2");
@@ -51,8 +57,11 @@ test.describe("f-template", async () => {
         await expect(customElementPluto).toHaveText("Hello mars");
     });
     test("create a when directive for a boolean: false", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElementShow = await page.locator("#show-not");
         const customElementHide = await page.locator("#hide-not");
@@ -61,8 +70,11 @@ test.describe("f-template", async () => {
         await expect(customElementHide).not.toHaveText("Hello world");
     });
     test("create a when directive value uses equals", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElementShow = await page.locator("#equals-true");
         const customElementHide = await page.locator("#equals-false");
@@ -71,8 +83,11 @@ test.describe("f-template", async () => {
         await expect(customElementHide).not.toHaveText("Equals 3");
     });
     test("create a when directive value uses not equals", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElementShow = await page.locator("#not-equals-true");
         const customElementHide = await page.locator("#not-equals-false");
@@ -83,8 +98,11 @@ test.describe("f-template", async () => {
     test("create a when directive value uses greater than or equals", async ({
         page,
     }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElementShow = await page.locator("#ge-true");
         const customElementHide = await page.locator("#ge-false");
@@ -93,8 +111,11 @@ test.describe("f-template", async () => {
         await expect(customElementHide).not.toHaveText("Two and Over");
     });
     test("create a when directive value uses greater than", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElementShow = await page.locator("#gt-true");
         const customElementHide = await page.locator("#gt-false");
@@ -103,8 +124,11 @@ test.describe("f-template", async () => {
         await expect(customElementHide).not.toHaveText("Over two");
     });
     test("create a when directive value uses less than or equals", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElementShow = await page.locator("#le-true");
         const customElementHide = await page.locator("#le-false");
@@ -113,8 +137,11 @@ test.describe("f-template", async () => {
         await expect(customElementHide).not.toHaveText("Two and Under");
     });
     test("create a when directive value uses less than", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElementShow = await page.locator("#lt-true");
         const customElementHide = await page.locator("#lt-false");
@@ -123,8 +150,11 @@ test.describe("f-template", async () => {
         await expect(customElementHide).not.toHaveText("Under two");
     });
     test("create a when directive value uses or", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElementShow = await page.locator("#or-true");
         const customElementHide = await page.locator("#or-false");
@@ -133,8 +163,11 @@ test.describe("f-template", async () => {
         await expect(customElementHide).not.toHaveText("This or That");
     });
     test("create a when directive value uses and", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
 
         const customElementShow = await page.locator("#and-true");
         const customElementHide = await page.locator("#and-false");
@@ -188,8 +221,11 @@ test.describe("f-template", async () => {
     });
 
     test("should fire events inside a when directive", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
         await page.goto("/fixtures/when/");
-        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
+        await hydrationCompleted;
         const element = page.locator("#event-show");
         const button = element.locator("button");
 
@@ -218,10 +254,11 @@ test.describe("f-template", async () => {
         test("initial state shows progress and hides error/button/retry", async ({
             page,
         }) => {
-            await page.goto("/fixtures/when/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/when/");
+            await hydrationCompleted;
             const element = page.locator("#nested-when");
 
             await expect(element.locator("progress")).toBeVisible();
@@ -232,10 +269,11 @@ test.describe("f-template", async () => {
         test("error state shows error div and retry button, hides progress", async ({
             page,
         }) => {
-            await page.goto("/fixtures/when/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/when/");
+            await hydrationCompleted;
             const element = page.locator("#nested-when");
 
             await expect(element.locator("progress")).toBeVisible();
@@ -283,10 +321,11 @@ test.describe("f-template", async () => {
         test("showProgress false shows continue button without disabled", async ({
             page,
         }) => {
-            await page.goto("/fixtures/when/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/when/");
+            await hydrationCompleted;
             const element = page.locator("#nested-when");
 
             await expect(element.locator("progress")).toBeVisible();
@@ -306,10 +345,11 @@ test.describe("f-template", async () => {
         test("toggling showProgress switches between progress and button", async ({
             page,
         }) => {
-            await page.goto("/fixtures/when/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/when/");
+            await hydrationCompleted;
             const element = page.locator("#nested-when");
 
             await expect(element.locator("progress")).toBeVisible();
@@ -333,10 +373,11 @@ test.describe("f-template", async () => {
         test("toggling error switches between error/retry and normal state", async ({
             page,
         }) => {
-            await page.goto("/fixtures/when/");
-            await page.waitForFunction(() =>
-                (window as any).getHydrationCompleteStatus(),
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
             );
+            await page.goto("/fixtures/when/");
+            await hydrationCompleted;
             const element = page.locator("#nested-when");
 
             await expect(element.locator(".error")).toHaveCount(0);

--- a/packages/fast-html/test/fixtures/when/when.spec.ts
+++ b/packages/fast-html/test/fixtures/when/when.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 test.describe("f-template", async () => {
     test("create a when directive for a boolean: true", async ({ page }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElementShow = await page.locator("#show");
         const customElementHide = await page.locator("#hide");
@@ -22,6 +23,7 @@ test.describe("f-template", async () => {
     });
     test("create a when directive for multiple string cases", async ({ page }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElementWorld = await page.locator("#multiple1");
         const customElementPluto = await page.locator("#multiple2");
@@ -50,6 +52,7 @@ test.describe("f-template", async () => {
     });
     test("create a when directive for a boolean: false", async ({ page }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElementShow = await page.locator("#show-not");
         const customElementHide = await page.locator("#hide-not");
@@ -59,6 +62,7 @@ test.describe("f-template", async () => {
     });
     test("create a when directive value uses equals", async ({ page }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElementShow = await page.locator("#equals-true");
         const customElementHide = await page.locator("#equals-false");
@@ -68,6 +72,7 @@ test.describe("f-template", async () => {
     });
     test("create a when directive value uses not equals", async ({ page }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElementShow = await page.locator("#not-equals-true");
         const customElementHide = await page.locator("#not-equals-false");
@@ -79,6 +84,7 @@ test.describe("f-template", async () => {
         page,
     }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElementShow = await page.locator("#ge-true");
         const customElementHide = await page.locator("#ge-false");
@@ -88,6 +94,7 @@ test.describe("f-template", async () => {
     });
     test("create a when directive value uses greater than", async ({ page }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElementShow = await page.locator("#gt-true");
         const customElementHide = await page.locator("#gt-false");
@@ -97,6 +104,7 @@ test.describe("f-template", async () => {
     });
     test("create a when directive value uses less than or equals", async ({ page }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElementShow = await page.locator("#le-true");
         const customElementHide = await page.locator("#le-false");
@@ -106,6 +114,7 @@ test.describe("f-template", async () => {
     });
     test("create a when directive value uses less than", async ({ page }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElementShow = await page.locator("#lt-true");
         const customElementHide = await page.locator("#lt-false");
@@ -115,6 +124,7 @@ test.describe("f-template", async () => {
     });
     test("create a when directive value uses or", async ({ page }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElementShow = await page.locator("#or-true");
         const customElementHide = await page.locator("#or-false");
@@ -124,6 +134,7 @@ test.describe("f-template", async () => {
     });
     test("create a when directive value uses and", async ({ page }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
 
         const customElementShow = await page.locator("#and-true");
         const customElementHide = await page.locator("#and-false");
@@ -178,6 +189,7 @@ test.describe("f-template", async () => {
 
     test("should fire events inside a when directive", async ({ page }) => {
         await page.goto("/fixtures/when/");
+        await page.waitForFunction(() => (window as any).getHydrationCompleteStatus());
         const element = page.locator("#event-show");
         const button = element.locator("button");
 
@@ -207,6 +219,9 @@ test.describe("f-template", async () => {
             page,
         }) => {
             await page.goto("/fixtures/when/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
             const element = page.locator("#nested-when");
 
             await expect(element.locator("progress")).toBeVisible();
@@ -218,6 +233,9 @@ test.describe("f-template", async () => {
             page,
         }) => {
             await page.goto("/fixtures/when/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
             const element = page.locator("#nested-when");
 
             await expect(element.locator("progress")).toBeVisible();
@@ -266,6 +284,9 @@ test.describe("f-template", async () => {
             page,
         }) => {
             await page.goto("/fixtures/when/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
             const element = page.locator("#nested-when");
 
             await expect(element.locator("progress")).toBeVisible();
@@ -286,6 +307,9 @@ test.describe("f-template", async () => {
             page,
         }) => {
             await page.goto("/fixtures/when/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
             const element = page.locator("#nested-when");
 
             await expect(element.locator("progress")).toBeVisible();
@@ -310,6 +334,9 @@ test.describe("f-template", async () => {
             page,
         }) => {
             await page.goto("/fixtures/when/");
+            await page.waitForFunction(() =>
+                (window as any).getHydrationCompleteStatus(),
+            );
             const element = page.locator("#nested-when");
 
             await expect(element.locator(".error")).toHaveCount(0);


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixture tests in `packages/fast-html/test/fixtures` were flaky because they asserted DOM state immediately after `page.goto()` without waiting for hydration to finish. This change adds a consistent `hydrationComplete()` tracking pattern to all 16 fixture suites so that every test waits for hydration before running assertions.

**What changed:**

- **`main.ts` (13 fixtures):** Added a `hydrationComplete()` lifecycle callback via `TemplateElement.config()` that sets a boolean flag, and exposed a global `getHydrationCompleteStatus()` getter for Playwright to poll.
- **`*.spec.ts` (14 fixtures):** Added `await page.waitForFunction(() => (window as any).getHydrationCompleteStatus())` after every `page.goto()` call.
- **`nested-elements/main.ts`:** Extended the existing `.config()` callback object to also set the hydration flag and expose the getter.
- Three fixtures (`lifecycle-callbacks`, `performance-metrics`) already had this pattern and were left unchanged.

## 📑 Test Plan

All 708 existing Playwright tests pass across Chromium, Firefox, and WebKit. No new tests were added — this change only prevents existing tests from starting before hydration is complete.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.