### PR TITLE
feat: add --config option to @microsoft/fast-build CLI

### DIFF
--- a/change/@microsoft-fast-build-0727e22e-b9e5-4c6d-8eec-a705b39ebd4c.json
+++ b/change/@microsoft-fast-build-0727e22e-b9e5-4c6d-8eec-a705b39ebd4c.json
@@ -3,5 +3,5 @@
   "comment": "feat: add --config option for loading build options from a JSON configuration file",
   "packageName": "@microsoft/fast-build",
   "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@microsoft-fast-build-0727e22e-b9e5-4c6d-8eec-a705b39ebd4c.json
+++ b/change/@microsoft-fast-build-0727e22e-b9e5-4c6d-8eec-a705b39ebd4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add --config option for loading build options from a JSON configuration file",
+  "packageName": "@microsoft/fast-build",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-build/DESIGN.md
+++ b/packages/fast-build/DESIGN.md
@@ -8,7 +8,7 @@ This document describes the internal architecture of the `@microsoft/fast-build`
 
 `@microsoft/fast-build` is a Node.js CLI tool that server-side renders FAST declarative HTML templates. It delegates all template rendering to a WebAssembly module compiled from the [`microsoft-fast-build`](../../crates/microsoft-fast-build) Rust crate. The Node.js layer is responsible only for:
 
-1. Parsing CLI arguments
+1. Parsing CLI arguments and loading configuration
 2. Locating and parsing template HTML files (glob scanning + `<f-template>` extraction)
 3. Loading the entry HTML and state JSON files
 4. Calling the WASM renderer
@@ -18,7 +18,14 @@ This document describes the internal architecture of the `@microsoft/fast-build`
 fast build [options]
         │
         ▼
-  parseArgs(argv)        ← --entry, --state, --output, --templates, --attribute-name-strategy
+  parseArgs(argv)        ← --entry, --state, --output, --templates, --attribute-name-strategy, --config
+        │
+        ├─ loadConfig(configPath)             ← load fast-build.config.json
+        │       │
+        │       ├─ explicit --config path     ← error if file missing
+        │       └─ default CWD lookup         ← silent fallback if missing
+        │
+        ├─ resolveOption(args, config, …)     ← CLI args override config values
         │
         ├─ wasm = require(WASM_MODULE)         ← load WASM first
         │
@@ -46,9 +53,43 @@ fast build [options]
 
 | File | Role |
 |------|------|
-| `bin/fast.js` | CLI entry point — argument parsing, file I/O, template scanning, WASM dispatch |
+| `bin/fast.js` | CLI entry point — argument parsing, config file loading, file I/O, template scanning, WASM dispatch |
 | `wasm/microsoft_fast_build.js` | WASM-generated JS bindings for the Rust renderer |
 | `wasm/microsoft_fast_build_bg.wasm` | Compiled Rust renderer binary |
+
+---
+
+## Configuration file — `loadConfig`
+
+The CLI supports an optional JSON configuration file that provides default values for all build options. This avoids repeating long argument lists in scripts and CI pipelines.
+
+### Resolution order
+
+1. If `--config=<path>` is provided, that file is loaded. An error is raised if the file does not exist.
+2. If `--config` is not provided, `fast-build.config.json` in the current working directory is loaded if it exists. If it does not exist, no config is applied (silent fallback).
+
+### Merge semantics
+
+CLI arguments always take precedence over config file values. The merge uses **presence-based** checking (`hasOwnProperty`), not truthiness, so an explicit `--entry=` on the command line will override a config file's `entry` value even if the CLI value is an empty string.
+
+When a value is not provided by either source, built-in defaults apply (`index.html`, `state.json`, `output.html`).
+
+### Path resolution
+
+File paths read from the config file (`entry`, `state`, `output`, `templates`) are resolved relative to the **config file's directory**, not the current working directory. This ensures configs work correctly regardless of where the CLI is invoked from.
+
+CLI-provided paths are resolved relative to the current working directory (the default Node.js behaviour).
+
+### Validation
+
+The config file must be a JSON object. Each key must be one of the allowed option names (`entry`, `state`, `output`, `templates`, `attribute-name-strategy`) and each value must be a string. Unknown keys and non-string values produce an error referencing the config file path.
+
+### Helpers
+
+| Function | Role |
+|----------|------|
+| `loadConfig(configPath)` | Reads, parses, and validates the config file. Returns `{ config, configDir }`. |
+| `resolveOption(args, config, configDir, key, defaultValue)` | Returns the CLI arg if present, otherwise the config value (with path resolution), otherwise the default. |
 
 ---
 
@@ -120,6 +161,12 @@ See the [`microsoft-fast-build` DESIGN.md](../../crates/microsoft-fast-build/DES
 
 | Condition | Behaviour |
 |-----------|-----------|
+| `--config` file not found (explicit) | Print error to stderr; exit code 1 |
+| Default `fast-build.config.json` not found | Silent; no config applied |
+| Config file is invalid JSON | Print error to stderr; exit code 1 |
+| Config file is not a JSON object | Print error to stderr; exit code 1 |
+| Config file has unknown key | Print error to stderr; exit code 1 |
+| Config file has non-string value | Print error to stderr; exit code 1 |
 | `--entry` file not found | Print error to stderr; exit code 1 |
 | `--state` file not found | Print error to stderr; exit code 1 |
 | `--templates` not provided | Warning to stderr; rendering continues without custom elements |

--- a/packages/fast-build/README.md
+++ b/packages/fast-build/README.md
@@ -40,6 +40,7 @@ fast build [options]
 | `--output="<path>"` | `output.html` | Where to write the rendered HTML |
 | `--templates="<glob>"` | _(none)_ | Glob pattern(s) for custom element template HTML files. Separate multiple patterns with commas. A warning is printed if not provided or if no files match a pattern. |
 | `--attribute-name-strategy="<strategy>"` | `none` | Strategy for mapping HTML attribute names to state property names on custom elements. `"none"` preserves dashes (e.g. `foo-bar` → `foo-bar`). `"camelCase"` converts dashes to camelCase (e.g. `foo-bar` → `fooBar`). See [Attribute name strategy](#attribute-name-strategy). |
+| `--config="<path>"` | `fast-build.config.json` | Path to a JSON configuration file. If omitted, `fast-build.config.json` in the current directory is used when present. CLI arguments take precedence over config values. See [Configuration file](#configuration-file). |
 
 ### Example
 
@@ -128,6 +129,31 @@ fast build \
   --state=state.json \
   --output=output.html
 ```
+
+### Configuration file
+
+Instead of passing every option on the command line, you can place a `fast-build.config.json` file alongside your project files:
+
+```json
+{
+    "entry": "index.html",
+    "state": "state.json",
+    "output": "output.html",
+    "templates": "./components/**/*.html"
+}
+```
+
+The CLI automatically loads `fast-build.config.json` from the current directory when it exists. To use a different file, pass `--config`:
+
+```shell
+fast build --config=configs/my-build.json
+```
+
+**Precedence:** CLI arguments always override config file values. For example, `--output=other.html` will override the `output` value in the config file.
+
+**Path resolution:** File paths in the config file (`entry`, `state`, `output`, `templates`) are resolved relative to the config file's directory, not the current working directory. This ensures the config works correctly regardless of where the CLI is invoked.
+
+All keys are optional. Only the following keys are allowed: `entry`, `state`, `output`, `templates`, `attribute-name-strategy`. Unknown keys or non-string values produce an error.
 
 ## Template syntax
 

--- a/packages/fast-build/bin/fast.js
+++ b/packages/fast-build/bin/fast.js
@@ -6,6 +6,14 @@ const fs = require("fs");
 const path = require("path");
 
 const WASM_MODULE = path.join(__dirname, "../wasm/microsoft_fast_build.js");
+const DEFAULT_CONFIG_FILENAME = "fast-build.config.json";
+const ALLOWED_CONFIG_KEYS = new Set([
+    "entry",
+    "state",
+    "output",
+    "templates",
+    "attribute-name-strategy",
+]);
 
 /**
  * Parse CLI arguments of the form --key="value" or --key=value.
@@ -21,6 +29,106 @@ function parseArgs(argv) {
         }
     }
     return args;
+}
+
+/**
+ * Load and validate a fast-build config file.
+ *
+ * - If `configPath` is provided, the file must exist (error if missing).
+ * - If `configPath` is not provided, looks for `fast-build.config.json` in CWD.
+ *   Returns an empty object if the default file does not exist.
+ *
+ * File paths in the returned config are resolved relative to the config
+ * file's directory so that the caller can use them directly.
+ *
+ * @param {string | undefined} configPath - Explicit path from --config, if any.
+ * @returns {{ config: Record<string, string>, configDir: string | null }}
+ */
+function loadConfig(configPath) {
+    /** @type {string} */
+    let resolvedPath;
+    /** @type {boolean} */
+    let isExplicit;
+
+    if (configPath !== undefined) {
+        resolvedPath = path.resolve(configPath);
+        isExplicit = true;
+    } else {
+        resolvedPath = path.resolve(DEFAULT_CONFIG_FILENAME);
+        isExplicit = false;
+    }
+
+    if (!fs.existsSync(resolvedPath)) {
+        if (isExplicit) {
+            process.stderr.write(
+                `Error: Config file "${configPath}" not found.\n`
+            );
+            process.exit(1);
+        }
+        return { config: {}, configDir: null };
+    }
+
+    let raw;
+    try {
+        raw = JSON.parse(fs.readFileSync(resolvedPath, "utf8"));
+    } catch (e) {
+        process.stderr.write(
+            `Error: Failed to parse config file "${resolvedPath}": ${e.message}\n`
+        );
+        process.exit(1);
+    }
+
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+        process.stderr.write(
+            `Error: Config file "${resolvedPath}" must contain a JSON object.\n`
+        );
+        process.exit(1);
+    }
+
+    for (const key of Object.keys(raw)) {
+        if (!ALLOWED_CONFIG_KEYS.has(key)) {
+            process.stderr.write(
+                `Error: Unknown key "${key}" in config file "${resolvedPath}". Allowed keys: ${[...ALLOWED_CONFIG_KEYS].join(", ")}.\n`
+            );
+            process.exit(1);
+        }
+        if (typeof raw[key] !== "string") {
+            process.stderr.write(
+                `Error: Value for "${key}" in config file "${resolvedPath}" must be a string.\n`
+            );
+            process.exit(1);
+        }
+    }
+
+    const configDir = path.dirname(resolvedPath);
+    return { config: raw, configDir };
+}
+
+/**
+ * Resolve a file path value, preferring the CLI arg over the config value.
+ * Config-derived paths are resolved relative to the config file's directory.
+ * CLI-derived paths are resolved relative to CWD (the default behaviour).
+ *
+ * @param {Record<string, string>} args - Parsed CLI arguments.
+ * @param {Record<string, string>} config - Parsed config file values.
+ * @param {string | null} configDir - Directory of the config file, or null.
+ * @param {string} key - The option key.
+ * @param {string} [defaultValue] - Fallback when neither source provides a value.
+ * @returns {string | undefined}
+ */
+function resolveOption(args, config, configDir, key, defaultValue) {
+    if (Object.prototype.hasOwnProperty.call(args, key)) {
+        return args[key];
+    }
+    if (Object.prototype.hasOwnProperty.call(config, key)) {
+        const value = config[key];
+        const isFilePath = key === "entry" || key === "state" || key === "output" || key === "templates";
+        if (isFilePath && configDir !== null) {
+            return path.resolve(configDir, value);
+        }
+        return value;
+    }
+    return defaultValue;
 }
 
 /**
@@ -163,11 +271,15 @@ function resolvePattern(pattern, wasm) {
 }
 
 async function runBuild(args) {
-    const templatesArg = args["templates"];
-    const output = args["output"] || "output.html";
-    const entry = args["entry"] || "index.html";
-    const stateFile = args["state"] || "state.json";
-    const attributeNameStrategy = args["attribute-name-strategy"];
+    const { config, configDir } = loadConfig(
+        Object.prototype.hasOwnProperty.call(args, "config") ? args["config"] : undefined
+    );
+
+    const templatesArg = resolveOption(args, config, configDir, "templates");
+    const output = resolveOption(args, config, configDir, "output", "output.html");
+    const entry = resolveOption(args, config, configDir, "entry", "index.html");
+    const stateFile = resolveOption(args, config, configDir, "state", "state.json");
+    const attributeNameStrategy = resolveOption(args, config, configDir, "attribute-name-strategy");
 
     if (attributeNameStrategy && attributeNameStrategy !== "none" && attributeNameStrategy !== "camelCase") {
         process.stderr.write(
@@ -247,7 +359,13 @@ async function main() {
             '  --state="state.json"   State JSON file (default: state.json)\n' +
             '  --attribute-name-strategy="none"\n' +
             '                         Strategy for mapping attribute names to property names.\n' +
-            '                         "none" (default) or "camelCase".\n'
+            '                         "none" (default) or "camelCase".\n' +
+            '  --config="<path>"      Path to a fast-build config JSON file.\n' +
+            '                         Defaults to "fast-build.config.json" in the\n' +
+            '                         current directory if it exists. File paths in\n' +
+            '                         the config are resolved relative to the config\n' +
+            '                         file\'s directory. CLI arguments take precedence\n' +
+            '                         over config file values.\n'
         );
         return;
     }

--- a/packages/fast-build/package.json
+++ b/packages/fast-build/package.json
@@ -28,7 +28,8 @@
     "wasm/microsoft_fast_build_bg.wasm.d.ts"
   ],
   "scripts": {
-    "build": "cargo build --manifest-path ../../crates/microsoft-fast-build/Cargo.toml && wasm-pack build --target nodejs ../../crates/microsoft-fast-build --out-dir ../../packages/fast-build/wasm"
+    "build": "cargo build --manifest-path ../../crates/microsoft-fast-build/Cargo.toml && wasm-pack build --target nodejs ../../crates/microsoft-fast-build --out-dir ../../packages/fast-build/wasm",
+    "test:node": "node --test test/config.test.js"
   },
   "engines": {
     "node": ">=22.18.0"

--- a/packages/fast-build/test/config.test.js
+++ b/packages/fast-build/test/config.test.js
@@ -1,0 +1,208 @@
+// @ts-check
+
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+
+const FAST_BIN = path.resolve(__dirname, "../bin/fast.js");
+
+function tmpDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), "fast-build-test-"));
+}
+
+function run(args, cwd) {
+    return execFileSync(process.execPath, [FAST_BIN, "build", ...args], {
+        cwd,
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+}
+
+function runWithStderr(args, cwd) {
+    try {
+        const stdout = execFileSync(process.execPath, [FAST_BIN, "build", ...args], {
+            cwd,
+            encoding: "utf8",
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+        return { stdout, stderr: "", exitCode: 0 };
+    } catch (e) {
+        return {
+            stdout: e.stdout || "",
+            stderr: e.stderr || "",
+            exitCode: e.status,
+        };
+    }
+}
+
+function writeFixture(dir, { entry, state, output, config, configName }) {
+    fs.writeFileSync(
+        path.join(dir, "entry.html"),
+        entry || "<html><body><h1>{{title}}</h1></body></html>",
+    );
+    fs.writeFileSync(path.join(dir, "state.json"), state || '{"title":"Hello"}');
+    if (config) {
+        fs.writeFileSync(
+            path.join(dir, configName || "fast-build.config.json"),
+            JSON.stringify(config),
+        );
+    }
+}
+
+describe("config file loading", () => {
+    /** @type {string} */
+    let dir;
+
+    beforeEach(() => {
+        dir = tmpDir();
+    });
+
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("loads default fast-build.config.json from CWD", () => {
+        writeFixture(dir, {
+            config: {
+                entry: "entry.html",
+                state: "state.json",
+                output: "out.html",
+            },
+        });
+        run([], dir);
+        const output = fs.readFileSync(path.join(dir, "out.html"), "utf8");
+        assert.ok(output.includes("Hello"));
+    });
+
+    it("proceeds without error when no default config exists", () => {
+        writeFixture(dir, {});
+        run(["--entry=entry.html", "--state=state.json", "--output=out.html"], dir);
+        const output = fs.readFileSync(path.join(dir, "out.html"), "utf8");
+        assert.ok(output.includes("Hello"));
+    });
+
+    it("loads an explicit --config file", () => {
+        writeFixture(dir, {
+            config: {
+                entry: "entry.html",
+                state: "state.json",
+                output: "out.html",
+            },
+            configName: "custom.json",
+        });
+        run(["--config=custom.json"], dir);
+        const output = fs.readFileSync(path.join(dir, "out.html"), "utf8");
+        assert.ok(output.includes("Hello"));
+    });
+
+    it("errors when explicit --config file does not exist", () => {
+        writeFixture(dir, {});
+        const result = runWithStderr(["--config=nonexistent.json"], dir);
+        assert.equal(result.exitCode, 1);
+        assert.ok(result.stderr.includes("not found"));
+    });
+
+    it("CLI arguments override config values", () => {
+        writeFixture(dir, {
+            config: {
+                entry: "entry.html",
+                state: "state.json",
+                output: "config-out.html",
+            },
+        });
+        run(["--output=cli-out.html"], dir);
+        assert.ok(fs.existsSync(path.join(dir, "cli-out.html")));
+        assert.ok(!fs.existsSync(path.join(dir, "config-out.html")));
+    });
+
+    it("resolves config paths relative to config file directory", () => {
+        const subDir = path.join(dir, "sub");
+        fs.mkdirSync(subDir);
+        writeFixture(subDir, {
+            config: {
+                entry: "entry.html",
+                state: "state.json",
+                output: "out.html",
+            },
+        });
+        run(["--config=sub/fast-build.config.json"], dir);
+        assert.ok(fs.existsSync(path.join(subDir, "out.html")));
+    });
+});
+
+describe("config validation", () => {
+    /** @type {string} */
+    let dir;
+
+    beforeEach(() => {
+        dir = tmpDir();
+    });
+
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("rejects unknown keys", () => {
+        writeFixture(dir, {});
+        fs.writeFileSync(path.join(dir, "fast-build.config.json"), '{"badkey":"val"}');
+        const result = runWithStderr([], dir);
+        assert.equal(result.exitCode, 1);
+        assert.ok(result.stderr.includes('Unknown key "badkey"'));
+    });
+
+    it("rejects non-string values", () => {
+        writeFixture(dir, {});
+        fs.writeFileSync(path.join(dir, "fast-build.config.json"), '{"entry":123}');
+        const result = runWithStderr([], dir);
+        assert.equal(result.exitCode, 1);
+        assert.ok(result.stderr.includes("must be a string"));
+    });
+
+    it("rejects arrays", () => {
+        writeFixture(dir, {});
+        fs.writeFileSync(path.join(dir, "fast-build.config.json"), "[]");
+        const result = runWithStderr([], dir);
+        assert.equal(result.exitCode, 1);
+        assert.ok(result.stderr.includes("must contain a JSON object"));
+    });
+
+    it("rejects invalid JSON", () => {
+        writeFixture(dir, {});
+        fs.writeFileSync(path.join(dir, "fast-build.config.json"), "{bad json");
+        const result = runWithStderr([], dir);
+        assert.equal(result.exitCode, 1);
+        assert.ok(result.stderr.includes("Failed to parse"));
+    });
+});
+
+describe("backward compatibility", () => {
+    /** @type {string} */
+    let dir;
+
+    beforeEach(() => {
+        dir = tmpDir();
+    });
+
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("works with only CLI args and no config file", () => {
+        writeFixture(dir, {});
+        run(["--entry=entry.html", "--state=state.json", "--output=out.html"], dir);
+        const output = fs.readFileSync(path.join(dir, "out.html"), "utf8");
+        assert.ok(output.includes("Hello"));
+    });
+
+    it("merges partial config with CLI args", () => {
+        writeFixture(dir, {
+            config: { entry: "entry.html" },
+        });
+        run(["--state=state.json", "--output=out.html"], dir);
+        const output = fs.readFileSync(path.join(dir, "out.html"), "utf8");
+        assert.ok(output.includes("Hello"));
+    });
+});


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds a `--config` option to the `@microsoft/fast-build` CLI that allows build options to be loaded from a JSON configuration file (`fast-build.config.json`).

### Behaviour

- If `--config` is not provided, the CLI automatically looks for `fast-build.config.json` in the current working directory. If the file does not exist, the CLI proceeds as before (no error).
- If `--config=<path>` is provided, the specified file must exist (error if missing).
- CLI arguments always take precedence over config file values (presence-based merging, not truthiness).
- File paths in the config (`entry`, `state`, `output`, `templates`) are resolved relative to the config file's directory, not CWD.

### Config file format

```json
{
    "entry": "index.html",
    "state": "state.json",
    "output": "output.html",
    "templates": "./components/**/*.html",
    "attribute-name-strategy": "camelCase"
}
```

### Validation

- Config must be a JSON object
- Only allowed keys: `entry`, `state`, `output`, `templates`, `attribute-name-strategy`
- All values must be strings
- Unknown keys or non-string values produce an error with the config file path

This feature complements the per-fixture `fast-build.config.json` infrastructure introduced in PR #7433, extending it to the CLI itself.

## 👩‍💻 Reviewer Notes

The core changes are in `packages/fast-build/bin/fast.js`:
- `loadConfig()` — reads, parses, and validates the config file
- `resolveOption()` — merges CLI args + config with proper precedence and path resolution
- `runBuild()` — updated to use config-aware option resolution

The `--config` key itself is excluded from the allowed config keys set since it is only meaningful on the command line.

## 📑 Test Plan

- 12 new Node.js integration tests in `packages/fast-build/test/config.test.js` covering:
  - Default config file discovery in CWD
  - No config file present (backward compatibility)
  - Explicit `--config=<path>`
  - Missing explicit config file (error)
  - CLI override of config values
  - Config-relative path resolution
  - Unknown key rejection
  - Non-string value rejection
  - Array config rejection
  - Invalid JSON rejection
  - CLI-only usage (backward compatibility)
  - Partial config + CLI merge
- All existing fast-html Playwright tests pass (767 passed, 1 pre-existing flaky)

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.