### PR TITLE
chore: add explicit isEnabled state for boolean attribute binding fixture

### DIFF
--- a/change/@microsoft-fast-html-9dbd172d-4357-4936-912d-9c65ba8a159a.json
+++ b/change/@microsoft-fast-html-9dbd172d-4357-4936-912d-9c65ba8a159a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add explicit isEnabled state for boolean attribute binding fixture",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-html/test/fixtures/attribute/state.json
+++ b/packages/fast-html/test/fixtures/attribute/state.json
@@ -3,5 +3,6 @@
     "active-group": "work",
     "current-group": "work",
     "activeGroup": "work",
-    "currentGroup": "work"
+    "currentGroup": "work",
+    "isEnabled": false
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds `"isEnabled": false` to the attribute fixture's `state.json` so the boolean binding `?disabled="{{!isEnabled}}"` is evaluated consistently by both `@microsoft/fast-build` and `@microsoft/webui`.

Previously, `isEnabled` was absent from the state. `fast-build` treats `!undefined` as truthy (matching JavaScript semantics), so it rendered the `disabled` attribute correctly. However, `webui` uses stricter JSON value evaluation and does not negate missing/undefined values to `true`, causing the `disabled` attribute to be omitted from the server-rendered shadow DOM. This discrepancy caused the `create a property to attribute binding` test to fail in the WebUI integration pipeline.

Adding the explicit `false` value ensures both renderers produce identical output without changing the test's semantics — `!false` is still `true`, so `disabled` is still rendered.

## 👩‍💻 Reviewer Notes

The `test-element-expression` component (`?disabled="{{activeGroup == currentGroup}}"`) was unaffected because both `activeGroup` and `currentGroup` were already explicitly provided in state. Only `test-element-property` relied on an implicit undefined value.

## 📑 Test Plan

- All 840 existing tests pass (`npm run test -w @microsoft/fast-html`)
- The previously failing WebUI integration test (`attribute.spec.ts:35 — create a property to attribute binding`) now passes
- No change file needed — this is a test fixture change under `test/fixtures/`

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.