### PR TITLE
chore: fix github pages pipeline to use Node 22

### DIFF
--- a/.github/workflows/cd-gh-pages.yml
+++ b/.github/workflows/cd-gh-pages.yml
@@ -13,17 +13,15 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [22.x]
 
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
         fetch-depth: 0
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 22
 
     - name: Set Git User
       run: |


### PR DESCRIPTION
# Pull Request

## 📖 Description

The GitHub pages deploy pipeline uses NodeJS version 20 which fails on scripts that use globSync, this change updates to version 22 with separate actions to pin the version.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

- Deploy GitHub pages