### PR TITLE
refactor: modularize Schema, ObserverMap, and AttributeMap in fast-html

### DIFF
--- a/change/@microsoft-fast-html-3d7093a2-e0fd-4abd-b1fa-6c9a9763c0a0.json
+++ b/change/@microsoft-fast-html-3d7093a2-e0fd-4abd-b1fa-6c9a9763c0a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "refactor: modularize Schema, ObserverMap, and AttributeMap in fast-html",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -73,7 +73,8 @@ Built during template parsing, one `Schema` instance per `<f-template>`. It reco
 
 - Describes the shape of each root property referenced in the template.
 - Tracks repeat context chains (parent/child array relationships).
-- Is stored statically per element name so it can be shared across instances.
+- Uses an instance-level `schemaMap` for its own property schemas.
+- Registers itself in the module-level `schemaRegistry` (keyed by custom element name) for cross-element `$ref` resolution.
 
 ### `ObserverMap` — automatic observable setup
 
@@ -164,8 +165,9 @@ packages/fast-html/
 │       ├── element.ts         # Element utilities
 │       ├── template.ts        # TemplateElement (<f-template>), lifecycle orchestration, options
 │       ├── template-parser.ts # TemplateParser — converts declarative HTML to ViewTemplate strings/values
-│       ├── schema.ts          # Schema class — JSON schema builder
-│       ├── observer-map.ts    # ObserverMap class — auto observable/proxy setup
+│       ├── schema.ts          # Schema class — JSON schema builder + schemaRegistry
+│       ├── observer-map.ts    # ObserverMap class + config types (ObserverMapConfig, ObserverMapPathEntry, etc.)
+│       ├── attribute-map.ts   # AttributeMap class + config types (AttributeMapConfig, AttributeMapOption)
 │       ├── utilities.ts       # Parsing engine, binding resolvers, proxy system
 │       └── syntax.ts          # Syntax delimiter constants
 ├── rules/                     # ast-grep YAML rules for converting html`` → declarative HTML
@@ -176,6 +178,19 @@ packages/fast-html/
     └── fixtures/              # One directory per feature, each with spec + index.html + main.ts
 ```
 
+### Module dependency direction
+
+Each module owns its configuration types and can be used independently:
+
+```
+template.ts ──imports──▶ observer-map.ts (ObserverMapConfig, ObserverMapOption)
+template.ts ──imports──▶ attribute-map.ts (AttributeMapConfig, AttributeMapOption)
+template.ts ──imports──▶ schema.ts (Schema)
+observer-map.ts ──imports──▶ schema.ts (Schema types)
+attribute-map.ts ──imports──▶ schema.ts (Schema types)
+utilities.ts ──imports──▶ schema.ts (schemaRegistry for cross-element $ref resolution)
+```
+
 ---
 
 ## Exports and Public API
@@ -184,28 +199,40 @@ packages/fast-html/
 import {
     TemplateElement,
     TemplateParser,
+    Schema,
+    schemaRegistry,
     ObserverMap,
+    AttributeMap,
     type ObserverMapConfig,
     type ObserverMapPathEntry,
     type ObserverMapPathNode,
+    type AttributeMapConfig,
+    type JSONSchema,
+    type CachedPathMap,
 } from "@microsoft/fast-html";
 ```
 
-Three primary exports are intended for application code:
+Primary exports intended for application code:
 
 | Export | Purpose |
 |---|---|
 | `TemplateElement` | Define the `<f-template>` element; configure callbacks and per-element options. |
 | `TemplateParser` | Standalone parser that converts declarative HTML into `ViewTemplate` strings/values. Can be used independently of `<f-template>` for programmatic template compilation. |
-| `ObserverMap` | Advanced: access the observer-map class directly if building tooling. |
+| `Schema` | JSON schema builder that records binding paths discovered during template parsing. Each instance owns its own schema map and registers itself in the `schemaRegistry` for cross-element `$ref` resolution. |
+| `schemaRegistry` | Module-level `Map<string, Map<string, JSONSchema>>` that indexes schemas by custom element name. Used for cross-element lookups (e.g. nested component `$ref` resolution). |
+| `ObserverMap` | Automatic observable setup using the schema; defines observable properties and installs proxy-based deep change tracking. Configuration types (`ObserverMapConfig`, `ObserverMapPathEntry`, `ObserverMapPathNode`) are co-located in this module. |
+| `AttributeMap` | Automatic `@attr` property registration for leaf bindings in the template. Configuration type (`AttributeMapConfig`) is co-located in this module. |
 
-Additionally, the following types are exported for use in `observerMap` configuration:
+Additionally, the following types are exported:
 
-| Type | Purpose |
-|---|---|
-| `ObserverMapConfig` | Configuration object for the `observerMap` option; accepts optional `properties` key. |
-| `ObserverMapPathEntry` | `boolean \| ObserverMapPathNode` — a node in the observation path tree. |
-| `ObserverMapPathNode` | Object node with optional `$observe` and child property overrides. |
+| Type | Source Module | Purpose |
+|---|---|---|
+| `ObserverMapConfig` | `observer-map.ts` | Configuration object for the `observerMap` option; accepts optional `properties` key. |
+| `ObserverMapPathEntry` | `observer-map.ts` | `boolean \| ObserverMapPathNode` — a node in the observation path tree. |
+| `ObserverMapPathNode` | `observer-map.ts` | Object node with optional `$observe` and child property overrides. |
+| `AttributeMapConfig` | `attribute-map.ts` | Configuration object for the `attributeMap` option; accepts `attribute-name-strategy`. |
+| `JSONSchema` | `schema.ts` | JSON Schema interface used by `Schema` for property structure. |
+| `CachedPathMap` | `schema.ts` | `Map<string, Map<string, JSONSchema>>` — the shape of the schema registry. |
 
 ---
 
@@ -377,13 +404,14 @@ innerHTML token
 
 ## Schema and Observer Map
 
-The `Schema` class accumulates all binding paths discovered during parsing into a static JSON Schema map indexed by `customElementName → rootPropertyName → JSONSchema`.
+The `Schema` class accumulates all binding paths discovered during parsing into an instance-level JSON Schema map (`schemaMap`) indexed by `rootPropertyName → JSONSchema`. Each `Schema` instance also registers itself in the module-level `schemaRegistry` (keyed by custom element name) for cross-element `$ref` resolution.
 
 ```mermaid
 flowchart LR
     A["Template binding\nuser.details.age"] --> B[bindingResolver]
     B --> C[schema.addPath\ntype:'access'\npath:'user.details.age'\nrootProperty:'user']
-    C --> D["Schema.jsonSchemaMap\n{'my-el' => {'user' => JSONSchema}}"]
+    C --> D["schema.schemaMap\n{'user' => JSONSchema}"]
+    C --> D2["schemaRegistry\n{'my-el' => schemaMap}"]
     D --> E[ObserverMap.defineProperties]
     E --> E1["applyConfigToSchema\nstamps $observe: false on excluded schema nodes"]
     E1 --> F[Observable.defineProperty on prototype\nfor 'user']

--- a/packages/fast-html/MIGRATION.md
+++ b/packages/fast-html/MIGRATION.md
@@ -84,3 +84,39 @@
        });
    }
    ```
+
+## Modularize Schema, ObserverMap, and AttributeMap
+
+### Import changes
+
+Configuration types have moved from `template.ts` to their owning modules. If you import types directly from internal paths, update your imports:
+
+| Before | After |
+|---|---|
+| `import type { ObserverMapConfig } from "./template.js"` | `import type { ObserverMapConfig } from "./observer-map.js"` |
+| `import type { AttributeMapConfig } from "./template.js"` | `import type { AttributeMapConfig } from "./attribute-map.js"` |
+
+Imports from the package barrel (`@microsoft/fast-html`) are unaffected.
+
+### Schema changes
+
+`Schema.jsonSchemaMap` (static property) has been replaced by:
+- An instance-level `schemaMap` on each `Schema` instance (private)
+- A module-level `schemaRegistry` export for cross-element lookups
+
+| Before | After |
+|---|---|
+| `Schema.jsonSchemaMap.get('my-element')` | `import { schemaRegistry } from "@microsoft/fast-html"; schemaRegistry.get('my-element')` |
+
+### New public exports
+
+The following are now part of the public API:
+
+| Export | Purpose |
+|---|---|
+| `Schema` | JSON schema builder class |
+| `schemaRegistry` | Module-level registry for cross-element schema lookups |
+| `AttributeMap` | Automatic `@attr` property registration |
+| `AttributeMapOption` | Constant for the `"all"` option value |
+| `JSONSchema` | JSON Schema type interface |
+| `CachedPathMap` | Schema registry map type |

--- a/packages/fast-html/SCHEMA_OBSERVER_MAP.md
+++ b/packages/fast-html/SCHEMA_OBSERVER_MAP.md
@@ -58,7 +58,7 @@ The `Schema` class is responsible for building JSON Schema definitions that map 
 ```typescript
 constructor(name: string)
 ```
-Creates a new schema instance for a specific custom element name and initializes an entry in the static `jsonSchemaMap`.
+Creates a new schema instance for a specific custom element name and initializes an instance-level `schemaMap`. The instance also registers itself in the module-level `schemaRegistry` for cross-element `$ref` resolution.
 
 #### addPath
 ```typescript
@@ -131,7 +131,7 @@ Creates an observer map instance that will configure the provided class prototyp
 public defineProperties(): void
 ```
 The main method that:
-1. Iterates through all root properties defined in the schema (each custom element in the jsonSchemaMap contains multiple schemas, one for each root property)
+1. Iterates through all root properties defined in the schema (each schema instance contains multiple root property schemas)
 2. Defines observable properties using FAST Element's `Observable.defineProperty` (an alternative to the `@observable` decorator syntax used in custom element classes)
 3. Sets up property change handlers that create proxies for nested objects
 
@@ -375,16 +375,18 @@ This creates nested context definitions where the `post` context understands its
 
 ## Technical Details
 
-### Static Schema Map
+### Schema Registry
 
-The `Schema` class maintains a static `CachedPathMap`:
+The `Schema` module exports a module-level `schemaRegistry`:
 ```typescript
-public static jsonSchemaMap: CachedPathMap = new Map();
+export const schemaRegistry: CachedPathMap = new Map();
 ```
 
-This map structure is: `Map<customElementName, Map<rootPropertyName, JSONSchema>>`
+Each `Schema` instance owns an instance-level `schemaMap: Map<string, JSONSchema>` and registers itself in `schemaRegistry` on construction.
 
-**Rationale for Static Property**: The static nature of this map is essential for handling nested components inside f-templates. When an object or array is passed to another custom element within an f-template, that nested component needs to observe the entire root property's structure based on the binding paths within that nested component. The static map allows all components to access and contribute to the same schema definitions, ensuring consistent observation behavior across component boundaries.
+The registry structure is: `Map<customElementName, Map<rootPropertyName, JSONSchema>>`
+
+**Rationale for Module-level Registry**: The registry allows cross-element `$ref` resolution for nested components inside f-templates. When an object or array is passed to another custom element within an f-template, that nested component needs to observe the entire root property's structure based on the binding paths within that nested component. The registry allows all components to access and contribute to the same schema definitions, ensuring consistent observation behavior across component boundaries.
 
 ### Context Tracking
 
@@ -408,15 +410,13 @@ The schema system tracks binding contexts using special metadata:
 
 ### Schema Inspection
 
-You can inspect generated schemas from any f-template custom element in the browser using the console:
+You can inspect generated schemas using the module-level `schemaRegistry` import:
 
 ```typescript
-// First, select an f-template element in the browser's developer tools
-// Then access the static jsonSchemaMap from the console:
-$0.schema.__proto__.constructor.jsonSchemaMap
+import { schemaRegistry } from "@microsoft/fast-html";
 
-// To get a specific schema for an element and property:
-const elementSchemas = $0.schema.__proto__.constructor.jsonSchemaMap.get('my-element');
+// Get all schemas for an element:
+const elementSchemas = schemaRegistry.get('my-element');
 const userSchema = elementSchemas?.get('users');
 console.log(JSON.stringify(userSchema, null, 2));
 ```

--- a/packages/fast-html/docs/api-report.api.md
+++ b/packages/fast-html/docs/api-report.api.md
@@ -5,8 +5,16 @@
 ```ts
 
 import { FASTElement } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { TemplateLifecycleCallbacks } from '@microsoft/fast-element';
 import { ViewTemplate } from '@microsoft/fast-element';
+
+// @public
+export class AttributeMap {
+    constructor(classPrototype: any, schema: Schema, definition?: FASTElementDefinition, config?: AttributeMapConfig);
+    // (undocumented)
+    defineProperties(): void;
+}
 
 // @public
 export interface AttributeMapConfig {
@@ -14,8 +22,58 @@ export interface AttributeMapConfig {
 }
 
 // @public
+export const AttributeMapOption: {
+    readonly all: "all";
+};
+
+// @public
+export type AttributeMapOption = (typeof AttributeMapOption)[keyof typeof AttributeMapOption] | AttributeMapConfig;
+
+// @public (undocumented)
+export type CachedPathMap = Map<string, Map<string, JSONSchema>>;
+
+// @public
+export interface ElementOptions {
+    // (undocumented)
+    attributeMap?: AttributeMapOption;
+    // Warning: (ae-forgotten-export) The symbol "ObserverMapOption" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    observerMap?: ObserverMapOption;
+}
+
+// @public
+export interface ElementOptionsDictionary<ElementOptionsType = ElementOptions> {
+    // (undocumented)
+    [key: string]: ElementOptionsType;
+}
+
+// @public
+export interface HydrationLifecycleCallbacks extends TemplateLifecycleCallbacks {
+    elementDidHydrate?(source: HTMLElement): void;
+    elementDidRegister?(name: string): void;
+    elementWillHydrate?(source: HTMLElement): void;
+    hydrationComplete?(): void;
+    hydrationStarted?(): void;
+    templateWillUpdate?(name: string): void;
+}
+
+// Warning: (ae-forgotten-export) The symbol "JSONSchemaCommon" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export interface JSONSchema extends JSONSchemaCommon {
+    // Warning: (ae-forgotten-export) The symbol "JSONSchemaDefinition" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    $defs?: Record<string, JSONSchemaDefinition>;
+    // (undocumented)
+    $id: string;
+    // (undocumented)
+    $schema: string;
+}
+
+// @public
 export class ObserverMap {
-    // Warning: (ae-forgotten-export) The symbol "Schema" needs to be exported by the entry point index.d.ts
     constructor(classPrototype: any, schema: Schema, config?: ObserverMapConfig);
     // (undocumented)
     defineProperties(): void;
@@ -48,13 +106,23 @@ export interface ResolvedStringsAndValues {
 }
 
 // @public
+export class Schema {
+    constructor(name: string);
+    // Warning: (ae-forgotten-export) The symbol "RegisterPathConfig" needs to be exported by the entry point index.d.ts
+    addPath(config: RegisterPathConfig): void;
+    getRootProperties(): IterableIterator<string>;
+    getSchema(rootPropertyName: string): JSONSchema | null;
+}
+
+// @public
+export const schemaRegistry: CachedPathMap;
+
+// @public
 export class TemplateElement extends FASTElement {
     constructor();
-    // Warning: (ae-forgotten-export) The symbol "HydrationLifecycleCallbacks" needs to be exported by the entry point index.d.ts
     static config(callbacks: HydrationLifecycleCallbacks): typeof TemplateElement;
     // (undocumented)
     connectedCallback(): void;
-    // Warning: (ae-forgotten-export) The symbol "ElementOptionsDictionary" needs to be exported by the entry point index.d.ts
     static elementOptions: ElementOptionsDictionary;
     name?: string;
     static options(elementOptions?: ElementOptionsDictionary): typeof TemplateElement;

--- a/packages/fast-html/src/components/attribute-map.ts
+++ b/packages/fast-html/src/components/attribute-map.ts
@@ -1,7 +1,41 @@
 import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { AttributeDefinition, Observable } from "@microsoft/fast-element";
 import type { Schema } from "./schema.js";
-import type { AttributeMapConfig } from "./template.js";
+
+/**
+ * Values for the attributeMap element option.
+ */
+export const AttributeMapOption = {
+    all: "all",
+} as const;
+
+/**
+ * Configuration object for the attributeMap element option.
+ * Passing an empty object (`{}`) is equivalent to `"all"`.
+ */
+export interface AttributeMapConfig {
+    /**
+     * Strategy for mapping template binding keys to HTML attribute names.
+     *
+     * - `"none"` (default): the binding key is used as-is for both the
+     *   property name and the attribute name (e.g. `{{foo-bar}}` →
+     *   property `foo-bar`, attribute `foo-bar`).
+     * - `"camelCase"`: the binding key is treated as a camelCase property
+     *   name and the attribute name is derived by converting it to
+     *   kebab-case (e.g. `{{fooBar}}` → property `fooBar`, attribute
+     *   `foo-bar`). This matches the build-time `attribute-name-strategy`
+     *   option in `@microsoft/fast-build`.
+     */
+    "attribute-name-strategy"?: "none" | "camelCase";
+}
+
+/**
+ * Type for the attributeMap element option.
+ * Accepts `"all"` or a configuration object.
+ */
+export type AttributeMapOption =
+    | (typeof AttributeMapOption)[keyof typeof AttributeMapOption]
+    | AttributeMapConfig;
 
 /**
  * Converts a camelCase string to kebab-case.

--- a/packages/fast-html/src/components/index.ts
+++ b/packages/fast-html/src/components/index.ts
@@ -1,15 +1,25 @@
-export { AttributeMap } from "./attribute-map.js";
-export { ObserverMap } from "./observer-map.js";
 export {
+    AttributeMap,
     type AttributeMapConfig,
     AttributeMapOption,
-    type ElementOptions,
-    type ElementOptionsDictionary,
-    type HydrationLifecycleCallbacks,
+} from "./attribute-map.js";
+export {
+    ObserverMap,
     type ObserverMapConfig,
     ObserverMapOption,
     type ObserverMapPathEntry,
     type ObserverMapPathNode,
+} from "./observer-map.js";
+export {
+    type CachedPathMap,
+    type JSONSchema,
+    Schema,
+    schemaRegistry,
+} from "./schema.js";
+export {
+    type ElementOptions,
+    type ElementOptionsDictionary,
+    type HydrationLifecycleCallbacks,
     TemplateElement,
 } from "./template.js";
 export { type ResolvedStringsAndValues, TemplateParser } from "./template-parser.js";

--- a/packages/fast-html/src/components/observer-map.spec.ts
+++ b/packages/fast-html/src/components/observer-map.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { ObserverMap } from "./observer-map.js";
-import { defsPropertyName, type JSONSchema, Schema } from "./schema.js";
+import { defsPropertyName, type JSONSchema, Schema, schemaRegistry } from "./schema.js";
 
 const testElementName = "test-class";
 
@@ -24,10 +24,7 @@ test.describe("ObserverMap", async () => {
     });
 
     test("proxies direct object assignments", async () => {
-        const schemaMap = Schema.jsonSchemaMap.get(testElementName) as Map<
-            string,
-            JSONSchema
-        >;
+        const schemaMap = schemaRegistry.get(testElementName) as Map<string, JSONSchema>;
         schemaMap.set("someData", {
             $schema: "https://json-schema.org/draft/2019-09/schema",
             $id: `https://fast.design/schemas/${testElementName}/someData.json`,
@@ -59,10 +56,7 @@ test.describe("ObserverMap", async () => {
                 public excluded: any;
             }
 
-            const schemaMap = Schema.jsonSchemaMap.get(testName) as Map<
-                string,
-                JSONSchema
-            >;
+            const schemaMap = schemaRegistry.get(testName) as Map<string, JSONSchema>;
             schemaMap.set("included", {
                 $schema: "https://json-schema.org/draft/2019-09/schema",
                 $id: `https://fast.design/schemas/${testName}/included.json`,
@@ -102,10 +96,7 @@ test.describe("ObserverMap", async () => {
                 public skipped: any;
             }
 
-            const schemaMap = Schema.jsonSchemaMap.get(testName) as Map<
-                string,
-                JSONSchema
-            >;
+            const schemaMap = schemaRegistry.get(testName) as Map<string, JSONSchema>;
             schemaMap.set("skipped", {
                 $schema: "https://json-schema.org/draft/2019-09/schema",
                 $id: `https://fast.design/schemas/${testName}/skipped.json`,
@@ -133,10 +124,7 @@ test.describe("ObserverMap", async () => {
                 public data: any;
             }
 
-            const schemaMap = Schema.jsonSchemaMap.get(testName) as Map<
-                string,
-                JSONSchema
-            >;
+            const schemaMap = schemaRegistry.get(testName) as Map<string, JSONSchema>;
             schemaMap.set("data", {
                 $schema: "https://json-schema.org/draft/2019-09/schema",
                 $id: `https://fast.design/schemas/${testName}/data.json`,
@@ -163,10 +151,7 @@ test.describe("ObserverMap", async () => {
                 public data: any;
             }
 
-            const schemaMap = Schema.jsonSchemaMap.get(testName) as Map<
-                string,
-                JSONSchema
-            >;
+            const schemaMap = schemaRegistry.get(testName) as Map<string, JSONSchema>;
             schemaMap.set("data", {
                 $schema: "https://json-schema.org/draft/2019-09/schema",
                 $id: `https://fast.design/schemas/${testName}/data.json`,

--- a/packages/fast-html/src/components/observer-map.ts
+++ b/packages/fast-html/src/components/observer-map.ts
@@ -1,7 +1,63 @@
 import { Observable } from "@microsoft/fast-element/observable.js";
 import type { JSONSchema, Schema } from "./schema.js";
-import type { ObserverMapConfig, ObserverMapPathEntry } from "./template.js";
 import { assignObservables, deepMerge } from "./utilities.js";
+
+/**
+ * Values for the observerMap element option.
+ */
+export const ObserverMapOption = {
+    all: "all",
+} as const;
+
+/**
+ * A node in the observer-map path tree.
+ *
+ * - `true`  → observe this path and all descendants (unless overridden by children).
+ * - `false` → do NOT observe this path or its descendants (unless overridden by children).
+ * - `ObserverMapPathNode` → configure child paths individually;
+ *       the node itself is observed if `$observe` is true (default when parent is observed).
+ */
+export type ObserverMapPathEntry = boolean | ObserverMapPathNode;
+
+/**
+ * A node object in the observer-map path tree.
+ *
+ * `$observe` controls whether this node itself is observed.
+ * When omitted the value is inherited from the nearest ancestor
+ * that explicitly sets `$observe`. At the root level the default is `true`.
+ *
+ * Child property overrides are keyed by property name.
+ */
+export interface ObserverMapPathNode {
+    $observe?: boolean;
+    [propertyName: string]: ObserverMapPathEntry | undefined;
+}
+
+/**
+ * Configuration object for the observerMap element option.
+ * When `properties` is omitted (i.e. `observerMap: {}`), behaves like `"all"` —
+ * every root property is observed. When `properties` is present, only listed
+ * root properties participate in observer-map observation.
+ */
+export interface ObserverMapConfig {
+    /**
+     * Per-root-property observation control.
+     * Keys are root property names discovered in the template schema.
+     * Only root properties listed here participate in observer-map observation.
+     * Omitting this field is equivalent to `"all"`.
+     */
+    properties?: {
+        [rootProperty: string]: ObserverMapPathEntry;
+    };
+}
+
+/**
+ * Type for the observerMap element option.
+ * Accepts `"all"` or a configuration object.
+ */
+export type ObserverMapOption =
+    | (typeof ObserverMapOption)[keyof typeof ObserverMapOption]
+    | ObserverMapConfig;
 
 /**
  * Determines whether a config entry (or any of its descendants) enables observation.

--- a/packages/fast-html/src/components/schema.ts
+++ b/packages/fast-html/src/components/schema.ts
@@ -81,6 +81,13 @@ export const defsPropertyName = "$defs";
 export const refPropertyName = "$ref";
 
 /**
+ * Module-level registry that maps custom element names to their schema maps.
+ * Used for cross-element `$ref` resolution (e.g. nested element schemas).
+ * Each Schema instance registers itself here on construction.
+ */
+export const schemaRegistry: CachedPathMap = new Map();
+
+/**
  * A constructed JSON schema from a template
  */
 export class Schema {
@@ -90,13 +97,14 @@ export class Schema {
     private customElementName: string;
 
     /**
-     * A JSON schema describing each root schema
+     * Instance-level JSON schema map describing each root property
      */
-    public static jsonSchemaMap: CachedPathMap = new Map();
+    private schemaMap: Map<string, JSONSchema>;
 
     constructor(name: string) {
         this.customElementName = name;
-        Schema.jsonSchemaMap.set(this.customElementName, new Map());
+        this.schemaMap = new Map();
+        schemaRegistry.set(name, this.schemaMap);
     }
 
     /**
@@ -105,20 +113,13 @@ export class Schema {
      */
     public addPath(config: RegisterPathConfig) {
         const splitPath = this.getSplitPath(config.pathConfig.path);
-        let schema: JSONSchema | undefined = (
-            Schema.jsonSchemaMap.get(this.customElementName) as Map<string, JSONSchema>
-        ).get(config.rootPropertyName);
+        let schema: JSONSchema | undefined = this.schemaMap.get(config.rootPropertyName);
         let childRef: string | null = null;
 
         // Create a root level property JSON
         if (!schema) {
             this.addNewSchema(config.rootPropertyName);
-            schema = (
-                Schema.jsonSchemaMap.get(this.customElementName) as Map<
-                    string,
-                    JSONSchema
-                >
-            ).get(config.rootPropertyName) as JSONSchema;
+            schema = this.schemaMap.get(config.rootPropertyName) as JSONSchema;
         }
 
         if (config.childrenMap) {
@@ -228,14 +229,7 @@ export class Schema {
      * @returns The JSON schema for the root property
      */
     public getSchema(rootPropertyName: string): JSONSchema | null {
-        return (
-            (
-                Schema.jsonSchemaMap.get(this.customElementName) as Map<
-                    string,
-                    JSONSchema
-                >
-            ).get(rootPropertyName) ?? null
-        );
+        return this.schemaMap.get(rootPropertyName) ?? null;
     }
 
     /**
@@ -243,9 +237,7 @@ export class Schema {
      * @returns IterableIterator<string>
      */
     public getRootProperties(): IterableIterator<string> {
-        return (
-            Schema.jsonSchemaMap.get(this.customElementName) as Map<string, JSONSchema>
-        ).keys();
+        return this.schemaMap.keys();
     }
 
     /**
@@ -281,14 +273,11 @@ export class Schema {
      * @param propertyName The name of the property to assign this JSON schema to
      */
     private addNewSchema(propertyName: string): void {
-        (Schema.jsonSchemaMap.get(this.customElementName) as Map<string, JSONSchema>).set(
-            propertyName,
-            {
-                $schema: "https://json-schema.org/draft/2019-09/schema",
-                $id: this.getSchemaId(this.customElementName, propertyName),
-                [defsPropertyName]: {},
-            },
-        );
+        this.schemaMap.set(propertyName, {
+            $schema: "https://json-schema.org/draft/2019-09/schema",
+            $id: this.getSchemaId(this.customElementName, propertyName),
+            [defsPropertyName]: {},
+        });
     }
 
     /**

--- a/packages/fast-html/src/components/template.ts
+++ b/packages/fast-html/src/components/template.ts
@@ -9,103 +9,29 @@ import {
 } from "@microsoft/fast-element";
 import "@microsoft/fast-element/install-hydratable-view-templates.js";
 import { Message } from "../interfaces.js";
-import { AttributeMap } from "./attribute-map.js";
-import { ObserverMap } from "./observer-map.js";
+import {
+    AttributeMap,
+    type AttributeMapConfig,
+    type AttributeMapOption,
+} from "./attribute-map.js";
+import { ObserverMap, type ObserverMapOption } from "./observer-map.js";
 import { Schema } from "./schema.js";
 import { TemplateParser } from "./template-parser.js";
 import { eventArgAccessor, transformInnerHTML } from "./utilities.js";
 
 /**
- * Values for the observerMap element option.
+ * Checks whether a map option (observerMap or attributeMap) is enabled.
+ * An option is enabled when it is `"all"` or a plain configuration object.
  */
-export const ObserverMapOption = {
-    all: "all",
-} as const;
+function isMapOptionEnabled(
+    option: ObserverMapOption | AttributeMapOption | undefined,
+): boolean {
+    if (option === "all") {
+        return true;
+    }
 
-/**
- * A node in the observer-map path tree.
- *
- * - `true`  → observe this path and all descendants (unless overridden by children).
- * - `false` → do NOT observe this path or its descendants (unless overridden by children).
- * - `ObserverMapPathNode` → configure child paths individually;
- *       the node itself is observed if `$observe` is true (default when parent is observed).
- */
-export type ObserverMapPathEntry = boolean | ObserverMapPathNode;
-
-/**
- * A node object in the observer-map path tree.
- *
- * `$observe` controls whether this node itself is observed.
- * When omitted the value is inherited from the nearest ancestor
- * that explicitly sets `$observe`. At the root level the default is `true`.
- *
- * Child property overrides are keyed by property name.
- */
-export interface ObserverMapPathNode {
-    $observe?: boolean;
-    [propertyName: string]: ObserverMapPathEntry | undefined;
+    return typeof option === "object" && !Array.isArray(option);
 }
-
-/**
- * Configuration object for the observerMap element option.
- * When `properties` is omitted (i.e. `observerMap: {}`), behaves like `"all"` —
- * every root property is observed. When `properties` is present, only listed
- * root properties participate in observer-map observation.
- */
-export interface ObserverMapConfig {
-    /**
-     * Per-root-property observation control.
-     * Keys are root property names discovered in the template schema.
-     * Only root properties listed here participate in observer-map observation.
-     * Omitting this field is equivalent to `"all"`.
-     */
-    properties?: {
-        [rootProperty: string]: ObserverMapPathEntry;
-    };
-}
-
-/**
- * Type for the observerMap element option.
- * Accepts `"all"` or a configuration object.
- */
-export type ObserverMapOption =
-    | (typeof ObserverMapOption)[keyof typeof ObserverMapOption]
-    | ObserverMapConfig;
-
-/**
- * Values for the attributeMap element option.
- */
-export const AttributeMapOption = {
-    all: "all",
-} as const;
-
-/**
- * Configuration object for the attributeMap element option.
- * Passing an empty object (`{}`) is equivalent to `"all"`.
- */
-export interface AttributeMapConfig {
-    /**
-     * Strategy for mapping template binding keys to HTML attribute names.
-     *
-     * - `"none"` (default): the binding key is used as-is for both the
-     *   property name and the attribute name (e.g. `{{foo-bar}}` →
-     *   property `foo-bar`, attribute `foo-bar`).
-     * - `"camelCase"`: the binding key is treated as a camelCase property
-     *   name and the attribute name is derived by converting it to
-     *   kebab-case (e.g. `{{fooBar}}` → property `fooBar`, attribute
-     *   `foo-bar`). This matches the build-time `attribute-name-strategy`
-     *   option in `@microsoft/fast-build`.
-     */
-    "attribute-name-strategy"?: "none" | "camelCase";
-}
-
-/**
- * Type for the attributeMap element option.
- * Accepts `"all"` or a configuration object.
- */
-export type AttributeMapOption =
-    | (typeof AttributeMapOption)[keyof typeof AttributeMapOption]
-    | AttributeMapConfig;
 
 /**
  * Element options the TemplateElement will use to update the registered element
@@ -120,20 +46,6 @@ export interface ElementOptions {
  */
 export interface ElementOptionsDictionary<ElementOptionsType = ElementOptions> {
     [key: string]: ElementOptionsType;
-}
-
-/**
- * Checks whether a map option (observerMap or attributeMap) is enabled.
- * An option is enabled when it is `"all"` or a plain configuration object.
- */
-function isMapOptionEnabled(
-    option: ObserverMapOption | AttributeMapOption | undefined,
-): boolean {
-    if (option === "all") {
-        return true;
-    }
-
-    return typeof option === "object" && !Array.isArray(option);
 }
 
 /**

--- a/packages/fast-html/src/components/utilities.ts
+++ b/packages/fast-html/src/components/utilities.ts
@@ -5,7 +5,8 @@ import {
     type JSONSchema,
     type JSONSchemaDefinition,
     refPropertyName,
-    Schema,
+    type Schema,
+    schemaRegistry,
 } from "./schema.js";
 import {
     attributeDirectivePrefix,
@@ -1150,10 +1151,11 @@ function getSchemaPropertiesFromAnyOf(anyOf: Array<any>): any | null {
             const customElement = splitRef.slice(-2)[0];
             const attributeName = splitRef.slice(-1)[0].slice(0, -5);
 
-            if (Schema.jsonSchemaMap.has(customElement)) {
-                const customElementSchemaMap = Schema.jsonSchemaMap.get(
-                    customElement,
-                ) as Map<string, JSONSchema>;
+            if (schemaRegistry.has(customElement)) {
+                const customElementSchemaMap = schemaRegistry.get(customElement) as Map<
+                    string,
+                    JSONSchema
+                >;
                 propertiesFromAnyOf = customElementSchemaMap.get(attributeName);
             }
         }

--- a/packages/fast-html/src/index.ts
+++ b/packages/fast-html/src/index.ts
@@ -4,12 +4,21 @@ import { debugMessages } from "./debug.js";
 FAST.addMessages(debugMessages);
 
 export {
+    AttributeMap,
     type AttributeMapConfig,
+    AttributeMapOption,
+    type CachedPathMap,
+    type ElementOptions,
+    type ElementOptionsDictionary,
+    type HydrationLifecycleCallbacks,
+    type JSONSchema,
     ObserverMap,
     type ObserverMapConfig,
     type ObserverMapPathEntry,
     type ObserverMapPathNode,
     type ResolvedStringsAndValues,
+    Schema,
+    schemaRegistry,
     TemplateElement,
     TemplateParser,
 } from "./components/index.js";


### PR DESCRIPTION
# Pull Request

## 📖 Description

Modularize Schema, ObserverMap, and AttributeMap in `@microsoft/fast-html` to reduce tight coupling with TemplateElement. This is a **breaking change**.

**Key changes:**
- Moved `ObserverMapConfig`, `ObserverMapPathEntry`, `ObserverMapPathNode`, and `ObserverMapOption` from `template.ts` to `observer-map.ts`
- Moved `AttributeMapConfig` and `AttributeMapOption` from `template.ts` to `attribute-map.ts`
- Replaced `Schema.jsonSchemaMap` (static property) with an instance-level `schemaMap` and a module-level `schemaRegistry` export for cross-element `$ref` resolution
- Added `Schema`, `AttributeMap`, `schemaRegistry`, `JSONSchema`, and `CachedPathMap` to the public API exports
- Reversed the dependency direction: `template.ts` now imports from `observer-map.ts` and `attribute-map.ts`, instead of the other way around

## 👩‍💻 Reviewer Notes

The module dependency direction is now:
```
template.ts ──imports──▶ observer-map.ts (config types)
template.ts ──imports──▶ attribute-map.ts (config types)
template.ts ──imports──▶ schema.ts
observer-map.ts ──imports──▶ schema.ts (types only)
attribute-map.ts ──imports──▶ schema.ts (types only)
utilities.ts ──imports──▶ schema.ts (schemaRegistry for cross-element $ref)
```

## 📑 Test Plan

All 873 existing tests pass across Chromium, Firefox, and WebKit. No new tests were needed as the refactor preserves all existing behavior — only the internal module boundaries and export surface changed.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.