### PR TITLE
feat: add declarativeTemplate currying function

### DIFF
--- a/change/@microsoft-fast-html-2f86f15c-320e-45d7-b63e-fe7793453228.json
+++ b/change/@microsoft-fast-html-2f86f15c-320e-45d7-b63e-fe7793453228.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add declarativeTemplate currying function",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -129,6 +129,19 @@ An optional layer that uses the `Schema` to automatically register `@attr`-style
 
 Enabled via `TemplateElement.options({ "my-element": { attributeMap: "all" } })` or by passing a configuration object `TemplateElement.options({ "my-element": { attributeMap: {} } })`. Both forms are equivalent and use the default `"none"` strategy. To use the `"camelCase"` strategy, pass `TemplateElement.options({ "my-element": { attributeMap: { "attribute-name-strategy": "camelCase" } } })`.
 
+### `declarativeTemplate` — currying helper
+
+A convenience function that encapsulates the common setup of defining the `<f-template>` element and obtaining a `Promise<ViewTemplate>` for a given component.
+
+The outer call (`declarativeTemplate()`) defines `TemplateElement` as `<f-template>` if it has not already been registered via `customElements.get("f-template")`. It returns a function that accepts `{ name: string }` — the custom element name whose template is desired.
+
+The inner function:
+
+1. Calls `FASTElementDefinition.registerAsync(name)` to wait for the component class to be registered.
+2. Looks up the `FASTElementDefinition` via `fastElementRegistry.getByType(type)`.
+3. If `definition.template` already exists (fast path), returns it immediately.
+4. Otherwise, subscribes to the observable `"template"` property on the definition via `Observable.getNotifier(definition)` and resolves when the template is assigned by `TemplateElement.connectedCallback`. The subscriber unsubscribes after resolving to avoid leaking.
+
 ### Syntax constants (`syntax.ts`)
 
 All delimiters used by the parser are defined in a single `Syntax` interface and exported as named constants from `syntax.ts`. This makes the syntax pluggable and easy to audit.
@@ -177,6 +190,7 @@ packages/fast-html/
 
 ```typescript
 import {
+    declarativeTemplate,
     TemplateElement,
     ObserverMap,
     type ObserverMapConfig,
@@ -185,10 +199,11 @@ import {
 } from "@microsoft/fast-html";
 ```
 
-Two primary exports are intended for application code:
+Three primary exports are intended for application code:
 
 | Export | Purpose |
 |---|---|
+| `declarativeTemplate` | Currying function that defines `<f-template>` and returns a `Promise<ViewTemplate>` for a given component name. |
 | `TemplateElement` | Define the `<f-template>` element; configure callbacks and per-element options. |
 | `ObserverMap` | Advanced: access the observer-map class directly if building tooling. |
 

--- a/packages/fast-html/README.md
+++ b/packages/fast-html/README.md
@@ -37,6 +37,24 @@ TemplateElement.define({
 
 This will include the `<f-template>` custom element and all logic for interpreting the declarative HTML syntax for a FAST web component. Components use `defineAsync()` for deferred template attachment.
 
+#### `declarativeTemplate` helper
+
+The `declarativeTemplate` currying function provides a convenient way to define the `<f-template>` custom element and obtain a `Promise<ViewTemplate>` for a given component. It defines the `TemplateElement` using `TemplateElement.define({ name: "f-template" })` if it has not already been defined, and returns a function that resolves a `ViewTemplate` when the component's declarative template has been processed.
+
+```typescript
+import { declarativeTemplate } from "@microsoft/fast-html";
+import { MyCustomElement } from "./my-custom-element";
+
+MyCustomElement.defineAsync({
+    name: "my-custom-element",
+    templateOptions: "defer-and-hydrate",
+});
+
+const template: Promise<ViewTemplate> = declarativeTemplate()({ name: "my-custom-element" });
+```
+
+The returned promise resolves once the `<f-template name="my-custom-element">` element is connected to the DOM and its template has been compiled into a `ViewTemplate`.
+
 The template must be wrapped in `<f-template name="[custom-element-name]"><template>[template logic]</template></f-template>` with a `name` attribute for the custom elements name, and the template logic inside.
 
 Example:

--- a/packages/fast-html/docs/api-report.api.md
+++ b/packages/fast-html/docs/api-report.api.md
@@ -6,11 +6,17 @@
 
 import { FASTElement } from '@microsoft/fast-element';
 import { TemplateLifecycleCallbacks } from '@microsoft/fast-element';
+import { ViewTemplate } from '@microsoft/fast-element';
 
 // @public
 export interface AttributeMapConfig {
     "attribute-name-strategy"?: "none" | "camelCase";
 }
+
+// @public
+export function declarativeTemplate(): (config: {
+    name: string;
+}) => Promise<ViewTemplate>;
 
 // @public
 export class ObserverMap {

--- a/packages/fast-html/src/components/index.ts
+++ b/packages/fast-html/src/components/index.ts
@@ -3,6 +3,7 @@ export { ObserverMap } from "./observer-map.js";
 export {
     type AttributeMapConfig,
     AttributeMapOption,
+    declarativeTemplate,
     type ElementOptions,
     type ElementOptionsDictionary,
     type HydrationLifecycleCallbacks,

--- a/packages/fast-html/src/components/template.ts
+++ b/packages/fast-html/src/components/template.ts
@@ -7,6 +7,7 @@ import {
     FASTElement,
     FASTElementDefinition,
     fastElementRegistry,
+    Observable,
     ref,
     repeat,
     slotted,
@@ -956,4 +957,45 @@ class TemplateElement extends FASTElement {
     }
 }
 
-export { TemplateElement };
+/**
+ * A currying function that defines the {@link TemplateElement} custom element
+ * (if not already defined) and returns a function that resolves a
+ * {@link @microsoft/fast-element#ViewTemplate} for a given component name.
+ *
+ * @example
+ * ```ts
+ * const template: Promise<ViewTemplate> = declarativeTemplate()({ name: "my-component" });
+ * ```
+ *
+ * @public
+ */
+function declarativeTemplate(): (config: { name: string }) => Promise<ViewTemplate> {
+    if (!customElements.get("f-template")) {
+        TemplateElement.define({ name: "f-template" });
+    }
+
+    return (config: { name: string }): Promise<ViewTemplate> => {
+        return FASTElementDefinition.registerAsync(config.name).then(type => {
+            const definition = fastElementRegistry.getByType(type);
+
+            if (definition?.template) {
+                return definition.template as ViewTemplate;
+            }
+
+            return new Promise<ViewTemplate>(resolve => {
+                const notifier = Observable.getNotifier(definition);
+                const subscriber = {
+                    handleChange() {
+                        if (definition?.template) {
+                            notifier.unsubscribe(subscriber, "template");
+                            resolve(definition.template as ViewTemplate);
+                        }
+                    },
+                };
+                notifier.subscribe(subscriber, "template");
+            });
+        });
+    };
+}
+
+export { declarativeTemplate, TemplateElement };

--- a/packages/fast-html/src/index.ts
+++ b/packages/fast-html/src/index.ts
@@ -5,6 +5,7 @@ FAST.addMessages(debugMessages);
 
 export {
     type AttributeMapConfig,
+    declarativeTemplate,
     ObserverMap,
     type ObserverMapConfig,
     type ObserverMapPathEntry,

--- a/packages/fast-html/test/fixtures/declarative-template/declarative-template.spec.ts
+++ b/packages/fast-html/test/fixtures/declarative-template/declarative-template.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("declarativeTemplate", async () => {
+    test("defines f-template and resolves a ViewTemplate", async ({ page }) => {
+        await page.goto("/fixtures/declarative-template/");
+
+        const result = await page.evaluate(async () => {
+            // Wait for the template promise to resolve
+            await new Promise<void>(resolve => {
+                const check = () => {
+                    if ((window as any).resolvedTemplate) {
+                        resolve();
+                    } else {
+                        setTimeout(check, 50);
+                    }
+                };
+                check();
+            });
+
+            return {
+                hasTemplate: !!(window as any).resolvedTemplate,
+                templateType: (window as any).resolvedTemplate?.constructor?.name,
+            };
+        });
+
+        expect(result.hasTemplate).toBe(true);
+        expect(result.templateType).toBe("ViewTemplate");
+    });
+
+    test("renders the component with the resolved template", async ({ page }) => {
+        await page.goto("/fixtures/declarative-template/");
+
+        const element = page.locator("test-element");
+        await expect(element).toHaveText("Hello");
+    });
+
+    test("responds to attribute changes after template resolution", async ({ page }) => {
+        await page.goto("/fixtures/declarative-template/");
+
+        const element = page.locator("test-element");
+        await expect(element).toHaveText("Hello");
+
+        await page.evaluate(() => {
+            document.querySelector("test-element")!.setAttribute("greeting", "World");
+        });
+
+        await expect(element).toHaveText("World");
+    });
+});

--- a/packages/fast-html/test/fixtures/declarative-template/entry.html
+++ b/packages/fast-html/test/fixtures/declarative-template/entry.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+    </head>
+    <body>
+        <test-element greeting="{{greeting}}"></test-element>
+        <script type="module" src="./main.ts"></script>
+    </body>
+</html>

--- a/packages/fast-html/test/fixtures/declarative-template/fast-build.config.json
+++ b/packages/fast-html/test/fixtures/declarative-template/fast-build.config.json
@@ -1,0 +1,6 @@
+{
+    "entry": "entry.html",
+    "state": "state.json",
+    "output": "index.html",
+    "templates": "templates.html"
+}

--- a/packages/fast-html/test/fixtures/declarative-template/index.html
+++ b/packages/fast-html/test/fixtures/declarative-template/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+    </head>
+    <body>
+        <test-element greeting="Hello"><template shadowrootmode="open" shadowroot="open"><!--fe-b$$start$$0$$greeting-0$$fe-b-->Hello<!--fe-b$$end$$0$$greeting-0$$fe-b--></template></test-element>
+<f-template name="test-element">
+    <template>{{greeting}}</template>
+</f-template>
+
+        <script type="module" src="./main.ts"></script>
+    </body>
+</html>

--- a/packages/fast-html/test/fixtures/declarative-template/main.ts
+++ b/packages/fast-html/test/fixtures/declarative-template/main.ts
@@ -1,0 +1,17 @@
+import { attr, FASTElement } from "@microsoft/fast-element";
+import { declarativeTemplate } from "@microsoft/fast-html";
+
+class TestElement extends FASTElement {
+    @attr
+    greeting: string = "Hello";
+}
+TestElement.defineAsync({
+    name: "test-element",
+    templateOptions: "defer-and-hydrate",
+});
+
+const templatePromise = declarativeTemplate()({ name: "test-element" });
+
+templatePromise.then(template => {
+    (window as any).resolvedTemplate = template;
+});

--- a/packages/fast-html/test/fixtures/declarative-template/state.json
+++ b/packages/fast-html/test/fixtures/declarative-template/state.json
@@ -1,0 +1,3 @@
+{
+    "greeting": "Hello"
+}

--- a/packages/fast-html/test/fixtures/declarative-template/templates.html
+++ b/packages/fast-html/test/fixtures/declarative-template/templates.html
@@ -1,0 +1,3 @@
+<f-template name="test-element">
+    <template>{{greeting}}</template>
+</f-template>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add a new `declarativeTemplate()` currying function to `@microsoft/fast-html` that simplifies the setup of declarative HTML templates. The function defines the `<f-template>` custom element (if not already defined) and returns a function that resolves a `Promise<ViewTemplate>` for a given component name.

```typescript
const template: Promise<ViewTemplate> = declarativeTemplate()({ name: "my-component" });
```

This provides a more concise alternative to manually calling `TemplateElement.define()` and subscribing to template readiness.

## 👩‍💻 Reviewer Notes

The implementation uses `FASTElementDefinition.registerAsync()` to wait for the component class registration, then subscribes to the observable `template` property on the definition. It includes a fast path for components that already have a template assigned, and properly unsubscribes after resolving.

## 📑 Test Plan

- Added a new `declarative-template` fixture test with 3 Playwright tests:
  - Verifies the function defines `<f-template>` and resolves a `ViewTemplate`
  - Verifies the component renders correctly with the resolved template
  - Verifies attribute reactivity works after template resolution
- All 274 existing tests continue to pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.