### PR TITLE
chore: skip CI pipelines on draft pull requests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,3 +3,10 @@
 To test workflows, use the GitHub CLI and trigger the workflow from a branch.
 
 For more information see the [GitHub CLI documentation](https://cli.github.com/manual/gh_workflow_run).
+
+## Draft Pull Requests
+
+All CI workflows that run against pull requests are configured to skip draft PRs:
+
+- **GitHub Actions** (`ci-validate-pr.yml`, `ci-validate-platforms.yml`, `ci-validate-rust.yml`): The `pull_request` trigger includes `ready_for_review` in its event types, and each job has a condition that skips execution when the PR is a draft. When a draft PR is marked as ready for review, the workflows will automatically trigger.
+- **Azure Pipelines** (`azure-pipelines-bench.yml`, `azure-pipelines-ci.yml`): The `pr` trigger uses `drafts: false` to prevent pipeline runs on draft PRs.

--- a/.github/workflows/ci-validate-platforms.yml
+++ b/.github/workflows/ci-validate-platforms.yml
@@ -9,12 +9,14 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, ready_for_review]
 
   schedule:
     - cron: 0 7 * * 3
 
 jobs:
   cross-platform_cross-browser:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/ci-validate-platforms.yml
+++ b/.github/workflows/ci-validate-platforms.yml
@@ -9,7 +9,11 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, ready_for_review]
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
 
   schedule:
     - cron: 0 7 * * 3

--- a/.github/workflows/ci-validate-pr.yml
+++ b/.github/workflows/ci-validate-pr.yml
@@ -11,9 +11,11 @@ on:
     - main
     - releases/*
     - features/*
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test_js:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     env:
       PLAYWRIGHT_BROWSERS_PATH: 0

--- a/.github/workflows/ci-validate-pr.yml
+++ b/.github/workflows/ci-validate-pr.yml
@@ -11,7 +11,11 @@ on:
     - main
     - releases/*
     - features/*
-    types: [opened, synchronize, reopened, ready_for_review]
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
 
 jobs:
   test_js:

--- a/.github/workflows/ci-validate-rust.yml
+++ b/.github/workflows/ci-validate-rust.yml
@@ -14,9 +14,11 @@ on:
     - main
     - releases/*
     - features/*
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test_rust:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci-validate-rust.yml
+++ b/.github/workflows/ci-validate-rust.yml
@@ -14,7 +14,11 @@ on:
     - main
     - releases/*
     - features/*
-    types: [opened, synchronize, reopened, ready_for_review]
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
 
 jobs:
   test_rust:

--- a/azure-pipelines-bench.yml
+++ b/azure-pipelines-bench.yml
@@ -5,7 +5,7 @@ trigger:
 pr:
   branches:
     include:
-    - main
+      - main
   drafts: false
 
 # The `resources` specify the location and version of the Pipeline Template.

--- a/azure-pipelines-bench.yml
+++ b/azure-pipelines-bench.yml
@@ -3,7 +3,10 @@ trigger:
     include:
     - main
 pr:
-  - main
+  branches:
+    include:
+    - main
+  drafts: false
 
 # The `resources` specify the location and version of the Pipeline Template.
 resources:

--- a/azure-pipelines-bench.yml
+++ b/azure-pipelines-bench.yml
@@ -5,7 +5,7 @@ trigger:
 pr:
   branches:
     include:
-      - main
+    - main
   drafts: false
 
 # The `resources` specify the location and version of the Pipeline Template.

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -1,7 +1,7 @@
 pr:
   branches:
     include:
-      - main
+    - main
   drafts: false
 
 # The `resources` specify the location and version of the 1ES PT.

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -1,5 +1,8 @@
 pr:
-  - main
+  branches:
+    include:
+    - main
+  drafts: false
 
 # The `resources` specify the location and version of the 1ES PT.
 resources:

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -1,7 +1,7 @@
 pr:
   branches:
     include:
-    - main
+      - main
   drafts: false
 
 # The `resources` specify the location and version of the 1ES PT.


### PR DESCRIPTION
# Pull Request

## 📖 Description

Configure all PR-triggered CI pipelines to skip execution when the pull request is in draft status. This saves CI resources by not running expensive build and test jobs until the PR is ready for review.

**GitHub Actions** (`ci-validate-pr`, `ci-validate-platforms`, `ci-validate-rust`):
- Added `ready_for_review` to `pull_request` event types so workflows re-trigger when a draft is marked ready.
- Added job-level condition `if: github.event_name != 'pull_request' || !github.event.pull_request.draft` to skip jobs on draft PRs while preserving push and workflow_dispatch triggers.

**Azure Pipelines** (`azure-pipelines-bench`, `azure-pipelines-ci`):
- Added `drafts: false` to the `pr` trigger configuration.

## 📑 Test Plan

These changes are CI configuration only. Verification:
- Draft PRs against `main` should show skipped workflow jobs in GitHub Actions and no Azure Pipeline runs.
- Marking a draft PR as "Ready for review" should trigger all CI workflows.
- Push events to `main` and `workflow_dispatch` triggers remain unaffected.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.