### PR TITLE
chore: add an all benchmark

### DIFF
--- a/packages/bench/src/scenarios/all/csr/index.html
+++ b/packages/bench/src/scenarios/all/csr/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>all / csr</title>
+    <style>.tree-node { background-color: #FF00FF10 }</style>
+</head>
+<body>
+    <div id="container"></div>
+    <script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/packages/bench/src/scenarios/all/csr/main.ts
+++ b/packages/bench/src/scenarios/all/csr/main.ts
@@ -2,7 +2,7 @@ import { runBenchmark } from "../../harness.js";
 import { BenchElement, template } from "../element.js";
 
 BenchElement.define({
-    name: "attr-reflect-bench-element",
+    name: "all-bench-element",
     template,
 });
 
@@ -10,9 +10,7 @@ let id = 0;
 
 runBenchmark(() => {
     const count = ++id;
-    const el = document.createElement("attr-reflect-bench-element") as BenchElement;
-    el.label = `item-${count}`;
+    const el = document.createElement("all-bench-element") as BenchElement;
     el.count = count;
-    el.active = true;
     return el;
 });

--- a/packages/bench/src/scenarios/all/element.ts
+++ b/packages/bench/src/scenarios/all/element.ts
@@ -1,0 +1,80 @@
+import {
+    attr,
+    FASTElement,
+    html,
+    nullableNumberConverter,
+} from "@microsoft/fast-element";
+import {
+    BenchElement as AttrReflectBenchElement,
+    template as attrReflectTemplate,
+} from "../attr-reflect/element.js";
+import {
+    BenchElement as BasicBenchElement,
+    template as basicTemplate,
+} from "../basic/element.js";
+import {
+    BenchElement as BindEventBenchElement,
+    template as bindEventTemplate,
+} from "../bind-event/element.js";
+import { BenchElement as DotSyntaxElement } from "../dot-syntax/element.js";
+import {
+    BenchElement as RefSlottedBenchElement,
+    template as refSlottedTemplate,
+} from "../ref-slotted/element.js";
+import {
+    BenchElement as RepeatBenchElement,
+    template as repeatTemplate,
+} from "../repeat/element.js";
+import {
+    BenchElement as WhenBenchElement,
+    template as whenTemplate,
+} from "../when/element.js";
+
+AttrReflectBenchElement.define({
+    name: "attr-reflect-bench-element",
+    template: attrReflectTemplate,
+});
+
+BasicBenchElement.define({
+    name: "basic-bench-element",
+    template: basicTemplate,
+});
+
+BindEventBenchElement.define({
+    name: "bind-event-bench-element",
+    template: bindEventTemplate,
+});
+
+RefSlottedBenchElement.define({
+    name: "ref-slotted-bench-element",
+    template: refSlottedTemplate,
+});
+
+RepeatBenchElement.define({
+    name: "repeat-bench-element",
+    template: repeatTemplate,
+});
+
+WhenBenchElement.define({
+    name: "when-bench-element",
+    template: whenTemplate,
+});
+
+DotSyntaxElement.define({
+    name: "dot-syntax-bench-element",
+});
+
+export class BenchElement extends FASTElement {
+    @attr({ converter: nullableNumberConverter })
+    count?: number;
+}
+
+export const template = html<BenchElement>`
+    <attr-reflect-bench-element label="label-${x => x.count}" count="${x => x.count}" active></attr-reflect-bench-element>
+    <basic-bench-element></basic-bench-element>
+    <bind-event-bench-element></bind-event-bench-element>
+    <ref-slotted-bench-element><span>slotted content</span></ref-slotted-bench-element>
+    <repeat-bench-element></repeat-bench-element>
+    <when-bench-element></when-bench-element>
+    <dot-syntax-bench-element></dot-syntax-bench-element>
+`;

--- a/packages/bench/src/scenarios/all/hydration/index.html
+++ b/packages/bench/src/scenarios/all/hydration/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>all / hydration</title>
+    <style>.tree-node { background-color: #FF00FF10 }</style>
+</head>
+<body>
+    <div id="container">
+        <!-- @bench-ssr-render -->
+    </div>
+    <!-- f-template-all -->
+    <script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/packages/bench/src/scenarios/all/hydration/main.ts
+++ b/packages/bench/src/scenarios/all/hydration/main.ts
@@ -3,7 +3,7 @@ import { signalDone } from "../../harness.js";
 import { BenchElement } from "../element.js";
 
 RenderableFASTElement(BenchElement).defineAsync({
-    name: "when-bench-element",
+    name: "all-bench-element",
     templateOptions: "defer-and-hydrate",
 });
 

--- a/packages/bench/src/scenarios/attr-reflect/element.ts
+++ b/packages/bench/src/scenarios/attr-reflect/element.ts
@@ -1,4 +1,9 @@
-import { attr, FASTElement, nullableNumberConverter } from "@microsoft/fast-element";
+import {
+    attr,
+    FASTElement,
+    html,
+    nullableNumberConverter,
+} from "@microsoft/fast-element";
 
 export class BenchElement extends FASTElement {
     @attr
@@ -10,3 +15,7 @@ export class BenchElement extends FASTElement {
     @attr({ mode: "boolean" })
     active?: boolean;
 }
+
+export const template = html<BenchElement>`
+    <span>${x => x.label} (${x => x.count})</span>
+`;

--- a/packages/bench/src/scenarios/attr-reflect/hydration/main.ts
+++ b/packages/bench/src/scenarios/attr-reflect/hydration/main.ts
@@ -3,7 +3,7 @@ import { signalDone } from "../../harness.js";
 import { BenchElement } from "../element.js";
 
 RenderableFASTElement(BenchElement).defineAsync({
-    name: "bench-element",
+    name: "attr-reflect-bench-element",
     templateOptions: "defer-and-hydrate",
 });
 

--- a/packages/bench/src/scenarios/attr-reflect/hydration/render.ts
+++ b/packages/bench/src/scenarios/attr-reflect/hydration/render.ts
@@ -2,13 +2,13 @@ export function render(index: number): string {
     const count = `${index + 1}`;
     const label = `item-${count}`;
     return /* html */ `
-        <bench-element needs-hydration label="${label}" count="${count}" active>
+        <attr-reflect-bench-element needs-hydration label="${label}" count="${count}" active>
             <template shadowrootmode="open">
                 <span
                     ><!--fe-b$$start$$0$$label$$fe-b-->${label}<!--fe-b$$end$$0$$label$$fe-b-->
                     (<!--fe-b$$start$$1$$count$$fe-b-->${count}<!--fe-b$$end$$1$$count$$fe-b-->)</span
                 >
             </template>
-        </bench-element>
+        </attr-reflect-bench-element>
     `;
 }

--- a/packages/bench/src/scenarios/attr-reflect/template.html
+++ b/packages/bench/src/scenarios/attr-reflect/template.html
@@ -1,4 +1,4 @@
-<f-template name="bench-element">
+<f-template name="attr-reflect-bench-element">
     <template>
         <span>{{label}} ({{count}})</span>
     </template>

--- a/packages/bench/src/scenarios/basic/csr/main.ts
+++ b/packages/bench/src/scenarios/basic/csr/main.ts
@@ -1,16 +1,13 @@
-import { html } from "@microsoft/fast-element";
 import { runBenchmark } from "../../harness.js";
-import { BenchElement } from "../element.js";
+import { BenchElement, template } from "../element.js";
 
 BenchElement.define({
-    name: "bench-element",
-    template: html`
-        <slot></slot>
-    `,
+    name: "basic-bench-element",
+    template,
 });
 
 runBenchmark(() => {
-    const el = document.createElement("bench-element");
+    const el = document.createElement("basic-bench-element");
     el.innerHTML = "hello";
     return el;
 });

--- a/packages/bench/src/scenarios/basic/element.ts
+++ b/packages/bench/src/scenarios/basic/element.ts
@@ -1,3 +1,7 @@
-import { FASTElement } from "@microsoft/fast-element";
+import { FASTElement, html } from "@microsoft/fast-element";
 
 export class BenchElement extends FASTElement {}
+
+export const template = html`
+    <slot></slot>
+`;

--- a/packages/bench/src/scenarios/basic/hydration/main.ts
+++ b/packages/bench/src/scenarios/basic/hydration/main.ts
@@ -3,7 +3,7 @@ import { signalDone } from "../../harness.js";
 import { BenchElement } from "../element.js";
 
 BenchElement.defineAsync({
-    name: "bench-element",
+    name: "basic-bench-element",
 });
 
 performance.mark("bench-start");

--- a/packages/bench/src/scenarios/basic/hydration/render.ts
+++ b/packages/bench/src/scenarios/basic/hydration/render.ts
@@ -1,10 +1,10 @@
 export function render(): string {
     return /* html */ `
-        <bench-element needs-hydration>
+        <basic-bench-element needs-hydration>
             <template shadowrootmode="open">
                 <slot></span>
             </template>
             hello
-        </bench-element>
+        </basic-bench-element>
     `;
 }

--- a/packages/bench/src/scenarios/basic/template.html
+++ b/packages/bench/src/scenarios/basic/template.html
@@ -1,4 +1,4 @@
-<f-template name="bench-element">
+<f-template name="basic-bench-element">
     <template>
         <slot></slot>
     </template>

--- a/packages/bench/src/scenarios/bind-event/csr/main.ts
+++ b/packages/bench/src/scenarios/bind-event/csr/main.ts
@@ -1,12 +1,9 @@
-import { html } from "@microsoft/fast-element";
 import { runBenchmark } from "../../harness.js";
-import { BenchElement } from "../element.js";
+import { BenchElement, template } from "../element.js";
 
 BenchElement.define({
-    name: "bench-element",
-    template: html<BenchElement>`
-        <button @click="${x => x.handleClick()}">Count: ${x => x.count}</button>
-    `,
+    name: "bind-event-bench-element",
+    template,
 });
 
-runBenchmark(() => document.createElement("bench-element"));
+runBenchmark(() => document.createElement("bind-event-bench-element"));

--- a/packages/bench/src/scenarios/bind-event/element.ts
+++ b/packages/bench/src/scenarios/bind-event/element.ts
@@ -1,4 +1,4 @@
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { attr, FASTElement, html } from "@microsoft/fast-element";
 
 export class BenchElement extends FASTElement {
     @attr count: string = "0";
@@ -7,3 +7,7 @@ export class BenchElement extends FASTElement {
         this.count = String(parseInt(this.count, 10) + 1);
     }
 }
+
+export const template = html<BenchElement>`
+    <button @click="${x => x.handleClick()}">Count: ${x => x.count}</button>
+`;

--- a/packages/bench/src/scenarios/bind-event/hydration/main.ts
+++ b/packages/bench/src/scenarios/bind-event/hydration/main.ts
@@ -3,7 +3,7 @@ import { signalDone } from "../../harness.js";
 import { BenchElement } from "../element.js";
 
 RenderableFASTElement(BenchElement).defineAsync({
-    name: "bench-element",
+    name: "bind-event-bench-element",
     templateOptions: "defer-and-hydrate",
 });
 

--- a/packages/bench/src/scenarios/bind-event/hydration/render.ts
+++ b/packages/bench/src/scenarios/bind-event/hydration/render.ts
@@ -1,9 +1,9 @@
 export function render(): string {
     return /* html */ `
-        <bench-element needs-hydration>
+        <bind-event-bench-element needs-hydration>
             <template shadowrootmode="open">
                 <button data-fe-b-0>Count: <!--fe-b$$start$$1$$count$$fe-b-->0<!--fe-b$$end$$1$$count$$fe-b--></button>
             </template>
-        </bench-element>
+        </bind-event-bench-element>
     `;
 }

--- a/packages/bench/src/scenarios/bind-event/template.html
+++ b/packages/bench/src/scenarios/bind-event/template.html
@@ -1,4 +1,4 @@
-<f-template name="bench-element">
+<f-template name="bind-event-bench-element">
     <template>
         <button @click="{handleClick()}">Count: {{count}}</button>
     </template>

--- a/packages/bench/src/scenarios/dot-syntax/csr/main.ts
+++ b/packages/bench/src/scenarios/dot-syntax/csr/main.ts
@@ -3,14 +3,14 @@ import { runBenchmark } from "../../harness.js";
 import { BenchElement } from "../element.js";
 
 BenchElement.defineAsync({
-    name: "bench-element",
+    name: "dot-syntax-bench-element",
     templateOptions: "defer-and-hydrate",
 });
 
 TemplateElement.options({
-    "bench-element": { observerMap: "all" },
+    "dot-syntax-bench-element": { observerMap: "all" },
 }).define({ name: "f-template" });
 
-await customElements.whenDefined("bench-element");
+await customElements.whenDefined("dot-syntax-bench-element");
 
-runBenchmark(() => document.createElement("bench-element"));
+runBenchmark(() => document.createElement("dot-syntax-bench-element"));

--- a/packages/bench/src/scenarios/dot-syntax/hydration/main.ts
+++ b/packages/bench/src/scenarios/dot-syntax/hydration/main.ts
@@ -3,7 +3,7 @@ import { signalDone } from "../../harness.js";
 import { BenchElement } from "../element.js";
 
 RenderableFASTElement(BenchElement).defineAsync({
-    name: "bench-element",
+    name: "dot-syntax-bench-element",
     templateOptions: "defer-and-hydrate",
 });
 
@@ -16,6 +16,6 @@ TemplateElement.config({
     },
 })
     .options({
-        "bench-element": { observerMap: "all" },
+        "dot-syntax-bench-element": { observerMap: "all" },
     })
     .define({ name: "f-template" });

--- a/packages/bench/src/scenarios/dot-syntax/hydration/render.ts
+++ b/packages/bench/src/scenarios/dot-syntax/hydration/render.ts
@@ -1,6 +1,6 @@
 export function render(): string {
     return /* html */ `
-        <bench-element needs-hydration>
+        <dot-syntax-bench-element needs-hydration>
             <template shadowrootmode="open">
                 <div>
                     <span><!--fe-b$$start$$0$$t0$$fe-b-->Jane<!--fe-b$$end$$0$$t0$$fe-b--></span>
@@ -8,6 +8,6 @@ export function render(): string {
                     <span><!--fe-b$$start$$2$$t0$$fe-b-->47.6<!--fe-b$$end$$2$$t0$$fe-b--></span>
                 </div>
             </template>
-        </bench-element>
+        </dot-syntax-bench-element>
     `;
 }

--- a/packages/bench/src/scenarios/dot-syntax/template.html
+++ b/packages/bench/src/scenarios/dot-syntax/template.html
@@ -1,4 +1,4 @@
-<f-template name="bench-element">
+<f-template name="dot-syntax-bench-element">
     <template>
         <div>
             <span>{{user.name}}</span>

--- a/packages/bench/src/scenarios/ref-slotted/csr/main.ts
+++ b/packages/bench/src/scenarios/ref-slotted/csr/main.ts
@@ -1,17 +1,13 @@
-import { html, ref, slotted } from "@microsoft/fast-element";
 import { runBenchmark } from "../../harness.js";
-import { BenchElement } from "../element.js";
+import { BenchElement, template } from "../element.js";
 
 BenchElement.define({
-    name: "bench-element",
-    template: html<BenchElement>`
-        <h3 ${ref("heading")}>Title</h3>
-        <slot ${slotted("slottedItems")}></slot>
-    `,
+    name: "ref-slotted-bench-element",
+    template,
 });
 
 runBenchmark(() => {
-    const el = document.createElement("bench-element") as BenchElement;
+    const el = document.createElement("ref-slotted-bench-element") as BenchElement;
     const child = document.createElement("span");
     child.textContent = "slotted content";
     el.appendChild(child);

--- a/packages/bench/src/scenarios/ref-slotted/element.ts
+++ b/packages/bench/src/scenarios/ref-slotted/element.ts
@@ -1,6 +1,11 @@
-import { FASTElement } from "@microsoft/fast-element";
+import { FASTElement, html, ref, slotted } from "@microsoft/fast-element";
 
 export class BenchElement extends FASTElement {
     heading!: HTMLHeadingElement;
     slottedItems!: Element[];
 }
+
+export const template = html<BenchElement>`
+    <h3 ${ref("heading")}>Title</h3>
+    <slot ${slotted("slottedItems")}></slot>
+`;

--- a/packages/bench/src/scenarios/ref-slotted/hydration/main.ts
+++ b/packages/bench/src/scenarios/ref-slotted/hydration/main.ts
@@ -3,7 +3,7 @@ import { signalDone } from "../../harness.js";
 import { BenchElement } from "../element.js";
 
 RenderableFASTElement(BenchElement).defineAsync({
-    name: "bench-element",
+    name: "ref-slotted-bench-element",
     templateOptions: "defer-and-hydrate",
 });
 

--- a/packages/bench/src/scenarios/ref-slotted/hydration/render.ts
+++ b/packages/bench/src/scenarios/ref-slotted/hydration/render.ts
@@ -1,11 +1,11 @@
 export function render(): string {
     return /* html */ `
-        <bench-element needs-hydration>
+        <ref-slotted-bench-element needs-hydration>
             <template shadowrootmode="open">
                 <h3 data-fe-b-0>Title</h3>
                 <slot data-fe-b-1></slot>
             </template>
             <span>slotted content</span>
-        </bench-element>
+        </ref-slotted-bench-element>
     `;
 }

--- a/packages/bench/src/scenarios/ref-slotted/template.html
+++ b/packages/bench/src/scenarios/ref-slotted/template.html
@@ -1,4 +1,4 @@
-<f-template name="bench-element">
+<f-template name="ref-slotted-bench-element">
     <template>
         <h3 f-ref="{heading}">Title</h3>
         <slot f-slotted="{slottedItems}"></slot>

--- a/packages/bench/src/scenarios/repeat/csr/main.ts
+++ b/packages/bench/src/scenarios/repeat/csr/main.ts
@@ -1,19 +1,9 @@
-import { html, repeat } from "@microsoft/fast-element";
 import { runBenchmark } from "../../harness.js";
-import { BenchElement } from "../element.js";
+import { BenchElement, template } from "../element.js";
 
 BenchElement.define({
-    name: "bench-element",
-    template: html<BenchElement>`
-        <ul>
-            ${repeat(
-                x => x.items,
-                html<string>`
-                    <li>${x => x}</li>
-                `
-            )}
-        </ul>
-    `,
+    name: "repeat-bench-element",
+    template,
 });
 
-runBenchmark(() => document.createElement("bench-element"), 100);
+runBenchmark(() => document.createElement("repeat-bench-element"), 100);

--- a/packages/bench/src/scenarios/repeat/element.ts
+++ b/packages/bench/src/scenarios/repeat/element.ts
@@ -1,7 +1,18 @@
-import { FASTElement } from "@microsoft/fast-element";
+import { FASTElement, html, repeat } from "@microsoft/fast-element";
 
 const items = Array.from({ length: 20 }, (_, i) => `Item ${i}`);
 
 export class BenchElement extends FASTElement {
     items = items;
 }
+
+export const template = html<BenchElement>`
+    <ul>
+        ${repeat(
+            x => x.items,
+            html<string>`
+                <li>${x => x}</li>
+            `,
+        )}
+    </ul>
+`;

--- a/packages/bench/src/scenarios/repeat/hydration/main.ts
+++ b/packages/bench/src/scenarios/repeat/hydration/main.ts
@@ -3,7 +3,7 @@ import { signalDone } from "../../harness.js";
 import { BenchElement } from "../element.js";
 
 RenderableFASTElement(BenchElement).defineAsync({
-    name: "bench-element",
+    name: "repeat-bench-element",
     templateOptions: "defer-and-hydrate",
 });
 

--- a/packages/bench/src/scenarios/repeat/hydration/render.ts
+++ b/packages/bench/src/scenarios/repeat/hydration/render.ts
@@ -2,7 +2,7 @@ const items = Array.from({ length: 20 }, (_, i) => `Item ${i}`);
 const listItems = items
     .map(
         (item, i) =>
-            `<!--fe-repeat$$start$$${i}$$fe-repeat--><li><!--fe-b$$start$$0$$ri$$fe-b-->${item}<!--fe-b$$end$$0$$ri$$fe-b--></li><!--fe-repeat$$end$$${i}$$fe-repeat-->`
+            `<!--fe-repeat$$start$$${i}$$fe-repeat--><li><!--fe-b$$start$$0$$ri$$fe-b-->${item}<!--fe-b$$end$$0$$ri$$fe-b--></li><!--fe-repeat$$end$$${i}$$fe-repeat-->`,
     )
     .join("");
 
@@ -10,8 +10,8 @@ const shadowContent = `<ul><!--fe-b$$start$$0$$rp$$fe-b-->${listItems}<!--fe-b$$
 
 export function render(): string {
     return /* html */ `
-        <bench-element needs-hydration>
+        <repeat-bench-element needs-hydration>
             <template shadowrootmode="open">${shadowContent}</template>
-        </bench-element>
+        </repeat-bench-element>
     `;
 }

--- a/packages/bench/src/scenarios/repeat/template.html
+++ b/packages/bench/src/scenarios/repeat/template.html
@@ -1,4 +1,4 @@
-<f-template name="bench-element">
+<f-template name="repeat-bench-element">
     <template>
         <ul>
             <f-repeat value="{{item in items}}">

--- a/packages/bench/src/scenarios/when/csr/main.ts
+++ b/packages/bench/src/scenarios/when/csr/main.ts
@@ -1,23 +1,9 @@
-import { html, when } from "@microsoft/fast-element";
 import { runBenchmark } from "../../harness.js";
-import { BenchElement } from "../element.js";
+import { BenchElement, template } from "../element.js";
 
 BenchElement.define({
-    name: "bench-element",
-    template: html<BenchElement>`
-        ${when(
-            x => x.show,
-            html`
-                <span>Visible</span>
-            `
-        )}
-        ${when(
-            x => !x.show,
-            html`
-                <span>Hidden</span>
-            `
-        )}
-    `,
+    name: "when-bench-element",
+    template,
 });
 
-runBenchmark(() => document.createElement("bench-element"));
+runBenchmark(() => document.createElement("when-bench-element"));

--- a/packages/bench/src/scenarios/when/element.ts
+++ b/packages/bench/src/scenarios/when/element.ts
@@ -1,5 +1,20 @@
-import { FASTElement, observable } from "@microsoft/fast-element";
+import { FASTElement, html, observable, when } from "@microsoft/fast-element";
 
 export class BenchElement extends FASTElement {
     @observable show = true;
 }
+
+export const template = html<BenchElement>`
+    ${when(
+        x => x.show,
+        html`
+            <span>Visible</span>
+        `,
+    )}
+    ${when(
+        x => !x.show,
+        html`
+            <span>Hidden</span>
+        `,
+    )}
+`;

--- a/packages/bench/src/scenarios/when/hydration/render.ts
+++ b/packages/bench/src/scenarios/when/hydration/render.ts
@@ -1,10 +1,10 @@
 export function render(): string {
     return /* html */ `
-        <bench-element needs-hydration>
+        <when-bench-element needs-hydration>
             <template shadowrootmode="open">
                 <!--fe-b$$start$$0$$w0$$fe-b--><span>Visible</span><!--fe-b$$end$$0$$w0$$fe-b-->
                 <!--fe-b$$start$$1$$w1$$fe-b--><!--fe-b$$end$$1$$w1$$fe-b-->
             </template>
-        </bench-element>
+        </when-bench-element>
     `;
 }

--- a/packages/bench/src/scenarios/when/template.html
+++ b/packages/bench/src/scenarios/when/template.html
@@ -1,4 +1,4 @@
-<f-template name="bench-element">
+<f-template name="when-bench-element">
     <template>
         <f-when value="{{show}}"><span>Visible</span></f-when>
         <f-when value="{{!show}}"><span>Hidden</span></f-when>

--- a/packages/bench/vite.config.ts
+++ b/packages/bench/vite.config.ts
@@ -1,17 +1,40 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
+import { render as attrReflectRender } from "./src/scenarios/attr-reflect/hydration/render.ts";
+import { render as basicRender } from "./src/scenarios/basic/hydration/render.ts";
+import { render as bindEventRender } from "./src/scenarios/bind-event/hydration/render.ts";
+import { render as dotSyntaxRender } from "./src/scenarios/dot-syntax/hydration/render.ts";
+import { render as refSlottedRender } from "./src/scenarios/ref-slotted/hydration/render.ts";
+import { render as repeatRender } from "./src/scenarios/repeat/hydration/render.ts";
 import {
     BENCH_TREE_CONFIG,
     buildTree,
     renderTreeToHTMLWith,
 } from "./src/scenarios/tree.js";
+import { render as whenRender } from "./src/scenarios/when/hydration/render.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const benchmarksDir = resolve(__dirname, "src", "scenarios");
 const buildId = process.env.BUILD_ID;
 const base = buildId ? `/${buildId}/` : "/";
+
+const scenarioRenders: Record<string, (index: number) => string> = {
+    "attr-reflect": attrReflectRender,
+    basic: basicRender,
+    "bind-event": bindEventRender,
+    "dot-syntax": dotSyntaxRender,
+    "ref-slotted": refSlottedRender,
+    repeat: repeatRender,
+    when: whenRender,
+};
+
+function allRender(index: number): string {
+    return Object.values(scenarioRenders)
+        .map(render => render(index))
+        .join("");
+}
 
 function discoverBenchmarkInputs(): Record<string, string> {
     const inputs: Record<string, string> = {
@@ -25,7 +48,7 @@ function discoverBenchmarkInputs(): Record<string, string> {
 
         const scenarioDir = resolve(benchmarksDir, scenario.name);
         const variants = readdirSync(scenarioDir, { withFileTypes: true }).filter(d =>
-            d.isDirectory()
+            d.isDirectory(),
         );
 
         for (const variant of variants) {
@@ -49,17 +72,34 @@ export default defineConfig({
             name: "html-transform",
             enforce: "pre",
             async transformIndexHtml(html, { filename }) {
-                // Render-function driven SSR: builds a deterministic
-                // tree (~1 000 nodes) and calls the scenario's render()
-                // function discovered next to the index.html being processed.
-                // <!-- @bench-ssr-render -->
-                const renderModulePath = resolve(dirname(filename), "render.ts");
+                if (html.includes("<!-- f-template-all -->")) {
+                    const allTemplates: string[] = [];
+                    for (const entry of readdirSync(benchmarksDir, {
+                        withFileTypes: true,
+                    })) {
+                        if (!entry.isDirectory() || entry.name === "all") {
+                            continue;
+                        }
+                        const tplPath = resolve(
+                            benchmarksDir,
+                            entry.name,
+                            "template.html",
+                        );
+                        if (existsSync(tplPath)) {
+                            allTemplates.push(readFileSync(tplPath, "utf-8"));
+                        }
+                    }
+                    html = html.replace(
+                        "<!-- f-template-all -->",
+                        allTemplates.join("\n"),
+                    );
+                }
 
                 if (html.includes("<!-- f-template -->")) {
                     const templatePath = resolve(
                         dirname(filename),
                         "..",
-                        "template.html"
+                        "template.html",
                     );
                     if (existsSync(templatePath)) {
                         const template = readFileSync(templatePath, "utf-8");
@@ -67,10 +107,11 @@ export default defineConfig({
                     }
                 }
 
-                if (html.includes("@bench-ssr-render") && existsSync(renderModulePath)) {
-                    const { render } = (await import(
-                        pathToFileURL(renderModulePath).href
-                    )) as { render: (index: number) => string };
+                if (html.includes("@bench-ssr-render")) {
+                    const scenarioName = resolve(dirname(filename), "..")
+                        .split("/")
+                        .pop()!;
+                    const render = scenarioRenders[scenarioName] ?? allRender;
 
                     html = html.replace(
                         /<!--\s*@bench-ssr-render(?:\s+(\d+))?\s*-->/g,
@@ -83,7 +124,7 @@ export default defineConfig({
                                 : BENCH_TREE_CONFIG;
                             const tree = buildTree(config);
                             return renderTreeToHTMLWith(tree, render);
-                        }
+                        },
                     );
                 }
 
@@ -93,7 +134,7 @@ export default defineConfig({
                     Object.keys(discoverBenchmarkInputs())
                         .filter(key => key !== "main")
                         .map(key => `<li><a href="${base}${key}/">${key}</a></li>`)
-                        .join("\n")
+                        .join("\n"),
                 );
 
                 return html;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change adds an "all" benchmark that includes all other benchmark components to allow for better performance benchmarking against multiple components.

### 🎫 Issues

Further work on #7248

## 👩‍💻 Reviewer Notes

This fills a gap where instead of multiple of the same component being iterated on this is all of the components. This should show more meaningful results for performance checking against things like many different components on a page.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.