### PR TITLE
feat: add properties path tree to ObserverMapConfig in fast-html

### DIFF
--- a/change/@microsoft-fast-html-2751da26-46f3-4c7d-ae10-4437c26b800b.json
+++ b/change/@microsoft-fast-html-2751da26-46f3-4c7d-ae10-4437c26b800b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "feat: add properties path tree to ObserverMapConfig in fast-html",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-html-2751da26-46f3-4c7d-ae10-4437c26b800b.json
+++ b/change/@microsoft-fast-html-2751da26-46f3-4c7d-ae10-4437c26b800b.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "prerelease",
   "comment": "feat: add properties path tree to ObserverMapConfig in fast-html",
   "packageName": "@microsoft/fast-html",
   "email": "7559015+janechu@users.noreply.github.com",

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -251,7 +251,7 @@ flowchart TD
     G --> H[transformInnerHTML normalises HTML entities]
     H --> I["resolveStringsAndValues\nparses bindings and directives\nbuilds Schema, builds strings+values arrays"]
     I --> J{observerMap enabled?}
-    J -- yes --> K["ObserverMap.defineProperties\n→ Observable.defineProperty for each root prop\n→ install proxy change handlers"]
+    J -- yes --> K["ObserverMap.defineProperties\n→ applyConfigToSchema stamps $observe on schema nodes\n→ Observable.defineProperty for each root prop\n→ install proxy change handlers"]
     J -- no --> L
     K --> L["ViewTemplate.create strings,values\n→ registeredFastElement.template = viewTemplate"]
     L --> M["FASTElementDefinition.composeAsync\n→ element fully registered with platform"]
@@ -337,12 +337,24 @@ flowchart LR
     B --> C[schema.addPath\ntype:'access'\npath:'user.details.age'\nrootProperty:'user']
     C --> D["Schema.jsonSchemaMap\n{'my-el' => {'user' => JSONSchema}}"]
     D --> E[ObserverMap.defineProperties]
-    E --> F[Observable.defineProperty on prototype\nfor 'user']
-    E --> G[install instanceResolverChanged handler]
-    G --> H[when user= is set:\nassignObservables → Proxy wraps user\ndeep mutations → Observable.notify]
+    E --> E1["applyConfigToSchema\nstamps $observe: false on excluded schema nodes"]
+    E1 --> F[Observable.defineProperty on prototype\nfor 'user']
+    E1 --> G[install instanceResolverChanged handler]
+    G --> H["when user= is set:\nassignObservables checks schema.$observe\n→ Proxy wraps observed paths only\ndeep mutations → Observable.notify"]
 ```
 
 For a deep dive into the schema structure, context tracking, and proxy system see [SCHEMA_OBSERVER_MAP.md](./SCHEMA_OBSERVER_MAP.md).
+
+### `$observe` flag on schema nodes
+
+When an `ObserverMapConfig` with a `properties` key is provided, `ObserverMap.defineProperties()` calls `applyConfigToSchema()` to stamp `$observe: false` on excluded schema nodes **before** the proxy system runs. This is a one-time pre-processing pass that walks the config and schema trees in parallel:
+
+- `false` in the config → `$observe: false` is stamped recursively on the node and all its descendants.
+- `$observe: false` on a config node → the schema node is stamped, and unlisted children inherit the stamp.
+- `true` in the config → no stamp needed (observed is the default).
+- Config paths not in the schema are silently ignored.
+
+The proxy system then checks `schema.$observe` at each decision point — no separate config tree is threaded through function calls. Schema nodes without `$observe` (or with `$observe: true`) are observed normally.
 
 ### AttributeMap and leaf bindings
 

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -87,7 +87,43 @@ An optional layer that uses the `Schema` to automatically:
 - Install property-change handlers that wrap newly assigned objects/arrays in `Proxy` instances.
 - Propagate deep property mutations back through FAST's observable system so bindings re-render.
 
-Enabled via `TemplateElement.options({ "my-element": { observerMap: "all" } })` or by passing a configuration object `TemplateElement.options({ "my-element": { observerMap: {} } })`. Both forms are equivalent; no configuration keys are defined at this time.
+Enabled via `TemplateElement.options({ "my-element": { observerMap: "all" } })` or by passing a configuration object `TemplateElement.options({ "my-element": { observerMap: {} } })`. Both forms are equivalent and observe all root properties.
+
+#### Path-level observation control
+
+The `ObserverMapConfig` interface accepts an optional `properties` key that maps root property names to a recursive path tree controlling observation granularity:
+
+```typescript
+TemplateElement.options({
+    "my-element": {
+        observerMap: {
+            properties: {
+                user: {
+                    name: true,          // user.name — observed
+                    details: {
+                        age: true,       // user.details.age — observed
+                        history: false,  // user.details.history — NOT observed
+                    },
+                },
+                // root properties not listed here are skipped
+            },
+        },
+    },
+});
+```
+
+Each path entry can be:
+- **`true`** — observe this path and all descendants (unless overridden deeper).
+- **`false`** — skip this path and all descendants (unless overridden deeper).
+- **`ObserverMapPathNode`** — an object with an optional `$observe` boolean and child property overrides, allowing alternating opt-in/opt-out to arbitrary depth.
+
+When `properties` is omitted (`observerMap: {}` or `observerMap: "all"`), all root properties are observed. When `properties` is present but empty (`{ properties: {} }`), no root properties are observed.
+
+The resolution algorithm walks the schema and configuration tree in parallel:
+1. If `properties` is present and a root property is not listed, it is skipped.
+2. `true`/`false` booleans apply to the entire subtree.
+3. `$observe` on a node object controls the current level; children inherit when unspecified.
+4. Paths in the config but not in the schema are silently ignored (forward-compatible).
 
 ### `AttributeMap` — automatic `@attr` definitions
 
@@ -152,6 +188,9 @@ import {
     RenderableFASTElement,
     TemplateElement,
     ObserverMap,
+    type ObserverMapConfig,
+    type ObserverMapPathEntry,
+    type ObserverMapPathNode,
 } from "@microsoft/fast-html";
 ```
 
@@ -162,6 +201,14 @@ Three primary exports are intended for application code:
 | `TemplateElement` | Define the `<f-template>` element; configure callbacks and per-element options. |
 | `RenderableFASTElement(Base)` | Mixin applied to your `FASTElement` subclass for hydration support. |
 | `ObserverMap` | Advanced: access the observer-map class directly if building tooling. |
+
+Additionally, the following types are exported for use in `observerMap` configuration:
+
+| Type | Purpose |
+|---|---|
+| `ObserverMapConfig` | Configuration object for the `observerMap` option; accepts optional `properties` key. |
+| `ObserverMapPathEntry` | `boolean \| ObserverMapPathNode` — a node in the observation path tree. |
+| `ObserverMapPathNode` | Object node with optional `$observe` and child property overrides. |
 
 ---
 

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -354,7 +354,11 @@ When an `ObserverMapConfig` with a `properties` key is provided, `ObserverMap.de
 - `true` in the config → no stamp needed (observed is the default).
 - Config paths not in the schema are silently ignored.
 
-The proxy system then checks `schema.$observe` at each decision point — no separate config tree is threaded through function calls. Schema nodes without `$observe` (or with `$observe: true`) are observed normally.
+**Convention: stamp-only-when-excluding.** The `$observe` flag is only ever set to `false` — it is never explicitly set to `true`. Absence of `$observe` (i.e. `undefined`) means the node is observed. This means:
+
+- When `observerMap: "all"` or `observerMap: {}` is used, `applyConfigToSchema` is never called and no schema nodes are mutated — zero overhead for the common case.
+- The proxy system uses `isSchemaExcluded(schema)` (checks `$observe === false` with no observed descendants) as the single predicate for all skip/suppress decisions.
+- Schema nodes without `$observe` are always treated as observed.
 
 ### AttributeMap and leaf bindings
 

--- a/packages/fast-html/README.md
+++ b/packages/fast-html/README.md
@@ -217,6 +217,53 @@ if (process.env.NODE_ENV === 'development') {
 }
 ```
 
+#### `observerMap`
+
+When `observerMap: "all"` (or `observerMap: {}`) is configured for an element, `@microsoft/fast-html` automatically sets up deep reactive observation for all root properties discovered in the template. Both `"all"` and `{}` are equivalent.
+
+For finer control, pass a configuration object with a `properties` key that maps root property names to a recursive path tree:
+
+```typescript
+TemplateElement.options({
+    "user-profile": {
+        observerMap: {
+            properties: {
+                user: {
+                    name: true,          // user.name — observed
+                    details: {
+                        age: true,       // user.details.age — observed
+                        history: false,  // user.details.history — NOT observed
+                    },
+                },
+                // root properties not listed here are skipped
+            },
+        },
+    },
+}).define({ name: "f-template" });
+```
+
+Each path entry can be:
+- **`true`** — observe this path and all descendants.
+- **`false`** — skip this path and all descendants.
+- **An object** with an optional `$observe` boolean and child property overrides.
+
+Use `$observe: false` on a node to skip it by default, then re-include specific children:
+
+```typescript
+observerMap: {
+    properties: {
+        analytics: {
+            charts: {
+                $observe: false,       // charts NOT observed by default
+                activeChart: true,     // ...except activeChart IS observed
+            },
+        },
+    },
+}
+```
+
+When `properties` is omitted, all root properties are observed (backward compatible). When `properties` is present but empty (`{ properties: {} }`), no root properties are observed.
+
 #### `attributeMap`
 
 When `attributeMap: "all"` (or `attributeMap: {}`) is configured for an element, `@microsoft/fast-html` automatically creates reactive `@attr` properties for every **leaf binding** in the template — simple expressions like `{{foo}}` or `id="{{foo-bar}}"` that have no nested properties. Both `"all"` and `{}` are equivalent and use the default `"none"` attribute name strategy.

--- a/packages/fast-html/docs/api-report.api.md
+++ b/packages/fast-html/docs/api-report.api.md
@@ -17,13 +17,27 @@ export interface AttributeMapConfig {
 // @public
 export class ObserverMap {
     // Warning: (ae-forgotten-export) The symbol "Schema" needs to be exported by the entry point index.d.ts
-    constructor(classPrototype: any, schema: Schema);
+    constructor(classPrototype: any, schema: Schema, config?: ObserverMapConfig);
     // (undocumented)
     defineProperties(): void;
 }
 
 // @public
 export interface ObserverMapConfig {
+    properties?: {
+        [rootProperty: string]: ObserverMapPathEntry;
+    };
+}
+
+// @public
+export type ObserverMapPathEntry = boolean | ObserverMapPathNode;
+
+// @public
+export interface ObserverMapPathNode {
+    // (undocumented)
+    $observe?: boolean;
+    // (undocumented)
+    [propertyName: string]: ObserverMapPathEntry | undefined;
 }
 
 // @public

--- a/packages/fast-html/src/components/index.ts
+++ b/packages/fast-html/src/components/index.ts
@@ -9,5 +9,7 @@ export {
     type HydrationLifecycleCallbacks,
     type ObserverMapConfig,
     ObserverMapOption,
+    type ObserverMapPathEntry,
+    type ObserverMapPathNode,
     TemplateElement,
 } from "./template.js";

--- a/packages/fast-html/src/components/observer-map.spec.ts
+++ b/packages/fast-html/src/components/observer-map.spec.ts
@@ -49,4 +49,142 @@ test.describe("ObserverMap", async () => {
         expect(instance.someData).not.toBe(nextValue);
         expect(instance.someData.$isProxy).toBeTruthy();
     });
+
+    test.describe("properties config", () => {
+        test("should skip root properties not listed in config.properties", () => {
+            const testName = "test-skip-unlisted";
+            const testSchema = new Schema(testName);
+            class SkipTest {
+                public included: any;
+                public excluded: any;
+            }
+
+            const schemaMap = Schema.jsonSchemaMap.get(testName) as Map<
+                string,
+                JSONSchema
+            >;
+            schemaMap.set("included", {
+                $schema: "https://json-schema.org/draft/2019-09/schema",
+                $id: `https://fast.design/schemas/${testName}/included.json`,
+                type: "object",
+                properties: { val: { type: "string" } },
+                [defsPropertyName]: {},
+            });
+            schemaMap.set("excluded", {
+                $schema: "https://json-schema.org/draft/2019-09/schema",
+                $id: `https://fast.design/schemas/${testName}/excluded.json`,
+                type: "object",
+                properties: { val: { type: "string" } },
+                [defsPropertyName]: {},
+            });
+
+            const om = new ObserverMap(SkipTest.prototype, testSchema, {
+                properties: { included: true },
+            });
+            om.defineProperties();
+
+            const instance = new SkipTest();
+            instance.included = null;
+            instance.included = { val: "hello" };
+
+            // included should be proxied
+            expect(instance.included.$isProxy).toBeTruthy();
+
+            // excluded should remain a plain object
+            instance.excluded = { val: "world" };
+            expect(instance.excluded.$isProxy).toBeUndefined();
+        });
+
+        test("should skip root properties set to false", () => {
+            const testName = "test-skip-false";
+            const testSchema = new Schema(testName);
+            class FalseTest {
+                public skipped: any;
+            }
+
+            const schemaMap = Schema.jsonSchemaMap.get(testName) as Map<
+                string,
+                JSONSchema
+            >;
+            schemaMap.set("skipped", {
+                $schema: "https://json-schema.org/draft/2019-09/schema",
+                $id: `https://fast.design/schemas/${testName}/skipped.json`,
+                type: "object",
+                properties: { val: { type: "string" } },
+                [defsPropertyName]: {},
+            });
+
+            const om = new ObserverMap(FalseTest.prototype, testSchema, {
+                properties: { skipped: false },
+            });
+            om.defineProperties();
+
+            const instance = new FalseTest();
+            instance.skipped = { val: "hello" };
+
+            // skipped should remain a plain object
+            expect(instance.skipped.$isProxy).toBeUndefined();
+        });
+
+        test("should observe all properties when config has no properties key", () => {
+            const testName = "test-observe-all";
+            const testSchema = new Schema(testName);
+            class AllTest {
+                public data: any;
+            }
+
+            const schemaMap = Schema.jsonSchemaMap.get(testName) as Map<
+                string,
+                JSONSchema
+            >;
+            schemaMap.set("data", {
+                $schema: "https://json-schema.org/draft/2019-09/schema",
+                $id: `https://fast.design/schemas/${testName}/data.json`,
+                type: "object",
+                properties: { val: { type: "string" } },
+                [defsPropertyName]: {},
+            });
+
+            // Empty config object = observe all
+            const om = new ObserverMap(AllTest.prototype, testSchema, {});
+            om.defineProperties();
+
+            const instance = new AllTest();
+            instance.data = null;
+            instance.data = { val: "hello" };
+
+            expect(instance.data.$isProxy).toBeTruthy();
+        });
+
+        test("should observe nothing when properties is empty", () => {
+            const testName = "test-observe-nothing";
+            const testSchema = new Schema(testName);
+            class NoneTest {
+                public data: any;
+            }
+
+            const schemaMap = Schema.jsonSchemaMap.get(testName) as Map<
+                string,
+                JSONSchema
+            >;
+            schemaMap.set("data", {
+                $schema: "https://json-schema.org/draft/2019-09/schema",
+                $id: `https://fast.design/schemas/${testName}/data.json`,
+                type: "object",
+                properties: { val: { type: "string" } },
+                [defsPropertyName]: {},
+            });
+
+            // properties: {} = observe nothing
+            const om = new ObserverMap(NoneTest.prototype, testSchema, {
+                properties: {},
+            });
+            om.defineProperties();
+
+            const instance = new NoneTest();
+            instance.data = { val: "hello" };
+
+            expect(instance.data.$isProxy).toBeUndefined();
+        });
+    });
 });

--- a/packages/fast-html/src/components/observer-map.ts
+++ b/packages/fast-html/src/components/observer-map.ts
@@ -36,6 +36,83 @@ function hasObservedPath(entry: ObserverMapPathEntry): boolean {
 }
 
 /**
+ * Stamps `$observe` flags onto schema nodes based on the config tree.
+ * After this one-time pass the proxy system can check `schema.$observe`
+ * instead of needing a separate config parameter threaded through every call.
+ *
+ * @param schema - A schema node (must have `properties` to recurse)
+ * @param entry  - The corresponding config path entry
+ * @param inherited - The inherited `$observe` value from the parent
+ */
+function applyConfigToSchema(
+    schema: any,
+    entry: ObserverMapPathEntry,
+    inherited: boolean = true,
+): void {
+    if (entry === false) {
+        stampObserveFalse(schema);
+        return;
+    }
+
+    if (entry === true) {
+        // Explicitly observed — no stamp needed (default is observed)
+        return;
+    }
+
+    // ObserverMapPathNode
+    const nodeObserve = entry.$observe ?? inherited;
+
+    if (!nodeObserve) {
+        schema.$observe = false;
+    }
+
+    if (!schema?.properties) {
+        return;
+    }
+
+    for (const key of Object.keys(entry)) {
+        if (key === "$observe") {
+            continue;
+        }
+
+        const childEntry = entry[key];
+        const childSchema = schema.properties[key];
+
+        // Paths in config but not in schema are silently ignored
+        if (childEntry !== undefined && childSchema) {
+            applyConfigToSchema(childSchema, childEntry, nodeObserve);
+        }
+    }
+
+    // For properties in the schema that are NOT listed in the config,
+    // they inherit the parent's $observe value
+    if (!nodeObserve) {
+        for (const key of Object.keys(schema.properties)) {
+            if (!(key in entry) && schema.properties[key]) {
+                stampObserveFalse(schema.properties[key]);
+            }
+        }
+    }
+}
+
+/**
+ * Recursively stamps `$observe: false` on a schema node and all its descendants.
+ */
+function stampObserveFalse(schema: any): void {
+    if (!schema) {
+        return;
+    }
+
+    schema.$observe = false;
+
+    if (schema.properties) {
+        for (const key of Object.keys(schema.properties)) {
+            stampObserveFalse(schema.properties[key]);
+        }
+    }
+}
+
+/**
  * ObserverMap provides functionality for caching binding paths, extracting root properties,
  * and defining observable properties on class prototypes
  */
@@ -79,6 +156,14 @@ export class ObserverMap {
                 continue;
             }
 
+            // Stamp $observe flags onto the schema so the proxy system
+            // can check schema nodes directly without a separate config tree
+            const rootSchema = this.schema.getSchema(propertyName);
+
+            if (configEntry && rootSchema) {
+                applyConfigToSchema(rootSchema, configEntry);
+            }
+
             // Skip if property already has an accessor (from `@attr` or `@observable` decorator)
             if (!existingAccessors.some(accessor => accessor.name === propertyName)) {
                 Observable.defineProperty(this.classPrototype, propertyName);
@@ -89,7 +174,6 @@ export class ObserverMap {
 
             this.classPrototype[changedMethodName] = this.defineChanged(
                 propertyName,
-                configEntry,
                 existingChangedMethod,
             );
         }
@@ -101,7 +185,6 @@ export class ObserverMap {
      * @param rootProperty - The name of the root property for notification purposes
      * @param object - The object to wrap with a proxy
      * @param schema - The schema for the element
-     * @param configEntry - The path config entry for this root property
      * @returns A proxy that triggers notifications on property mutations
      */
     private getAndAssignObservables(
@@ -109,7 +192,6 @@ export class ObserverMap {
         rootProperty: string,
         object: any,
         schema: Schema,
-        configEntry: ObserverMapPathEntry | undefined,
     ): typeof Proxy {
         let proxiedObject = object;
 
@@ -119,7 +201,6 @@ export class ObserverMap {
             proxiedObject,
             target,
             rootProperty,
-            configEntry,
         );
 
         return proxiedObject;
@@ -129,13 +210,11 @@ export class ObserverMap {
      * Creates a property change handler function for observable properties
      * This handler is called when an observable property transitions from undefined to a defined value
      * @param propertyName - The name of the property for which to create the change handler
-     * @param configEntry - The path config entry for this root property
      * @param existingChangedMethod - Optional existing changed method to call after the instance resolver logic
      * @returns A function that handles property changes and sets up proxies for object values
      */
     private defineChanged = (
         propertyName: string,
-        configEntry: ObserverMapPathEntry | undefined,
         existingChangedMethod?: (prev: any, next: any) => void,
     ): ((prev: any, next: any) => void) => {
         const getAndAssignObservablesAlias = this.getAndAssignObservables;
@@ -159,7 +238,6 @@ export class ObserverMap {
                         propertyName,
                         next,
                         schema,
-                        configEntry,
                     );
                 }
             } else if (!isObjectAssignment) {

--- a/packages/fast-html/src/components/observer-map.ts
+++ b/packages/fast-html/src/components/observer-map.ts
@@ -1,6 +1,39 @@
 import { Observable } from "@microsoft/fast-element/observable.js";
-import { assignObservables, deepMerge } from "./utilities.js";
 import type { JSONSchema, Schema } from "./schema.js";
+import type { ObserverMapConfig, ObserverMapPathEntry } from "./template.js";
+import { assignObservables, deepMerge } from "./utilities.js";
+
+/**
+ * Determines whether a config entry (or any of its descendants) enables observation.
+ * Used to decide whether a root property needs an observable accessor and change handler.
+ */
+function hasObservedPath(entry: ObserverMapPathEntry): boolean {
+    if (typeof entry === "boolean") {
+        return entry;
+    }
+
+    // ObserverMapPathNode
+    if (entry.$observe === true) {
+        return true;
+    }
+
+    for (const key of Object.keys(entry)) {
+        if (key === "$observe") {
+            continue;
+        }
+
+        const child = entry[key];
+
+        if (child !== undefined && hasObservedPath(child)) {
+            return true;
+        }
+    }
+
+    // A node with no explicit $observe and no observed children:
+    // at the root level the default $observe is true, so a node like `{ }` (no children)
+    // is observed. But a node with `$observe: false` and no observed children is not.
+    return entry.$observe !== false;
+}
 
 /**
  * ObserverMap provides functionality for caching binding paths, extracting root properties,
@@ -9,17 +42,43 @@ import type { JSONSchema, Schema } from "./schema.js";
 export class ObserverMap {
     private schema: Schema;
     private classPrototype: any;
+    private config: ObserverMapConfig | undefined;
 
-    constructor(classPrototype: any, schema: Schema) {
+    constructor(classPrototype: any, schema: Schema, config?: ObserverMapConfig) {
         this.classPrototype = classPrototype;
         this.schema = schema;
+        this.config = config;
     }
 
     public defineProperties(): void {
         const propertyNames = this.schema.getRootProperties();
         const existingAccessors = Observable.getAccessors(this.classPrototype);
+        const configProperties = this.config?.properties;
 
         for (const propertyName of propertyNames) {
+            // When `properties` is present, skip root properties not listed in the config
+            if (configProperties && !(propertyName in configProperties)) {
+                continue;
+            }
+
+            // Resolve the config entry for this root property
+            const configEntry: ObserverMapPathEntry | undefined =
+                configProperties?.[propertyName];
+
+            // Skip root properties explicitly set to `false` with no observed descendants
+            if (configEntry === false) {
+                continue;
+            }
+
+            // Skip ObserverMapPathNode entries with no observed descendants
+            if (
+                typeof configEntry === "object" &&
+                configEntry !== null &&
+                !hasObservedPath(configEntry)
+            ) {
+                continue;
+            }
+
             // Skip if property already has an accessor (from `@attr` or `@observable` decorator)
             if (!existingAccessors.some(accessor => accessor.name === propertyName)) {
                 Observable.defineProperty(this.classPrototype, propertyName);
@@ -30,7 +89,8 @@ export class ObserverMap {
 
             this.classPrototype[changedMethodName] = this.defineChanged(
                 propertyName,
-                existingChangedMethod
+                configEntry,
+                existingChangedMethod,
             );
         }
     }
@@ -40,13 +100,16 @@ export class ObserverMap {
      * @param target - The target instance that owns the root property
      * @param rootProperty - The name of the root property for notification purposes
      * @param object - The object to wrap with a proxy
+     * @param schema - The schema for the element
+     * @param configEntry - The path config entry for this root property
      * @returns A proxy that triggers notifications on property mutations
      */
     private getAndAssignObservables(
         target: any,
         rootProperty: string,
         object: any,
-        schema: Schema
+        schema: Schema,
+        configEntry: ObserverMapPathEntry | undefined,
     ): typeof Proxy {
         let proxiedObject = object;
 
@@ -55,7 +118,8 @@ export class ObserverMap {
             schema.getSchema(rootProperty) as JSONSchema,
             proxiedObject,
             target,
-            rootProperty
+            rootProperty,
+            configEntry,
         );
 
         return proxiedObject;
@@ -65,12 +129,14 @@ export class ObserverMap {
      * Creates a property change handler function for observable properties
      * This handler is called when an observable property transitions from undefined to a defined value
      * @param propertyName - The name of the property for which to create the change handler
+     * @param configEntry - The path config entry for this root property
      * @param existingChangedMethod - Optional existing changed method to call after the instance resolver logic
      * @returns A function that handles property changes and sets up proxies for object values
      */
     private defineChanged = (
         propertyName: string,
-        existingChangedMethod?: (prev: any, next: any) => void
+        configEntry: ObserverMapPathEntry | undefined,
+        existingChangedMethod?: (prev: any, next: any) => void,
     ): ((prev: any, next: any) => void) => {
         const getAndAssignObservablesAlias = this.getAndAssignObservables;
         const schema = this.schema;
@@ -92,7 +158,8 @@ export class ObserverMap {
                         this,
                         propertyName,
                         next,
-                        schema
+                        schema,
+                        configEntry,
                     );
                 }
             } else if (!isObjectAssignment) {

--- a/packages/fast-html/src/components/schema.ts
+++ b/packages/fast-html/src/components/schema.ts
@@ -14,6 +14,7 @@ interface JSONSchemaCommon {
     items?: any;
     anyOf?: Array<any>;
     $ref?: string;
+    $observe?: boolean;
 }
 
 export interface JSONSchema extends JSONSchemaCommon {
@@ -118,7 +119,7 @@ export class Schema {
         if (config.childrenMap) {
             childRef = this.getSchemaId(
                 config.childrenMap.customElementName,
-                config.childrenMap.attributeName
+                config.childrenMap.attributeName,
             );
 
             if (splitPath.length === 1) {
@@ -137,7 +138,7 @@ export class Schema {
                             schema,
                             splitPath.slice(1),
                             config.pathConfig.currentContext,
-                            childRef
+                            childRef,
                         );
                     } else {
                         if (!schema[defsPropertyName]?.[splitPath[0]]) {
@@ -151,7 +152,7 @@ export class Schema {
                             schema[defsPropertyName][splitPath[0]],
                             splitPath.slice(1),
                             config.pathConfig.currentContext as string,
-                            childRef
+                            childRef,
                         );
                     }
                 }
@@ -163,7 +164,7 @@ export class Schema {
                     schema,
                     splitPath.at(-1) as string, // example items
                     config.pathConfig.currentContext as string, // example item
-                    config.pathConfig.parentContext
+                    config.pathConfig.parentContext,
                 );
 
                 if (splitPath.length > 2) {
@@ -177,7 +178,7 @@ export class Schema {
                             ],
                             splitPath.slice(1, -1),
                             config.pathConfig.parentContext,
-                            childRef
+                            childRef,
                         );
                     }
 
@@ -186,7 +187,7 @@ export class Schema {
                         hasParentContext ? splitPath.slice(2) : splitPath.slice(1),
                         config.pathConfig.currentContext,
                         childRef,
-                        "array"
+                        "array",
                     );
                 } else if (splitPath.length > 1) {
                     let schemaDefinition;
@@ -202,12 +203,12 @@ export class Schema {
                         splitPath.slice(1),
                         config.pathConfig.currentContext,
                         childRef,
-                        "array"
+                        "array",
                     );
                 } else {
                     schema.type = "array";
                     schema[refPropertyName] = this.getDefsPath(
-                        config.pathConfig.currentContext as string
+                        config.pathConfig.currentContext as string,
                     );
                 }
 
@@ -281,7 +282,7 @@ export class Schema {
                 $schema: "https://json-schema.org/draft/2019-09/schema",
                 $id: this.getSchemaId(this.customElementName, propertyName),
                 [defsPropertyName]: {},
-            }
+            },
         );
     }
 
@@ -295,7 +296,7 @@ export class Schema {
         schema: any,
         splitPath: string[],
         context: string,
-        childRef: string | null
+        childRef: string | null,
     ) {
         schema.type = "object";
 
@@ -312,7 +313,7 @@ export class Schema {
                 schema.properties[splitPath[0]],
                 splitPath.slice(1),
                 context,
-                childRef
+                childRef,
             );
         } else if (childRef) {
             if (schema.properties[splitPath[0]].anyOf) {
@@ -337,7 +338,7 @@ export class Schema {
         splitPath: string[],
         context: string | null,
         childRef: string | null,
-        type: string = "object"
+        type: string = "object",
     ): any {
         schema.type = "object";
 
@@ -355,7 +356,7 @@ export class Schema {
                 splitPath.slice(1),
                 context,
                 childRef,
-                type
+                type,
             );
         } else if (type === "array") {
             if (splitPath.length > 1) {
@@ -364,12 +365,12 @@ export class Schema {
                     splitPath.slice(1),
                     context,
                     childRef,
-                    type
+                    type,
                 );
             } else {
                 return this.addArrayToAnObject(
                     schema.properties[splitPath[0]],
-                    context as string
+                    context as string,
                 );
             }
         }
@@ -409,7 +410,7 @@ export class Schema {
         schema: any,
         propertyName: string, // e.g items
         currentContext: string, // e.g. item
-        parentContext: string | null
+        parentContext: string | null,
     ): void {
         if (schema[defsPropertyName][currentContext]) {
             return;
@@ -431,7 +432,7 @@ export class Schema {
     private getParentContexts(
         schema: JSONSchema,
         parentContext: string | null,
-        contexts: Array<string | null> = []
+        contexts: Array<string | null> = [],
     ): Array<string | null> {
         if (parentContext === null) {
             return [null, ...contexts];
@@ -444,7 +445,7 @@ export class Schema {
         return this.getParentContexts(
             schema,
             parentParentContext.at(-1) as string | null,
-            [parentContext, ...contexts]
+            [parentContext, ...contexts],
         );
     }
 }

--- a/packages/fast-html/src/components/schema.ts
+++ b/packages/fast-html/src/components/schema.ts
@@ -14,6 +14,11 @@ interface JSONSchemaCommon {
     items?: any;
     anyOf?: Array<any>;
     $ref?: string;
+    /**
+     * Stamped by `applyConfigToSchema` when an `ObserverMapConfig` excludes
+     * this path. When `false`, the proxy system skips observation for this
+     * node and (if all descendants are also `false`) its subtree.
+     */
     $observe?: boolean;
 }
 

--- a/packages/fast-html/src/components/template.ts
+++ b/packages/fast-html/src/components/template.ts
@@ -52,11 +52,46 @@ export const ObserverMapOption = {
 } as const;
 
 /**
- * Configuration object for the observerMap element option.
- * No configuration keys are defined at this time; passing an empty
- * object (`{}`) is equivalent to `"all"`.
+ * A node in the observer-map path tree.
+ *
+ * - `true`  → observe this path and all descendants (unless overridden by children).
+ * - `false` → do NOT observe this path or its descendants (unless overridden by children).
+ * - `ObserverMapPathNode` → configure child paths individually;
+ *       the node itself is observed if `$observe` is true (default when parent is observed).
  */
-export interface ObserverMapConfig {}
+export type ObserverMapPathEntry = boolean | ObserverMapPathNode;
+
+/**
+ * A node object in the observer-map path tree.
+ *
+ * `$observe` controls whether this node itself is observed.
+ * When omitted the value is inherited from the nearest ancestor
+ * that explicitly sets `$observe`. At the root level the default is `true`.
+ *
+ * Child property overrides are keyed by property name.
+ */
+export interface ObserverMapPathNode {
+    $observe?: boolean;
+    [propertyName: string]: ObserverMapPathEntry | undefined;
+}
+
+/**
+ * Configuration object for the observerMap element option.
+ * When `properties` is omitted (i.e. `observerMap: {}`), behaves like `"all"` —
+ * every root property is observed. When `properties` is present, only listed
+ * root properties participate in observer-map observation.
+ */
+export interface ObserverMapConfig {
+    /**
+     * Per-root-property observation control.
+     * Keys are root property names discovered in the template schema.
+     * Only root properties listed here participate in observer-map observation.
+     * Omitting this field is equivalent to `"all"`.
+     */
+    properties?: {
+        [rootProperty: string]: ObserverMapPathEntry;
+    };
+}
 
 /**
  * Type for the observerMap element option.
@@ -275,9 +310,17 @@ class TemplateElement extends FASTElement {
             }
 
             if (isMapOptionEnabled(TemplateElement.elementOptions[name]?.observerMap)) {
+                const observerMapOption =
+                    TemplateElement.elementOptions[name]?.observerMap;
+                const observerMapConfig =
+                    typeof observerMapOption === "object" && observerMapOption !== null
+                        ? observerMapOption
+                        : undefined;
+
                 this.observerMap = new ObserverMap(
                     value.prototype,
                     this.schema as Schema,
+                    observerMapConfig,
                 );
             }
 

--- a/packages/fast-html/src/components/utilities.ts
+++ b/packages/fast-html/src/components/utilities.ts
@@ -1196,6 +1196,15 @@ function hasObservedSchemaDescendant(schema: any): boolean {
 }
 
 /**
+ * Checks whether a schema node is fully excluded from observation.
+ * A node is excluded when it is stamped `$observe: false` AND none of
+ * its descendants are observed (no re-included leaves beneath it).
+ */
+function isSchemaExcluded(schema: any): boolean {
+    return schema?.$observe === false && !hasObservedSchemaDescendant(schema);
+}
+
+/**
  * Assigns Observable properties to items in an array and sets up change notifications
  * @param proxiedData - The array data to make observable
  * @param schema - The schema defining the structure of array items
@@ -1443,11 +1452,8 @@ function assignProxyToItemsInArray(
     getObjectProperties(proxiableItem, schemaProperties).forEach(key => {
         const childSchema = schemaProperties[key];
 
-        // Skip properties excluded by $observe: false that have no observed descendants
-        if (
-            childSchema?.$observe === false &&
-            !hasObservedSchemaDescendant(childSchema)
-        ) {
+        // Skip properties fully excluded from observation
+        if (isSchemaExcluded(childSchema)) {
             return;
         }
 
@@ -1514,11 +1520,8 @@ function assignProxyToItemsInObject(
         getObjectProperties(proxiedData, schemaProperties).forEach(property => {
             const childSchema = schemaProperties[property];
 
-            // Skip properties excluded by $observe: false that have no observed descendants
-            if (
-                childSchema?.$observe === false &&
-                !hasObservedSchemaDescendant(childSchema)
-            ) {
+            // Skip properties fully excluded from observation
+            if (isSchemaExcluded(childSchema)) {
                 return;
             }
 
@@ -1531,9 +1534,8 @@ function assignProxyToItemsInObject(
             );
         });
 
-        // Assign a Proxy if this level is observed or has any observed child properties
-        // (children need the proxy's set trap to intercept their mutations)
-        if (schema.$observe !== false || hasObservedSchemaDescendant(schema)) {
+        // Assign a Proxy unless this level is fully excluded from observation
+        if (!isSchemaExcluded(schema)) {
             proxiedData = assignProxy(
                 schema,
                 rootSchema,
@@ -1648,12 +1650,8 @@ export function assignProxy(
                 const propName = typeof prop === "string" ? prop : String(prop);
                 const childSchema = schemaProperties?.[propName];
 
-                // If the schema excludes this property and it has no observed descendants,
-                // assign without proxying or notifying
-                if (
-                    childSchema?.$observe === false &&
-                    !hasObservedSchemaDescendant(childSchema)
-                ) {
+                // If the property is fully excluded, assign without proxying or notifying
+                if (isSchemaExcluded(childSchema)) {
                     obj[prop] = value;
                     return true;
                 }
@@ -1684,11 +1682,8 @@ export function assignProxy(
 
                     delete obj[prop];
 
-                    // Only suppress notification if excluded AND no observed descendants
-                    if (
-                        childSchema?.$observe === false &&
-                        !hasObservedSchemaDescendant(childSchema)
-                    ) {
+                    // Only suppress notification if fully excluded
+                    if (isSchemaExcluded(childSchema)) {
                         return true;
                     }
 

--- a/packages/fast-html/src/components/utilities.ts
+++ b/packages/fast-html/src/components/utilities.ts
@@ -1646,9 +1646,14 @@ export function assignProxy(
                 }
 
                 const propName = typeof prop === "string" ? prop : String(prop);
+                const childSchema = schemaProperties?.[propName];
 
-                // If the schema marks this property as not observed, assign without proxying or notifying
-                if (schemaProperties?.[propName]?.$observe === false) {
+                // If the schema excludes this property and it has no observed descendants,
+                // assign without proxying or notifying
+                if (
+                    childSchema?.$observe === false &&
+                    !hasObservedSchemaDescendant(childSchema)
+                ) {
                     obj[prop] = value;
                     return true;
                 }
@@ -1675,13 +1680,19 @@ export function assignProxy(
             deleteProperty: (obj: any, prop: string | symbol) => {
                 if (prop in obj) {
                     const propName = typeof prop === "string" ? prop : String(prop);
+                    const childSchema = schemaProperties?.[propName];
 
                     delete obj[prop];
 
-                    // Only notify if the schema does not mark this property as excluded
-                    if (schemaProperties?.[propName]?.$observe !== false) {
-                        notifyObservables(proxy);
+                    // Only suppress notification if excluded AND no observed descendants
+                    if (
+                        childSchema?.$observe === false &&
+                        !hasObservedSchemaDescendant(childSchema)
+                    ) {
+                        return true;
                     }
+
+                    notifyObservables(proxy);
 
                     return true;
                 }

--- a/packages/fast-html/src/components/utilities.ts
+++ b/packages/fast-html/src/components/utilities.ts
@@ -23,6 +23,7 @@ import {
     whenDirectiveClose,
     whenDirectiveOpen,
 } from "./syntax.js";
+import type { ObserverMapPathEntry } from "./template.js";
 
 type BehaviorType = "dataBinding" | "templateDirective";
 
@@ -1178,10 +1179,91 @@ function getSchemaProperties(schema: any): any | null {
 }
 
 /**
+ * Resolves the config entry for a child property within a parent config node.
+ * When the parent is `true`/`undefined`, all children are observed.
+ * When the parent is `false`, all children are skipped.
+ * When the parent is an object node, the child inherits `$observe` when not listed.
+ */
+function getChildConfigEntry(
+    parentConfig: ObserverMapPathEntry | undefined,
+    propertyName: string,
+): ObserverMapPathEntry | undefined {
+    if (parentConfig === undefined || parentConfig === true) {
+        return undefined; // inherit: observe all
+    }
+
+    if (parentConfig === false) {
+        return false; // inherit: skip all
+    }
+
+    // ObserverMapPathNode
+    if (propertyName in parentConfig) {
+        return parentConfig[propertyName];
+    }
+
+    // Child inherits the node's $observe value
+    return parentConfig.$observe ?? undefined;
+}
+
+/**
+ * Determines whether a config entry indicates the current path should be observed.
+ * `undefined` means "inherit from parent" and defaults to observed.
+ */
+function shouldObserveAtPath(configEntry: ObserverMapPathEntry | undefined): boolean {
+    if (configEntry === undefined || configEntry === true) {
+        return true;
+    }
+
+    if (configEntry === false) {
+        return false;
+    }
+
+    // ObserverMapPathNode: $observe defaults to true when unspecified
+    return configEntry.$observe !== false;
+}
+
+/**
+ * Determines whether a config entry has any observed path in its subtree.
+ * Used to decide whether to recurse into an object even if the current level is skipped.
+ */
+function hasObservedDescendant(configEntry: ObserverMapPathEntry | undefined): boolean {
+    if (configEntry === undefined || configEntry === true) {
+        return true;
+    }
+
+    if (configEntry === false) {
+        return false;
+    }
+
+    // ObserverMapPathNode
+    if (configEntry.$observe === true) {
+        return true;
+    }
+
+    for (const key of Object.keys(configEntry)) {
+        if (key === "$observe") {
+            continue;
+        }
+
+        const child = configEntry[key];
+
+        if (child !== undefined && hasObservedDescendant(child)) {
+            return true;
+        }
+    }
+
+    // A node with $observe unset (defaults to true) and no children entries: observed
+    return configEntry.$observe !== false;
+}
+
+/**
  * Assigns Observable properties to items in an array and sets up change notifications
  * @param proxiedData - The array data to make observable
  * @param schema - The schema defining the structure of array items
  * @param rootSchema - The root schema for the entire data structure
+ * @param target - The target element
+ * @param rootProperty - The root property name
+ * @param configEntry - Optional path config entry controlling observation granularity
  * @returns The array with observable properties and change notifications
  */
 function assignObservablesToArray(
@@ -1190,6 +1272,7 @@ function assignObservablesToArray(
     rootSchema: JSONSchema,
     target: any,
     rootProperty: string,
+    configEntry?: ObserverMapPathEntry,
 ): any {
     const schemaProperties = getSchemaProperties(schema);
 
@@ -1199,7 +1282,13 @@ function assignObservablesToArray(
         ? proxiedData.map((item: any) => {
               const originalItem = Object.assign({}, item);
 
-              assignProxyToItemsInArray(item, originalItem, schema, rootSchema);
+              assignProxyToItemsInArray(
+                  item,
+                  originalItem,
+                  schema,
+                  rootSchema,
+                  configEntry,
+              );
 
               return Object.assign(item, originalItem);
           })
@@ -1219,6 +1308,7 @@ function assignObservablesToArray(
                                 originalItem,
                                 schema,
                                 rootSchema,
+                                configEntry,
                             );
 
                             Object.assign(item, originalItem);
@@ -1332,6 +1422,7 @@ function assignSubscribeToObservableArray(
  * @param data - The data
  * @param target - The target custom element
  * @param rootProperty - The root property
+ * @param configEntry - Optional path config entry controlling observation granularity
  * @returns
  */
 export function assignObservables(
@@ -1340,6 +1431,7 @@ export function assignObservables(
     data: any,
     target: any,
     rootProperty: string,
+    configEntry?: ObserverMapPathEntry,
 ): typeof Proxy {
     const dataType = getDataType(data);
     let proxiedData = data;
@@ -1357,6 +1449,7 @@ export function assignObservables(
                     rootSchema,
                     target,
                     rootProperty,
+                    configEntry,
                 );
 
                 if (!observedArraysMap.has(proxiedData)) {
@@ -1371,6 +1464,7 @@ export function assignObservables(
                                 rootSchema,
                                 target,
                                 rootProperty,
+                                configEntry,
                             ),
                         ),
                     );
@@ -1385,6 +1479,7 @@ export function assignObservables(
                     rootSchema,
                     target,
                     rootProperty,
+                    configEntry,
                 );
             }
 
@@ -1397,6 +1492,7 @@ export function assignObservables(
                 proxiedData,
                 schema,
                 rootSchema,
+                configEntry,
             );
             break;
         }
@@ -1411,16 +1507,24 @@ export function assignObservables(
  * @param originalItem - The original array item
  * @param schema - The schema mapping to the items in the array
  * @param rootSchema - The root schema assigned to the root property
+ * @param configEntry - Optional path config entry controlling observation granularity
  */
 function assignProxyToItemsInArray(
     proxiableItem: any,
     originalItem: any,
     schema: JSONSchema | JSONSchemaDefinition,
     rootSchema: JSONSchema,
+    configEntry?: ObserverMapPathEntry,
 ): void {
     const schemaProperties = getSchemaProperties(schema);
 
     getObjectProperties(proxiableItem, schemaProperties).forEach(key => {
+        const childConfig = getChildConfigEntry(configEntry, key);
+
+        // Skip this property if config excludes it entirely
+        if (childConfig === false && !hasObservedDescendant(childConfig)) {
+            return;
+        }
         // Initialize the property as undefined if it doesn't exist
         if (!(key in originalItem)) {
             originalItem[key] = undefined;
@@ -1433,6 +1537,7 @@ function assignProxyToItemsInArray(
             originalItem[key],
             schemaProperties[key],
             rootSchema,
+            childConfig,
         );
 
         // Then make the property observable
@@ -1466,6 +1571,7 @@ function getObjectProperties(data: any, schemaProperties: any): string[] {
  * @param data - The data to proxy
  * @param schema - The schema for the data
  * @param rootSchema - The root schema for the root property
+ * @param configEntry - Optional path config entry controlling observation granularity
  * @returns a Proxy
  */
 function assignProxyToItemsInObject(
@@ -1474,6 +1580,7 @@ function assignProxyToItemsInObject(
     data: any,
     schema: JSONSchema | JSONSchemaDefinition,
     rootSchema: JSONSchema,
+    configEntry?: ObserverMapPathEntry,
 ): any | typeof Proxy {
     const type = getDataType(data);
     const schemaProperties = getSchemaProperties(schema);
@@ -1482,20 +1589,46 @@ function assignProxyToItemsInObject(
     if (type === "object" && schemaProperties) {
         // navigate through all items in the object
         getObjectProperties(proxiedData, schemaProperties).forEach(property => {
+            const childConfig = getChildConfigEntry(configEntry, property);
+
+            // Skip properties that are excluded by config with no observed descendants
+            if (childConfig === false) {
+                return;
+            }
+
+            if (
+                typeof childConfig === "object" &&
+                childConfig !== null &&
+                !hasObservedDescendant(childConfig)
+            ) {
+                return;
+            }
+
             proxiedData[property] = assignProxyToItemsInObject(
                 target,
                 rootProperty,
                 proxiedData[property],
                 schemaProperties[property],
                 rootSchema,
+                childConfig,
             );
         });
 
-        // assign a Proxy to the object
-        proxiedData = assignProxy(schema, rootSchema, target, rootProperty, proxiedData);
+        // Assign a Proxy if this level is observed OR has observed descendants
+        // (descendants need the proxy's set trap to intercept their mutations)
+        if (shouldObserveAtPath(configEntry) || hasObservedDescendant(configEntry)) {
+            proxiedData = assignProxy(
+                schema,
+                rootSchema,
+                target,
+                rootProperty,
+                proxiedData,
+                configEntry,
+            );
 
-        // Add this target to the object's target list
-        addTargetToObject(proxiedData, target, rootProperty);
+            // Add this target to the object's target list
+            addTargetToObject(proxiedData, target, rootProperty);
+        }
     } else if (type === "array") {
         const context = findDef((schema as JSONSchema).items);
 
@@ -1509,6 +1642,7 @@ function assignProxyToItemsInObject(
                     rootSchema,
                     target,
                     rootProperty,
+                    configEntry,
                 );
 
                 if (!observedArraysMap.has(proxiedData)) {
@@ -1520,6 +1654,7 @@ function assignProxyToItemsInObject(
                             rootSchema,
                             target,
                             rootProperty,
+                            configEntry,
                         ),
                     );
                 }
@@ -1575,6 +1710,7 @@ function notifyObservables(targetObject: any) {
  * @param target - The target custom element
  * @param rootProperty - The root property
  * @param object - The object to assign the proxy to
+ * @param configEntry - Optional path config entry controlling observation granularity
  * @returns Proxy object
  */
 export function assignProxy(
@@ -1583,6 +1719,7 @@ export function assignProxy(
     target: any,
     rootProperty: string,
     object: any,
+    configEntry?: ObserverMapPathEntry,
 ): typeof Proxy {
     if (!object.$isProxy) {
         // Create a proxy for the object that triggers Observable.notify on mutations
@@ -1594,12 +1731,22 @@ export function assignProxy(
                     return true;
                 }
 
+                const propName = typeof prop === "string" ? prop : String(prop);
+                const childConfig = getChildConfigEntry(configEntry, propName);
+
+                // If this property is excluded by config, assign without proxying or notifying
+                if (childConfig === false) {
+                    obj[prop] = value;
+                    return true;
+                }
+
                 obj[prop] = assignObservables(
                     schema,
                     rootSchema,
                     value,
                     target,
                     rootProperty,
+                    childConfig,
                 );
 
                 notifyObservables(proxy);
@@ -1615,9 +1762,15 @@ export function assignProxy(
             },
             deleteProperty: (obj: any, prop: string | symbol) => {
                 if (prop in obj) {
+                    const propName = typeof prop === "string" ? prop : String(prop);
+                    const childConfig = getChildConfigEntry(configEntry, propName);
+
                     delete obj[prop];
 
-                    notifyObservables(proxy);
+                    // Only notify if this property is not excluded by config
+                    if (childConfig !== false) {
+                        notifyObservables(proxy);
+                    }
 
                     return true;
                 }

--- a/packages/fast-html/src/components/utilities.ts
+++ b/packages/fast-html/src/components/utilities.ts
@@ -23,7 +23,6 @@ import {
     whenDirectiveClose,
     whenDirectiveOpen,
 } from "./syntax.js";
-import type { ObserverMapPathEntry } from "./template.js";
 
 type BehaviorType = "dataBinding" | "templateDirective";
 
@@ -1179,81 +1178,21 @@ function getSchemaProperties(schema: any): any | null {
 }
 
 /**
- * Resolves the config entry for a child property within a parent config node.
- * When the parent is `true`/`undefined`, all children are observed.
- * When the parent is `false`, all children are skipped.
- * When the parent is an object node, the child inherits `$observe` when not listed.
+ * Checks whether a schema node (or any of its descendants) has observation enabled.
+ * Returns false only when the node and ALL its descendants are stamped with `$observe: false`.
  */
-function getChildConfigEntry(
-    parentConfig: ObserverMapPathEntry | undefined,
-    propertyName: string,
-): ObserverMapPathEntry | undefined {
-    if (parentConfig === undefined || parentConfig === true) {
-        return undefined; // inherit: observe all
-    }
-
-    if (parentConfig === false) {
-        return false; // inherit: skip all
-    }
-
-    // ObserverMapPathNode
-    if (propertyName in parentConfig) {
-        return parentConfig[propertyName];
-    }
-
-    // Child inherits the node's $observe value
-    return parentConfig.$observe ?? undefined;
-}
-
-/**
- * Determines whether a config entry indicates the current path should be observed.
- * `undefined` means "inherit from parent" and defaults to observed.
- */
-function shouldObserveAtPath(configEntry: ObserverMapPathEntry | undefined): boolean {
-    if (configEntry === undefined || configEntry === true) {
+function hasObservedSchemaDescendant(schema: any): boolean {
+    if (schema?.$observe !== false) {
         return true;
     }
 
-    if (configEntry === false) {
+    const props = getSchemaProperties(schema);
+
+    if (!props) {
         return false;
     }
 
-    // ObserverMapPathNode: $observe defaults to true when unspecified
-    return configEntry.$observe !== false;
-}
-
-/**
- * Determines whether a config entry has any observed path in its subtree.
- * Used to decide whether to recurse into an object even if the current level is skipped.
- */
-function hasObservedDescendant(configEntry: ObserverMapPathEntry | undefined): boolean {
-    if (configEntry === undefined || configEntry === true) {
-        return true;
-    }
-
-    if (configEntry === false) {
-        return false;
-    }
-
-    // ObserverMapPathNode
-    if (configEntry.$observe === true) {
-        return true;
-    }
-
-    for (const key of Object.keys(configEntry)) {
-        if (key === "$observe") {
-            continue;
-        }
-
-        const child = configEntry[key];
-
-        if (child !== undefined && hasObservedDescendant(child)) {
-            return true;
-        }
-    }
-
-    // A node with $observe unset (defaults to true) and no children entries: observed
-    return configEntry.$observe !== false;
+    return Object.keys(props).some(k => hasObservedSchemaDescendant(props[k]));
 }
 
 /**
@@ -1263,7 +1202,6 @@ function hasObservedDescendant(configEntry: ObserverMapPathEntry | undefined): b
  * @param rootSchema - The root schema for the entire data structure
  * @param target - The target element
  * @param rootProperty - The root property name
- * @param configEntry - Optional path config entry controlling observation granularity
  * @returns The array with observable properties and change notifications
  */
 function assignObservablesToArray(
@@ -1272,7 +1210,6 @@ function assignObservablesToArray(
     rootSchema: JSONSchema,
     target: any,
     rootProperty: string,
-    configEntry?: ObserverMapPathEntry,
 ): any {
     const schemaProperties = getSchemaProperties(schema);
 
@@ -1282,13 +1219,7 @@ function assignObservablesToArray(
         ? proxiedData.map((item: any) => {
               const originalItem = Object.assign({}, item);
 
-              assignProxyToItemsInArray(
-                  item,
-                  originalItem,
-                  schema,
-                  rootSchema,
-                  configEntry,
-              );
+              assignProxyToItemsInArray(item, originalItem, schema, rootSchema);
 
               return Object.assign(item, originalItem);
           })
@@ -1308,7 +1239,6 @@ function assignObservablesToArray(
                                 originalItem,
                                 schema,
                                 rootSchema,
-                                configEntry,
                             );
 
                             Object.assign(item, originalItem);
@@ -1422,7 +1352,6 @@ function assignSubscribeToObservableArray(
  * @param data - The data
  * @param target - The target custom element
  * @param rootProperty - The root property
- * @param configEntry - Optional path config entry controlling observation granularity
  * @returns
  */
 export function assignObservables(
@@ -1431,7 +1360,6 @@ export function assignObservables(
     data: any,
     target: any,
     rootProperty: string,
-    configEntry?: ObserverMapPathEntry,
 ): typeof Proxy {
     const dataType = getDataType(data);
     let proxiedData = data;
@@ -1449,7 +1377,6 @@ export function assignObservables(
                     rootSchema,
                     target,
                     rootProperty,
-                    configEntry,
                 );
 
                 if (!observedArraysMap.has(proxiedData)) {
@@ -1464,7 +1391,6 @@ export function assignObservables(
                                 rootSchema,
                                 target,
                                 rootProperty,
-                                configEntry,
                             ),
                         ),
                     );
@@ -1479,7 +1405,6 @@ export function assignObservables(
                     rootSchema,
                     target,
                     rootProperty,
-                    configEntry,
                 );
             }
 
@@ -1492,7 +1417,6 @@ export function assignObservables(
                 proxiedData,
                 schema,
                 rootSchema,
-                configEntry,
             );
             break;
         }
@@ -1507,24 +1431,26 @@ export function assignObservables(
  * @param originalItem - The original array item
  * @param schema - The schema mapping to the items in the array
  * @param rootSchema - The root schema assigned to the root property
- * @param configEntry - Optional path config entry controlling observation granularity
  */
 function assignProxyToItemsInArray(
     proxiableItem: any,
     originalItem: any,
     schema: JSONSchema | JSONSchemaDefinition,
     rootSchema: JSONSchema,
-    configEntry?: ObserverMapPathEntry,
 ): void {
     const schemaProperties = getSchemaProperties(schema);
 
     getObjectProperties(proxiableItem, schemaProperties).forEach(key => {
-        const childConfig = getChildConfigEntry(configEntry, key);
+        const childSchema = schemaProperties[key];
 
-        // Skip this property if config excludes it entirely
-        if (childConfig === false && !hasObservedDescendant(childConfig)) {
+        // Skip properties excluded by $observe: false that have no observed descendants
+        if (
+            childSchema?.$observe === false &&
+            !hasObservedSchemaDescendant(childSchema)
+        ) {
             return;
         }
+
         // Initialize the property as undefined if it doesn't exist
         if (!(key in originalItem)) {
             originalItem[key] = undefined;
@@ -1537,7 +1463,6 @@ function assignProxyToItemsInArray(
             originalItem[key],
             schemaProperties[key],
             rootSchema,
-            childConfig,
         );
 
         // Then make the property observable
@@ -1571,7 +1496,6 @@ function getObjectProperties(data: any, schemaProperties: any): string[] {
  * @param data - The data to proxy
  * @param schema - The schema for the data
  * @param rootSchema - The root schema for the root property
- * @param configEntry - Optional path config entry controlling observation granularity
  * @returns a Proxy
  */
 function assignProxyToItemsInObject(
@@ -1580,7 +1504,6 @@ function assignProxyToItemsInObject(
     data: any,
     schema: JSONSchema | JSONSchemaDefinition,
     rootSchema: JSONSchema,
-    configEntry?: ObserverMapPathEntry,
 ): any | typeof Proxy {
     const type = getDataType(data);
     const schemaProperties = getSchemaProperties(schema);
@@ -1589,17 +1512,12 @@ function assignProxyToItemsInObject(
     if (type === "object" && schemaProperties) {
         // navigate through all items in the object
         getObjectProperties(proxiedData, schemaProperties).forEach(property => {
-            const childConfig = getChildConfigEntry(configEntry, property);
+            const childSchema = schemaProperties[property];
 
-            // Skip properties that are excluded by config with no observed descendants
-            if (childConfig === false) {
-                return;
-            }
-
+            // Skip properties excluded by $observe: false that have no observed descendants
             if (
-                typeof childConfig === "object" &&
-                childConfig !== null &&
-                !hasObservedDescendant(childConfig)
+                childSchema?.$observe === false &&
+                !hasObservedSchemaDescendant(childSchema)
             ) {
                 return;
             }
@@ -1610,20 +1528,18 @@ function assignProxyToItemsInObject(
                 proxiedData[property],
                 schemaProperties[property],
                 rootSchema,
-                childConfig,
             );
         });
 
-        // Assign a Proxy if this level is observed OR has observed descendants
-        // (descendants need the proxy's set trap to intercept their mutations)
-        if (shouldObserveAtPath(configEntry) || hasObservedDescendant(configEntry)) {
+        // Assign a Proxy if this level is observed or has any observed child properties
+        // (children need the proxy's set trap to intercept their mutations)
+        if (schema.$observe !== false || hasObservedSchemaDescendant(schema)) {
             proxiedData = assignProxy(
                 schema,
                 rootSchema,
                 target,
                 rootProperty,
                 proxiedData,
-                configEntry,
             );
 
             // Add this target to the object's target list
@@ -1642,7 +1558,6 @@ function assignProxyToItemsInObject(
                     rootSchema,
                     target,
                     rootProperty,
-                    configEntry,
                 );
 
                 if (!observedArraysMap.has(proxiedData)) {
@@ -1654,7 +1569,6 @@ function assignProxyToItemsInObject(
                             rootSchema,
                             target,
                             rootProperty,
-                            configEntry,
                         ),
                     );
                 }
@@ -1710,7 +1624,6 @@ function notifyObservables(targetObject: any) {
  * @param target - The target custom element
  * @param rootProperty - The root property
  * @param object - The object to assign the proxy to
- * @param configEntry - Optional path config entry controlling observation granularity
  * @returns Proxy object
  */
 export function assignProxy(
@@ -1719,9 +1632,10 @@ export function assignProxy(
     target: any,
     rootProperty: string,
     object: any,
-    configEntry?: ObserverMapPathEntry,
 ): typeof Proxy {
     if (!object.$isProxy) {
+        const schemaProperties = getSchemaProperties(schema);
+
         // Create a proxy for the object that triggers Observable.notify on mutations
         const proxy = new Proxy(object, {
             set: (obj: any, prop: string | symbol, value: any) => {
@@ -1732,10 +1646,9 @@ export function assignProxy(
                 }
 
                 const propName = typeof prop === "string" ? prop : String(prop);
-                const childConfig = getChildConfigEntry(configEntry, propName);
 
-                // If this property is excluded by config, assign without proxying or notifying
-                if (childConfig === false) {
+                // If the schema marks this property as not observed, assign without proxying or notifying
+                if (schemaProperties?.[propName]?.$observe === false) {
                     obj[prop] = value;
                     return true;
                 }
@@ -1746,7 +1659,6 @@ export function assignProxy(
                     value,
                     target,
                     rootProperty,
-                    childConfig,
                 );
 
                 notifyObservables(proxy);
@@ -1763,12 +1675,11 @@ export function assignProxy(
             deleteProperty: (obj: any, prop: string | symbol) => {
                 if (prop in obj) {
                     const propName = typeof prop === "string" ? prop : String(prop);
-                    const childConfig = getChildConfigEntry(configEntry, propName);
 
                     delete obj[prop];
 
-                    // Only notify if this property is not excluded by config
-                    if (childConfig !== false) {
+                    // Only notify if the schema does not mark this property as excluded
+                    if (schemaProperties?.[propName]?.$observe !== false) {
                         notifyObservables(proxy);
                     }
 

--- a/packages/fast-html/src/index.ts
+++ b/packages/fast-html/src/index.ts
@@ -7,6 +7,8 @@ export {
     type AttributeMapConfig,
     ObserverMap,
     type ObserverMapConfig,
+    type ObserverMapPathEntry,
+    type ObserverMapPathNode,
     RenderableFASTElement,
     TemplateElement,
 } from "./components/index.js";

--- a/packages/fast-html/test/fixtures/observer-map-properties/entry.html
+++ b/packages/fast-html/test/fixtures/observer-map-properties/entry.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+    </head>
+    <body>
+        <selective-obs-element></selective-obs-element>
+        <all-obs-element></all-obs-element>
+        <empty-props-element></empty-props-element>
+        <array-selective-element></array-selective-element>
+        <script type="module" src="./main.ts"></script>
+    </body>
+</html>

--- a/packages/fast-html/test/fixtures/observer-map-properties/fast-build.config.json
+++ b/packages/fast-html/test/fixtures/observer-map-properties/fast-build.config.json
@@ -1,0 +1,6 @@
+{
+    "entry": "entry.html",
+    "state": "state.json",
+    "output": "index.html",
+    "templates": "templates.html"
+}

--- a/packages/fast-html/test/fixtures/observer-map-properties/index.html
+++ b/packages/fast-html/test/fixtures/observer-map-properties/index.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+    </head>
+    <body>
+        <selective-obs-element><template shadowrootmode="open" shadowroot="open"><div class="user-section">
+            <span class="user-name"><!--fe-b$$start$$0$$user.name-0$$fe-b-->Alice<!--fe-b$$end$$0$$user.name-0$$fe-b--></span>
+            <span class="user-age"><!--fe-b$$start$$1$$user.age-1$$fe-b-->28<!--fe-b$$end$$1$$user.age-1$$fe-b--></span>
+            <span class="user-history-joined"><!--fe-b$$start$$2$$user.history.joined-2$$fe-b-->2020-01-01<!--fe-b$$end$$2$$user.history.joined-2$$fe-b--></span>
+            <span class="user-history-visits"><!--fe-b$$start$$3$$user.history.visits-3$$fe-b-->100<!--fe-b$$end$$3$$user.history.visits-3$$fe-b--></span>
+            <span class="user-location-city"><!--fe-b$$start$$4$$user.location.city-4$$fe-b-->New York<!--fe-b$$end$$4$$user.location.city-4$$fe-b--></span>
+        </div>
+        <div class="settings-section">
+            <span class="settings-theme"><!--fe-b$$start$$5$$settings.theme-5$$fe-b-->dark<!--fe-b$$end$$5$$settings.theme-5$$fe-b--></span>
+        </div>
+        <div class="analytics-section">
+            <span class="active-chart"><!--fe-b$$start$$6$$analytics.charts.activeChart-6$$fe-b-->line<!--fe-b$$end$$6$$analytics.charts.activeChart-6$$fe-b--></span>
+            <span class="cached-data"><!--fe-b$$start$$7$$analytics.charts.cachedData-7$$fe-b-->heavy-data<!--fe-b$$end$$7$$analytics.charts.cachedData-7$$fe-b--></span>
+            <span class="analytics-summary"><!--fe-b$$start$$8$$analytics.summary-8$$fe-b-->good<!--fe-b$$end$$8$$analytics.summary-8$$fe-b--></span>
+        </div>
+        <button data-fe-c-9-1>Update Name</button>
+        <button data-fe-c-10-1>Update Age</button>
+        <button data-fe-c-11-1>Update History</button>
+        <button data-fe-c-12-1>Update Location</button>
+        <button data-fe-c-13-1>Update Settings</button>
+        <button data-fe-c-14-1>Update Active Chart</button>
+        <button data-fe-c-15-1>Update Cached Data</button>
+        <button data-fe-c-16-1>Update Summary</button></template></selective-obs-element>
+        <all-obs-element><template shadowrootmode="open" shadowroot="open"><span class="user-name"><!--fe-b$$start$$0$$user.name-0$$fe-b-->Alice<!--fe-b$$end$$0$$user.name-0$$fe-b--></span>
+        <span class="settings-theme"><!--fe-b$$start$$1$$settings.theme-1$$fe-b-->dark<!--fe-b$$end$$1$$settings.theme-1$$fe-b--></span>
+        <button data-fe-c-2-1>Update Name</button>
+        <button data-fe-c-3-1>Update Settings</button></template></all-obs-element>
+        <empty-props-element><template shadowrootmode="open" shadowroot="open"><span class="user-name"><!--fe-b$$start$$0$$user.name-0$$fe-b-->Alice<!--fe-b$$end$$0$$user.name-0$$fe-b--></span>
+        <span class="settings-theme"><!--fe-b$$start$$1$$settings.theme-1$$fe-b-->dark<!--fe-b$$end$$1$$settings.theme-1$$fe-b--></span>
+        <button data-fe-c-2-1>Update Name</button>
+        <button data-fe-c-3-1>Update Settings</button></template></empty-props-element>
+        <array-selective-element><template shadowrootmode="open" shadowroot="open"><!--fe-b$$start$$0$$repeat-0$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
+            <div class="item-row">
+                <span class="item-text"><!--fe-b$$start$$0$$item.text-0$$fe-b-->item-1<!--fe-b$$end$$0$$item.text-0$$fe-b--></span>
+                <span class="item-count"><!--fe-b$$start$$1$$item.meta.count-1$$fe-b-->1<!--fe-b$$end$$1$$item.meta.count-1$$fe-b--></span>
+            </div>
+        <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
+            <div class="item-row">
+                <span class="item-text"><!--fe-b$$start$$0$$item.text-0$$fe-b-->item-2<!--fe-b$$end$$0$$item.text-0$$fe-b--></span>
+                <span class="item-count"><!--fe-b$$start$$1$$item.meta.count-1$$fe-b-->2<!--fe-b$$end$$1$$item.meta.count-1$$fe-b--></span>
+            </div>
+        <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$0$$repeat-0$$fe-b-->
+        <button data-fe-c-1-1>Update Item Text</button>
+        <button data-fe-c-2-1>Add Item</button></template></array-selective-element>
+<f-template name="selective-obs-element">
+    <template>
+        <div class="user-section">
+            <span class="user-name">{{user.name}}</span>
+            <span class="user-age">{{user.age}}</span>
+            <span class="user-history-joined">{{user.history.joined}}</span>
+            <span class="user-history-visits">{{user.history.visits}}</span>
+            <span class="user-location-city">{{user.location.city}}</span>
+        </div>
+        <div class="settings-section">
+            <span class="settings-theme">{{settings.theme}}</span>
+        </div>
+        <div class="analytics-section">
+            <span class="active-chart">{{analytics.charts.activeChart}}</span>
+            <span class="cached-data">{{analytics.charts.cachedData}}</span>
+            <span class="analytics-summary">{{analytics.summary}}</span>
+        </div>
+        <button @click="{updateUserName()}">Update Name</button>
+        <button @click="{updateUserAge()}">Update Age</button>
+        <button @click="{updateHistory()}">Update History</button>
+        <button @click="{updateLocation()}">Update Location</button>
+        <button @click="{updateSettings()}">Update Settings</button>
+        <button @click="{updateActiveChart()}">Update Active Chart</button>
+        <button @click="{updateCachedData()}">Update Cached Data</button>
+        <button @click="{updateSummary()}">Update Summary</button>
+    </template>
+</f-template>
+<f-template name="all-obs-element">
+    <template>
+        <span class="user-name">{{user.name}}</span>
+        <span class="settings-theme">{{settings.theme}}</span>
+        <button @click="{updateUserName()}">Update Name</button>
+        <button @click="{updateSettings()}">Update Settings</button>
+    </template>
+</f-template>
+<f-template name="empty-props-element">
+    <template>
+        <span class="user-name">{{user.name}}</span>
+        <span class="settings-theme">{{settings.theme}}</span>
+        <button @click="{updateUserName()}">Update Name</button>
+        <button @click="{updateSettings()}">Update Settings</button>
+    </template>
+</f-template>
+<f-template name="array-selective-element">
+    <template>
+        <f-repeat value="{{item in items}}">
+            <div class="item-row">
+                <span class="item-text">{{item.text}}</span>
+                <span class="item-count">{{item.meta.count}}</span>
+            </div>
+        </f-repeat>
+        <button @click="{updateItemText()}">Update Item Text</button>
+        <button @click="{addItem()}">Add Item</button>
+    </template>
+</f-template>
+
+        <script type="module" src="./main.ts"></script>
+    </body>
+</html>

--- a/packages/fast-html/test/fixtures/observer-map-properties/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map-properties/main.ts
@@ -1,0 +1,169 @@
+import { FASTElement } from "@microsoft/fast-element";
+import { TemplateElement } from "@microsoft/fast-html";
+
+class SelectiveObsElement extends FASTElement {
+    public user = {
+        name: "Alice",
+        age: 28,
+        history: {
+            joined: "2020-01-01",
+            visits: 100,
+        },
+        location: {
+            city: "New York",
+            country: "USA",
+        },
+    };
+
+    public settings = {
+        theme: "dark",
+        language: "en",
+    };
+
+    public analytics = {
+        charts: {
+            activeChart: "line",
+            cachedData: "heavy-data",
+        },
+        summary: "good",
+    };
+
+    public updateUserName = () => {
+        this.user.name = "Bob";
+    };
+
+    public updateUserAge = () => {
+        this.user.age = 29;
+    };
+
+    public updateHistory = () => {
+        this.user.history.visits = 200;
+    };
+
+    public updateLocation = () => {
+        this.user.location.city = "London";
+    };
+
+    public updateSettings = () => {
+        this.settings.theme = "light";
+    };
+
+    public updateActiveChart = () => {
+        this.analytics.charts.activeChart = "bar";
+    };
+
+    public updateCachedData = () => {
+        this.analytics.charts.cachedData = "updated-heavy-data";
+    };
+
+    public updateSummary = () => {
+        this.analytics.summary = "excellent";
+    };
+}
+
+SelectiveObsElement.defineAsync({
+    name: "selective-obs-element",
+});
+
+class AllObsElement extends FASTElement {
+    public user = {
+        name: "Alice",
+    };
+
+    public settings = {
+        theme: "dark",
+    };
+
+    public updateUserName = () => {
+        this.user.name = "Bob";
+    };
+
+    public updateSettings = () => {
+        this.settings.theme = "light";
+    };
+}
+
+AllObsElement.defineAsync({
+    name: "all-obs-element",
+});
+
+class EmptyPropsElement extends FASTElement {
+    public user = {
+        name: "Alice",
+    };
+
+    public settings = {
+        theme: "dark",
+    };
+
+    public updateUserName = () => {
+        this.user.name = "Bob";
+    };
+
+    public updateSettings = () => {
+        this.settings.theme = "light";
+    };
+}
+
+EmptyPropsElement.defineAsync({
+    name: "empty-props-element",
+});
+
+class ArraySelectiveElement extends FASTElement {
+    public items: any[] = [
+        { text: "item-1", meta: { count: 1 } },
+        { text: "item-2", meta: { count: 2 } },
+    ];
+
+    public updateItemText = () => {
+        this.items[0].text = "updated-item-1";
+    };
+
+    public addItem = () => {
+        this.items.push({ text: "item-3", meta: { count: 3 } });
+    };
+}
+
+ArraySelectiveElement.defineAsync({
+    name: "array-selective-element",
+});
+
+TemplateElement.options({
+    "selective-obs-element": {
+        observerMap: {
+            properties: {
+                user: {
+                    name: true,
+                    age: true,
+                    history: false,
+                    location: true,
+                },
+                // settings is NOT listed → skipped
+                analytics: {
+                    charts: {
+                        $observe: false,
+                        activeChart: true,
+                    },
+                    summary: true,
+                },
+            },
+        },
+    },
+    "all-obs-element": {
+        observerMap: {},
+    },
+    "empty-props-element": {
+        observerMap: {
+            properties: {},
+        },
+    },
+    "array-selective-element": {
+        observerMap: {
+            properties: {
+                items: true,
+            },
+        },
+    },
+}).define({
+    name: "f-template",
+});

--- a/packages/fast-html/test/fixtures/observer-map-properties/observer-map-properties.spec.ts
+++ b/packages/fast-html/test/fixtures/observer-map-properties/observer-map-properties.spec.ts
@@ -1,0 +1,179 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("ObserverMap properties", async () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/fixtures/observer-map-properties/");
+        await page.waitForSelector("selective-obs-element");
+    });
+
+    test.describe("selective observation", () => {
+        test("should render initial values", async ({ page }) => {
+            const el = page.locator("selective-obs-element");
+
+            await expect(el.locator(".user-name")).toHaveText("Alice");
+            await expect(el.locator(".user-age")).toHaveText("28");
+            await expect(el.locator(".user-location-city")).toHaveText("New York");
+            await expect(el.locator(".active-chart")).toHaveText("line");
+            await expect(el.locator(".analytics-summary")).toHaveText("good");
+        });
+
+        test("should update observed property: user.name", async ({ page }) => {
+            const el = page.locator("selective-obs-element");
+            await el.locator("button:has-text('Update Name')").click();
+
+            await expect(el.locator(".user-name")).toHaveText("Bob");
+        });
+
+        test("should update observed property: user.age", async ({ page }) => {
+            const el = page.locator("selective-obs-element");
+            await el.locator("button:has-text('Update Age')").click();
+
+            await expect(el.locator(".user-age")).toHaveText("29");
+        });
+
+        test("should NOT update excluded property: user.history (false)", async ({
+            page,
+        }) => {
+            const el = page.locator("selective-obs-element");
+            const initialValue = await el.locator(".user-history-visits").textContent();
+
+            await el.locator("button:has-text('Update History')").click();
+
+            // Wait a frame
+            await page.evaluate(
+                () => new Promise(resolve => requestAnimationFrame(() => resolve(true))),
+            );
+
+            // The text should NOT have updated because history is excluded
+            await expect(el.locator(".user-history-visits")).toHaveText(initialValue!);
+        });
+
+        test("should update observed property: user.location (true)", async ({
+            page,
+        }) => {
+            const el = page.locator("selective-obs-element");
+            await el.locator("button:has-text('Update Location')").click();
+
+            await expect(el.locator(".user-location-city")).toHaveText("London");
+        });
+
+        test("should NOT update unlisted root property: settings", async ({ page }) => {
+            const el = page.locator("selective-obs-element");
+            const initialValue = await el.locator(".settings-theme").textContent();
+
+            await el.locator("button:has-text('Update Settings')").click();
+
+            await page.evaluate(
+                () => new Promise(resolve => requestAnimationFrame(() => resolve(true))),
+            );
+
+            // settings is not listed in properties → skipped
+            await expect(el.locator(".settings-theme")).toHaveText(initialValue!);
+        });
+
+        test("should update observed property inside $observe:false branch: analytics.charts.activeChart", async ({
+            page,
+        }) => {
+            const el = page.locator("selective-obs-element");
+            await el.locator("button:has-text('Update Active Chart')").click();
+
+            await expect(el.locator(".active-chart")).toHaveText("bar");
+        });
+
+        test("should NOT update excluded property: analytics.charts.cachedData (inherits $observe:false)", async ({
+            page,
+        }) => {
+            const el = page.locator("selective-obs-element");
+            const initialValue = await el.locator(".cached-data").textContent();
+
+            await el.locator("button:has-text('Update Cached Data')").click();
+
+            await page.evaluate(
+                () => new Promise(resolve => requestAnimationFrame(() => resolve(true))),
+            );
+
+            // cachedData inherits $observe:false from charts node
+            await expect(el.locator(".cached-data")).toHaveText(initialValue!);
+        });
+
+        test("should update observed property: analytics.summary (true)", async ({
+            page,
+        }) => {
+            const el = page.locator("selective-obs-element");
+            await el.locator("button:has-text('Update Summary')").click();
+
+            await expect(el.locator(".analytics-summary")).toHaveText("excellent");
+        });
+    });
+
+    test.describe("empty config object (observe all)", () => {
+        test("should update user.name with observerMap: {}", async ({ page }) => {
+            const el = page.locator("all-obs-element");
+            await el.locator("button:has-text('Update Name')").click();
+
+            await expect(el.locator(".user-name")).toHaveText("Bob");
+        });
+
+        test("should update settings.theme with observerMap: {}", async ({ page }) => {
+            const el = page.locator("all-obs-element");
+            await el.locator("button:has-text('Update Settings')").click();
+
+            await expect(el.locator(".settings-theme")).toHaveText("light");
+        });
+    });
+
+    test.describe("empty properties object (observe nothing)", () => {
+        test("should NOT update user.name with properties: {}", async ({ page }) => {
+            const el = page.locator("empty-props-element");
+            const initialValue = await el.locator(".user-name").textContent();
+
+            await el.locator("button:has-text('Update Name')").click();
+
+            await page.evaluate(
+                () => new Promise(resolve => requestAnimationFrame(() => resolve(true))),
+            );
+
+            await expect(el.locator(".user-name")).toHaveText(initialValue!);
+        });
+
+        test("should NOT update settings.theme with properties: {}", async ({ page }) => {
+            const el = page.locator("empty-props-element");
+            const initialValue = await el.locator(".settings-theme").textContent();
+
+            await el.locator("button:has-text('Update Settings')").click();
+
+            await page.evaluate(
+                () => new Promise(resolve => requestAnimationFrame(() => resolve(true))),
+            );
+
+            await expect(el.locator(".settings-theme")).toHaveText(initialValue!);
+        });
+    });
+
+    test.describe("array with selective observation", () => {
+        test("should render initial array items", async ({ page }) => {
+            const el = page.locator("array-selective-element");
+
+            await expect(el.locator(".item-text").first()).toHaveText("item-1");
+            await expect(el.locator(".item-text").nth(1)).toHaveText("item-2");
+        });
+
+        test("should update item text in observed array", async ({ page }) => {
+            const el = page.locator("array-selective-element");
+            await el.locator("button:has-text('Update Item Text')").click();
+
+            await expect(el.locator(".item-text").first()).toHaveText("updated-item-1");
+        });
+
+        test("should add items to observed array", async ({ page }) => {
+            const el = page.locator("array-selective-element");
+
+            await expect(el.locator(".item-row")).toHaveCount(2);
+
+            await el.locator("button:has-text('Add Item')").click();
+
+            await expect(el.locator(".item-row")).toHaveCount(3);
+            await expect(el.locator(".item-text").nth(2)).toHaveText("item-3");
+        });
+    });
+});

--- a/packages/fast-html/test/fixtures/observer-map-properties/state.json
+++ b/packages/fast-html/test/fixtures/observer-map-properties/state.json
@@ -1,0 +1,29 @@
+{
+    "user": {
+        "name": "Alice",
+        "age": 28,
+        "history": {
+            "joined": "2020-01-01",
+            "visits": 100
+        },
+        "location": {
+            "city": "New York",
+            "country": "USA"
+        }
+    },
+    "settings": {
+        "theme": "dark",
+        "language": "en"
+    },
+    "analytics": {
+        "charts": {
+            "activeChart": "line",
+            "cachedData": "heavy-data"
+        },
+        "summary": "good"
+    },
+    "items": [
+        { "text": "item-1", "meta": { "count": 1 } },
+        { "text": "item-2", "meta": { "count": 2 } }
+    ]
+}

--- a/packages/fast-html/test/fixtures/observer-map-properties/templates.html
+++ b/packages/fast-html/test/fixtures/observer-map-properties/templates.html
@@ -1,0 +1,55 @@
+<f-template name="selective-obs-element">
+    <template>
+        <div class="user-section">
+            <span class="user-name">{{user.name}}</span>
+            <span class="user-age">{{user.age}}</span>
+            <span class="user-history-joined">{{user.history.joined}}</span>
+            <span class="user-history-visits">{{user.history.visits}}</span>
+            <span class="user-location-city">{{user.location.city}}</span>
+        </div>
+        <div class="settings-section">
+            <span class="settings-theme">{{settings.theme}}</span>
+        </div>
+        <div class="analytics-section">
+            <span class="active-chart">{{analytics.charts.activeChart}}</span>
+            <span class="cached-data">{{analytics.charts.cachedData}}</span>
+            <span class="analytics-summary">{{analytics.summary}}</span>
+        </div>
+        <button @click="{updateUserName()}">Update Name</button>
+        <button @click="{updateUserAge()}">Update Age</button>
+        <button @click="{updateHistory()}">Update History</button>
+        <button @click="{updateLocation()}">Update Location</button>
+        <button @click="{updateSettings()}">Update Settings</button>
+        <button @click="{updateActiveChart()}">Update Active Chart</button>
+        <button @click="{updateCachedData()}">Update Cached Data</button>
+        <button @click="{updateSummary()}">Update Summary</button>
+    </template>
+</f-template>
+<f-template name="all-obs-element">
+    <template>
+        <span class="user-name">{{user.name}}</span>
+        <span class="settings-theme">{{settings.theme}}</span>
+        <button @click="{updateUserName()}">Update Name</button>
+        <button @click="{updateSettings()}">Update Settings</button>
+    </template>
+</f-template>
+<f-template name="empty-props-element">
+    <template>
+        <span class="user-name">{{user.name}}</span>
+        <span class="settings-theme">{{settings.theme}}</span>
+        <button @click="{updateUserName()}">Update Name</button>
+        <button @click="{updateSettings()}">Update Settings</button>
+    </template>
+</f-template>
+<f-template name="array-selective-element">
+    <template>
+        <f-repeat value="{{item in items}}">
+            <div class="item-row">
+                <span class="item-text">{{item.text}}</span>
+                <span class="item-count">{{item.meta.count}}</span>
+            </div>
+        </f-repeat>
+        <button @click="{updateItemText()}">Update Item Text</button>
+        <button @click="{addItem()}">Add Item</button>
+    </template>
+</f-template>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds a `properties` key to the `ObserverMapConfig` interface in `@microsoft/fast-html` so that developers can opt specific root properties and nested sub-paths in or out of automatic observer-map observation, rather than the current all-or-nothing approach.

Each path entry can be:
- **`true`** — observe this path and all descendants
- **`false`** — skip this path and all descendants
- **`ObserverMapPathNode`** — an object with optional `$observe` boolean and child overrides, enabling alternating opt-in/opt-out to arbitrary depth

When `properties` is omitted (`observerMap: {}` or `observerMap: "all"`), current behavior is preserved. When `properties` is present but empty (`{ properties: {} }`), no root properties are observed.

### 🎫 Issues

- Resolves https://github.com/microsoft/fast/issues/7445

## 👩‍💻 Reviewer Notes

Key areas to review:
- **`observer-map.ts`**: New `hasObservedPath` helper and config filtering logic in `defineProperties()`
- **`utilities.ts`**: Config threading through the proxy system (`assignObservables`, `assignProxyToItemsInObject`, `assignProxy`), particularly the `set` trap changes that skip notification for excluded properties
- **`template.ts`**: New types (`ObserverMapPathEntry`, `ObserverMapPathNode`) and config extraction for `ObserverMap` constructor

## 📑 Test Plan

- All 289 existing + new Chromium tests pass
- New unit tests in `observer-map.spec.ts` covering:
  - Skipping unlisted root properties
  - Skipping `false` root properties
  - Observe-all with empty config (`{}`)
  - Observe-nothing with empty properties (`{ properties: {} }`)
- New fixture tests in `observer-map-properties/` covering:
  - Selective root property observation
  - Excluded subtrees (`false`)
  - Re-included leaf within `$observe: false` branch
  - Unlisted root properties remaining unobserved
  - Array observation with selective config
  - Empty config object backward compatibility

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.