### PR TITLE
test: skip no-template error test for webui integration

### DIFF
--- a/change/@microsoft-fast-html-ca50770c-6ac6-492b-974e-cb3339001c51.json
+++ b/change/@microsoft-fast-html-ca50770c-6ac6-492b-974e-cb3339001c51.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: skip no-template error test for webui integration",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -470,6 +470,12 @@ A separate integration test suite validates that `@microsoft/webui` can build an
 
 Run locally with `npm run test:webui-integration` or via the `ci-webui-integration.yml` GitHub Action on PRs and pushes to `main`.
 
+#### Skipped tests
+
+Some tests are conditionally skipped when running under the webui integration config. The `playwright.webui.config.ts` sets `process.env.FAST_WEBUI_INTEGRATION = "true"`, and individual tests check this variable with `test.skip()` to opt out of cases that exercise known differences between `fast-build` and `webui` rendering:
+
+- **`errors.spec.ts` — "throws an error when no template element is present"**: webui does not render `<f-template>` elements that lack a `<template>` child, so the expected error is never thrown.
+
 ### Hydration readiness
 
 Every fixture must wait for hydration to complete before running assertions. Each `main.ts` registers a `hydrationComplete()` callback via `TemplateElement.config()` that sets a global flag, and each spec file calls `page.waitForFunction()` after `page.goto()` to block until the flag is set. See [test/fixtures/README.md](./test/fixtures/README.md) for the implementation pattern.

--- a/packages/fast-html/README.md
+++ b/packages/fast-html/README.md
@@ -483,3 +483,5 @@ npm exec -w @microsoft/fast-html -- playwright test --config=playwright.webui.co
 ```
 
 This is also run automatically in CI via the `ci-webui-integration.yml` GitHub Action on pull requests and pushes to `main`.
+
+Some tests are conditionally skipped during webui integration runs due to known rendering differences between `fast-build` and `webui`. The `playwright.webui.config.ts` sets `FAST_WEBUI_INTEGRATION=true`, and affected tests use `test.skip()` with a descriptive reason. See the WebUI Integration Tests section in [DESIGN.md](./DESIGN.md) for the full list.

--- a/packages/fast-html/playwright.webui.config.ts
+++ b/packages/fast-html/playwright.webui.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+process.env.FAST_WEBUI_INTEGRATION = "true";
+
 export default defineConfig({
     testDir: "./test/fixtures",
     testMatch: "**/*.spec.ts",

--- a/packages/fast-html/test/fixtures/errors/errors.spec.ts
+++ b/packages/fast-html/test/fixtures/errors/errors.spec.ts
@@ -14,6 +14,10 @@ test.describe("f-template errors", () => {
     });
 
     test("throws an error when no template element is present", async ({ page }) => {
+        test.skip(
+            !!process.env.FAST_WEBUI_INTEGRATION,
+            "WebUI does not render <f-template> without <template> child (see WEBUI_ISSUES.md #3)",
+        );
         await page.goto("/fixtures/errors/");
 
         await expect


### PR DESCRIPTION
# Pull Request

## 📖 Description

Skip the "throws an error when no template element is present" test in the `errors` fixture when running under the WebUI integration test config (`playwright.webui.config.ts`).

WebUI does not render `<f-template>` elements that lack a `<template>` child, so the expected "must be a `<template>`" error is never thrown during WebUI integration runs. This is a known behavioral difference between `fast-build` and `webui`.

The skip uses a `FAST_WEBUI_INTEGRATION` environment variable set in `playwright.webui.config.ts` and checked via `test.skip()` in the specific test, so the regular test suite is unaffected.

## 📑 Test Plan

- Regular tests: both `errors.spec.ts` tests pass (2 passed, 0 skipped).
- WebUI integration tests: the no-template test is correctly skipped (1 skipped), while the multiple-templates test still runs. Overall results: 149 passed, 1 skipped (plus pre-existing failures unrelated to this change).

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.