### PR TITLE
chore: update fixture from a relative path to target package exports

### DIFF
--- a/change/@microsoft-fast-html-3e5ed5fa-232d-44b9-9ea8-b5b57dfb528d.json
+++ b/change/@microsoft-fast-html-3e5ed5fa-232d-44b9-9ea8-b5b57dfb528d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: update fixture from a relative path to target package exports",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-html/test/fixtures/deep-merge/main.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/main.ts
@@ -1,6 +1,6 @@
 import { FASTElement, observable } from "@microsoft/fast-element";
-import { deepMerge } from "../../../src/components/utilities.js";
-import { RenderableFASTElement, TemplateElement } from "../../../src/index.js";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
+import { deepMerge } from "@microsoft/fast-html/utilities.js";
 
 interface Product {
     id: number;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Part of the reason the integration tests fail is due to the presence of relative imports. This fixes these to point to the package and should resolve properly if copied to another directory in the mono-repository as they are doing for the webui integration tests.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.