### PR TITLE
feat: change default attribute-name-strategy from none to camelCase

### DIFF
--- a/change/@microsoft-fast-build-285b7229-8023-4304-83b0-25de34f617ce.json
+++ b/change/@microsoft-fast-build-285b7229-8023-4304-83b0-25de34f617ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: change default attribute-name-strategy from none to camelCase",
+  "packageName": "@microsoft/fast-build",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-html-c20e636d-e975-46f4-9e0b-c7b6c8143ef6.json
+++ b/change/@microsoft-fast-html-c20e636d-e975-46f4-9e0b-c7b6c8143ef6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: change default attribute-name-strategy from none to camelCase",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/crates/microsoft-fast-build/DESIGN.md
+++ b/crates/microsoft-fast-build/DESIGN.md
@@ -267,8 +267,8 @@ Controls how HTML attribute names are mapped to state property names when buildi
 
 | Strategy | Behaviour | Example |
 |----------|-----------|---------|
-| `"none"` (default) | Attribute names are lowercased as-is. Dashes are preserved. | `foo-bar` → `foo-bar` → `{{foo-bar}}` |
-| `"camelCase"` | Dashed attribute names are converted to camelCase. | `foo-bar` → `fooBar` → `{{fooBar}}` |
+| `"camelCase"` (default) | Dashed attribute names are converted to camelCase. | `foo-bar` → `fooBar` → `{{fooBar}}` |
+| `"none"` | Attribute names are lowercased as-is. Dashes are preserved. | `foo-bar` → `foo-bar` → `{{foo-bar}}` |
 
 The `camelCase` strategy only applies to attributes that are **not** already handled by a specialized conversion:
 

--- a/crates/microsoft-fast-build/src/config.rs
+++ b/crates/microsoft-fast-build/src/config.rs
@@ -8,13 +8,13 @@
 pub enum AttributeNameStrategy {
     /// No conversion — attribute names are lowercased as-is.
     /// `foo-bar` stays `foo-bar`, matching `{{foo-bar}}` in the template.
-    #[default]
     None,
     /// Convert dashed attribute names to camelCase.
     /// `foo-bar` becomes `fooBar`, matching `{{fooBar}}` in the template.
     /// Attributes that are already handled by specialized lookup tables
     /// (`data-*`, `aria-*`, and HTML global attributes like `tabindex`)
     /// are unaffected — those always use their standard property names.
+    #[default]
     CamelCase,
 }
 

--- a/crates/microsoft-fast-build/src/wasm.rs
+++ b/crates/microsoft-fast-build/src/wasm.rs
@@ -13,8 +13,8 @@ pub fn render(entry: &str, state: &str) -> Result<String, JsValue> {
 /// Render a FAST HTML template with custom element templates and a JSON state string.
 /// `templates_json` is a JSON object mapping element names to their HTML template strings,
 /// e.g. `{"my-button": "<template>...</template>"}`.
-/// `attribute_name_strategy` controls attribute-to-property mapping: `"none"` (default)
-/// or `"camelCase"`. Pass an empty string for the default.
+/// `attribute_name_strategy` controls attribute-to-property mapping: `"camelCase"` (default)
+/// or `"none"`. Pass an empty string for the default.
 /// Returns the rendered HTML or throws a JavaScript error.
 #[wasm_bindgen]
 pub fn render_with_templates(entry: &str, templates_json: &str, state: &str, attribute_name_strategy: &str) -> Result<String, JsValue> {
@@ -32,8 +32,8 @@ pub fn render_with_templates(entry: &str, templates_json: &str, state: &str, att
 /// output, while non-primitive values (`array`, `object`, `null`) are stripped.
 ///
 /// `templates_json` is a JSON object mapping element names to their HTML template strings.
-/// `attribute_name_strategy` controls attribute-to-property mapping: `"none"` (default)
-/// or `"camelCase"`. Pass an empty string for the default.
+/// `attribute_name_strategy` controls attribute-to-property mapping: `"camelCase"` (default)
+/// or `"none"`. Pass an empty string for the default.
 /// Returns the rendered HTML or throws a JavaScript error.
 #[wasm_bindgen]
 pub fn render_entry_with_templates(entry: &str, templates_json: &str, state: &str, attribute_name_strategy: &str) -> Result<String, JsValue> {
@@ -102,12 +102,12 @@ fn parse_templates_map(templates_json: &str) -> Result<HashMap<String, String>, 
 }
 
 /// Build an `Option<RenderConfig>` from the strategy string.
-/// Returns `None` for `""` or `"none"` (use defaults), `Some(config)` otherwise.
+/// Returns `None` for `""` or `"camelCase"` (use defaults), `Some(config)` for `"none"`.
 fn build_config(strategy: &str) -> Result<Option<RenderConfig>, JsValue> {
     match strategy {
-        "" | "none" => Ok(None),
-        "camelCase" => Ok(Some(
-            RenderConfig::new().with_attribute_name_strategy(AttributeNameStrategy::CamelCase),
+        "" | "camelCase" => Ok(None),
+        "none" => Ok(Some(
+            RenderConfig::new().with_attribute_name_strategy(AttributeNameStrategy::None),
         )),
         _ => Err(JsValue::from_str(&format!(
             "Invalid attribute-name-strategy '{}': expected 'none' or 'camelCase'",

--- a/crates/microsoft-fast-build/tests/attribute_name_strategy.rs
+++ b/crates/microsoft-fast-build/tests/attribute_name_strategy.rs
@@ -118,24 +118,24 @@ fn test_none_strategy_multi_dashed_attr_preserved() {
     assert!(result.contains("42"), "none strategy should preserve dashes: {result}");
 }
 
-// ── default config matches none strategy ──────────────────────────────────────
+// ── default config matches camelCase strategy ─────────────────────────────────
 
 #[test]
-fn test_default_config_matches_none() {
-    let locator = make_locator(&[("my-el", "<span>{{foo-bar}}</span>")]);
+fn test_default_config_matches_camel_case() {
+    let locator = make_locator(&[("my-el", "<span>{{fooBar}}</span>")]);
     let result_default = render_with_locator(
         r#"<my-el foo-bar="hello"></my-el>"#,
         &empty_root(),
         &locator,
         None,
     ).unwrap();
-    let result_none = render_with_locator(
+    let result_camel = render_with_locator(
         r#"<my-el foo-bar="hello"></my-el>"#,
         &empty_root(),
         &locator,
-        Some(&none_config()),
+        Some(&camel_config()),
     ).unwrap();
-    assert_eq!(result_default, result_none, "default should match none strategy");
+    assert_eq!(result_default, result_camel, "default should match camelCase strategy");
 }
 
 // ── camelCase with binding resolution ─────────────────────────────────────────

--- a/crates/microsoft-fast-build/tests/custom_elements.rs
+++ b/crates/microsoft-fast-build/tests/custom_elements.rs
@@ -1,6 +1,6 @@
 mod common;
 use common::{make_locator, empty_root};
-use microsoft_fast_build::{render_template, render_with_locator, render_template_with_locator, render_entry_template_with_locator, Locator, RenderError};
+use microsoft_fast_build::{render_template, render_with_locator, render_template_with_locator, render_entry_template_with_locator, Locator, RenderError, RenderConfig, AttributeNameStrategy};
 
 // ── attribute → state mapping ─────────────────────────────────────────────────
 
@@ -218,26 +218,28 @@ fn test_locator_name_from_f_template_attribute_not_file_stem() {
 
 #[test]
 fn test_custom_element_kebab_attr_hyphens_preserved() {
-    // kebab-case attr names are lowercased; hyphens are preserved
+    // kebab-case attr names are lowercased; with explicit none strategy, hyphens are preserved
     let locator = make_locator(&[("my-el", "<span>{{selected-user-id}}</span>")]);
+    let none_config = RenderConfig::new().with_attribute_name_strategy(AttributeNameStrategy::None);
     let result = render_template_with_locator(
         r#"<my-el selected-user-id="42"></my-el>"#,
         "{}",
         &locator,
-        None,
+        Some(&none_config),
     ).unwrap();
     assert!(result.contains("42"), "kebab attr resolved: {result}");
 }
 
 #[test]
 fn test_custom_element_multi_word_kebab_attrs() {
-    // multiple kebab-case attrs are lowercased and passed to the child scope as-is
+    // multiple kebab-case attrs are lowercased; with explicit none strategy, passed to the child scope as-is
     let locator = make_locator(&[("my-el", "<p>{{show-details}}</p><p>{{enable-continue}}</p>")]);
+    let none_config = RenderConfig::new().with_attribute_name_strategy(AttributeNameStrategy::None);
     let result = render_template_with_locator(
         r#"<my-el show-details="true" enable-continue="false"></my-el>"#,
         "{}",
         &locator,
-        None,
+        Some(&none_config),
     ).unwrap();
     assert!(result.contains("true"), "show-details: {result}");
     assert!(result.contains("false"), "enable-continue: {result}");

--- a/packages/fast-build/DESIGN.md
+++ b/packages/fast-build/DESIGN.md
@@ -148,7 +148,7 @@ Three WASM functions are used:
 | Function | Used when |
 |----------|-----------|
 | `wasm.render(entry, state)` | No custom element templates |
-| `wasm.render_entry_with_templates(entry, templatesJson, state, strategy)` | At least one template was loaded. `strategy` is `"none"` or `"camelCase"`. |
+| `wasm.render_entry_with_templates(entry, templatesJson, state, strategy)` | At least one template was loaded. `strategy` is `"camelCase"` or `"none"`. |
 | `wasm.parse_f_templates(html)` | Parsing `<f-template>` elements from each matched HTML file |
 
 `templatesJson` is a JSON-stringified object mapping element names to their raw inner template strings (the content extracted from `<template>` inside `<f-template>`). The WASM renderer uses this map to resolve custom element tags and inject Declarative Shadow DOM.

--- a/packages/fast-build/README.md
+++ b/packages/fast-build/README.md
@@ -39,7 +39,7 @@ fast build [options]
 | `--state="<path>"` | `state.json` | JSON file containing the template state |
 | `--output="<path>"` | `output.html` | Where to write the rendered HTML |
 | `--templates="<glob>"` | _(none)_ | Glob pattern(s) for custom element template HTML files. Separate multiple patterns with commas. A warning is printed if not provided or if no files match a pattern. |
-| `--attribute-name-strategy="<strategy>"` | `none` | Strategy for mapping HTML attribute names to state property names on custom elements. `"none"` preserves dashes (e.g. `foo-bar` → `foo-bar`). `"camelCase"` converts dashes to camelCase (e.g. `foo-bar` → `fooBar`). See [Attribute name strategy](#attribute-name-strategy). |
+| `--attribute-name-strategy="<strategy>"` | `camelCase` | Strategy for mapping HTML attribute names to state property names on custom elements. `"camelCase"` converts dashes to camelCase (e.g. `foo-bar` → `fooBar`). `"none"` preserves dashes (e.g. `foo-bar` → `foo-bar`). See [Attribute name strategy](#attribute-name-strategy). |
 | `--config="<path>"` | `fast-build.config.json` | Path to a JSON configuration file. If omitted, `fast-build.config.json` in the current directory is used when present. CLI arguments take precedence over config values. See [Configuration file](#configuration-file). |
 
 ### Example
@@ -113,8 +113,8 @@ The `--attribute-name-strategy` option controls how HTML attribute names on cust
 
 | Strategy | Behaviour | Template binding |
 |---|---|---|
-| `none` (default) | Attribute names lowercased as-is, dashes preserved | `foo-bar` → `{{foo-bar}}` |
-| `camelCase` | Dashed attribute names converted to camelCase | `foo-bar` → `{{fooBar}}` |
+| `camelCase` (default) | Dashed attribute names converted to camelCase | `foo-bar` → `{{fooBar}}` |
+| `none` | Attribute names lowercased as-is, dashes preserved | `foo-bar` → `{{foo-bar}}` |
 
 The `camelCase` strategy only affects "plain" custom element attributes. It does **not** change:
 - `data-*` attributes (always use `dataset.*` grouping)

--- a/packages/fast-build/bin/fast.js
+++ b/packages/fast-build/bin/fast.js
@@ -335,7 +335,7 @@ async function runBuild(args) {
     let rendered;
     if (Object.keys(templatesMap).length > 0) {
         rendered = wasm.render_entry_with_templates(
-            entryContent, JSON.stringify(templatesMap), stateContent, attributeNameStrategy || "none"
+            entryContent, JSON.stringify(templatesMap), stateContent, attributeNameStrategy || ""
         );
     } else {
         rendered = wasm.render(entryContent, stateContent);
@@ -357,9 +357,9 @@ async function main() {
             '  --output="output.html" Output file path (default: output.html)\n' +
             '  --entry="index.html"   Entry HTML template file (default: index.html)\n' +
             '  --state="state.json"   State JSON file (default: state.json)\n' +
-            '  --attribute-name-strategy="none"\n' +
+            '  --attribute-name-strategy="camelCase"\n' +
             '                         Strategy for mapping attribute names to property names.\n' +
-            '                         "none" (default) or "camelCase".\n' +
+            '                         "camelCase" (default) or "none".\n' +
             '  --config="<path>"      Path to a fast-build config JSON file.\n' +
             '                         Defaults to "fast-build.config.json" in the\n' +
             '                         current directory if it exists. File paths in\n' +

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -127,15 +127,14 @@ The resolution algorithm walks the schema and configuration tree in parallel:
 
 ### `AttributeMap` — automatic `@attr` definitions
 
-An optional layer that uses the `Schema` to automatically register `@attr`-style reactive properties for every **leaf binding** in the template — i.e. simple expressions like `{{foo}}` or `id="{{foo-bar}}"` that have no nested properties, no explicit type, and no child element references.
+An optional layer that uses the `Schema` to automatically register `@attr`-style reactive properties for every **leaf binding** in the template — i.e. simple expressions like `{{foo}}` or `id="{{fooBar}}"` that have no nested properties, no explicit type, and no child element references.
 
-- By default (`attribute-name-strategy: "none"`), the **attribute name** and **property name** are both the binding key exactly as written in the template (e.g. `{{foo-bar}}` → attribute `foo-bar`, property `foo-bar`). No normalization is applied.
-- When `attribute-name-strategy` is `"camelCase"`, the binding key is treated as a camelCase property name and the HTML attribute name is derived by converting it to kebab-case (e.g. `{{fooBar}}` → property `fooBar`, attribute `foo-bar`). This matches the build-time `--attribute-name-strategy` option in `@microsoft/fast-build`.
-- Because HTML attributes are case-insensitive, binding keys should use lowercase names (optionally dash-separated) when using the `"none"` strategy.
+- By default (`attribute-name-strategy: "camelCase"`), the binding key is treated as a camelCase property name and the HTML attribute name is derived by converting it to kebab-case (e.g. `{{fooBar}}` → property `fooBar`, attribute `foo-bar`). This matches the build-time `--attribute-name-strategy` option in `@microsoft/fast-build`.
+- When `attribute-name-strategy` is `"none"`, the **attribute name** and **property name** are both the binding key exactly as written in the template (e.g. `{{foo-bar}}` → attribute `foo-bar`, property `foo-bar`). No normalization is applied. Because HTML attributes are case-insensitive, binding keys should use lowercase names (optionally dash-separated) when using the `"none"` strategy.
 - Properties already decorated with `@attr` or `@observable` are left untouched.
 - `FASTElementDefinition.attributeLookup` is keyed by the HTML attribute name, and `propertyLookup` is keyed by the JS property name so `attributeChangedCallback` correctly delegates to the new `AttributeDefinition`.
 
-Enabled via `TemplateElement.options({ "my-element": { attributeMap: "all" } })` or by passing a configuration object `TemplateElement.options({ "my-element": { attributeMap: {} } })`. Both forms are equivalent and use the default `"none"` strategy. To use the `"camelCase"` strategy, pass `TemplateElement.options({ "my-element": { attributeMap: { "attribute-name-strategy": "camelCase" } } })`.
+Enabled via `TemplateElement.options({ "my-element": { attributeMap: "all" } })` or by passing a configuration object `TemplateElement.options({ "my-element": { attributeMap: {} } })`. Both forms are equivalent and use the default `"camelCase"` strategy. To use the `"none"` strategy, pass `TemplateElement.options({ "my-element": { attributeMap: { "attribute-name-strategy": "none" } } })`.
 
 ### Syntax constants (`syntax.ts`)
 
@@ -366,8 +365,8 @@ When `attributeMap` is enabled (via `"all"`, `{}`, or a configuration object), `
 
 1. The schema key is used as the **JS property name**.
 2. The **HTML attribute name** depends on the `attribute-name-strategy`:
-   - `"none"` (default): the attribute name equals the property name (e.g. `foo-bar` → `foo-bar`).
-   - `"camelCase"`: the attribute name is derived by converting the camelCase property name to kebab-case (e.g. `fooBar` → `foo-bar`).
+   - `"camelCase"` (default): the attribute name is derived by converting the camelCase property name to kebab-case (e.g. `fooBar` → `foo-bar`).
+   - `"none"`: the attribute name equals the property name (e.g. `foo-bar` → `foo-bar`).
 3. A new `AttributeDefinition` is registered via `Observable.defineProperty`.
 4. `FASTElementDefinition.attributeLookup` is keyed by the HTML attribute name and `propertyLookup` is keyed by the JS property name so `attributeChangedCallback` can route attribute changes to the correct property.
 

--- a/packages/fast-html/README.md
+++ b/packages/fast-html/README.md
@@ -266,9 +266,9 @@ When `properties` is omitted, all root properties are observed (backward compati
 
 #### `attributeMap`
 
-When `attributeMap: "all"` (or `attributeMap: {}`) is configured for an element, `@microsoft/fast-html` automatically creates reactive `@attr` properties for every **leaf binding** in the template — simple expressions like `{{foo}}` or `id="{{foo-bar}}"` that have no nested properties. Both `"all"` and `{}` are equivalent and use the default `"none"` attribute name strategy.
+When `attributeMap: "all"` (or `attributeMap: {}`) is configured for an element, `@microsoft/fast-html` automatically creates reactive `@attr` properties for every **leaf binding** in the template — simple expressions like `{{foo}}` or `id="{{fooBar}}"` that have no nested properties. Both `"all"` and `{}` are equivalent and use the default `"camelCase"` attribute name strategy.
 
-By default, the **attribute name** and **property name** are both the binding key exactly as written in the template — no normalization is applied. Because HTML attributes are case-insensitive, binding keys should use lowercase names (optionally dash-separated). Properties with dashes must be accessed via bracket notation (e.g. `element["foo-bar"]`).
+By default, the binding key is treated as a **camelCase property name** and the HTML attribute name is derived by converting it to kebab-case (e.g. `{{fooBar}}` → property `fooBar`, attribute `foo-bar`). This matches the build-time `--attribute-name-strategy` option in `@microsoft/fast-build`.
 
 Properties already decorated with `@attr` or `@observable` on the class are left untouched.
 
@@ -286,12 +286,12 @@ With the template:
 <f-template name="my-element">
     <template>
         <p>{{greeting}}</p>
-        <p>{{first-name}}</p>
+        <p>{{firstName}}</p>
     </template>
 </f-template>
 ```
 
-This registers `greeting` (attribute `greeting`, property `greeting`) and `first-name` (attribute `first-name`, property `first-name`) as `@attr` properties on the element prototype, enabling `setAttribute("first-name", "Jane")` to trigger a template re-render automatically.
+This registers `greeting` (attribute `greeting`, property `greeting`) and `firstName` (attribute `first-name`, property `firstName`) as `@attr` properties on the element prototype, enabling `setAttribute("first-name", "Jane")` to trigger a template re-render automatically, and the property is accessible as `element.firstName`.
 
 ##### `attribute-name-strategy`
 
@@ -299,14 +299,14 @@ The `attribute-name-strategy` configuration option controls how template binding
 
 | Strategy | Behaviour | Example |
 |---|---|---|
-| `"none"` (default) | Binding key used as-is for both property and attribute | `{{foo-bar}}` → property `foo-bar`, attribute `foo-bar` |
-| `"camelCase"` | Binding key is the camelCase property; attribute name derived as kebab-case | `{{fooBar}}` → property `fooBar`, attribute `foo-bar` |
+| `"camelCase"` (default) | Binding key is the camelCase property; attribute name derived as kebab-case | `{{fooBar}}` → property `fooBar`, attribute `foo-bar` |
+| `"none"` | Binding key used as-is for both property and attribute | `{{foo-bar}}` → property `foo-bar`, attribute `foo-bar` |
 
 ```typescript
 TemplateElement.options({
     "my-element": {
         attributeMap: {
-            "attribute-name-strategy": "camelCase",
+            "attribute-name-strategy": "none",
         },
     },
 }).define({ name: "f-template" });
@@ -318,12 +318,12 @@ With the template:
 <f-template name="my-element">
     <template>
         <p>{{greeting}}</p>
-        <p>{{firstName}}</p>
+        <p>{{first-name}}</p>
     </template>
 </f-template>
 ```
 
-This registers `greeting` (attribute `greeting`, property `greeting`) and `firstName` (attribute `first-name`, property `firstName`) as `@attr` properties. `setAttribute("first-name", "Jane")` triggers a re-render, and the property is accessible as `element.firstName`.
+This registers `greeting` (attribute `greeting`, property `greeting`) and `first-name` (attribute `first-name`, property `first-name`) as `@attr` properties. `setAttribute("first-name", "Jane")` triggers a re-render, and the property must be accessed via bracket notation as `element["first-name"]`.
 
 ### Syntax
 

--- a/packages/fast-html/src/components/attribute-map.spec.ts
+++ b/packages/fast-html/src/components/attribute-map.spec.ts
@@ -20,13 +20,15 @@ test.describe("AttributeMap", () => {
         expect(hasFooAccessor).toBeTruthy();
     });
 
-    test("should define @attr for a dash-case property", async ({ page }) => {
+    test("should define @attr for a camelCase property derived from binding key", async ({
+        page,
+    }) => {
         const element = page.locator("attribute-map-test-element");
 
         const hasFooBarAccessor = await element.evaluate(node => {
             const desc = Object.getOwnPropertyDescriptor(
                 Object.getPrototypeOf(node),
-                "foo-bar",
+                "fooBar",
             );
             return typeof desc?.get === "function";
         });
@@ -34,14 +36,14 @@ test.describe("AttributeMap", () => {
         expect(hasFooBarAccessor).toBeTruthy();
     });
 
-    test("should use binding key as-is for both attribute and property name", async ({
+    test("should use camelCase property name with kebab-case attribute name", async ({
         page,
     }) => {
         const element = page.locator("attribute-map-test-element");
 
-        // Setting the foo-bar attribute should update the foo-bar property (no conversion)
+        // Setting the foo-bar attribute should update the fooBar property (camelCase conversion)
         await element.evaluate(node => node.setAttribute("foo-bar", "dash-case-test"));
-        const propValue = await element.evaluate(node => (node as any)["foo-bar"]);
+        const propValue = await element.evaluate(node => (node as any).fooBar);
 
         expect(propValue).toBe("dash-case-test");
     });
@@ -79,7 +81,7 @@ test.describe("AttributeMap", () => {
         await expect(page.locator(".foo-value")).toHaveText("attr-value");
     });
 
-    test("should update template when dash-case attribute is set via setAttribute", async ({
+    test("should update template when foo-bar attribute is set via setAttribute", async ({
         page,
     }) => {
         const element = page.locator("attribute-map-test-element");
@@ -115,14 +117,14 @@ test.describe("AttributeMap", () => {
         expect(propValue).toBe("lookup-test");
     });
 
-    test("should update definition attributeLookup for dash-case properties", async ({
+    test("should update definition attributeLookup for camelCase properties", async ({
         page,
     }) => {
         const element = page.locator("attribute-map-test-element");
 
-        // setAttribute with foo-bar triggers attributeChangedCallback for the foo-bar property
+        // setAttribute with foo-bar triggers attributeChangedCallback for the fooBar property
         await element.evaluate(node => node.setAttribute("foo-bar", "lookup-bar-test"));
-        const propValue = await element.evaluate(node => (node as any)["foo-bar"]);
+        const propValue = await element.evaluate(node => (node as any).fooBar);
 
         expect(propValue).toBe("lookup-bar-test");
     });

--- a/packages/fast-html/src/components/attribute-map.ts
+++ b/packages/fast-html/src/components/attribute-map.ts
@@ -21,13 +21,13 @@ function camelToKebab(str: string): string {
  * A property is a candidate for @attr when its schema entry has no nested `properties`,
  * no `type`, and no `anyOf` — i.e. it is a plain binding like {{foo}} or id="{{foo-bar}}".
  *
- * When `attribute-name-strategy` is `"none"` (the default), the binding key is used
- * as both the attribute name and property name — no normalization is applied.
- *
- * When `attribute-name-strategy` is `"camelCase"`, the binding key is treated as a
+ * When `attribute-name-strategy` is `"camelCase"` (the default), the binding key is treated as a
  * camelCase property name and the HTML attribute name is derived by converting it to
  * kebab-case (e.g. property `fooBar` → attribute `foo-bar`). This matches the
  * build-time `attribute-name-strategy` option in `@microsoft/fast-build`.
+ *
+ * When `attribute-name-strategy` is `"none"`, the binding key is used
+ * as both the attribute name and property name — no normalization is applied.
  *
  * Properties already decorated with `@attr` or `@observable` on the class are left
  * untouched.
@@ -55,7 +55,7 @@ export class AttributeMap {
         const existingAccessorNames = new Set(
             Observable.getAccessors(this.classPrototype).map(a => a.name),
         );
-        const strategy = this.config?.["attribute-name-strategy"] ?? "none";
+        const strategy = this.config?.["attribute-name-strategy"] ?? "camelCase";
 
         for (const propertyName of propertyNames) {
             const propertySchema = this.schema.getSchema(propertyName);

--- a/packages/fast-html/src/components/template.ts
+++ b/packages/fast-html/src/components/template.ts
@@ -116,14 +116,14 @@ export interface AttributeMapConfig {
     /**
      * Strategy for mapping template binding keys to HTML attribute names.
      *
-     * - `"none"` (default): the binding key is used as-is for both the
-     *   property name and the attribute name (e.g. `{{foo-bar}}` →
-     *   property `foo-bar`, attribute `foo-bar`).
-     * - `"camelCase"`: the binding key is treated as a camelCase property
-     *   name and the attribute name is derived by converting it to
+     * - `"camelCase"` (default): the binding key is treated as a camelCase
+     *   property name and the attribute name is derived by converting it to
      *   kebab-case (e.g. `{{fooBar}}` → property `fooBar`, attribute
      *   `foo-bar`). This matches the build-time `attribute-name-strategy`
      *   option in `@microsoft/fast-build`.
+     * - `"none"`: the binding key is used as-is for both the
+     *   property name and the attribute name (e.g. `{{foo-bar}}` →
+     *   property `foo-bar`, attribute `foo-bar`).
      */
     "attribute-name-strategy"?: "none" | "camelCase";
 }

--- a/packages/fast-html/test/fixtures/attribute-map/attribute-map.spec.ts
+++ b/packages/fast-html/test/fixtures/attribute-map/attribute-map.spec.ts
@@ -15,21 +15,21 @@ test.describe("AttributeMap", () => {
             const proto = Object.getPrototypeOf(node);
             const isAccessor = (name: string) =>
                 typeof Object.getOwnPropertyDescriptor(proto, name)?.get === "function";
-            return { foo: isAccessor("foo"), "foo-bar": isAccessor("foo-bar") };
+            return { foo: isAccessor("foo"), fooBar: isAccessor("fooBar") };
         });
 
         expect(accessors.foo).toBeTruthy();
-        expect(accessors["foo-bar"]).toBeTruthy();
+        expect(accessors.fooBar).toBeTruthy();
     });
 
-    test("should use binding key as-is for attribute and property name", async ({
+    test("should use camelCase property name and kebab-case attribute name", async ({
         page,
     }) => {
         const element = page.locator("attribute-map-test-element");
 
-        // Setting foo-bar attribute should update the foo-bar property (no conversion)
+        // Setting foo-bar attribute should update the fooBar property (camelCase conversion)
         await element.evaluate(node => node.setAttribute("foo-bar", "dash-test"));
-        const propValue = await element.evaluate(node => (node as any)["foo-bar"]);
+        const propValue = await element.evaluate(node => (node as any).fooBar);
 
         expect(propValue).toBe("dash-test");
     });
@@ -90,13 +90,13 @@ test.describe("AttributeMap", () => {
         expect(attrValue).toBe("reflected-value");
     });
 
-    test("should reflect foo-bar property value back to foo-bar attribute", async ({
+    test("should reflect fooBar property value back to foo-bar attribute", async ({
         page,
     }) => {
         const element = page.locator("attribute-map-test-element");
 
         await element.evaluate(node => {
-            (node as any)["foo-bar"] = "bar-reflected";
+            (node as any).fooBar = "bar-reflected";
         });
 
         await page.evaluate(() => new Promise(r => requestAnimationFrame(r)));

--- a/packages/fast-html/test/fixtures/attribute-map/index.html
+++ b/packages/fast-html/test/fixtures/attribute-map/index.html
@@ -5,26 +5,41 @@
         <title></title>
     </head>
     <body>
-        <attribute-map-test-element id="test-element"><template shadowrootmode="open" shadowroot="open"><div class="foo-value"><!--fe-b$$start$$0$$foo-0$$fe-b--><!--fe-b$$end$$0$$foo-0$$fe-b--></div>
-        <div class="foo-bar-value"><!--fe-b$$start$$1$$foo-bar-1$$fe-b--><!--fe-b$$end$$1$$foo-bar-1$$fe-b--></div>
-        <button type="button" data-fe-c-2-1>Set Foo</button>
-        <button type="button" data-fe-c-3-1>Set FooBar</button>
-        <button type="button" data-fe-c-4-1>Set Multiple</button></template></attribute-map-test-element>
-        <attribute-map-existing-attr-test-element id="existing-attr-test-element"><template shadowrootmode="open" shadowroot="open"><div class="existing-foo-value"><!--fe-b$$start$$0$$foo-0$$fe-b--><!--fe-b$$end$$0$$foo-0$$fe-b--></div></template></attribute-map-existing-attr-test-element>
-<f-template name="attribute-map-test-element">
-    <template>
-        <div class="foo-value">{{foo}}</div>
-        <div class="foo-bar-value">{{foo-bar}}</div>
-        <button type="button" @click="{setFoo()}">Set Foo</button>
-        <button type="button" @click="{setFooBar()}">Set FooBar</button>
-        <button type="button" @click="{setMultiple()}">Set Multiple</button>
-    </template>
-</f-template>
-<f-template name="attribute-map-existing-attr-test-element">
-    <template>
-        <div class="existing-foo-value">{{foo}}</div>
-    </template>
-</f-template>
+        <attribute-map-test-element id="test-element"
+            ><template shadowrootmode="open" shadowroot="open"
+                ><div class="foo-value">
+                    <!--fe-b$$start$$0$$foo-0$$fe-b-->
+                    <!--fe-b$$end$$0$$foo-0$$fe-b-->
+                </div>
+                <div class="foo-bar-value">
+                    <!--fe-b$$start$$1$$fooBar-1$$fe-b-->
+                    <!--fe-b$$end$$1$$fooBar-1$$fe-b-->
+                </div>
+                <button type="button" data-fe-c-2-1>Set Foo</button>
+                <button type="button" data-fe-c-3-1>Set FooBar</button>
+                <button type="button" data-fe-c-4-1>Set Multiple</button></template
+            ></attribute-map-test-element
+        >
+        <attribute-map-existing-attr-test-element id="existing-attr-test-element"
+            ><template shadowrootmode="open" shadowroot="open"
+                ><div class="existing-foo-value">
+                    <!--fe-b$$start$$0$$foo-0$$fe-b-->
+                    <!--fe-b$$end$$0$$foo-0$$fe-b-->
+                </div></template
+            ></attribute-map-existing-attr-test-element
+        >
+        <f-template name="attribute-map-test-element">
+            <template>
+                <div class="foo-value">{{ foo }}</div>
+                <div class="foo-bar-value">{{ fooBar }}</div>
+                <button type="button" @click="{setFoo()}">Set Foo</button>
+                <button type="button" @click="{setFooBar()}">Set FooBar</button>
+                <button type="button" @click="{setMultiple()}">Set Multiple</button>
+            </template>
+        </f-template>
+        <f-template name="attribute-map-existing-attr-test-element">
+            <template> <div class="existing-foo-value">{{ foo }}</div> </template>
+        </f-template>
 
         <script type="module" src="./main.ts"></script>
     </body>

--- a/packages/fast-html/test/fixtures/attribute-map/index.html
+++ b/packages/fast-html/test/fixtures/attribute-map/index.html
@@ -5,41 +5,26 @@
         <title></title>
     </head>
     <body>
-        <attribute-map-test-element id="test-element"
-            ><template shadowrootmode="open" shadowroot="open"
-                ><div class="foo-value">
-                    <!--fe-b$$start$$0$$foo-0$$fe-b-->
-                    <!--fe-b$$end$$0$$foo-0$$fe-b-->
-                </div>
-                <div class="foo-bar-value">
-                    <!--fe-b$$start$$1$$fooBar-1$$fe-b-->
-                    <!--fe-b$$end$$1$$fooBar-1$$fe-b-->
-                </div>
-                <button type="button" data-fe-c-2-1>Set Foo</button>
-                <button type="button" data-fe-c-3-1>Set FooBar</button>
-                <button type="button" data-fe-c-4-1>Set Multiple</button></template
-            ></attribute-map-test-element
-        >
-        <attribute-map-existing-attr-test-element id="existing-attr-test-element"
-            ><template shadowrootmode="open" shadowroot="open"
-                ><div class="existing-foo-value">
-                    <!--fe-b$$start$$0$$foo-0$$fe-b-->
-                    <!--fe-b$$end$$0$$foo-0$$fe-b-->
-                </div></template
-            ></attribute-map-existing-attr-test-element
-        >
-        <f-template name="attribute-map-test-element">
-            <template>
-                <div class="foo-value">{{ foo }}</div>
-                <div class="foo-bar-value">{{ fooBar }}</div>
-                <button type="button" @click="{setFoo()}">Set Foo</button>
-                <button type="button" @click="{setFooBar()}">Set FooBar</button>
-                <button type="button" @click="{setMultiple()}">Set Multiple</button>
-            </template>
-        </f-template>
-        <f-template name="attribute-map-existing-attr-test-element">
-            <template> <div class="existing-foo-value">{{ foo }}</div> </template>
-        </f-template>
+        <attribute-map-test-element id="test-element"><template shadowrootmode="open" shadowroot="open"><div class="foo-value"><!--fe-b$$start$$0$$foo-0$$fe-b--><!--fe-b$$end$$0$$foo-0$$fe-b--></div>
+        <div class="foo-bar-value"><!--fe-b$$start$$1$$fooBar-1$$fe-b--><!--fe-b$$end$$1$$fooBar-1$$fe-b--></div>
+        <button type="button" data-fe-c-2-1>Set Foo</button>
+        <button type="button" data-fe-c-3-1>Set FooBar</button>
+        <button type="button" data-fe-c-4-1>Set Multiple</button></template></attribute-map-test-element>
+        <attribute-map-existing-attr-test-element id="existing-attr-test-element"><template shadowrootmode="open" shadowroot="open"><div class="existing-foo-value"><!--fe-b$$start$$0$$foo-0$$fe-b--><!--fe-b$$end$$0$$foo-0$$fe-b--></div></template></attribute-map-existing-attr-test-element>
+<f-template name="attribute-map-test-element">
+    <template>
+        <div class="foo-value">{{foo}}</div>
+        <div class="foo-bar-value">{{fooBar}}</div>
+        <button type="button" @click="{setFoo()}">Set Foo</button>
+        <button type="button" @click="{setFooBar()}">Set FooBar</button>
+        <button type="button" @click="{setMultiple()}">Set Multiple</button>
+    </template>
+</f-template>
+<f-template name="attribute-map-existing-attr-test-element">
+    <template>
+        <div class="existing-foo-value">{{foo}}</div>
+    </template>
+</f-template>
 
         <script type="module" src="./main.ts"></script>
     </body>

--- a/packages/fast-html/test/fixtures/attribute-map/main.ts
+++ b/packages/fast-html/test/fixtures/attribute-map/main.ts
@@ -7,12 +7,12 @@ class AttributeMapTestElement extends FASTElement {
     }
 
     public setFooBar() {
-        (this as any)["foo-bar"] = "world";
+        (this as any).fooBar = "world";
     }
 
     public setMultiple() {
         (this as any).foo = "updated";
-        (this as any)["foo-bar"] = "also-updated";
+        (this as any).fooBar = "also-updated";
     }
 }
 

--- a/packages/fast-html/test/fixtures/attribute-map/state.json
+++ b/packages/fast-html/test/fixtures/attribute-map/state.json
@@ -1,4 +1,4 @@
 {
     "foo": "",
-    "foo-bar": ""
+    "fooBar": ""
 }

--- a/packages/fast-html/test/fixtures/attribute-map/templates.html
+++ b/packages/fast-html/test/fixtures/attribute-map/templates.html
@@ -1,14 +1,12 @@
 <f-template name="attribute-map-test-element">
     <template>
-        <div class="foo-value">{{foo}}</div>
-        <div class="foo-bar-value">{{foo-bar}}</div>
+        <div class="foo-value">{{ foo }}</div>
+        <div class="foo-bar-value">{{ fooBar }}</div>
         <button type="button" @click="{setFoo()}">Set Foo</button>
         <button type="button" @click="{setFooBar()}">Set FooBar</button>
         <button type="button" @click="{setMultiple()}">Set Multiple</button>
     </template>
 </f-template>
 <f-template name="attribute-map-existing-attr-test-element">
-    <template>
-        <div class="existing-foo-value">{{foo}}</div>
-    </template>
+    <template> <div class="existing-foo-value">{{ foo }}</div> </template>
 </f-template>

--- a/packages/fast-html/test/fixtures/attribute-map/templates.html
+++ b/packages/fast-html/test/fixtures/attribute-map/templates.html
@@ -1,12 +1,14 @@
 <f-template name="attribute-map-test-element">
     <template>
-        <div class="foo-value">{{ foo }}</div>
-        <div class="foo-bar-value">{{ fooBar }}</div>
+        <div class="foo-value">{{foo}}</div>
+        <div class="foo-bar-value">{{fooBar}}</div>
         <button type="button" @click="{setFoo()}">Set Foo</button>
         <button type="button" @click="{setFooBar()}">Set FooBar</button>
         <button type="button" @click="{setMultiple()}">Set Multiple</button>
     </template>
 </f-template>
 <f-template name="attribute-map-existing-attr-test-element">
-    <template> <div class="existing-foo-value">{{ foo }}</div> </template>
+    <template>
+        <div class="existing-foo-value">{{foo}}</div>
+    </template>
 </f-template>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Changes the default `attribute-name-strategy` from `"none"` to `"camelCase"` across the FAST monorepo. This applies to:

- **`microsoft-fast-build` Rust crate**: The `AttributeNameStrategy` enum's `#[default]` is moved from `None` to `CamelCase`
- **`@microsoft/fast-build` CLI**: Default strategy passed to the WASM renderer and CLI help text updated
- **`@microsoft/fast-html` AttributeMap**: Default fallback changed from `"none"` to `"camelCase"`

With this change, dashed HTML attribute names on custom elements (e.g. `foo-bar`) are now converted to camelCase state keys (e.g. `fooBar`) by default. The `"none"` strategy remains available as an explicit opt-in.

## 📑 Test Plan

- All existing Rust tests pass (`cargo test`)
- All Playwright tests pass (`npm run test`)
- All fixtures rebuilt successfully (`npm run build:fixtures`)
- Biome check passes (`npm run biome:check`)
- Change files validated (`npm run checkchange`)

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.