### PR TITLE
fix: dispose coupled-lifetime observers on view unbind

### DIFF
--- a/change/@microsoft-fast-element-dispose-coupled-lifetime.json
+++ b/change/@microsoft-fast-element-dispose-coupled-lifetime.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: dispose coupled-lifetime observers on view unbind to eliminate stale subscriptions",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-element/DESIGN.md
+++ b/packages/fast-element/DESIGN.md
@@ -127,6 +127,12 @@ The `KernelServiceId` object controls which numeric/string keys are used for sha
 
 This gives FAST automatic, fine-grained dependency tracking without explicit declarations.
 
+##### Observer disposal on unbind
+
+Every expression observer registers for disposal when its controller unbinds (via `controller.onUnbind(this)`). When the view is unbound — for example, when a parent `when` directive tears down a child element — the observer's `dispose()` method unsubscribes from all tracked property notifiers, preventing stale notifications from reaching expressions that would evaluate against a null source.
+
+> **Defence-in-depth**: `HTMLBindingDirective.handleChange` and `RenderBehavior.handleChange` also check `controller.isBound` before re-evaluating, providing a secondary guard against any notification that arrives after the view has been unbound.
+
 ---
 
 ### Bindings
@@ -364,15 +370,21 @@ flowchart TD
     ENQ["Updates.enqueue(binding task)"]
     RAF["requestAnimationFrame fires\nUpdates.process()"]
     EVAL["ExpressionNotifier re-evaluates expression"]
+    GUARD{"Controller still bound?"}
     DOM["DOM aspect updated\n(attribute / property / content / event)"]
+    DROP["Notification dropped\n(stale observer)"]
 
     SET --> NOTIFY
     NOTIFY --> SUBS
     SUBS --> ENQ
     ENQ --> RAF
     RAF --> EVAL
-    EVAL --> DOM
+    EVAL --> GUARD
+    GUARD -->|yes| DOM
+    GUARD -->|no| DROP
 ```
+
+> **Observer disposal on unbind**: All expression observers register for disposal when their controller unbinds. When a view is unbound (e.g., after a parent `when` directive tears down a child element), the observer's `dispose()` method unsubscribes from all tracked property notifiers, eliminating stale subscriptions at the source. The `isBound` guard shown above acts as a secondary defence in `HTMLBindingDirective.handleChange` and `RenderBehavior.handleChange` for any edge case where a notification is already queued before disposal completes.
 
 ---
 

--- a/packages/fast-element/docs/api-report.api.md
+++ b/packages/fast-element/docs/api-report.api.md
@@ -797,7 +797,7 @@ export function render<TSource = any, TItem = any, TParent = any>(value?: Expres
 export class RenderBehavior<TSource = any> implements ViewBehavior, Subscriber {
     constructor(directive: RenderDirective);
     bind(controller: ViewController): void;
-    // @internal (undocumented)
+    // @internal
     handleChange(source: any, observer: ExpressionObserver): void;
     unbind(controller: ViewController): void;
 }

--- a/packages/fast-element/src/observation/observable.ts
+++ b/packages/fast-element/src/observation/observable.ts
@@ -41,7 +41,7 @@ export interface Accessor {
  */
 export type Expression<TSource = any, TReturn = any, TParent = any> = (
     source: TSource,
-    context: ExecutionContext<TParent>
+    context: ExecutionContext<TParent>,
 ) => TReturn;
 
 /**
@@ -187,7 +187,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
                 ? (found = createArrayObserver(source))
                 : notifierLookup.set(
                       source,
-                      (found = new PropertyChangeNotifier(source))
+                      (found = new PropertyChangeNotifier(source)),
                   );
         }
 
@@ -245,12 +245,11 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         private propertyName: string | undefined = void 0;
         private notifier: Notifier | undefined = void 0;
         private next: SubscriptionRecord | undefined = void 0;
-        private controller: ExpressionController;
 
         constructor(
             private expression: Expression<TSource, TReturn>,
             initialSubscriber?: Subscriber,
-            private isVolatileBinding: boolean = false
+            private isVolatileBinding: boolean = false,
         ) {
             super(expression, initialSubscriber);
         }
@@ -260,23 +259,13 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         }
 
         public bind(controller: ExpressionController) {
-            this.controller = controller;
-
             const value = this.observe(controller.source, controller.context);
 
-            if (!controller.isBound && this.requiresUnbind(controller)) {
+            if (!controller.isBound) {
                 controller.onUnbind(this);
             }
 
             return value;
-        }
-
-        private requiresUnbind(controller: ExpressionController) {
-            return (
-                controller.sourceLifetime !== SourceLifetime.coupled ||
-                this.first !== this.last ||
-                this.first.propertySource !== controller.source
-            );
         }
 
         public unbind(controller: ExpressionController) {
@@ -465,12 +454,12 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         binding<TSource = any, TReturn = any>(
             expression: Expression<TSource, TReturn>,
             initialSubscriber?: Subscriber,
-            isVolatileBinding: boolean = this.isVolatileBinding(expression)
+            isVolatileBinding: boolean = this.isVolatileBinding(expression),
         ): ExpressionNotifier<TSource, TReturn> {
             return new ExpressionNotifierImplementation(
                 expression,
                 initialSubscriber,
-                isVolatileBinding
+                isVolatileBinding,
             );
         },
 
@@ -480,7 +469,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
          * @param expression - The binding to inspect.
          */
         isVolatileBinding<TSource = any, TReturn = any>(
-            expression: Expression<TSource, TReturn>
+            expression: Expression<TSource, TReturn>,
         ): boolean {
             return volatileRegex.test(expression.toString());
         },
@@ -507,7 +496,7 @@ export function observable(target: {}, nameOrAccessor: string | Accessor): void 
 export function volatile(
     target: {},
     name: string | Accessor,
-    descriptor: PropertyDescriptor
+    descriptor: PropertyDescriptor,
 ): PropertyDescriptor {
     return Object.assign({}, descriptor, {
         get(this: any) {

--- a/packages/fast-element/src/templating/binding.pw.spec.ts
+++ b/packages/fast-element/src/templating/binding.pw.spec.ts
@@ -565,7 +565,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "knownValue");
 
                 const directive = new HTMLBindingDirective(
-                    oneWay((x: any) => x.computedValue)
+                    oneWay((x: any) => x.computedValue),
                 );
                 directive.id = nextId();
                 directive.targetNodeId = "r";
@@ -634,7 +634,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "knownValue");
 
                 const directive = new HTMLBindingDirective(
-                    oneWay((x: any) => x.computedValue)
+                    oneWay((x: any) => x.computedValue),
                 );
                 directive.id = nextId();
                 directive.targetNodeId = "r";
@@ -706,7 +706,7 @@ test.describe("The HTML binding directive", () => {
                 const template = html`
                     ${(x: any) =>
                         html`<${html.partial(x.knownValue)}>Hi there!</${html.partial(
-                            x.knownValue
+                            x.knownValue,
                         )}>`}
                 `;
                 const model = new Model(template);
@@ -813,7 +813,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "knownValue");
 
                     const directive = new HTMLBindingDirective(
-                        oneWay((x: any) => x.value)
+                        oneWay((x: any) => x.value),
                     );
                     directive.id = nextId();
                     directive.targetNodeId = "r";
@@ -987,7 +987,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        oneWay((x: any) => x.value)
+                        oneWay((x: any) => x.value),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1052,7 +1052,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            oneWay((x: any) => x.value)
+                            oneWay((x: any) => x.value),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1127,7 +1127,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            oneWay((x: any) => x.value)
+                            oneWay((x: any) => x.value),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1167,7 +1167,7 @@ test.describe("The HTML binding directive", () => {
 
                         return { initialValue, afterUnbindValue };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -1202,7 +1202,7 @@ test.describe("The HTML binding directive", () => {
 
                         const policy = createTrackableDOMPolicy();
                         const directive = new HTMLBindingDirective(
-                            oneWay((x: any) => x.value, policy)
+                            oneWay((x: any) => x.value, policy),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1238,7 +1238,7 @@ test.describe("The HTML binding directive", () => {
                             policyUsed: policy.used,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(nodeValue).toBe(modelValue);
@@ -1270,7 +1270,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        oneWay((x: any) => x.value)
+                        oneWay((x: any) => x.value),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1358,7 +1358,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        oneTime((x: any) => x.value)
+                        oneTime((x: any) => x.value),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1424,7 +1424,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            oneTime((x: any) => x.value)
+                            oneTime((x: any) => x.value),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1463,7 +1463,7 @@ test.describe("The HTML binding directive", () => {
 
                         return { initialValue, afterUpdateValue };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -1497,7 +1497,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            oneTime((x: any) => x.value)
+                            oneTime((x: any) => x.value),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1537,7 +1537,7 @@ test.describe("The HTML binding directive", () => {
 
                         return { initialValue, afterUnbindValue };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -1572,7 +1572,7 @@ test.describe("The HTML binding directive", () => {
 
                         const policy = createTrackableDOMPolicy();
                         const directive = new HTMLBindingDirective(
-                            oneTime((x: any) => x.value, policy)
+                            oneTime((x: any) => x.value, policy),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1608,7 +1608,7 @@ test.describe("The HTML binding directive", () => {
                             policyUsed: policy.used,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(nodeValue).toBe(modelValue);
@@ -1640,7 +1640,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        oneTime((x: any) => x.value)
+                        oneTime((x: any) => x.value),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1728,7 +1728,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        signal((x: any) => x.value, "test-signal")
+                        signal((x: any) => x.value, "test-signal"),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1800,7 +1800,7 @@ test.describe("The HTML binding directive", () => {
 
                     const signalName = "test-signal";
                     const directive = new HTMLBindingDirective(
-                        signal((x: any) => x.value, signalName)
+                        signal((x: any) => x.value, signalName),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1884,7 +1884,7 @@ test.describe("The HTML binding directive", () => {
 
                         const signalName = "test-signal";
                         const directive = new HTMLBindingDirective(
-                            signal((x: any) => x.value, signalName)
+                            signal((x: any) => x.value, signalName),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1925,7 +1925,7 @@ test.describe("The HTML binding directive", () => {
 
                         return { initialValue, afterUnbindValue };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -1960,7 +1960,7 @@ test.describe("The HTML binding directive", () => {
 
                         const policy = createTrackableDOMPolicy();
                         const directive = new HTMLBindingDirective(
-                            signal((x: any) => x.value, "test-signal", policy)
+                            signal((x: any) => x.value, "test-signal", policy),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1996,7 +1996,7 @@ test.describe("The HTML binding directive", () => {
                             policyUsed: policy.used,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(nodeValue).toBe(modelValue);
@@ -2028,7 +2028,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        signal((x: any) => x.value, "test-signal")
+                        signal((x: any) => x.value, "test-signal"),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2116,7 +2116,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        twoWay((x: any) => x.value, {})
+                        twoWay((x: any) => x.value, {}),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2182,7 +2182,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, {})
+                            twoWay((x: any) => x.value, {}),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2257,7 +2257,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, {})
+                            twoWay((x: any) => x.value, {}),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2294,7 +2294,7 @@ test.describe("The HTML binding directive", () => {
                                 DOM.setBooleanAttribute(
                                     n,
                                     scenario.sourceAspect.slice(1),
-                                    val
+                                    val,
                                 );
                             } else if (scenario.sourceAspect.startsWith(":")) {
                                 n[scenario.sourceAspect.slice(1)] = val;
@@ -2314,7 +2314,7 @@ test.describe("The HTML binding directive", () => {
                             modelValueAfterEvent: model.value,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -2349,7 +2349,7 @@ test.describe("The HTML binding directive", () => {
 
                         const fromView = (_value: any) => "fixed value";
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, { fromView })
+                            twoWay((x: any) => x.value, { fromView }),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2386,7 +2386,7 @@ test.describe("The HTML binding directive", () => {
                                 DOM.setBooleanAttribute(
                                     n,
                                     scenario.sourceAspect.slice(1),
-                                    val
+                                    val,
                                 );
                             } else if (scenario.sourceAspect.startsWith(":")) {
                                 n[scenario.sourceAspect.slice(1)] = val;
@@ -2406,7 +2406,7 @@ test.describe("The HTML binding directive", () => {
                             modelValueAfterEvent: model.value,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -2441,7 +2441,7 @@ test.describe("The HTML binding directive", () => {
 
                         const changeEvent = "foo";
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, { changeEvent })
+                            twoWay((x: any) => x.value, { changeEvent }),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2478,7 +2478,7 @@ test.describe("The HTML binding directive", () => {
                                 DOM.setBooleanAttribute(
                                     n,
                                     scenario.sourceAspect.slice(1),
-                                    val
+                                    val,
                                 );
                             } else if (scenario.sourceAspect.startsWith(":")) {
                                 n[scenario.sourceAspect.slice(1)] = val;
@@ -2498,7 +2498,7 @@ test.describe("The HTML binding directive", () => {
                             modelValueAfterEvent: model.value,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -2532,7 +2532,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, {})
+                            twoWay((x: any) => x.value, {}),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2572,7 +2572,7 @@ test.describe("The HTML binding directive", () => {
 
                         return { initialValue, afterUnbindValue };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -2607,7 +2607,7 @@ test.describe("The HTML binding directive", () => {
 
                         const policy = createTrackableDOMPolicy();
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, {}, policy)
+                            twoWay((x: any) => x.value, {}, policy),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2643,7 +2643,7 @@ test.describe("The HTML binding directive", () => {
                             policyUsed: policy.used,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(nodeValue).toBe(modelValue);
@@ -2675,7 +2675,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        twoWay((x: any) => x.value, {})
+                        twoWay((x: any) => x.value, {}),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2737,7 +2737,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "value");
 
                 const directive = new HTMLBindingDirective(
-                    listener((x: any) => x.invokeAction(), {})
+                    listener((x: any) => x.invokeAction(), {}),
                 );
                 HTMLDirective.assignAspect(directive, "@my-event");
 
@@ -2789,7 +2789,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "value");
 
                 const directive = new HTMLBindingDirective(
-                    listener((x: any) => x.invokeAction(), {})
+                    listener((x: any) => x.invokeAction(), {}),
                 );
                 HTMLDirective.assignAspect(directive, "@my-event");
 
@@ -2855,7 +2855,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "value");
 
                 const directive = new HTMLBindingDirective(
-                    listener((x: any) => x.invokeAction(), { once: true })
+                    listener((x: any) => x.invokeAction(), { once: true }),
                 );
                 HTMLDirective.assignAspect(directive, "@my-event");
 
@@ -2917,7 +2917,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "value");
 
                 const directive = new HTMLBindingDirective(
-                    listener((x: any) => x.invokeAction(), {})
+                    listener((x: any) => x.invokeAction(), {}),
                 );
                 HTMLDirective.assignAspect(directive, "@my-event");
 
@@ -2981,7 +2981,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "value");
 
                 const directive = new HTMLBindingDirective(
-                    listener((x: any) => x.invokeAction(), {})
+                    listener((x: any) => x.invokeAction(), {}),
                 );
                 HTMLDirective.assignAspect(directive, "@my-event");
 
@@ -3041,7 +3041,7 @@ test.describe("The HTML binding directive", () => {
                         target,
                         directive.targetAspect,
                         value,
-                        Fake.viewController()
+                        Fake.viewController(),
                     );
                 }
 
@@ -3152,6 +3152,145 @@ test.describe("The HTML binding directive", () => {
             });
 
             expect(didNotThrow).toBe(true);
+        });
+    });
+
+    test.describe("coupled-lifetime observer disposal", () => {
+        test("should dispose observers on unbind so stale notifications do not reach bindings", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, html, when, Observable, Updates } = await import(
+                    "/main.js"
+                );
+
+                class ChildDisposal extends FASTElement {
+                    data: any;
+                }
+                Observable.defineProperty(ChildDisposal.prototype, "data");
+                ChildDisposal.define({
+                    name: "test-child-disposal",
+                    template: html<ChildDisposal>`
+                        <span>${x => x.data?.label ?? ""}</span>
+                    `,
+                });
+
+                class ParentDisposal extends FASTElement {
+                    currentData: any;
+                }
+                Observable.defineProperty(ParentDisposal.prototype, "currentData");
+                ParentDisposal.define({
+                    name: "test-parent-disposal",
+                    template: html<ParentDisposal>`
+                        ${when(
+                            x => x.currentData,
+                            html<ParentDisposal>`
+                                <test-child-disposal
+                                    :data="${x => x.currentData}"
+                                ></test-child-disposal>
+                            `,
+                        )}
+                    `,
+                });
+
+                const parent = document.createElement("test-parent-disposal") as any;
+                document.body.appendChild(parent);
+                await Updates.next();
+
+                // Show child with initial data.
+                parent.currentData = { label: "A" };
+                await Updates.next();
+
+                const child = parent.shadowRoot!.querySelector(
+                    "test-child-disposal",
+                ) as any;
+                const childNotifier = Observable.getNotifier(child);
+                const subscribersBefore = childNotifier.subscribers?.length ?? 0;
+
+                // Toggle off — tears down child view.
+                parent.currentData = undefined;
+                await Updates.next();
+
+                // After unbind, mutating the old child's data property
+                // should not cause errors or reach any binding subscriber.
+                let errorOccurred = false;
+                try {
+                    child.data = { label: "stale" };
+                    await Updates.next();
+                } catch (e) {
+                    errorOccurred = true;
+                }
+
+                // Toggle back on and verify updates resume correctly.
+                parent.currentData = { label: "B" };
+                await Updates.next();
+
+                const newChild = parent.shadowRoot!.querySelector(
+                    "test-child-disposal",
+                ) as any;
+                const renderedLabel = newChild?.shadowRoot
+                    ?.querySelector("span")
+                    ?.textContent?.trim();
+
+                document.body.removeChild(parent);
+
+                return {
+                    errorOccurred,
+                    renderedLabel,
+                };
+            });
+
+            expect(result.errorOccurred).toBe(false);
+            expect(result.renderedLabel).toBe("B");
+        });
+
+        test("should resume updates correctly after disconnect and reconnect cycle", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, html, Observable, Updates } = await import(
+                    "/main.js"
+                );
+
+                class ReconnectElement extends FASTElement {
+                    value: string = "initial";
+                }
+                Observable.defineProperty(ReconnectElement.prototype, "value");
+                ReconnectElement.define({
+                    name: "test-reconnect-element",
+                    template: html<ReconnectElement>`
+                        <span>${x => x.value}</span>
+                    `,
+                });
+
+                const el = document.createElement("test-reconnect-element") as any;
+                document.body.appendChild(el);
+                await Updates.next();
+
+                const label1 = el.shadowRoot?.querySelector("span")?.textContent?.trim();
+
+                // Disconnect and reconnect.
+                document.body.removeChild(el);
+                await Updates.next();
+
+                document.body.appendChild(el);
+                await Updates.next();
+
+                // Update after reconnect.
+                el.value = "updated";
+                await Updates.next();
+
+                const label2 = el.shadowRoot?.querySelector("span")?.textContent?.trim();
+
+                document.body.removeChild(el);
+
+                return { label1, label2 };
+            });
+
+            expect(result.label1).toBe("initial");
+            expect(result.label2).toBe("updated");
         });
     });
 });

--- a/packages/fast-element/src/templating/html-binding-directive.ts
+++ b/packages/fast-element/src/templating/html-binding-directive.ts
@@ -24,7 +24,7 @@ type UpdateTarget = (
     target: Node,
     aspect: string,
     value: any,
-    controller: ViewController
+    controller: ViewController,
 ) => void;
 
 /**
@@ -104,7 +104,7 @@ function updateContent(
     target: ContentTarget,
     aspect: string,
     value: any,
-    controller: ViewController
+    controller: ViewController,
 ): void {
     // If there's no actual value, then this equates to the
     // empty string for the purposes of content bindings.
@@ -193,7 +193,7 @@ function updateTokenList(
     this: HTMLBindingDirective,
     target: Element,
     aspect: string,
-    value: any
+    value: any,
 ): void {
     const lookup = `${this.id}-t`;
     const state: TokenListState =
@@ -342,7 +342,7 @@ export class HTMLBindingDirective
                 this.targetTagName,
                 this.aspectType,
                 this.targetAspect,
-                sink
+                sink,
             );
         }
 
@@ -374,13 +374,13 @@ export class HTMLBindingDirective
                 target.addEventListener(
                     this.targetAspect,
                     this,
-                    this.dataBinding.options
+                    this.dataBinding.options,
                 );
                 break;
             case DOMAspect.content:
                 controller.onUnbind(this);
             // intentional fall through
-            default:
+            default: {
                 const observer =
                     target[this.data] ??
                     (target[this.data] = this.dataBinding.createObserver(this, this));
@@ -402,9 +402,10 @@ export class HTMLBindingDirective
                     target,
                     this.targetAspect,
                     observer.bind(controller),
-                    controller
+                    controller,
                 );
                 break;
+            }
         }
     }
 
@@ -434,7 +435,7 @@ export class HTMLBindingDirective
             ExecutionContext.setEvent(event);
             const result = this.dataBinding.evaluate(
                 controller.source,
-                controller.context
+                controller.context,
             );
             ExecutionContext.setEvent(null);
 
@@ -449,16 +450,27 @@ export class HTMLBindingDirective
      * Re-evaluates the binding expression via observer.bind() and pushes
      * the new value to the DOM through the updateTarget sink function.
      * This is the reactive update path that keeps the DOM in sync with data.
+     *
+     * Guards against stale notifications: when a view is unbound (e.g., after
+     * a parent `when` directive tears down a child element), observers are
+     * disposed to unsubscribe from tracked properties. This guard provides
+     * additional defence against any notification already queued before
+     * disposal completed.
      * @internal
      */
     handleChange(binding: Expression, observer: ExpressionObserver): void {
-        const target = (observer as any).target;
         const controller = (observer as any).controller;
+
+        if (!controller.isBound) {
+            return;
+        }
+
+        const target = (observer as any).target;
         this.updateTarget!(
             target,
             this.targetAspect,
             observer.bind(controller),
-            controller
+            controller,
         );
     }
 }

--- a/packages/fast-element/src/templating/render.pw.spec.ts
+++ b/packages/fast-element/src/templating/render.pw.spec.ts
@@ -83,7 +83,7 @@ test.describe("The render", () => {
 
                 const data = directive.dataBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
 
                 return data === source;
@@ -132,7 +132,7 @@ test.describe("The render", () => {
 
                 const data = directive.dataBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
 
                 return data === source.child;
@@ -182,7 +182,7 @@ test.describe("The render", () => {
 
                 const data = directive.dataBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
 
                 return data === node;
@@ -232,7 +232,7 @@ test.describe("The render", () => {
 
                 const data = directive.dataBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
 
                 return data === obj;
@@ -289,7 +289,7 @@ test.describe("The render", () => {
                 const directive = render(x => x.child, childEditTemplate);
                 const template = directive.templateBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
                 return template === childEditTemplate;
             });
@@ -336,7 +336,7 @@ test.describe("The render", () => {
                 const directive = render();
                 const template = directive.templateBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
                 return template === parentTemplate;
             });
@@ -383,7 +383,7 @@ test.describe("The render", () => {
                 const directive = render(x => x.child);
                 const template = directive.templateBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
                 return template === childTemplate;
             });
@@ -437,7 +437,7 @@ test.describe("The render", () => {
                 const directive = render(() => node);
                 const template = directive.templateBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
                 return template instanceof NodeTemplate && template.node === node;
             });
@@ -492,11 +492,11 @@ test.describe("The render", () => {
                 const source = new TestParent();
                 const directive = render(
                     x => x.child,
-                    () => "edit"
+                    () => "edit",
                 );
                 const template = directive.templateBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
                 return template === childEditTemplate;
             });
@@ -549,11 +549,11 @@ test.describe("The render", () => {
                 const node = document.createElement("div");
                 const directive = render(
                     x => x.child,
-                    () => node
+                    () => node,
                 );
                 const template = directive.templateBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
                 return template instanceof NodeTemplate && template.node === node;
             });
@@ -608,11 +608,11 @@ test.describe("The render", () => {
                 const source = new TestParent();
                 const directive = render(
                     x => x.child,
-                    () => childEditTemplate
+                    () => childEditTemplate,
                 );
                 const template = directive.templateBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
                 return template === childEditTemplate;
             });
@@ -675,7 +675,7 @@ test.describe("The render", () => {
                 const directive = render(() => node, "edit");
                 const template = directive.templateBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
                 return template instanceof NodeTemplate && template.node === node;
             });
@@ -731,7 +731,7 @@ test.describe("The render", () => {
                 const directive = render(x => x.child, "edit");
                 const template = directive.templateBinding.evaluate(
                     source,
-                    Fake.executionContext()
+                    Fake.executionContext(),
                 );
                 return template === childEditTemplate;
             });
@@ -931,7 +931,7 @@ test.describe("The render", () => {
                         typeMatch: instruction.type === TestClass,
                         isViewTemplate: template instanceof ViewTemplate,
                         includesContent: template.html.includes(
-                            `${content}</${tagName}>`
+                            `${content}</${tagName}>`,
                         ),
                     };
                 }, operation);
@@ -981,7 +981,7 @@ test.describe("The render", () => {
                         typeMatch: instruction.type === TestClass,
                         isViewTemplate: template instanceof ViewTemplate,
                         includesContent: template.html.includes(
-                            `${content}</${tagName}>`
+                            `${content}</${tagName}>`,
                         ),
                         includesFoo: template.html.includes(`foo="`),
                         includesBaz: template.html.includes(`baz="`),
@@ -1094,7 +1094,7 @@ test.describe("The render", () => {
                         typeMatch: instruction.type === TestClass,
                         isViewTemplate: template instanceof ViewTemplate,
                         includesContent: template.html.includes(
-                            `${content}</${tagName}>`
+                            `${content}</${tagName}>`,
                         ),
                     };
                 }, operation);
@@ -1136,7 +1136,7 @@ test.describe("The render", () => {
                         typeMatch: instruction.type === TestClass,
                         isViewTemplate: template instanceof ViewTemplate,
                         includesContent: template.html.includes(
-                            `${content}</${tagName}>`
+                            `${content}</${tagName}>`,
                         ),
                         includesFoo: template.html.includes(`foo="`),
                         includesBaz: template.html.includes(`baz="`),
@@ -1585,7 +1585,7 @@ test.describe("The render", () => {
 
                 const directive = render(
                     x => x.child,
-                    x => x.template
+                    x => x.template,
                 );
                 directive.targetNodeId = "r";
 
@@ -1673,7 +1673,7 @@ test.describe("The render", () => {
 
                 const directive = render(
                     x => x.child,
-                    x => x.template
+                    x => x.template,
                 );
                 directive.targetNodeId = "r";
 
@@ -1704,6 +1704,7 @@ test.describe("The render", () => {
                 };
 
                 behavior.bind(controller);
+                controller.isBound = true;
 
                 const before = removeWhitespace(toHTML(parentNode));
 
@@ -1761,7 +1762,7 @@ test.describe("The render", () => {
 
                 const directive = render(
                     x => x.child,
-                    x => x.template
+                    x => x.template,
                 );
                 directive.targetNodeId = "r";
 
@@ -1792,6 +1793,7 @@ test.describe("The render", () => {
                 };
 
                 behavior.bind(controller);
+                controller.isBound = true;
                 const inserted = node.previousSibling;
 
                 const before = removeWhitespace(toHTML(parentNode));
@@ -1849,7 +1851,7 @@ test.describe("The render", () => {
 
                 const directive = render(
                     x => x.child,
-                    x => x.template
+                    x => x.template,
                 );
                 directive.targetNodeId = "r";
 
@@ -1935,7 +1937,7 @@ test.describe("The render", () => {
 
                 const directive = render(
                     x => x.child,
-                    x => x.template
+                    x => x.template,
                 );
                 directive.targetNodeId = "r";
 
@@ -2035,7 +2037,7 @@ test.describe("The render", () => {
 
                 const template = RenderInstruction.createElementTemplate(
                     "button",
-                    templateAttributeOptions
+                    templateAttributeOptions,
                 );
 
                 const targetNode = document.createElement("div");
@@ -2071,7 +2073,7 @@ test.describe("The render", () => {
 
                 const template = RenderInstruction.createElementTemplate(
                     "button",
-                    templateStaticViewOptions
+                    templateStaticViewOptions,
                 );
                 const targetNode = document.createElement("div");
                 const view = template.create();
@@ -2294,6 +2296,73 @@ test.describe("The render", () => {
             expect(result.sourceMatch).toBe(true);
             expect(result.isHTMLElement).toBe(true);
             expect(result.childCount).toBe(3);
+        });
+    });
+
+    test.describe("coupled-lifetime observer disposal in render behavior", () => {
+        test("should not crash when render source is mutated after view is unbound", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, html, render, Observable, Updates } = await import(
+                    "/main.js"
+                );
+
+                class RenderChild extends FASTElement {
+                    item: any;
+                }
+                Observable.defineProperty(RenderChild.prototype, "item");
+                RenderChild.define({
+                    name: "test-render-child",
+                    template: html<RenderChild>`
+                        <span>${x => x.item?.name ?? ""}</span>
+                    `,
+                });
+
+                class RenderParent extends FASTElement {
+                    child: any;
+                }
+                Observable.defineProperty(RenderParent.prototype, "child");
+                RenderParent.define({
+                    name: "test-render-parent",
+                    template: html<RenderParent>`
+                        ${render(x => x.child)}
+                    `,
+                });
+
+                const parent = document.createElement("test-render-parent") as any;
+                document.body.appendChild(parent);
+                await Updates.next();
+
+                try {
+                    // Show child.
+                    parent.child = { name: "First" };
+                    await Updates.next();
+
+                    // Remove child.
+                    parent.child = null;
+                    await Updates.next();
+
+                    // Reassign child.
+                    parent.child = { name: "Second" };
+                    await Updates.next();
+
+                    const shadowRoot = parent.shadowRoot!;
+                    const rendered = shadowRoot.textContent?.trim();
+
+                    document.body.removeChild(parent);
+
+                    return { success: true, rendered };
+                } catch (e: any) {
+                    document.body.removeChild(parent);
+                    return { success: false, error: e.message };
+                }
+            });
+
+            expect(result.success).toBe(true);
         });
     });
 });

--- a/packages/fast-element/src/templating/render.ts
+++ b/packages/fast-element/src/templating/render.ts
@@ -58,7 +58,7 @@ export class RenderBehavior<TSource = any> implements ViewBehavior, Subscriber {
         this.dataBindingObserver = directive.dataBinding.createObserver(this, directive);
         this.templateBindingObserver = directive.templateBinding.createObserver(
             this,
-            directive
+            directive,
         );
     }
 
@@ -104,8 +104,18 @@ export class RenderBehavior<TSource = any> implements ViewBehavior, Subscriber {
         }
     }
 
-    /** @internal */
+    /**
+     * Handles changes from data or template binding observers.
+     * Guards against stale notifications that may arrive after the
+     * controller's view has been unbound (e.g., when a parent `when`
+     * directive tears down and later recreates a child element).
+     * @internal
+     */
     public handleChange(source: any, observer: ExpressionObserver): void {
+        if (!this.controller!.isBound) {
+            return;
+        }
+
         if (observer === this.dataBindingObserver) {
             this.data = this.dataBindingObserver.bind(this.controller!);
         }
@@ -183,7 +193,7 @@ export class RenderDirective<TSource = any>
     public constructor(
         public readonly dataBinding: Binding<TSource>,
         public readonly templateBinding: Binding<TSource, ContentTemplate>,
-        public readonly templateBindingDependsOnData: boolean
+        public readonly templateBindingDependsOnData: boolean,
     ) {}
 
     /**
@@ -260,7 +270,7 @@ export type TemplateRenderOptions = CommonRenderOptions & {
  */
 export type BaseElementRenderOptions<
     TSource = any,
-    TParent = any
+    TParent = any,
 > = CommonRenderOptions & {
     /**
      * Attributes to use when creating the element template.
@@ -313,7 +323,7 @@ export type ElementCreateOptions<TSource = any, TParent = any> = Omit<
  */
 export type ElementConstructorRenderOptions<
     TSource = any,
-    TParent = any
+    TParent = any,
 > = BaseElementRenderOptions<TSource, TParent> & {
     /**
      * The element to use when rendering.
@@ -366,7 +376,7 @@ function instructionToTemplate(def: RenderInstruction | undefined) {
 
 function createElementTemplate<TSource = any, TParent = any>(
     tagName: string,
-    options?: ElementCreateOptions
+    options?: ElementCreateOptions,
 ): ViewTemplate<TSource, TParent> {
     const markup: Array<string> = [];
     const values: Array<TemplateValue<TSource, TParent>> = [];
@@ -428,7 +438,7 @@ function create(options: any): RenderInstruction {
 
         if (!tagName) {
             const def = FASTElementDefinition.getByType(
-                (options as ElementConstructorRenderOptions).element
+                (options as ElementConstructorRenderOptions).element,
             );
 
             if (def) {
@@ -468,7 +478,7 @@ function register(optionsOrInstruction: any): RenderInstruction {
     if (lookup === void 0) {
         typeToInstructionLookup.set(
             optionsOrInstruction.type,
-            (lookup = Object.create(null) as {})
+            (lookup = Object.create(null) as {}),
         );
     }
 
@@ -572,7 +582,7 @@ export function renderWith(options: Omit<TagNameRenderOptions, "type">): ClassDe
  * @public
  */
 export function renderWith(
-    options: Omit<ElementConstructorRenderOptions, "type">
+    options: Omit<ElementConstructorRenderOptions, "type">,
 ): ClassDecorator;
 /**
  * Decorates a type with render instruction metadata.
@@ -588,7 +598,7 @@ export function renderWith(options: Omit<TemplateRenderOptions, "type">): ClassD
  */
 export function renderWith(
     element: Constructable<FASTElement>,
-    name?: string
+    name?: string,
 ): ClassDecorator;
 /**
  * Decorates a type with render instruction metadata.
@@ -665,7 +675,7 @@ export function render<TSource = any, TItem = any, TParent = any>(
         | ContentTemplate
         | string
         | Expression<TSource, ContentTemplate | string | Node, TParent>
-        | Binding<TSource, ContentTemplate | string | Node, TParent>
+        | Binding<TSource, ContentTemplate | string | Node, TParent>,
 ): CaptureType<TSource, TParent> {
     let dataBinding: Binding<TSource>;
 
@@ -696,7 +706,7 @@ export function render<TSource = any, TItem = any, TParent = any>(
 
                 if (isString(result)) {
                     result = instructionToTemplate(
-                        getForInstance(dataBinding.evaluate(s, c), result)
+                        getForInstance(dataBinding.evaluate(s, c), result),
                     );
                 } else if (result instanceof Node) {
                     result = (result as any).$fastTemplate ?? new NodeTemplate(result);
@@ -705,7 +715,7 @@ export function render<TSource = any, TItem = any, TParent = any>(
                 return result;
             },
             void 0,
-            true
+            true,
         );
     } else if (isString(template)) {
         templateBindingDependsOnData = true;
@@ -726,7 +736,7 @@ export function render<TSource = any, TItem = any, TParent = any>(
 
             if (isString(result)) {
                 result = instructionToTemplate(
-                    getForInstance(dataBinding.evaluate(s, c), result)
+                    getForInstance(dataBinding.evaluate(s, c), result),
                 );
             } else if (result instanceof Node) {
                 result = (result as any).$fastTemplate ?? new NodeTemplate(result);
@@ -743,6 +753,6 @@ export function render<TSource = any, TItem = any, TParent = any>(
     return new RenderDirective<TSource>(
         dataBinding,
         templateBinding,
-        templateBindingDependsOnData
+        templateBindingDependsOnData,
     );
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Removes the coupled-lifetime optimisation in `ExpressionNotifierImplementation` that skipped unbind registration for observers with a single subscription on the controller source. All expression observers now register for disposal when their controller unbinds via `controller.onUnbind(this)`, ensuring stale subscriptions are eliminated when views are torn down (e.g., by a parent `when` directive that caches and reuses views).

This is the root-cause follow-up to #7435, which added subscriber-level `isBound` guards as a defensive fix. Those guards are retained as defence-in-depth.

### 🎫 Issues

- Follow-up to https://github.com/microsoft/fast/pull/7435
- Related to https://github.com/microsoft/fast/issues/7422

## 👩‍💻 Reviewer Notes

The key change is in `ExpressionNotifierImplementation.bind()` — the `requiresUnbind()` private method has been removed entirely and `controller.onUnbind(this)` is now called unconditionally (when `!controller.isBound`). The now-unused `private controller` field has also been removed.

The `isBound` guards in `HTMLBindingDirective.handleChange()` and `RenderBehavior.handleChange()` are kept as a secondary safety net against notifications already enqueued before disposal runs.

Render test fixtures that use raw controller objects with `isBound: false` have been updated to set `isBound = true` after `behavior.bind()` to match real `HTMLView` lifecycle behaviour.

## 📑 Test Plan

Three new Playwright tests added:

1. **Coupled-lifetime disposal test** (`binding.pw.spec.ts`) — Verifies that after a `when` directive tears down a child, mutating the old child's observable properties does not cause errors, and re-creating the child renders correctly.

2. **Disconnect/reconnect cycle test** (`binding.pw.spec.ts`) — Verifies that element disconnect and reconnect preserves reactive updates.

3. **RenderBehavior disposal test** (`render.pw.spec.ts`) — Verifies the render directive path handles null/reassign cycles without crashing.

All 1424 Chromium tests pass. All 4272 tests pass across Chromium, Firefox, and WebKit.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.