### PR TITLE
feat: trust rendered content during hydration binding

### DIFF
--- a/change/@microsoft-fast-element-7e0549e9-c885-4e2f-aabf-43f37f5e9d3d.json
+++ b/change/@microsoft-fast-element-7e0549e9-c885-4e2f-aabf-43f37f5e9d3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: trust rendered content during hydration binding",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-element/DESIGN.md
+++ b/packages/fast-element/DESIGN.md
@@ -429,7 +429,7 @@ Below is a conceptual map of the major subsystems and their relationships:
 2. `FASTElement.define` → `FASTElementDefinition.compose(...).define()` registers the element with the Custom Element Registry.
 3. When the browser upgrades the element, `ElementController.forCustomElement(element)` is called in the constructor.
 4. On `connectedCallback`, the controller renders the template (`ViewTemplate.render`) into the shadow root. Compilation is lazy: the first render call triggers `Compiler.compile()`, subsequent calls clone the already-compiled `DocumentFragment`.
-5. `HTMLView.bind(source)` wires up each `ViewBehavior`. `oneWay` bindings create `ExpressionNotifier`s that track observable dependencies automatically.
+5. `HTMLView.bind(source)` wires up each `ViewBehavior`. `oneWay` bindings create `ExpressionNotifier`s that track observable dependencies automatically. During hydration, bindings trust the server-rendered DOM: attribute, boolean-attribute, property, and tokenList bindings skip their initial DOM update, while content template bindings hydrate their view hierarchy without creating new nodes. See [TEMPLATE-BINDINGS.md](./src/templating/TEMPLATE-BINDINGS.md) for details.
 6. When an observed property changes, its notifier fans out to all subscribers. Each binding enqueues a DOM update via `Updates`. The next animation frame drains the queue and applies the mutations.
 7. On `disconnectedCallback`, `HTMLView.unbind()` tears down all bindings; behaviors disconnect; styles are removed.
 

--- a/packages/fast-element/src/templating/TEMPLATE-BINDINGS.md
+++ b/packages/fast-element/src/templating/TEMPLATE-BINDINGS.md
@@ -486,8 +486,10 @@ stateDiagram-v2
         buildViewBindingTargets() scans DOM
         Markers parsed, targets resolved
         Behaviors created and bound
-        Attribute bindings skip DOM update
-        (server already set correct values)
+        Non-content bindings skip DOM update
+        (server already rendered correct values)
+        Content template bindings still hydrate
+        views but skip primitive text updates
     end note
 
     hydrating --> hydrated: All behaviors bound
@@ -500,14 +502,23 @@ stateDiagram-v2
     hydrated --> hydrated: rebind with new source
 ```
 
-During the `hydrating` stage, attribute and boolean-attribute bindings **skip their initial DOM update** (the server already rendered the correct value). This avoids unnecessary DOM writes during hydration:
+During the `hydrating` stage, bindings **skip their initial DOM update** to trust the server-rendered content. This avoids unnecessary DOM writes and prevents overwriting correct SSR output. The specific behavior depends on the aspect type:
+
+- **Attribute, boolean-attribute, property, and tokenList bindings**: The observer is bound to set up dependency tracking, but `updateTarget` is not called. For tokenList bindings, the version state is seeded from the evaluated binding value so that class removals work correctly on the first post-hydration change.
+- **Content bindings**: The `updateContent` sink is still called because `ContentTemplate` values require view hierarchy setup (the `HydrationView` creation path). However, for primitive text values during hydration, the `textContent` write is skipped since the text is already in the DOM.
+- **Event bindings**: Attached normally (events are not rendered content).
+
+After hydration completes (stage transitions to `hydrated`), all subsequent reactive changes trigger DOM updates through the normal `handleChange` path. Components created after hydration (without the `needs-hydration` attribute) use the standard binding path with immediate DOM updates.
 
 ```typescript
 // In HTMLBindingDirective.bind(), during hydration:
-if (isHydrating && (this.aspectType === DOMAspect.attribute ||
-                    this.aspectType === DOMAspect.booleanAttribute)) {
-    observer.bind(controller);  // Set up observation only
-    break;                      // Skip updateTarget — server value is current
+if (isHydrating && this.aspectType !== DOMAspect.content) {
+    const value = observer.bind(controller);  // Set up observation only
+
+    // Seed tokenList state so class removals work on first change
+    if (this.aspectType === DOMAspect.tokenList) { /* ... */ }
+
+    break;  // Skip updateTarget — trust server-rendered content
 }
 ```
 

--- a/packages/fast-element/src/templating/binding.pw.spec.ts
+++ b/packages/fast-element/src/templating/binding.pw.spec.ts
@@ -565,7 +565,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "knownValue");
 
                 const directive = new HTMLBindingDirective(
-                    oneWay((x: any) => x.computedValue)
+                    oneWay((x: any) => x.computedValue),
                 );
                 directive.id = nextId();
                 directive.targetNodeId = "r";
@@ -634,7 +634,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "knownValue");
 
                 const directive = new HTMLBindingDirective(
-                    oneWay((x: any) => x.computedValue)
+                    oneWay((x: any) => x.computedValue),
                 );
                 directive.id = nextId();
                 directive.targetNodeId = "r";
@@ -706,7 +706,7 @@ test.describe("The HTML binding directive", () => {
                 const template = html`
                     ${(x: any) =>
                         html`<${html.partial(x.knownValue)}>Hi there!</${html.partial(
-                            x.knownValue
+                            x.knownValue,
                         )}>`}
                 `;
                 const model = new Model(template);
@@ -813,7 +813,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "knownValue");
 
                     const directive = new HTMLBindingDirective(
-                        oneWay((x: any) => x.value)
+                        oneWay((x: any) => x.value),
                     );
                     directive.id = nextId();
                     directive.targetNodeId = "r";
@@ -987,7 +987,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        oneWay((x: any) => x.value)
+                        oneWay((x: any) => x.value),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1052,7 +1052,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            oneWay((x: any) => x.value)
+                            oneWay((x: any) => x.value),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1127,7 +1127,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            oneWay((x: any) => x.value)
+                            oneWay((x: any) => x.value),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1167,7 +1167,7 @@ test.describe("The HTML binding directive", () => {
 
                         return { initialValue, afterUnbindValue };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -1202,7 +1202,7 @@ test.describe("The HTML binding directive", () => {
 
                         const policy = createTrackableDOMPolicy();
                         const directive = new HTMLBindingDirective(
-                            oneWay((x: any) => x.value, policy)
+                            oneWay((x: any) => x.value, policy),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1238,7 +1238,7 @@ test.describe("The HTML binding directive", () => {
                             policyUsed: policy.used,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(nodeValue).toBe(modelValue);
@@ -1270,7 +1270,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        oneWay((x: any) => x.value)
+                        oneWay((x: any) => x.value),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1358,7 +1358,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        oneTime((x: any) => x.value)
+                        oneTime((x: any) => x.value),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1424,7 +1424,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            oneTime((x: any) => x.value)
+                            oneTime((x: any) => x.value),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1463,7 +1463,7 @@ test.describe("The HTML binding directive", () => {
 
                         return { initialValue, afterUpdateValue };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -1497,7 +1497,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            oneTime((x: any) => x.value)
+                            oneTime((x: any) => x.value),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1537,7 +1537,7 @@ test.describe("The HTML binding directive", () => {
 
                         return { initialValue, afterUnbindValue };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -1572,7 +1572,7 @@ test.describe("The HTML binding directive", () => {
 
                         const policy = createTrackableDOMPolicy();
                         const directive = new HTMLBindingDirective(
-                            oneTime((x: any) => x.value, policy)
+                            oneTime((x: any) => x.value, policy),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1608,7 +1608,7 @@ test.describe("The HTML binding directive", () => {
                             policyUsed: policy.used,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(nodeValue).toBe(modelValue);
@@ -1640,7 +1640,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        oneTime((x: any) => x.value)
+                        oneTime((x: any) => x.value),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1728,7 +1728,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        signal((x: any) => x.value, "test-signal")
+                        signal((x: any) => x.value, "test-signal"),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1800,7 +1800,7 @@ test.describe("The HTML binding directive", () => {
 
                     const signalName = "test-signal";
                     const directive = new HTMLBindingDirective(
-                        signal((x: any) => x.value, signalName)
+                        signal((x: any) => x.value, signalName),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1884,7 +1884,7 @@ test.describe("The HTML binding directive", () => {
 
                         const signalName = "test-signal";
                         const directive = new HTMLBindingDirective(
-                            signal((x: any) => x.value, signalName)
+                            signal((x: any) => x.value, signalName),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1925,7 +1925,7 @@ test.describe("The HTML binding directive", () => {
 
                         return { initialValue, afterUnbindValue };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -1960,7 +1960,7 @@ test.describe("The HTML binding directive", () => {
 
                         const policy = createTrackableDOMPolicy();
                         const directive = new HTMLBindingDirective(
-                            signal((x: any) => x.value, "test-signal", policy)
+                            signal((x: any) => x.value, "test-signal", policy),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -1996,7 +1996,7 @@ test.describe("The HTML binding directive", () => {
                             policyUsed: policy.used,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(nodeValue).toBe(modelValue);
@@ -2028,7 +2028,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        signal((x: any) => x.value, "test-signal")
+                        signal((x: any) => x.value, "test-signal"),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2116,7 +2116,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        twoWay((x: any) => x.value, {})
+                        twoWay((x: any) => x.value, {}),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2182,7 +2182,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, {})
+                            twoWay((x: any) => x.value, {}),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2257,7 +2257,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, {})
+                            twoWay((x: any) => x.value, {}),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2294,7 +2294,7 @@ test.describe("The HTML binding directive", () => {
                                 DOM.setBooleanAttribute(
                                     n,
                                     scenario.sourceAspect.slice(1),
-                                    val
+                                    val,
                                 );
                             } else if (scenario.sourceAspect.startsWith(":")) {
                                 n[scenario.sourceAspect.slice(1)] = val;
@@ -2314,7 +2314,7 @@ test.describe("The HTML binding directive", () => {
                             modelValueAfterEvent: model.value,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -2349,7 +2349,7 @@ test.describe("The HTML binding directive", () => {
 
                         const fromView = (_value: any) => "fixed value";
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, { fromView })
+                            twoWay((x: any) => x.value, { fromView }),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2386,7 +2386,7 @@ test.describe("The HTML binding directive", () => {
                                 DOM.setBooleanAttribute(
                                     n,
                                     scenario.sourceAspect.slice(1),
-                                    val
+                                    val,
                                 );
                             } else if (scenario.sourceAspect.startsWith(":")) {
                                 n[scenario.sourceAspect.slice(1)] = val;
@@ -2406,7 +2406,7 @@ test.describe("The HTML binding directive", () => {
                             modelValueAfterEvent: model.value,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -2441,7 +2441,7 @@ test.describe("The HTML binding directive", () => {
 
                         const changeEvent = "foo";
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, { changeEvent })
+                            twoWay((x: any) => x.value, { changeEvent }),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2478,7 +2478,7 @@ test.describe("The HTML binding directive", () => {
                                 DOM.setBooleanAttribute(
                                     n,
                                     scenario.sourceAspect.slice(1),
-                                    val
+                                    val,
                                 );
                             } else if (scenario.sourceAspect.startsWith(":")) {
                                 n[scenario.sourceAspect.slice(1)] = val;
@@ -2498,7 +2498,7 @@ test.describe("The HTML binding directive", () => {
                             modelValueAfterEvent: model.value,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -2532,7 +2532,7 @@ test.describe("The HTML binding directive", () => {
                         Observable.defineProperty(Model.prototype, "value");
 
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, {})
+                            twoWay((x: any) => x.value, {}),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2572,7 +2572,7 @@ test.describe("The HTML binding directive", () => {
 
                         return { initialValue, afterUnbindValue };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(initialValue).toBe(aspectScenario.originalValue);
@@ -2607,7 +2607,7 @@ test.describe("The HTML binding directive", () => {
 
                         const policy = createTrackableDOMPolicy();
                         const directive = new HTMLBindingDirective(
-                            twoWay((x: any) => x.value, {}, policy)
+                            twoWay((x: any) => x.value, {}, policy),
                         );
                         if (scenario.sourceAspect) {
                             HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2643,7 +2643,7 @@ test.describe("The HTML binding directive", () => {
                             policyUsed: policy.used,
                         };
                     },
-                    aspectScenario
+                    aspectScenario,
                 );
 
                 expect(nodeValue).toBe(modelValue);
@@ -2675,7 +2675,7 @@ test.describe("The HTML binding directive", () => {
                     Observable.defineProperty(Model.prototype, "value");
 
                     const directive = new HTMLBindingDirective(
-                        twoWay((x: any) => x.value, {})
+                        twoWay((x: any) => x.value, {}),
                     );
                     if (scenario.sourceAspect) {
                         HTMLDirective.assignAspect(directive, scenario.sourceAspect);
@@ -2737,7 +2737,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "value");
 
                 const directive = new HTMLBindingDirective(
-                    listener((x: any) => x.invokeAction(), {})
+                    listener((x: any) => x.invokeAction(), {}),
                 );
                 HTMLDirective.assignAspect(directive, "@my-event");
 
@@ -2789,7 +2789,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "value");
 
                 const directive = new HTMLBindingDirective(
-                    listener((x: any) => x.invokeAction(), {})
+                    listener((x: any) => x.invokeAction(), {}),
                 );
                 HTMLDirective.assignAspect(directive, "@my-event");
 
@@ -2855,7 +2855,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "value");
 
                 const directive = new HTMLBindingDirective(
-                    listener((x: any) => x.invokeAction(), { once: true })
+                    listener((x: any) => x.invokeAction(), { once: true }),
                 );
                 HTMLDirective.assignAspect(directive, "@my-event");
 
@@ -2917,7 +2917,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "value");
 
                 const directive = new HTMLBindingDirective(
-                    listener((x: any) => x.invokeAction(), {})
+                    listener((x: any) => x.invokeAction(), {}),
                 );
                 HTMLDirective.assignAspect(directive, "@my-event");
 
@@ -2981,7 +2981,7 @@ test.describe("The HTML binding directive", () => {
                 Observable.defineProperty(Model.prototype, "value");
 
                 const directive = new HTMLBindingDirective(
-                    listener((x: any) => x.invokeAction(), {})
+                    listener((x: any) => x.invokeAction(), {}),
                 );
                 HTMLDirective.assignAspect(directive, "@my-event");
 
@@ -3041,7 +3041,7 @@ test.describe("The HTML binding directive", () => {
                         target,
                         directive.targetAspect,
                         value,
-                        Fake.viewController()
+                        Fake.viewController(),
                     );
                 }
 
@@ -3152,6 +3152,407 @@ test.describe("The HTML binding directive", () => {
             });
 
             expect(didNotThrow).toBe(true);
+        });
+    });
+
+    test.describe("when hydrating", () => {
+        test("does not update attribute binding during hydration", async ({ page }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    HTMLBindingDirective,
+                    HTMLDirective,
+                    Observable,
+                    Fake,
+                    DOM,
+                    Updates,
+                    nextId,
+                    oneWay,
+                    Hydratable,
+                    HydrationStage,
+                } = await import("/main.js");
+
+                class Model {
+                    constructor(value: any) {
+                        this.value = value;
+                    }
+                    value: any;
+                }
+
+                Observable.defineProperty(Model.prototype, "value");
+
+                const directive = new HTMLBindingDirective(oneWay((x: any) => x.value));
+                HTMLDirective.assignAspect(directive, "test-attr");
+
+                const node = document.createElement("div");
+                node.setAttribute("test-attr", "server-value");
+
+                directive.id = nextId();
+                directive.targetNodeId = "r";
+                directive.targetTagName = node.tagName ?? null;
+                directive.policy = DOM.policy;
+
+                const targets = { r: node };
+                const behavior = directive.createBehavior();
+                const parentNode = document.createElement("div");
+                parentNode.appendChild(node);
+
+                const model = new Model("client-value");
+                const controller = Fake.viewController(targets, behavior);
+                // Make the controller hydratable
+                (controller as any)[Hydratable] = Hydratable;
+                (controller as any).hydrationStage = HydrationStage.hydrating;
+                (controller as any).bindingViewBoundaries = {};
+                controller.bind(model);
+
+                const afterHydration = node.getAttribute("test-attr");
+
+                // Now simulate a post-hydration change
+                (controller as any).hydrationStage = HydrationStage.hydrated;
+                model.value = "updated-value";
+                await Updates.next();
+                const afterChange = node.getAttribute("test-attr");
+
+                return { afterHydration, afterChange };
+            });
+
+            // During hydration, the server-rendered value should be trusted
+            expect(result.afterHydration).toBe("server-value");
+            // After hydration, reactive changes should update normally
+            expect(result.afterChange).toBe("updated-value");
+        });
+
+        test("does not update boolean attribute binding during hydration", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    HTMLBindingDirective,
+                    HTMLDirective,
+                    Observable,
+                    Fake,
+                    DOM,
+                    Updates,
+                    nextId,
+                    oneWay,
+                    Hydratable,
+                    HydrationStage,
+                } = await import("/main.js");
+
+                class Model {
+                    constructor(value: any) {
+                        this.value = value;
+                    }
+                    value: any;
+                }
+
+                Observable.defineProperty(Model.prototype, "value");
+
+                const directive = new HTMLBindingDirective(oneWay((x: any) => x.value));
+                HTMLDirective.assignAspect(directive, "?hidden");
+
+                const node = document.createElement("div");
+                // Server rendered with hidden attribute
+                node.setAttribute("hidden", "");
+
+                directive.id = nextId();
+                directive.targetNodeId = "r";
+                directive.targetTagName = node.tagName ?? null;
+                directive.policy = DOM.policy;
+
+                const targets = { r: node };
+                const behavior = directive.createBehavior();
+                const parentNode = document.createElement("div");
+                parentNode.appendChild(node);
+
+                // Client evaluates to false, but hydration should trust server
+                const model = new Model(false);
+                const controller = Fake.viewController(targets, behavior);
+                (controller as any)[Hydratable] = Hydratable;
+                (controller as any).hydrationStage = HydrationStage.hydrating;
+                (controller as any).bindingViewBoundaries = {};
+                controller.bind(model);
+
+                const afterHydration = node.hasAttribute("hidden");
+
+                // After hydration, reactive changes should work
+                (controller as any).hydrationStage = HydrationStage.hydrated;
+                model.value = true;
+                await Updates.next();
+                const afterChangeTrue = node.hasAttribute("hidden");
+
+                model.value = false;
+                await Updates.next();
+                const afterChangeFalse = node.hasAttribute("hidden");
+
+                return { afterHydration, afterChangeTrue, afterChangeFalse };
+            });
+
+            // During hydration, server-rendered hidden attribute is trusted
+            expect(result.afterHydration).toBe(true);
+            // After hydration, reactive changes update normally
+            expect(result.afterChangeTrue).toBe(true);
+            expect(result.afterChangeFalse).toBe(false);
+        });
+
+        test("does not update property binding during hydration", async ({ page }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    HTMLBindingDirective,
+                    HTMLDirective,
+                    Observable,
+                    Fake,
+                    DOM,
+                    Updates,
+                    nextId,
+                    oneWay,
+                    Hydratable,
+                    HydrationStage,
+                } = await import("/main.js");
+
+                class Model {
+                    constructor(value: any) {
+                        this.value = value;
+                    }
+                    value: any;
+                }
+
+                Observable.defineProperty(Model.prototype, "value");
+
+                const directive = new HTMLBindingDirective(oneWay((x: any) => x.value));
+                HTMLDirective.assignAspect(directive, ":testProp");
+
+                const node = document.createElement("div") as any;
+                // Simulate server-rendered property state
+                node.testProp = "server-value";
+
+                directive.id = nextId();
+                directive.targetNodeId = "r";
+                directive.targetTagName = node.tagName ?? null;
+                directive.policy = DOM.policy;
+
+                const targets = { r: node };
+                const behavior = directive.createBehavior();
+                const parentNode = document.createElement("div");
+                parentNode.appendChild(node);
+
+                const model = new Model("client-value");
+                const controller = Fake.viewController(targets, behavior);
+                (controller as any)[Hydratable] = Hydratable;
+                (controller as any).hydrationStage = HydrationStage.hydrating;
+                (controller as any).bindingViewBoundaries = {};
+                controller.bind(model);
+
+                const afterHydration = node.testProp;
+
+                // After hydration, reactive changes should update the property
+                (controller as any).hydrationStage = HydrationStage.hydrated;
+                model.value = "updated-value";
+                await Updates.next();
+                const afterChange = node.testProp;
+
+                return { afterHydration, afterChange };
+            });
+
+            // During hydration, property is not updated
+            expect(result.afterHydration).toBe("server-value");
+            // After hydration, reactive changes update the property
+            expect(result.afterChange).toBe("updated-value");
+        });
+
+        test("does not update tokenList binding during hydration but seeds state for removals", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    HTMLBindingDirective,
+                    HTMLDirective,
+                    Observable,
+                    Fake,
+                    DOM,
+                    Updates,
+                    nextId,
+                    oneWay,
+                    Hydratable,
+                    HydrationStage,
+                } = await import("/main.js");
+
+                class Model {
+                    constructor(value: any) {
+                        this.value = value;
+                    }
+                    value: any;
+                }
+
+                Observable.defineProperty(Model.prototype, "value");
+
+                const directive = new HTMLBindingDirective(oneWay((x: any) => x.value));
+                HTMLDirective.assignAspect(directive, ":classList");
+
+                const node = document.createElement("div");
+                // Simulate server-rendered classes
+                node.classList.add("class-a", "class-b");
+
+                directive.id = nextId();
+                directive.targetNodeId = "r";
+                directive.targetTagName = node.tagName ?? null;
+                directive.policy = DOM.policy;
+
+                const targets = { r: node };
+                const behavior = directive.createBehavior();
+                const parentNode = document.createElement("div");
+                parentNode.appendChild(node);
+
+                const model = new Model("class-a class-b");
+                const controller = Fake.viewController(targets, behavior);
+                (controller as any)[Hydratable] = Hydratable;
+                (controller as any).hydrationStage = HydrationStage.hydrating;
+                (controller as any).bindingViewBoundaries = {};
+                controller.bind(model);
+
+                const afterHydration = {
+                    hasA: node.classList.contains("class-a"),
+                    hasB: node.classList.contains("class-b"),
+                };
+
+                // After hydration, change the value — class-b should be removed
+                (controller as any).hydrationStage = HydrationStage.hydrated;
+                model.value = "class-a class-c";
+                await Updates.next();
+                const afterChange = {
+                    hasA: node.classList.contains("class-a"),
+                    hasB: node.classList.contains("class-b"),
+                    hasC: node.classList.contains("class-c"),
+                };
+
+                return { afterHydration, afterChange };
+            });
+
+            // During hydration, classList is not modified
+            expect(result.afterHydration.hasA).toBe(true);
+            expect(result.afterHydration.hasB).toBe(true);
+            // After hydration, class-b is removed and class-c is added
+            expect(result.afterChange.hasA).toBe(true);
+            expect(result.afterChange.hasB).toBe(false);
+            expect(result.afterChange.hasC).toBe(true);
+        });
+
+        test("does not update text content binding during hydration", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    HTMLBindingDirective,
+                    Observable,
+                    Fake,
+                    DOM,
+                    Updates,
+                    nextId,
+                    oneWay,
+                    Hydratable,
+                    HydrationStage,
+                } = await import("/main.js");
+
+                class Model {
+                    constructor(value: any) {
+                        this.value = value;
+                    }
+                    value: any;
+                }
+
+                Observable.defineProperty(Model.prototype, "value");
+
+                const directive = new HTMLBindingDirective(oneWay((x: any) => x.value));
+
+                directive.id = nextId();
+                directive.targetNodeId = "r";
+                directive.targetTagName = null;
+                directive.policy = DOM.policy;
+
+                const node = document.createTextNode("server-rendered text");
+                const targets = { r: node };
+                const behavior = directive.createBehavior();
+                const parentNode = document.createElement("div");
+                parentNode.appendChild(node);
+
+                const model = new Model("client text");
+                const controller = Fake.viewController(targets, behavior);
+                (controller as any)[Hydratable] = Hydratable;
+                (controller as any).hydrationStage = HydrationStage.hydrating;
+                (controller as any).bindingViewBoundaries = {};
+                controller.bind(model);
+
+                const afterHydration = node.textContent;
+
+                // After hydration, reactive changes should work
+                (controller as any).hydrationStage = HydrationStage.hydrated;
+                model.value = "updated text";
+                await Updates.next();
+                const afterChange = node.textContent;
+
+                return { afterHydration, afterChange };
+            });
+
+            // During hydration, server-rendered text is trusted
+            expect(result.afterHydration).toBe("server-rendered text");
+            // After hydration, reactive changes update normally
+            expect(result.afterChange).toBe("updated text");
+        });
+
+        test("newly created components (post-hydration) bind normally", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    HTMLBindingDirective,
+                    HTMLDirective,
+                    Observable,
+                    Fake,
+                    DOM,
+                    nextId,
+                    oneWay,
+                } = await import("/main.js");
+
+                class Model {
+                    constructor(value: any) {
+                        this.value = value;
+                    }
+                    value: any;
+                }
+
+                Observable.defineProperty(Model.prototype, "value");
+
+                const directive = new HTMLBindingDirective(oneWay((x: any) => x.value));
+                HTMLDirective.assignAspect(directive, "test-attr");
+
+                const node = document.createElement("div");
+                node.setAttribute("test-attr", "original");
+
+                directive.id = nextId();
+                directive.targetNodeId = "r";
+                directive.targetTagName = node.tagName ?? null;
+                directive.policy = DOM.policy;
+
+                const targets = { r: node };
+                const behavior = directive.createBehavior();
+                const parentNode = document.createElement("div");
+                parentNode.appendChild(node);
+
+                // Non-hydratable controller (normal post-hydration component)
+                const model = new Model("new-value");
+                const controller = Fake.viewController(targets, behavior);
+                controller.bind(model);
+
+                return node.getAttribute("test-attr");
+            });
+
+            // Non-hydrating bindings update immediately as normal
+            expect(result).toBe("new-value");
         });
     });
 });

--- a/packages/fast-element/src/templating/html-binding-directive.ts
+++ b/packages/fast-element/src/templating/html-binding-directive.ts
@@ -24,7 +24,7 @@ type UpdateTarget = (
     target: Node,
     aspect: string,
     value: any,
-    controller: ViewController
+    controller: ViewController,
 ) => void;
 
 /**
@@ -104,7 +104,7 @@ function updateContent(
     target: ContentTarget,
     aspect: string,
     value: any,
-    controller: ViewController
+    controller: ViewController,
 ): void {
     // If there's no actual value, then this equates to the
     // empty string for the purposes of content bindings.
@@ -174,6 +174,15 @@ function updateContent(
             }
         }
 
+        // During hydration, trust the server-rendered text content.
+        if (
+            isHydratable(controller) &&
+            controller.hydrationStage &&
+            controller.hydrationStage !== HydrationStage.hydrated
+        ) {
+            return;
+        }
+
         target.textContent = value;
     }
 }
@@ -193,7 +202,7 @@ function updateTokenList(
     this: HTMLBindingDirective,
     target: Element,
     aspect: string,
-    value: any
+    value: any,
 ): void {
     const lookup = `${this.id}-t`;
     const state: TokenListState =
@@ -342,7 +351,7 @@ export class HTMLBindingDirective
                 this.targetTagName,
                 this.aspectType,
                 this.targetAspect,
-                sink
+                sink,
             );
         }
 
@@ -359,6 +368,11 @@ export class HTMLBindingDirective
      * - For all non-event bindings: creates (or reuses) an ExpressionObserver, evaluates
      *   the binding expression, and applies the result to the DOM via the updateTarget
      *   sink function. The observer will call handleChange() on future data changes.
+     * - During hydration: non-content bindings skip the initial DOM update to trust
+     *   server-rendered content. The observer is still bound to set up dependency
+     *   tracking so reactive changes post-hydration update normally. Content bindings
+     *   still call updateTarget since ContentTemplate values need view hierarchy
+     *   setup, but primitive text content writes are skipped.
      * @internal
      */
     bind(controller: ViewController): void {
@@ -374,13 +388,13 @@ export class HTMLBindingDirective
                 target.addEventListener(
                     this.targetAspect,
                     this,
-                    this.dataBinding.options
+                    this.dataBinding.options,
                 );
                 break;
             case DOMAspect.content:
                 controller.onUnbind(this);
             // intentional fall through
-            default:
+            default: {
                 const observer =
                     target[this.data] ??
                     (target[this.data] = this.dataBinding.createObserver(this, this));
@@ -388,13 +402,28 @@ export class HTMLBindingDirective
                 (observer as any).target = target;
                 (observer as any).controller = controller;
 
-                if (
-                    isHydrating &&
-                    (this.aspectType === DOMAspect.attribute ||
-                        this.aspectType === DOMAspect.booleanAttribute)
-                ) {
-                    observer.bind(controller);
-                    // Skip updating target during bind for attributes
+                if (isHydrating && this.aspectType !== DOMAspect.content) {
+                    const value = observer.bind(controller);
+
+                    // For tokenList bindings, seed the version state from
+                    // the binding value so class removals work on the first
+                    // post-hydration update.
+                    if (this.aspectType === DOMAspect.tokenList) {
+                        const lookup = `${this.id}-t`;
+                        const cv = Object.create(null);
+                        if (value !== null && value !== undefined && value.length) {
+                            const names = (value as string).split(/\s+/);
+                            for (let i = 0, ii = names.length; i < ii; ++i) {
+                                if (names[i] !== "") {
+                                    cv[names[i]] = 0;
+                                }
+                            }
+                        }
+                        target[lookup] = { v: 1, cv };
+                    }
+
+                    // Skip updating target during hydration — trust
+                    // the server-rendered content.
                     break;
                 }
 
@@ -402,9 +431,10 @@ export class HTMLBindingDirective
                     target,
                     this.targetAspect,
                     observer.bind(controller),
-                    controller
+                    controller,
                 );
                 break;
+            }
         }
     }
 
@@ -434,7 +464,7 @@ export class HTMLBindingDirective
             ExecutionContext.setEvent(event);
             const result = this.dataBinding.evaluate(
                 controller.source,
-                controller.context
+                controller.context,
             );
             ExecutionContext.setEvent(null);
 
@@ -458,7 +488,7 @@ export class HTMLBindingDirective
             target,
             this.targetAspect,
             observer.bind(controller),
-            controller
+            controller,
         );
     }
 }

--- a/packages/fast-element/test/main.ts
+++ b/packages/fast-element/test/main.ts
@@ -1,30 +1,30 @@
 import "../src/debug.js";
 
-export { customElement, FASTElement } from "../src/components/fast-element.js";
 export {
-    attr,
     AttributeConfiguration,
     AttributeDefinition,
+    attr,
 } from "../src/components/attributes.js";
 export {
+    AdoptedStyleSheetsStrategy,
+    deferHydrationAttribute,
     ElementController,
     HydratableElementController,
-    AdoptedStyleSheetsStrategy,
-    StyleElementStrategy,
     needsHydrationAttribute,
-    deferHydrationAttribute,
+    StyleElementStrategy,
 } from "../src/components/element-controller.js";
 export { FASTElementDefinition } from "../src/components/fast-definitions.js";
-export { HydrationMarkup } from "../src/components/hydration.js";
+export { customElement, FASTElement } from "../src/components/fast-element.js";
+export { Hydratable, HydrationMarkup } from "../src/components/hydration.js";
 export { Context } from "../src/context.js";
 export {
+    all,
     Container,
     ContainerConfiguration,
     ContainerImpl,
     DefaultResolver,
     DI,
     FactoryImpl,
-    all,
     inject,
     lazy,
     optional,
@@ -42,13 +42,13 @@ export { css } from "../src/styles/css.js";
 export { ElementStyles } from "../src/styles/element-styles.js";
 export { ref } from "../src/templating/ref.js";
 export { html } from "../src/templating/template.js";
+export { Fake } from "../src/testing/fakes.js";
 export { uniqueElementName } from "../src/testing/fixture.js";
 export { ChildModel, DerivedModel, Model } from "../src/testing/models.js";
-export { Fake } from "../src/testing/fakes.js";
 export { composedContains, composedParent } from "../src/utilities.js";
 export const conditionalTimeout = function (
     condition: boolean,
-    iteration = 0
+    iteration = 0,
 ): Promise<boolean> {
     return new Promise(function (resolve) {
         setTimeout(() => {
@@ -60,41 +60,40 @@ export const conditionalTimeout = function (
         }, 5);
     });
 };
-export { ArrayObserver, lengthOf, Splice } from "../src/observation/arrays.js";
-export { ownedState, reactive, state, watch } from "../src/state/exports.js";
-export { fixture } from "../src/testing/fixture.js";
-export { CSSBindingDirective } from "../src/styles/css-binding-directive.js";
-export { cssDirective, CSSDirective } from "../src/styles/css-directive.js";
-export { ExecutionContext } from "../src/observation/observable.js";
+export { createTrackableDOMPolicy, toHTML } from "../src/__test__/helpers.js";
 export { Binding } from "../src/binding/binding.js";
 export { oneTime } from "../src/binding/one-time.js";
-export { oneWay, listener } from "../src/binding/one-way.js";
+export { listener, oneWay } from "../src/binding/one-way.js";
 export { Signal, signal } from "../src/binding/signal.js";
 export { twoWay } from "../src/binding/two-way.js";
-export { HTMLBindingDirective } from "../src/templating/html-binding-directive.js";
-export { ViewTemplate } from "../src/templating/template.js";
-export { HTMLView } from "../src/templating/view.js";
-export { HTMLDirective, htmlDirective } from "../src/templating/html-directive.js";
-export { nextId } from "../src/templating/markup.js";
-export { createTrackableDOMPolicy, toHTML } from "../src/__test__/helpers.js";
-export { children, ChildrenDirective } from "../src/templating/children.js";
-export { elements } from "../src/templating/node-observation.js";
+export { isString } from "../src/interfaces.js";
+export { Metadata } from "../src/metadata.js";
+export { ArrayObserver, lengthOf, Splice } from "../src/observation/arrays.js";
+export { ExecutionContext } from "../src/observation/observable.js";
+export { emptyArray, FAST } from "../src/platform.js";
+export { ownedState, reactive, state, watch } from "../src/state/exports.js";
+export { CSSBindingDirective } from "../src/styles/css-binding-directive.js";
+export { CSSDirective, cssDirective } from "../src/styles/css-directive.js";
+export { ChildrenDirective, children } from "../src/templating/children.js";
 export { Compiler } from "../src/templating/compiler.js";
-export { Markup, Parser } from "../src/templating/markup.js";
-export { when } from "../src/templating/when.js";
+export { HTMLBindingDirective } from "../src/templating/html-binding-directive.js";
+export { HTMLDirective, htmlDirective } from "../src/templating/html-directive.js";
+export { Markup, nextId, Parser } from "../src/templating/markup.js";
+export { elements } from "../src/templating/node-observation.js";
 export {
-    render,
+    NodeTemplate,
     RenderBehavior,
     RenderDirective,
     RenderInstruction,
-    NodeTemplate,
+    render,
     renderWith,
 } from "../src/templating/render.js";
-export { repeat, RepeatBehavior, RepeatDirective } from "../src/templating/repeat.js";
-export { slotted, SlottedDirective } from "../src/templating/slotted.js";
-export { isString } from "../src/interfaces.js";
-export { FAST, emptyArray } from "../src/platform.js";
-export { Metadata } from "../src/metadata.js";
+export { RepeatBehavior, RepeatDirective, repeat } from "../src/templating/repeat.js";
+export { SlottedDirective, slotted } from "../src/templating/slotted.js";
+export { ViewTemplate } from "../src/templating/template.js";
+export { HTMLView, HydrationStage } from "../src/templating/view.js";
+export { when } from "../src/templating/when.js";
+export { fixture } from "../src/testing/fixture.js";
 export function removeWhitespace(str: string): string {
     return str
         .trim()


### PR DESCRIPTION
# Pull Request

## 📖 Description

Extends the hydration binding behavior in `@microsoft/fast-element` to trust server-rendered content across all binding aspect types. Previously, only attribute and boolean-attribute bindings skipped their initial DOM update during hydration. Now all non-event bindings trust the SSR-rendered output:

- **Attribute/boolean-attribute bindings**: Already skipped (unchanged)
- **Property bindings**: Now skip initial DOM update during hydration
- **TokenList bindings**: Skip initial DOM update and seed version state from the binding value so class removals work correctly on the first post-hydration change
- **Content bindings**: ContentTemplate values still hydrate their view hierarchy, but primitive textContent writes are skipped during hydration
- **Event bindings**: Unchanged (attached normally)

After hydration completes, all subsequent reactive changes flow through the normal `handleChange` path and update the DOM as expected. Components created after hydration (without the `needs-hydration` attribute) use the standard binding path with immediate DOM updates.

## 👩‍💻 Reviewer Notes

The core change is in `packages/fast-element/src/templating/html-binding-directive.ts`:

1. The `bind()` method's hydration condition was broadened from `(attribute || booleanAttribute)` to `!== content`. This means property and tokenList bindings now also skip during hydration.

2. For tokenList specifically, a version state seeding step was added so that the first post-hydration `updateTokenList` call can correctly remove classes that were present in SSR but are no longer in the binding value.

3. In `updateContent()`, a hydration check was added for primitive text values to skip the redundant `textContent` write when the text is already server-rendered.

## 📑 Test Plan

6 new Playwright tests added to `binding.pw.spec.ts` covering:
- Attribute bindings trust server-rendered values during hydration
- Boolean-attribute bindings trust server-rendered values during hydration
- Property bindings skip initial update during hydration, update post-hydration
- TokenList bindings skip during hydration with proper seeding for class removals
- Text content bindings trust server-rendered text during hydration
- Newly created (non-hydrating) components bind normally

All 4281 tests pass across Chromium, Firefox, and WebKit (4263 existing + 18 new).

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
