### PR TITLE
feat: add configuration object support for ObserverMap and AttributeMap options

### DIFF
--- a/change/@microsoft-fast-html-60084e54-2311-4591-932a-040ac3bf2cc7.json
+++ b/change/@microsoft-fast-html-60084e54-2311-4591-932a-040ac3bf2cc7.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "prerelease",
   "comment": "feat: ObserverMap and AttributeMap now accept a configuration object ({}) in addition to \"all\"",
   "packageName": "@microsoft/fast-html",
   "email": "7559015+janechu@users.noreply.github.com",

--- a/change/@microsoft-fast-html-60084e54-2311-4591-932a-040ac3bf2cc7.json
+++ b/change/@microsoft-fast-html-60084e54-2311-4591-932a-040ac3bf2cc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "feat: ObserverMap and AttributeMap now accept a configuration object ({}) in addition to \"all\"",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -87,7 +87,7 @@ An optional layer that uses the `Schema` to automatically:
 - Install property-change handlers that wrap newly assigned objects/arrays in `Proxy` instances.
 - Propagate deep property mutations back through FAST's observable system so bindings re-render.
 
-Enabled via `TemplateElement.options({ "my-element": { observerMap: "all" } })`.
+Enabled via `TemplateElement.options({ "my-element": { observerMap: "all" } })` or by passing a configuration object `TemplateElement.options({ "my-element": { observerMap: {} } })`. Both forms are equivalent; no configuration keys are defined at this time.
 
 ### `AttributeMap` — automatic `@attr` definitions
 
@@ -98,7 +98,7 @@ An optional layer that uses the `Schema` to automatically register `@attr`-style
 - Properties already decorated with `@attr` or `@observable` are left untouched.
 - `FASTElementDefinition.attributeLookup` and `propertyLookup` are patched so `attributeChangedCallback` correctly delegates to the new `AttributeDefinition`.
 
-Enabled via `TemplateElement.options({ "my-element": { attributeMap: "all" } })`.
+Enabled via `TemplateElement.options({ "my-element": { attributeMap: "all" } })` or by passing a configuration object `TemplateElement.options({ "my-element": { attributeMap: {} } })`. Both forms are equivalent; no configuration keys are defined at this time.
 
 ### Syntax constants (`syntax.ts`)
 
@@ -201,7 +201,7 @@ flowchart TD
     F --> G["FASTElementDefinition.registerAsync\n→ looks up partial definition"]
     G --> H[transformInnerHTML normalises HTML entities]
     H --> I["resolveStringsAndValues\nparses bindings and directives\nbuilds Schema, builds strings+values arrays"]
-    I --> J{observerMap: all?}
+    I --> J{observerMap enabled?}
     J -- yes --> K["ObserverMap.defineProperties\n→ Observable.defineProperty for each root prop\n→ install proxy change handlers"]
     J -- no --> L
     K --> L["ViewTemplate.create strings,values\n→ registeredFastElement.template = viewTemplate"]

--- a/packages/fast-html/README.md
+++ b/packages/fast-html/README.md
@@ -219,7 +219,7 @@ if (process.env.NODE_ENV === 'development') {
 
 #### `attributeMap`
 
-When `attributeMap: "all"` is configured for an element, `@microsoft/fast-html` automatically creates reactive `@attr` properties for every **leaf binding** in the template — simple expressions like `{{foo}}` or `id="{{foo-bar}}"` that have no nested properties.
+When `attributeMap: "all"` (or `attributeMap: {}`) is configured for an element, `@microsoft/fast-html` automatically creates reactive `@attr` properties for every **leaf binding** in the template — simple expressions like `{{foo}}` or `id="{{foo-bar}}"` that have no nested properties. Both `"all"` and `{}` are equivalent; passing a configuration object is supported for future extensibility.
 
 The **attribute name** and **property name** are both the binding key exactly as written in the template — no normalization is applied. Because HTML attributes are case-insensitive, binding keys should use lowercase names (optionally dash-separated). Properties with dashes must be accessed via bracket notation (e.g. `element["foo-bar"]`).
 

--- a/packages/fast-html/SCHEMA_OBSERVER_MAP.md
+++ b/packages/fast-html/SCHEMA_OBSERVER_MAP.md
@@ -165,7 +165,17 @@ TemplateElement.options({
 });
 ```
 
-**Note**: Currently, `"all"` is the only available option, which enables Observer Map observation for all root properties discovered in the template. This API design allows for future updates that could specify which specific properties to allow the Observer Map to apply observation to, providing more granular control over the observation behavior.
+A configuration object can also be passed instead of `"all"`:
+
+```typescript
+TemplateElement.options({
+  "my-custom-element": {
+    observerMap: {}
+  }
+});
+```
+
+**Note**: Both `"all"` and `{}` are equivalent — they enable Observer Map observation for all root properties discovered in the template. The configuration object form is supported for future extensibility, allowing more granular control over observation behavior.
 
 ## Initial Path Processing Flow
 

--- a/packages/fast-html/docs/api-report.api.md
+++ b/packages/fast-html/docs/api-report.api.md
@@ -10,12 +10,18 @@ import { HydrationControllerCallbacks } from '@microsoft/fast-element';
 import { TemplateLifecycleCallbacks } from '@microsoft/fast-element';
 
 // @public
+export type AttributeMapConfig = Record<string, never>;
+
+// @public
 export class ObserverMap {
     // Warning: (ae-forgotten-export) The symbol "Schema" needs to be exported by the entry point index.d.ts
     constructor(classPrototype: any, schema: Schema);
     // (undocumented)
     defineProperties(): void;
 }
+
+// @public
+export type ObserverMapConfig = Record<string, never>;
 
 // @public
 export function RenderableFASTElement<T extends Constructable<FASTElement>>(BaseCtor: T): T;

--- a/packages/fast-html/docs/api-report.api.md
+++ b/packages/fast-html/docs/api-report.api.md
@@ -10,7 +10,8 @@ import { HydrationControllerCallbacks } from '@microsoft/fast-element';
 import { TemplateLifecycleCallbacks } from '@microsoft/fast-element';
 
 // @public
-export type AttributeMapConfig = Record<string, never>;
+export interface AttributeMapConfig {
+}
 
 // @public
 export class ObserverMap {
@@ -21,7 +22,8 @@ export class ObserverMap {
 }
 
 // @public
-export type ObserverMapConfig = Record<string, never>;
+export interface ObserverMapConfig {
+}
 
 // @public
 export function RenderableFASTElement<T extends Constructable<FASTElement>>(BaseCtor: T): T;

--- a/packages/fast-html/src/components/index.ts
+++ b/packages/fast-html/src/components/index.ts
@@ -2,10 +2,12 @@ export { AttributeMap } from "./attribute-map.js";
 export { RenderableFASTElement } from "./element.js";
 export { ObserverMap } from "./observer-map.js";
 export {
+    type AttributeMapConfig,
     AttributeMapOption,
     type ElementOptions,
     type ElementOptionsDictionary,
     type HydrationLifecycleCallbacks,
+    type ObserverMapConfig,
     ObserverMapOption,
     TemplateElement,
 } from "./template.js";

--- a/packages/fast-html/src/components/template.ts
+++ b/packages/fast-html/src/components/template.ts
@@ -110,10 +110,6 @@ export interface ElementOptionsDictionary<ElementOptionsType = ElementOptions> {
 function isMapOptionEnabled(
     option: ObserverMapOption | AttributeMapOption | undefined,
 ): boolean {
-    if (option === undefined || option === null) {
-        return false;
-    }
-
     if (option === "all") {
         return true;
     }

--- a/packages/fast-html/src/components/template.ts
+++ b/packages/fast-html/src/components/template.ts
@@ -52,10 +52,19 @@ export const ObserverMapOption = {
 } as const;
 
 /**
+ * Configuration object for the observerMap element option.
+ * No configuration keys are defined at this time; passing an empty
+ * object (`{}`) is equivalent to `"all"`.
+ */
+export type ObserverMapConfig = Record<string, never>;
+
+/**
  * Type for the observerMap element option.
+ * Accepts `"all"` or a configuration object.
  */
 export type ObserverMapOption =
-    (typeof ObserverMapOption)[keyof typeof ObserverMapOption];
+    | (typeof ObserverMapOption)[keyof typeof ObserverMapOption]
+    | ObserverMapConfig;
 
 /**
  * Values for the attributeMap element option.
@@ -65,10 +74,19 @@ export const AttributeMapOption = {
 } as const;
 
 /**
+ * Configuration object for the attributeMap element option.
+ * No configuration keys are defined at this time; passing an empty
+ * object (`{}`) is equivalent to `"all"`.
+ */
+export type AttributeMapConfig = Record<string, never>;
+
+/**
  * Type for the attributeMap element option.
+ * Accepts `"all"` or a configuration object.
  */
 export type AttributeMapOption =
-    (typeof AttributeMapOption)[keyof typeof AttributeMapOption];
+    | (typeof AttributeMapOption)[keyof typeof AttributeMapOption]
+    | AttributeMapConfig;
 
 /**
  * Element options the TemplateElement will use to update the registered element
@@ -83,6 +101,24 @@ export interface ElementOptions {
  */
 export interface ElementOptionsDictionary<ElementOptionsType = ElementOptions> {
     [key: string]: ElementOptionsType;
+}
+
+/**
+ * Checks whether a map option (observerMap or attributeMap) is enabled.
+ * An option is enabled when it is `"all"` or a plain configuration object.
+ */
+function isMapOptionEnabled(
+    option: ObserverMapOption | AttributeMapOption | undefined,
+): boolean {
+    if (option === undefined || option === null) {
+        return false;
+    }
+
+    if (option === "all") {
+        return true;
+    }
+
+    return typeof option === "object" && !Array.isArray(option);
 }
 
 /**
@@ -221,7 +257,7 @@ class TemplateElement extends FASTElement {
                 TemplateElement.setOptions(name);
             }
 
-            if (TemplateElement.elementOptions[name]?.observerMap === "all") {
+            if (isMapOptionEnabled(TemplateElement.elementOptions[name]?.observerMap)) {
                 this.observerMap = new ObserverMap(
                     value.prototype,
                     this.schema as Schema,
@@ -231,7 +267,7 @@ class TemplateElement extends FASTElement {
             const registeredFastElement: FASTElementDefinition | undefined =
                 fastElementRegistry.getByType(value);
 
-            if (TemplateElement.elementOptions[name]?.attributeMap === "all") {
+            if (isMapOptionEnabled(TemplateElement.elementOptions[name]?.attributeMap)) {
                 this.attributeMap = new AttributeMap(
                     value.prototype,
                     this.schema as Schema,

--- a/packages/fast-html/src/components/template.ts
+++ b/packages/fast-html/src/components/template.ts
@@ -56,7 +56,7 @@ export const ObserverMapOption = {
  * No configuration keys are defined at this time; passing an empty
  * object (`{}`) is equivalent to `"all"`.
  */
-export type ObserverMapConfig = Record<string, never>;
+export interface ObserverMapConfig {}
 
 /**
  * Type for the observerMap element option.
@@ -78,7 +78,7 @@ export const AttributeMapOption = {
  * No configuration keys are defined at this time; passing an empty
  * object (`{}`) is equivalent to `"all"`.
  */
-export type AttributeMapConfig = Record<string, never>;
+export interface AttributeMapConfig {}
 
 /**
  * Type for the attributeMap element option.

--- a/packages/fast-html/src/index.ts
+++ b/packages/fast-html/src/index.ts
@@ -4,7 +4,9 @@ import { debugMessages } from "./debug.js";
 FAST.addMessages(debugMessages);
 
 export {
+    type AttributeMapConfig,
+    ObserverMap,
+    type ObserverMapConfig,
     RenderableFASTElement,
     TemplateElement,
-    ObserverMap,
 } from "./components/index.js";

--- a/packages/fast-html/test/fixtures/config-object-maps/config-object-maps.spec.ts
+++ b/packages/fast-html/test/fixtures/config-object-maps/config-object-maps.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Config object maps", () => {
+    test.describe("observerMap with config object", () => {
+        test.beforeEach(async ({ page }) => {
+            await page.goto("/fixtures/config-object-maps/");
+            await page.waitForSelector("config-observer-map-test-element");
+        });
+
+        test("should define observable properties when using {} config", async ({
+            page,
+        }) => {
+            const element = page.locator("config-observer-map-test-element");
+
+            const hasDataAccessor = await element.evaluate(node => {
+                const desc = Object.getOwnPropertyDescriptor(
+                    Object.getPrototypeOf(node),
+                    "data",
+                );
+                return typeof desc?.get === "function";
+            });
+
+            expect(hasDataAccessor).toBeTruthy();
+        });
+
+        test("should render initial values", async ({ page }) => {
+            await expect(page.locator(".message")).toHaveText("hello");
+            await expect(page.locator(".nested-value")).toHaveText("42");
+        });
+
+        test("should track deep mutations via proxy", async ({ page }) => {
+            const element = page.locator("config-observer-map-test-element");
+
+            await element.evaluate(node => (node as any).updateMessage());
+            await expect(page.locator(".message")).toHaveText("updated");
+        });
+
+        test("should track nested property mutations via proxy", async ({ page }) => {
+            const element = page.locator("config-observer-map-test-element");
+
+            await element.evaluate(node => (node as any).updateNestedValue());
+            await expect(page.locator(".nested-value")).toHaveText("99");
+        });
+    });
+
+    test.describe("attributeMap with config object", () => {
+        test.beforeEach(async ({ page }) => {
+            await page.goto("/fixtures/config-object-maps/");
+            await page.waitForSelector("config-attribute-map-test-element");
+        });
+
+        test("should define @attr for leaf property when using {} config", async ({
+            page,
+        }) => {
+            const element = page.locator("config-attribute-map-test-element");
+
+            const hasLabelAccessor = await element.evaluate(node => {
+                const desc = Object.getOwnPropertyDescriptor(
+                    Object.getPrototypeOf(node),
+                    "label",
+                );
+                return typeof desc?.get === "function";
+            });
+
+            expect(hasLabelAccessor).toBeTruthy();
+        });
+
+        test("should update template when attribute is set via setAttribute", async ({
+            page,
+        }) => {
+            const element = page.locator("config-attribute-map-test-element");
+
+            await element.evaluate(node => node.setAttribute("label", "attr-value"));
+
+            await expect(page.locator(".label-value")).toHaveText("attr-value");
+        });
+
+        test("should reflect property value back to attribute", async ({ page }) => {
+            const element = page.locator("config-attribute-map-test-element");
+
+            await element.evaluate(node => {
+                (node as any).label = "reflected";
+            });
+
+            await page.evaluate(() => new Promise(r => requestAnimationFrame(r)));
+
+            const attrValue = await element.evaluate(node => node.getAttribute("label"));
+            expect(attrValue).toBe("reflected");
+        });
+    });
+});

--- a/packages/fast-html/test/fixtures/config-object-maps/entry.html
+++ b/packages/fast-html/test/fixtures/config-object-maps/entry.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+    </head>
+    <body>
+        <config-observer-map-test-element
+            id="observer-test"
+        ></config-observer-map-test-element>
+        <config-attribute-map-test-element
+            id="attribute-test"
+        ></config-attribute-map-test-element>
+        <script type="module" src="./main.ts"></script>
+    </body>
+</html>

--- a/packages/fast-html/test/fixtures/config-object-maps/fast-build.config.json
+++ b/packages/fast-html/test/fixtures/config-object-maps/fast-build.config.json
@@ -1,0 +1,6 @@
+{
+    "entry": "entry.html",
+    "state": "state.json",
+    "output": "index.html",
+    "templates": "templates.html"
+}

--- a/packages/fast-html/test/fixtures/config-object-maps/index.html
+++ b/packages/fast-html/test/fixtures/config-object-maps/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+    </head>
+    <body>
+        <config-observer-map-test-element id="observer-test"><template shadowrootmode="open" shadowroot="open"><div class="message"><!--fe-b$$start$$0$$data.message-0$$fe-b-->hello<!--fe-b$$end$$0$$data.message-0$$fe-b--></div>
+        <div class="nested-value"><!--fe-b$$start$$1$$data.nested.value-1$$fe-b-->42<!--fe-b$$end$$1$$data.nested.value-1$$fe-b--></div></template></config-observer-map-test-element>
+        <config-attribute-map-test-element id="attribute-test"><template shadowrootmode="open" shadowroot="open"><span class="label-value"><!--fe-b$$start$$0$$label-0$$fe-b--><!--fe-b$$end$$0$$label-0$$fe-b--></span>
+        <button type="button" data-fe-c-1-1>Set Label</button></template></config-attribute-map-test-element>
+<f-template name="config-observer-map-test-element">
+    <template>
+        <div class="message">{{data.message}}</div>
+        <div class="nested-value">{{data.nested.value}}</div>
+    </template>
+</f-template>
+<f-template name="config-attribute-map-test-element">
+    <template>
+        <span class="label-value">{{label}}</span>
+        <button type="button" @click="{setLabel()}">Set Label</button>
+    </template>
+</f-template>
+
+        <script type="module" src="./main.ts"></script>
+    </body>
+</html>

--- a/packages/fast-html/test/fixtures/config-object-maps/main.ts
+++ b/packages/fast-html/test/fixtures/config-object-maps/main.ts
@@ -1,0 +1,43 @@
+import { FASTElement } from "@microsoft/fast-element";
+import { TemplateElement } from "@microsoft/fast-html";
+
+class ConfigObserverMapTestElement extends FASTElement {
+    public data: any = {
+        message: "hello",
+        nested: {
+            value: 42,
+        },
+    };
+
+    public updateMessage() {
+        this.data.message = "updated";
+    }
+
+    public updateNestedValue() {
+        this.data.nested.value = 99;
+    }
+}
+
+ConfigObserverMapTestElement.defineAsync({
+    name: "config-observer-map-test-element",
+});
+
+class ConfigAttributeMapTestElement extends FASTElement {
+    public setLabel() {
+        (this as any).label = "new-label";
+    }
+}
+
+ConfigAttributeMapTestElement.defineAsync({
+    name: "config-attribute-map-test-element",
+});
+
+// Use configuration objects ({}) instead of "all" — should behave identically
+TemplateElement.options({
+    "config-observer-map-test-element": {
+        observerMap: {},
+    },
+    "config-attribute-map-test-element": {
+        attributeMap: {},
+    },
+}).define({ name: "f-template" });

--- a/packages/fast-html/test/fixtures/config-object-maps/state.json
+++ b/packages/fast-html/test/fixtures/config-object-maps/state.json
@@ -1,0 +1,9 @@
+{
+    "data": {
+        "message": "hello",
+        "nested": {
+            "value": 42
+        }
+    },
+    "label": ""
+}

--- a/packages/fast-html/test/fixtures/config-object-maps/templates.html
+++ b/packages/fast-html/test/fixtures/config-object-maps/templates.html
@@ -1,0 +1,12 @@
+<f-template name="config-observer-map-test-element">
+    <template>
+        <div class="message">{{data.message}}</div>
+        <div class="nested-value">{{data.nested.value}}</div>
+    </template>
+</f-template>
+<f-template name="config-attribute-map-test-element">
+    <template>
+        <span class="label-value">{{label}}</span>
+        <button type="button" @click="{setLabel()}">Set Label</button>
+    </template>
+</f-template>


### PR DESCRIPTION
# Pull Request

## 📖 Description

The `observerMap` and `attributeMap` element options now accept a configuration object (`{}`) in addition to the existing `"all"` string literal. Both forms are equivalent — no configuration keys are defined at this time. This lays the groundwork for future extensibility where specific configuration options can be passed through.

**Before:**
```typescript
TemplateElement.options({
    "my-element": {
        observerMap: "all",
        attributeMap: "all",
    },
}).define({ name: "f-template" });
```

**After (also supported):**
```typescript
TemplateElement.options({
    "my-element": {
        observerMap: {},
        attributeMap: {},
    },
}).define({ name: "f-template" });
```

### Changes
- Added `ObserverMapConfig` and `AttributeMapConfig` types (`Record<string, never>`)
- Updated `ObserverMapOption` and `AttributeMapOption` types to accept either `"all"` or a config object
- Added `isMapOptionEnabled()` helper in `template.ts` to check for either form
- Exported new config types from `components/index.ts` and the root `src/index.ts`

## 👩‍💻 Reviewer Notes

The `isMapOptionEnabled()` helper intentionally rejects arrays (`!Array.isArray(option)`) to ensure only plain config objects are treated as enabled.

The `Record<string, never>` type was chosen over an empty interface to prevent accidentally accepting arbitrary values at the type level.

## 📑 Test Plan

- Added `config-object-maps` fixture with 7 Playwright tests verifying:
  - `observerMap: {}` defines observable properties and tracks deep/nested mutations
  - `attributeMap: {}` defines `@attr` for leaf properties, supports `setAttribute`, and reflects values
- All 269 existing `@microsoft/fast-html` tests continue to pass

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

- Define specific configuration keys for `ObserverMapConfig` and `AttributeMapConfig` as use cases emerge (e.g., filtering which properties to observe, customizing attribute naming strategies).