### PR TITLE
feat: add attribute-name-strategy option to AttributeMap configuration

### DIFF
--- a/change/@microsoft-fast-html-64bd82f6-93ea-458e-8b32-d076dd4eefce.json
+++ b/change/@microsoft-fast-html-64bd82f6-93ea-458e-8b32-d076dd4eefce.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add attribute-name-strategy option to AttributeMap configuration",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -93,12 +93,13 @@ Enabled via `TemplateElement.options({ "my-element": { observerMap: "all" } })` 
 
 An optional layer that uses the `Schema` to automatically register `@attr`-style reactive properties for every **leaf binding** in the template — i.e. simple expressions like `{{foo}}` or `id="{{foo-bar}}"` that have no nested properties, no explicit type, and no child element references.
 
-- The **attribute name** and **property name** are both the binding key exactly as written in the template (e.g. `{{foo-bar}}` → attribute `foo-bar`, property `foo-bar`). No normalization is applied.
-- Because HTML attributes are case-insensitive, binding keys should use lowercase names (optionally dash-separated).
+- By default (`attribute-name-strategy: "none"`), the **attribute name** and **property name** are both the binding key exactly as written in the template (e.g. `{{foo-bar}}` → attribute `foo-bar`, property `foo-bar`). No normalization is applied.
+- When `attribute-name-strategy` is `"camelCase"`, the binding key is treated as a camelCase property name and the HTML attribute name is derived by converting it to kebab-case (e.g. `{{fooBar}}` → property `fooBar`, attribute `foo-bar`). This matches the build-time `--attribute-name-strategy` option in `@microsoft/fast-build`.
+- Because HTML attributes are case-insensitive, binding keys should use lowercase names (optionally dash-separated) when using the `"none"` strategy.
 - Properties already decorated with `@attr` or `@observable` are left untouched.
-- `FASTElementDefinition.attributeLookup` and `propertyLookup` are patched so `attributeChangedCallback` correctly delegates to the new `AttributeDefinition`.
+- `FASTElementDefinition.attributeLookup` is keyed by the HTML attribute name, and `propertyLookup` is keyed by the JS property name so `attributeChangedCallback` correctly delegates to the new `AttributeDefinition`.
 
-Enabled via `TemplateElement.options({ "my-element": { attributeMap: "all" } })` or by passing a configuration object `TemplateElement.options({ "my-element": { attributeMap: {} } })`. Both forms are equivalent; no configuration keys are defined at this time.
+Enabled via `TemplateElement.options({ "my-element": { attributeMap: "all" } })` or by passing a configuration object `TemplateElement.options({ "my-element": { attributeMap: {} } })`. Both forms are equivalent and use the default `"none"` strategy. To use the `"camelCase"` strategy, pass `TemplateElement.options({ "my-element": { attributeMap: { "attribute-name-strategy": "camelCase" } } })`.
 
 ### Syntax constants (`syntax.ts`)
 
@@ -297,13 +298,16 @@ For a deep dive into the schema structure, context tracking, and proxy system se
 
 ### AttributeMap and leaf bindings
 
-When `attributeMap: "all"` is set, `AttributeMap.defineProperties()` is called after parsing. It iterates `Schema.getRootProperties()` and skips any property whose schema entry contains `properties`, `type`, or `anyOf` — keeping only plain leaf bindings. For each leaf:
+When `attributeMap` is enabled (via `"all"`, `{}`, or a configuration object), `AttributeMap.defineProperties()` is called after parsing. It iterates `Schema.getRootProperties()` and skips any property whose schema entry contains `properties`, `type`, or `anyOf` — keeping only plain leaf bindings. For each leaf:
 
-1. The schema key (e.g. `foo-bar`) is used as both the **attribute name** and the **JS property name** — no conversion is applied.
-2. A new `AttributeDefinition` is registered via `Observable.defineProperty`.
-3. `FASTElementDefinition.attributeLookup` and `propertyLookup` are updated so `attributeChangedCallback` can route attribute changes to the correct property.
+1. The schema key is used as the **JS property name**.
+2. The **HTML attribute name** depends on the `attribute-name-strategy`:
+   - `"none"` (default): the attribute name equals the property name (e.g. `foo-bar` → `foo-bar`).
+   - `"camelCase"`: the attribute name is derived by converting the camelCase property name to kebab-case (e.g. `fooBar` → `foo-bar`).
+3. A new `AttributeDefinition` is registered via `Observable.defineProperty`.
+4. `FASTElementDefinition.attributeLookup` is keyed by the HTML attribute name and `propertyLookup` is keyed by the JS property name so `attributeChangedCallback` can route attribute changes to the correct property.
 
-Because property names may contain dashes, they must be accessed via bracket notation (e.g. `element["foo-bar"]`).
+When using the `"none"` strategy, property names may contain dashes and must be accessed via bracket notation (e.g. `element["foo-bar"]`). When using `"camelCase"`, property names are standard JS identifiers (e.g. `element.fooBar`).
 
 ---
 

--- a/packages/fast-html/README.md
+++ b/packages/fast-html/README.md
@@ -219,9 +219,9 @@ if (process.env.NODE_ENV === 'development') {
 
 #### `attributeMap`
 
-When `attributeMap: "all"` (or `attributeMap: {}`) is configured for an element, `@microsoft/fast-html` automatically creates reactive `@attr` properties for every **leaf binding** in the template — simple expressions like `{{foo}}` or `id="{{foo-bar}}"` that have no nested properties. Both `"all"` and `{}` are equivalent; passing a configuration object is supported for future extensibility.
+When `attributeMap: "all"` (or `attributeMap: {}`) is configured for an element, `@microsoft/fast-html` automatically creates reactive `@attr` properties for every **leaf binding** in the template — simple expressions like `{{foo}}` or `id="{{foo-bar}}"` that have no nested properties. Both `"all"` and `{}` are equivalent and use the default `"none"` attribute name strategy.
 
-The **attribute name** and **property name** are both the binding key exactly as written in the template — no normalization is applied. Because HTML attributes are case-insensitive, binding keys should use lowercase names (optionally dash-separated). Properties with dashes must be accessed via bracket notation (e.g. `element["foo-bar"]`).
+By default, the **attribute name** and **property name** are both the binding key exactly as written in the template — no normalization is applied. Because HTML attributes are case-insensitive, binding keys should use lowercase names (optionally dash-separated). Properties with dashes must be accessed via bracket notation (e.g. `element["foo-bar"]`).
 
 Properties already decorated with `@attr` or `@observable` on the class are left untouched.
 
@@ -245,6 +245,38 @@ With the template:
 ```
 
 This registers `greeting` (attribute `greeting`, property `greeting`) and `first-name` (attribute `first-name`, property `first-name`) as `@attr` properties on the element prototype, enabling `setAttribute("first-name", "Jane")` to trigger a template re-render automatically.
+
+##### `attribute-name-strategy`
+
+The `attribute-name-strategy` configuration option controls how template binding keys map to HTML attribute names. This matches the build-time `--attribute-name-strategy` option in `@microsoft/fast-build`.
+
+| Strategy | Behaviour | Example |
+|---|---|---|
+| `"none"` (default) | Binding key used as-is for both property and attribute | `{{foo-bar}}` → property `foo-bar`, attribute `foo-bar` |
+| `"camelCase"` | Binding key is the camelCase property; attribute name derived as kebab-case | `{{fooBar}}` → property `fooBar`, attribute `foo-bar` |
+
+```typescript
+TemplateElement.options({
+    "my-element": {
+        attributeMap: {
+            "attribute-name-strategy": "camelCase",
+        },
+    },
+}).define({ name: "f-template" });
+```
+
+With the template:
+
+```html
+<f-template name="my-element">
+    <template>
+        <p>{{greeting}}</p>
+        <p>{{firstName}}</p>
+    </template>
+</f-template>
+```
+
+This registers `greeting` (attribute `greeting`, property `greeting`) and `firstName` (attribute `first-name`, property `firstName`) as `@attr` properties. `setAttribute("first-name", "Jane")` triggers a re-render, and the property is accessible as `element.firstName`.
 
 ### Syntax
 

--- a/packages/fast-html/docs/api-report.api.md
+++ b/packages/fast-html/docs/api-report.api.md
@@ -11,6 +11,7 @@ import { TemplateLifecycleCallbacks } from '@microsoft/fast-element';
 
 // @public
 export interface AttributeMapConfig {
+    "attribute-name-strategy"?: "none" | "camelCase";
 }
 
 // @public

--- a/packages/fast-html/src/components/attribute-map.ts
+++ b/packages/fast-html/src/components/attribute-map.ts
@@ -1,6 +1,18 @@
 import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { AttributeDefinition, Observable } from "@microsoft/fast-element";
 import type { Schema } from "./schema.js";
+import type { AttributeMapConfig } from "./template.js";
+
+/**
+ * Converts a camelCase string to kebab-case.
+ *
+ * @example camelToKebab("fooBar")       // "foo-bar"
+ * @example camelToKebab("myCustomProp") // "my-custom-prop"
+ * @example camelToKebab("label")        // "label"
+ */
+function camelToKebab(str: string): string {
+    return str.replace(/[A-Z]/g, m => `-${m.toLowerCase()}`);
+}
 
 /**
  * AttributeMap provides functionality for detecting simple (leaf) properties in
@@ -9,20 +21,33 @@ import type { Schema } from "./schema.js";
  * A property is a candidate for @attr when its schema entry has no nested `properties`,
  * no `type`, and no `anyOf` — i.e. it is a plain binding like {{foo}} or id="{{foo-bar}}".
  *
- * Attribute names are **not** normalized — the binding key as written in the template
- * is used as both the attribute name and the property name. Because HTML attributes are
- * case-insensitive, binding keys should be lowercase (optionally dash-separated).
- * For example, {{foo-bar}} results in attribute `foo-bar` and property `foo-bar`.
+ * When `attribute-name-strategy` is `"none"` (the default), the binding key is used
+ * as both the attribute name and property name — no normalization is applied.
+ *
+ * When `attribute-name-strategy` is `"camelCase"`, the binding key is treated as a
+ * camelCase property name and the HTML attribute name is derived by converting it to
+ * kebab-case (e.g. property `fooBar` → attribute `foo-bar`). This matches the
+ * build-time `attribute-name-strategy` option in `@microsoft/fast-build`.
+ *
+ * Properties already decorated with `@attr` or `@observable` on the class are left
+ * untouched.
  */
 export class AttributeMap {
     private schema: Schema;
     private classPrototype: any;
     private definition: FASTElementDefinition | undefined;
+    private config: AttributeMapConfig | undefined;
 
-    constructor(classPrototype: any, schema: Schema, definition?: FASTElementDefinition) {
+    constructor(
+        classPrototype: any,
+        schema: Schema,
+        definition?: FASTElementDefinition,
+        config?: AttributeMapConfig,
+    ) {
         this.classPrototype = classPrototype;
         this.schema = schema;
         this.definition = definition;
+        this.config = config;
     }
 
     public defineProperties(): void {
@@ -30,6 +55,7 @@ export class AttributeMap {
         const existingAccessorNames = new Set(
             Observable.getAccessors(this.classPrototype).map(a => a.name),
         );
+        const strategy = this.config?.["attribute-name-strategy"] ?? "none";
 
         for (const propertyName of propertyNames) {
             const propertySchema = this.schema.getSchema(propertyName);
@@ -52,10 +78,16 @@ export class AttributeMap {
                 continue;
             }
 
+            // Derive the HTML attribute name from the property name.
+            // With "camelCase" strategy, convert camelCase to kebab-case
+            // (e.g. fooBar → foo-bar). With "none", use the property name as-is.
+            const attributeName =
+                strategy === "camelCase" ? camelToKebab(propertyName) : propertyName;
+
             const attrDef = new AttributeDefinition(
                 this.classPrototype.constructor,
                 propertyName,
-                propertyName,
+                attributeName,
             );
 
             Observable.defineProperty(this.classPrototype, attrDef);
@@ -72,14 +104,14 @@ export class AttributeMap {
             ).observedAttributes;
             if (
                 Array.isArray(existingObservedAttrs) &&
-                !existingObservedAttrs.includes(propertyName)
+                !existingObservedAttrs.includes(attributeName)
             ) {
-                existingObservedAttrs.push(propertyName);
+                existingObservedAttrs.push(attributeName);
             }
 
             if (this.definition) {
                 (this.definition.attributeLookup as Record<string, AttributeDefinition>)[
-                    propertyName
+                    attributeName
                 ] = attrDef;
                 (this.definition.propertyLookup as Record<string, AttributeDefinition>)[
                     propertyName

--- a/packages/fast-html/src/components/template.ts
+++ b/packages/fast-html/src/components/template.ts
@@ -75,10 +75,23 @@ export const AttributeMapOption = {
 
 /**
  * Configuration object for the attributeMap element option.
- * No configuration keys are defined at this time; passing an empty
- * object (`{}`) is equivalent to `"all"`.
+ * Passing an empty object (`{}`) is equivalent to `"all"`.
  */
-export interface AttributeMapConfig {}
+export interface AttributeMapConfig {
+    /**
+     * Strategy for mapping template binding keys to HTML attribute names.
+     *
+     * - `"none"` (default): the binding key is used as-is for both the
+     *   property name and the attribute name (e.g. `{{foo-bar}}` →
+     *   property `foo-bar`, attribute `foo-bar`).
+     * - `"camelCase"`: the binding key is treated as a camelCase property
+     *   name and the attribute name is derived by converting it to
+     *   kebab-case (e.g. `{{fooBar}}` → property `fooBar`, attribute
+     *   `foo-bar`). This matches the build-time `attribute-name-strategy`
+     *   option in `@microsoft/fast-build`.
+     */
+    "attribute-name-strategy"?: "none" | "camelCase";
+}
 
 /**
  * Type for the attributeMap element option.
@@ -264,10 +277,15 @@ class TemplateElement extends FASTElement {
                 fastElementRegistry.getByType(value);
 
             if (isMapOptionEnabled(TemplateElement.elementOptions[name]?.attributeMap)) {
+                const mapOption = TemplateElement.elementOptions[name]?.attributeMap;
+                const mapConfig: AttributeMapConfig | undefined =
+                    typeof mapOption === "object" ? mapOption : undefined;
+
                 this.attributeMap = new AttributeMap(
                     value.prototype,
                     this.schema as Schema,
                     registeredFastElement,
+                    mapConfig,
                 );
             }
 

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/attribute-map-naming-strategy.spec.ts
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/attribute-map-naming-strategy.spec.ts
@@ -74,6 +74,18 @@ test.describe("AttributeMap with attribute-name-strategy: camelCase", () => {
         await expect(page.locator(".my-custom-prop-value")).toHaveText("world");
     });
 
+    test("should update template when camelCase property is set directly", async ({
+        page,
+    }) => {
+        const element = page.locator("naming-strategy-test");
+
+        await element.evaluate(node => {
+            (node as any).fooBar = "property-set";
+        });
+
+        await expect(page.locator(".foo-bar-value")).toHaveText("property-set");
+    });
+
     test("non-dashed attribute name is unaffected by camelCase strategy", async ({
         page,
     }) => {
@@ -85,5 +97,12 @@ test.describe("AttributeMap with attribute-name-strategy: camelCase", () => {
 
         expect(propValue).toBe("no-dash-test");
         await expect(page.locator(".label-value")).toHaveText("no-dash-test");
+    });
+
+    test("non-dashed attribute renders initial value from entry HTML", async ({
+        page,
+    }) => {
+        await page.waitForSelector("naming-strategy-no-dash-test");
+        await expect(page.locator(".label-value")).toHaveText("simple");
     });
 });

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/attribute-map-naming-strategy.spec.ts
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/attribute-map-naming-strategy.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("AttributeMap with attribute-name-strategy: camelCase", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/fixtures/attribute-map-naming-strategy/");
+        await page.waitForSelector("naming-strategy-test");
+    });
+
+    test("should define @attr accessors with camelCase property names", async ({
+        page,
+    }) => {
+        const element = page.locator("naming-strategy-test");
+
+        const accessors = await element.evaluate(node => {
+            const proto = Object.getPrototypeOf(node);
+            const isAccessor = (name: string) =>
+                typeof Object.getOwnPropertyDescriptor(proto, name)?.get === "function";
+            return {
+                fooBar: isAccessor("fooBar"),
+                myCustomProp: isAccessor("myCustomProp"),
+            };
+        });
+
+        expect(accessors.fooBar).toBeTruthy();
+        expect(accessors.myCustomProp).toBeTruthy();
+    });
+
+    test("should map kebab-case attribute to camelCase property via setAttribute", async ({
+        page,
+    }) => {
+        const element = page.locator("naming-strategy-test");
+
+        await element.evaluate(node => node.setAttribute("foo-bar", "attr-test"));
+        const propValue = await element.evaluate(node => (node as any).fooBar);
+
+        expect(propValue).toBe("attr-test");
+    });
+
+    test("should update template when kebab-case attribute is set", async ({ page }) => {
+        const element = page.locator("naming-strategy-test");
+
+        await element.evaluate(node => node.setAttribute("foo-bar", "hello-via-attr"));
+
+        await expect(page.locator(".foo-bar-value")).toHaveText("hello-via-attr");
+    });
+
+    test("should update template for multi-dashed attribute", async ({ page }) => {
+        const element = page.locator("naming-strategy-test");
+
+        await element.evaluate(node =>
+            node.setAttribute("my-custom-prop", "multi-dash-test"),
+        );
+
+        await expect(page.locator(".my-custom-prop-value")).toHaveText("multi-dash-test");
+    });
+
+    test("should reflect camelCase property value back to kebab-case attribute", async ({
+        page,
+    }) => {
+        const element = page.locator("naming-strategy-test");
+
+        await element.evaluate(node => {
+            (node as any).fooBar = "reflected-value";
+        });
+
+        await page.evaluate(() => new Promise(r => requestAnimationFrame(r)));
+
+        const attrValue = await element.evaluate(node => node.getAttribute("foo-bar"));
+        expect(attrValue).toBe("reflected-value");
+    });
+
+    test("should render initial attribute values from entry HTML", async ({ page }) => {
+        await expect(page.locator(".foo-bar-value")).toHaveText("hello");
+        await expect(page.locator(".my-custom-prop-value")).toHaveText("world");
+    });
+
+    test("non-dashed attribute name is unaffected by camelCase strategy", async ({
+        page,
+    }) => {
+        await page.waitForSelector("naming-strategy-no-dash-test");
+        const element = page.locator("naming-strategy-no-dash-test");
+
+        await element.evaluate(node => node.setAttribute("label", "no-dash-test"));
+        const propValue = await element.evaluate(node => (node as any).label);
+
+        expect(propValue).toBe("no-dash-test");
+        await expect(page.locator(".label-value")).toHaveText("no-dash-test");
+    });
+});

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/attribute-map-naming-strategy.spec.ts
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/attribute-map-naming-strategy.spec.ts
@@ -69,9 +69,11 @@ test.describe("AttributeMap with attribute-name-strategy: camelCase", () => {
         expect(attrValue).toBe("reflected-value");
     });
 
-    test("should render initial attribute values from entry HTML", async ({ page }) => {
-        await expect(page.locator(".foo-bar-value")).toHaveText("hello");
-        await expect(page.locator(".my-custom-prop-value")).toHaveText("world");
+    test("should render initial attribute values from state defaults", async ({
+        page,
+    }) => {
+        await expect(page.locator(".foo-bar-value")).toHaveText("default-foo");
+        await expect(page.locator(".my-custom-prop-value")).toHaveText("default-prop");
     });
 
     test("should update template when camelCase property is set directly", async ({
@@ -99,10 +101,10 @@ test.describe("AttributeMap with attribute-name-strategy: camelCase", () => {
         await expect(page.locator(".label-value")).toHaveText("no-dash-test");
     });
 
-    test("non-dashed attribute renders initial value from entry HTML", async ({
+    test("non-dashed attribute renders initial value from state defaults", async ({
         page,
     }) => {
         await page.waitForSelector("naming-strategy-no-dash-test");
-        await expect(page.locator(".label-value")).toHaveText("simple");
+        await expect(page.locator(".label-value")).toHaveText("default-label");
     });
 });

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/entry.html
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/entry.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+    </head>
+    <body>
+        <naming-strategy-test id="test-element" foo-bar="hello" my-custom-prop="world"></naming-strategy-test>
+        <naming-strategy-no-dash-test id="no-dash-test" label="simple"></naming-strategy-no-dash-test>
+        <script type="module" src="./main.ts"></script>
+    </body>
+</html>

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/entry.html
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/entry.html
@@ -5,8 +5,8 @@
         <title></title>
     </head>
     <body>
-        <naming-strategy-test id="test-element" foo-bar="hello" my-custom-prop="world"></naming-strategy-test>
-        <naming-strategy-no-dash-test id="no-dash-test" label="simple"></naming-strategy-no-dash-test>
+        <naming-strategy-test id="test-element" foo-bar="{{fooBar}}" my-custom-prop="{{myCustomProp}}"></naming-strategy-test>
+        <naming-strategy-no-dash-test id="no-dash-test" label="{{label}}"></naming-strategy-no-dash-test>
         <script type="module" src="./main.ts"></script>
     </body>
 </html>

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/fast-build.config.json
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/fast-build.config.json
@@ -1,0 +1,7 @@
+{
+    "entry": "entry.html",
+    "state": "state.json",
+    "output": "index.html",
+    "templates": "templates.html",
+    "attribute-name-strategy": "camelCase"
+}

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/index.html
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+    </head>
+    <body>
+        <naming-strategy-test id="test-element" foo-bar="hello" my-custom-prop="world"><template shadowrootmode="open" shadowroot="open"><div class="foo-bar-value"><!--fe-b$$start$$0$$fooBar-0$$fe-b-->hello<!--fe-b$$end$$0$$fooBar-0$$fe-b--></div>
+        <div class="my-custom-prop-value"><!--fe-b$$start$$1$$myCustomProp-1$$fe-b-->world<!--fe-b$$end$$1$$myCustomProp-1$$fe-b--></div></template></naming-strategy-test>
+        <naming-strategy-no-dash-test id="no-dash-test" label="simple"><template shadowrootmode="open" shadowroot="open"><div class="label-value"><!--fe-b$$start$$0$$label-0$$fe-b-->simple<!--fe-b$$end$$0$$label-0$$fe-b--></div></template></naming-strategy-no-dash-test>
+<f-template name="naming-strategy-test">
+    <template>
+        <div class="foo-bar-value">{{fooBar}}</div>
+        <div class="my-custom-prop-value">{{myCustomProp}}</div>
+    </template>
+</f-template>
+<f-template name="naming-strategy-no-dash-test">
+    <template>
+        <div class="label-value">{{label}}</div>
+    </template>
+</f-template>
+
+        <script type="module" src="./main.ts"></script>
+    </body>
+</html>

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/index.html
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/index.html
@@ -5,9 +5,9 @@
         <title></title>
     </head>
     <body>
-        <naming-strategy-test id="test-element" foo-bar="hello" my-custom-prop="world"><template shadowrootmode="open" shadowroot="open"><div class="foo-bar-value"><!--fe-b$$start$$0$$fooBar-0$$fe-b-->hello<!--fe-b$$end$$0$$fooBar-0$$fe-b--></div>
-        <div class="my-custom-prop-value"><!--fe-b$$start$$1$$myCustomProp-1$$fe-b-->world<!--fe-b$$end$$1$$myCustomProp-1$$fe-b--></div></template></naming-strategy-test>
-        <naming-strategy-no-dash-test id="no-dash-test" label="simple"><template shadowrootmode="open" shadowroot="open"><div class="label-value"><!--fe-b$$start$$0$$label-0$$fe-b-->simple<!--fe-b$$end$$0$$label-0$$fe-b--></div></template></naming-strategy-no-dash-test>
+        <naming-strategy-test id="test-element" foo-bar="default-foo" my-custom-prop="default-prop"><template shadowrootmode="open" shadowroot="open"><div class="foo-bar-value"><!--fe-b$$start$$0$$fooBar-0$$fe-b-->default-foo<!--fe-b$$end$$0$$fooBar-0$$fe-b--></div>
+        <div class="my-custom-prop-value"><!--fe-b$$start$$1$$myCustomProp-1$$fe-b-->default-prop<!--fe-b$$end$$1$$myCustomProp-1$$fe-b--></div></template></naming-strategy-test>
+        <naming-strategy-no-dash-test id="no-dash-test" label="default-label"><template shadowrootmode="open" shadowroot="open"><div class="label-value"><!--fe-b$$start$$0$$label-0$$fe-b-->default-label<!--fe-b$$end$$0$$label-0$$fe-b--></div></template></naming-strategy-no-dash-test>
 <f-template name="naming-strategy-test">
     <template>
         <div class="foo-bar-value">{{fooBar}}</div>

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/main.ts
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/main.ts
@@ -1,0 +1,27 @@
+import { FASTElement } from "@microsoft/fast-element";
+import { TemplateElement } from "@microsoft/fast-html";
+
+class NamingStrategyTestElement extends FASTElement {}
+
+NamingStrategyTestElement.defineAsync({
+    name: "naming-strategy-test",
+});
+
+class NamingStrategyNoDashTestElement extends FASTElement {}
+
+NamingStrategyNoDashTestElement.defineAsync({
+    name: "naming-strategy-no-dash-test",
+});
+
+TemplateElement.options({
+    "naming-strategy-test": {
+        attributeMap: {
+            "attribute-name-strategy": "camelCase",
+        },
+    },
+    "naming-strategy-no-dash-test": {
+        attributeMap: {
+            "attribute-name-strategy": "camelCase",
+        },
+    },
+}).define({ name: "f-template" });

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/state.json
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/state.json
@@ -1,5 +1,5 @@
 {
-    "fooBar": "",
-    "myCustomProp": "",
-    "label": ""
+    "fooBar": "default-foo",
+    "myCustomProp": "default-prop",
+    "label": "default-label"
 }

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/state.json
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/state.json
@@ -1,0 +1,5 @@
+{
+    "fooBar": "",
+    "myCustomProp": "",
+    "label": ""
+}

--- a/packages/fast-html/test/fixtures/attribute-map-naming-strategy/templates.html
+++ b/packages/fast-html/test/fixtures/attribute-map-naming-strategy/templates.html
@@ -1,0 +1,11 @@
+<f-template name="naming-strategy-test">
+    <template>
+        <div class="foo-bar-value">{{fooBar}}</div>
+        <div class="my-custom-prop-value">{{myCustomProp}}</div>
+    </template>
+</f-template>
+<f-template name="naming-strategy-no-dash-test">
+    <template>
+        <div class="label-value">{{label}}</div>
+    </template>
+</f-template>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds an `attribute-name-strategy` configuration option to the `AttributeMapConfig` interface in `@microsoft/fast-html`. This controls how template binding keys are mapped to HTML attribute names when `attributeMap` auto-defines `@attr` properties.

Two strategies are supported:
- `"none"` (default) — the binding key is used as-is for both the property name and the attribute name (e.g. `{{foo-bar}}` → property `foo-bar`, attribute `foo-bar`). This preserves the existing behavior.
- `"camelCase"` — the binding key is treated as a camelCase property name and the HTML attribute name is derived by converting it to kebab-case (e.g. `{{fooBar}}` → property `fooBar`, attribute `foo-bar`).

The `"camelCase"` strategy matches the build-time `--attribute-name-strategy` option added to `@microsoft/fast-build` in #7433, enabling end-to-end camelCase property mapping from build-time rendering through client-side hydration.

### Usage

```typescript
TemplateElement.options({
    "my-element": {
        attributeMap: {
            "attribute-name-strategy": "camelCase",
        },
    },
}).define({ name: "f-template" });
```

## 👩‍💻 Reviewer Notes

The config only affects `AttributeMap.defineProperties()`. With `"camelCase"`, the `AttributeDefinition` is created with a camelCase property name and a kebab-case attribute name. `attributeLookup` is keyed by the HTML attribute name and `propertyLookup` by the JS property name so both `setAttribute("foo-bar", ...)` and `element.fooBar = ...` work correctly.

## 📑 Test Plan

- 7 new Playwright tests in `test/fixtures/attribute-map-naming-strategy/` covering:
  - `@attr` accessor creation with camelCase property names
  - `setAttribute` with kebab-case attribute updating camelCase property
  - Template re-rendering on attribute change
  - Multi-dashed attribute mapping
  - Property-to-attribute reflection (camelCase → kebab-case)
  - Initial attribute values from entry HTML
  - Non-dashed attributes unaffected by camelCase strategy
- All 276 existing tests pass unchanged

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.