### PR TITLE
chore: update @microsoft/webui dependency to 0.0.9

### DIFF
--- a/change/@microsoft-fast-html-36bb24ef-5699-4a58-81d9-564b55ae4a78.json
+++ b/change/@microsoft-fast-html-36bb24ef-5699-4a58-81d9-564b55ae4a78.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: update @microsoft/webui dependency to 0.0.9",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1617,9 +1617,9 @@
       }
     },
     "node_modules/@microsoft/webui": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/webui/-/webui-0.0.8.tgz",
-      "integrity": "sha512-ireYNZY0yI+AVkdHOqaDQrYs3tsBLJDp4/Xkr/9DdYcwmicnzYusAMhAhB0wVbAjVWEXyd9vRT3A3qtGWgYsWQ==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/webui/-/webui-0.0.9.tgz",
+      "integrity": "sha512-jAV7GiTeICbuAhNmwc5Fyf07oNGcRqbsqrC8DqUM0P6yxqnFTt1PmB/VzTP8NhMVxufaqGcy2qY6QueG9Asypg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1630,18 +1630,18 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@microsoft/webui-darwin-arm64": "0.0.8",
-        "@microsoft/webui-darwin-x64": "0.0.8",
-        "@microsoft/webui-linux-arm64": "0.0.8",
-        "@microsoft/webui-linux-x64": "0.0.8",
-        "@microsoft/webui-win32-arm64": "0.0.8",
-        "@microsoft/webui-win32-x64": "0.0.8"
+        "@microsoft/webui-darwin-arm64": "0.0.9",
+        "@microsoft/webui-darwin-x64": "0.0.9",
+        "@microsoft/webui-linux-arm64": "0.0.9",
+        "@microsoft/webui-linux-x64": "0.0.9",
+        "@microsoft/webui-win32-arm64": "0.0.9",
+        "@microsoft/webui-win32-x64": "0.0.9"
       }
     },
     "node_modules/@microsoft/webui-darwin-arm64": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/webui-darwin-arm64/-/webui-darwin-arm64-0.0.8.tgz",
-      "integrity": "sha512-ekU7bTzsHEnGfJK4IlpAJdKp5aU7+lTzcG3RBMwUrVelnENUq8DeC0XZg9YmOvTxS9I0LBcbEDKk2AlBZU1whA==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/webui-darwin-arm64/-/webui-darwin-arm64-0.0.9.tgz",
+      "integrity": "sha512-91HprvaitU62IzdYgt22qMCiEXvr0Utg9vxUc6Mt3mh4KVfSsFVmN7Z6J7eXZQ858CEW4xXKSfpeiEXKkpNGSg==",
       "cpu": [
         "arm64"
       ],
@@ -1653,9 +1653,9 @@
       ]
     },
     "node_modules/@microsoft/webui-darwin-x64": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/webui-darwin-x64/-/webui-darwin-x64-0.0.8.tgz",
-      "integrity": "sha512-rx7Apv4MK8PeYc48FfWaGa1ogvWFKS/zQcp+ZwyQsRMsTy7CEIIvlK+n/FJzqAoxnXI8axbILI6odSw4FYgYzg==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/webui-darwin-x64/-/webui-darwin-x64-0.0.9.tgz",
+      "integrity": "sha512-JDVmFki6CRRpj+F9CNTPI+b67fIQicLn3AmUQLFFCp0JQqaeGwpdUmXjzPy/Am+dQDCYVL4bKOeysmz4pHDDMA==",
       "cpu": [
         "x64"
       ],
@@ -1667,9 +1667,9 @@
       ]
     },
     "node_modules/@microsoft/webui-linux-arm64": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/webui-linux-arm64/-/webui-linux-arm64-0.0.8.tgz",
-      "integrity": "sha512-QtbmXNdebX8yUDMv/1MF/WK24gMxFpG3nEqHxZhImPPLiPlwSPvl2A+MOHL5P/ug+zht08MKVo2mcge/Oq3I5g==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/webui-linux-arm64/-/webui-linux-arm64-0.0.9.tgz",
+      "integrity": "sha512-fGcSTZi3QfqtdTXsGkSVQ8JT8o4gLpx/32i10qCxf/FvVxkxs7DosgjXgl7lx+kJ2XuTqCOCbSrLLjIK8T/WdA==",
       "cpu": [
         "arm64"
       ],
@@ -1681,9 +1681,9 @@
       ]
     },
     "node_modules/@microsoft/webui-linux-x64": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/webui-linux-x64/-/webui-linux-x64-0.0.8.tgz",
-      "integrity": "sha512-Qa5vGNd12iZfKVcc7akPBao6q91Nbzt2qbsoKIaSxY9583wWbONU8TYjImll9Jlg8CZjULoey+tsyH5IpL2Y0g==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/webui-linux-x64/-/webui-linux-x64-0.0.9.tgz",
+      "integrity": "sha512-w4AtqZevHbf+AUSMuSq0388DPfZEDi0DoajxVdNas5NBZ8qEr4d/2iP0VSx1vMBcH7nIPHjzM7DJnr9rYnt4Mw==",
       "cpu": [
         "x64"
       ],
@@ -1695,9 +1695,9 @@
       ]
     },
     "node_modules/@microsoft/webui-win32-arm64": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/webui-win32-arm64/-/webui-win32-arm64-0.0.8.tgz",
-      "integrity": "sha512-9Ugw0zakVMSGleC6xLZzNvz6qAIj9r7q+wA15MaFQvODccEbFv7Z8VfkpSNN0dRrUPrEEg2n+J9kBIvwV3EaoQ==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/webui-win32-arm64/-/webui-win32-arm64-0.0.9.tgz",
+      "integrity": "sha512-nNl7yvIu7uZ2y0/ViJ9tpOwflB0sqd1hHF0P53PK8dBfT7bqhby+UNv6tLAFjUYiu1xjnpTje8QIeQZKh2+Qow==",
       "cpu": [
         "arm64"
       ],
@@ -1709,9 +1709,9 @@
       ]
     },
     "node_modules/@microsoft/webui-win32-x64": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/webui-win32-x64/-/webui-win32-x64-0.0.8.tgz",
-      "integrity": "sha512-q5wdJ0v0yQiI6vSl6VFxxe7NuT7C7MwiUtMQsTI7kO3UbdLM5n3Kz71pRoe1Hcx3o0wTLHn/vcTGtusoHqCtdA==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/webui-win32-x64/-/webui-win32-x64-0.0.9.tgz",
+      "integrity": "sha512-FH4gprnUnNcEYgDkPHQS9D8h9gRQqYiy5Wswkgi75EgcELg2k8usGERexLOl/nmLMv4E3su7alhDKQm5oMXIJQ==",
       "cpu": [
         "x64"
       ],
@@ -8713,7 +8713,7 @@
       "devDependencies": {
         "@microsoft/fast-build": "^0.3.2",
         "@microsoft/fast-element": "^2.10.3",
-        "@microsoft/webui": "0.0.8"
+        "@microsoft/webui": "0.0.9"
       },
       "peerDependencies": {
         "@microsoft/fast-element": "^2.10.3"

--- a/packages/fast-html/package.json
+++ b/packages/fast-html/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@microsoft/fast-build": "^0.3.2",
     "@microsoft/fast-element": "^2.10.3",
-    "@microsoft/webui": "0.0.8"
+    "@microsoft/webui": "0.0.9"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
# Pull Request

## 📖 Description

Update the `@microsoft/webui` devDependency in `@microsoft/fast-html` from 0.0.8 to 0.0.9.

## 📑 Test Plan

All 807 existing `@microsoft/fast-html` tests pass. The `checkchange` and `biome:check` gates also pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.