### PR TITLE
docs: add declarative template documentation to 3.x docs site

### DIFF
--- a/packages/fast-element/DECLARATIVE_HTML.md
+++ b/packages/fast-element/DECLARATIVE_HTML.md
@@ -14,6 +14,9 @@ For package installation, importing `TemplateElement`, basic registration, and
 the package-level hydration overview, see the
 [FAST Element README](./README.md#declarative-html) and
 [Prerendered Content Optimization](./README.md#prerendered-content-optimization).
+For user-facing guides covering f-template syntax, element definition, and
+server-side rendering, see the
+[Declarative HTML docs](../../sites/website/src/docs/3.x/declarative-templates/).
 
 ## Template Structure
 

--- a/packages/fast-element/DECLARATIVE_HTML.md
+++ b/packages/fast-element/DECLARATIVE_HTML.md
@@ -16,7 +16,7 @@ the package-level hydration overview, see the
 [Prerendered Content Optimization](./README.md#prerendered-content-optimization).
 For user-facing guides covering f-template syntax, element definition, and
 server-side rendering, see the
-[Declarative HTML docs](../../sites/website/src/docs/3.x/declarative-templates/).
+[Declarative HTML docs](https://fast.design/docs/3.x/declarative-templates/overview/).
 
 ## Template Structure
 

--- a/packages/fast-element/README.md
+++ b/packages/fast-element/README.md
@@ -101,9 +101,12 @@ TemplateElement.define({ name: "f-template" });
 
 Declarative utilities such as `deepMerge` are available from
 `@microsoft/fast-element/declarative/utilities.js`. See
-[`DECLARATIVE_HTML.md`](./DECLARATIVE_HTML.md) for declarative usage details.
-Declarative event bindings use `$e` for the DOM event object and `$c` for the
-execution context.
+[`DECLARATIVE_HTML.md`](./DECLARATIVE_HTML.md) for declarative implementation
+details and the
+[Declarative HTML docs](../../sites/website/src/docs/3.x/declarative-templates/)
+for guides on writing f-templates, defining declarative elements, and
+server-side rendering. Declarative event bindings use `$e` for the DOM event
+object and `$c` for the execution context.
 
 ## Prerendered Content Optimization
 

--- a/packages/fast-element/README.md
+++ b/packages/fast-element/README.md
@@ -103,7 +103,7 @@ Declarative utilities such as `deepMerge` are available from
 `@microsoft/fast-element/declarative/utilities.js`. See
 [`DECLARATIVE_HTML.md`](./DECLARATIVE_HTML.md) for declarative implementation
 details and the
-[Declarative HTML docs](../../sites/website/src/docs/3.x/declarative-templates/)
+[Declarative HTML docs](https://fast.design/docs/3.x/declarative-templates/overview/)
 for guides on writing f-templates, defining declarative elements, and
 server-side rendering. Declarative event bindings use `$e` for the DOM event
 object and `$c` for the execution context.

--- a/packages/fast-element/src/declarative/attribute-map.ts
+++ b/packages/fast-element/src/declarative/attribute-map.ts
@@ -18,14 +18,14 @@ export interface AttributeMapConfig {
     /**
      * Strategy for mapping template binding keys to HTML attribute names.
      *
-     * - `"none"` (default): the binding key is used as-is for both the
-     *   property name and the attribute name (e.g. `{{foo-bar}}` →
-     *   property `foo-bar`, attribute `foo-bar`).
-     * - `"camelCase"`: the binding key is treated as a camelCase property
+     * - `"camelCase"` (default): the binding key is treated as a camelCase property
      *   name and the attribute name is derived by converting it to
      *   kebab-case (e.g. `{{fooBar}}` → property `fooBar`, attribute
      *   `foo-bar`). This matches the build-time `attribute-name-strategy`
      *   option in `@microsoft/fast-build`.
+     * - `"none"`: the binding key is used as-is for both the
+     *   property name and the attribute name (e.g. `{{foo-bar}}` →
+     *   property `foo-bar`, attribute `foo-bar`).
      */
     "attribute-name-strategy"?: "none" | "camelCase";
 }
@@ -56,13 +56,13 @@ function camelToKebab(str: string): string {
  * A property is a candidate for @attr when its schema entry has no nested `properties`,
  * no `type`, and no `anyOf` — i.e. it is a plain binding like {{foo}} or id="{{foo-bar}}".
  *
- * When `attribute-name-strategy` is `"none"` (the default), the binding key is used
- * as both the attribute name and property name — no normalization is applied.
- *
- * When `attribute-name-strategy` is `"camelCase"`, the binding key is treated as a
+ * When `attribute-name-strategy` is `"camelCase"` (the default), the binding key is treated as a
  * camelCase property name and the HTML attribute name is derived by converting it to
  * kebab-case (e.g. property `fooBar` → attribute `foo-bar`). This matches the
  * build-time `attribute-name-strategy` option in `@microsoft/fast-build`.
+ *
+ * When `attribute-name-strategy` is `"none"`, the binding key is used
+ * as both the attribute name and property name — no normalization is applied.
  *
  * Properties already decorated with `@attr` or `@observable` on the class are left
  * untouched.
@@ -90,7 +90,7 @@ export class AttributeMap {
         const existingAccessorNames = new Set(
             Observable.getAccessors(this.classPrototype).map(a => a.name),
         );
-        const strategy = this.config?.["attribute-name-strategy"] ?? "none";
+        const strategy = this.config?.["attribute-name-strategy"] ?? "camelCase";
 
         for (const propertyName of propertyNames) {
             const propertySchema = this.schema.getSchema(propertyName);

--- a/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.attributemap.md
+++ b/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.attributemap.md
@@ -19,9 +19,9 @@ AttributeMap provides functionality for detecting simple (leaf) properties in a 
 
 A property is a candidate for  when its schema entry has no nested `properties`<!-- -->, no `type`<!-- -->, and no `anyOf` — i.e. it is a plain binding like {<!-- -->{<!-- -->foo<!-- -->}<!-- -->} or id="<!-- -->{<!-- -->{<!-- -->foo-bar<!-- -->}<!-- -->}<!-- -->".
 
-When `attribute-name-strategy` is `"none"` (the default), the binding key is used as both the attribute name and property name — no normalization is applied.
+When `attribute-name-strategy` is `"camelCase"` (the default), the binding key is treated as a camelCase property name and the HTML attribute name is derived by converting it to kebab-case (e.g. property `fooBar` → attribute `foo-bar`<!-- -->). This matches the build-time `attribute-name-strategy` option in `@microsoft/fast-build`<!-- -->.
 
-When `attribute-name-strategy` is `"camelCase"`<!-- -->, the binding key is treated as a camelCase property name and the HTML attribute name is derived by converting it to kebab-case (e.g. property `fooBar` → attribute `foo-bar`<!-- -->). This matches the build-time `attribute-name-strategy` option in `@microsoft/fast-build`<!-- -->.
+When `attribute-name-strategy` is `"none"`<!-- -->, the binding key is used as both the attribute name and property name — no normalization is applied.
 
 Properties already decorated with `@attr` or `@observable` on the class are left untouched.
 

--- a/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.attributemapconfig._attribute-name-strategy_.md
+++ b/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.attributemapconfig._attribute-name-strategy_.md
@@ -17,7 +17,7 @@ navigationOptions:
 
 Strategy for mapping template binding keys to HTML attribute names.
 
-- `"none"` (default): the binding key is used as-is for both the property name and the attribute name (e.g. `{{foo-bar}}` → property `foo-bar`<!-- -->, attribute `foo-bar`<!-- -->). - `"camelCase"`<!-- -->: the binding key is treated as a camelCase property name and the attribute name is derived by converting it to kebab-case (e.g. `{{fooBar}}` → property `fooBar`<!-- -->, attribute `foo-bar`<!-- -->). This matches the build-time `attribute-name-strategy` option in `@microsoft/fast-build`<!-- -->.
+- `"camelCase"` (default): the binding key is treated as a camelCase property name and the attribute name is derived by converting it to kebab-case (e.g. `{{fooBar}}` → property `fooBar`<!-- -->, attribute `foo-bar`<!-- -->). This matches the build-time `attribute-name-strategy` option in `@microsoft/fast-build`<!-- -->. - `"none"`<!-- -->: the binding key is used as-is for both the property name and the attribute name (e.g. `{{foo-bar}}` → property `foo-bar`<!-- -->, attribute `foo-bar`<!-- -->).
 
 **Signature:**
 

--- a/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.attributemapconfig.md
+++ b/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.attributemapconfig.md
@@ -63,7 +63,7 @@ Description
 
 _(Optional)_ Strategy for mapping template binding keys to HTML attribute names.
 
-- `"none"` (default): the binding key is used as-is for both the property name and the attribute name (e.g. `{{foo-bar}}` → property `foo-bar`<!-- -->, attribute `foo-bar`<!-- -->). - `"camelCase"`<!-- -->: the binding key is treated as a camelCase property name and the attribute name is derived by converting it to kebab-case (e.g. `{{fooBar}}` → property `fooBar`<!-- -->, attribute `foo-bar`<!-- -->). This matches the build-time `attribute-name-strategy` option in `@microsoft/fast-build`<!-- -->.
+- `"camelCase"` (default): the binding key is treated as a camelCase property name and the attribute name is derived by converting it to kebab-case (e.g. `{{fooBar}}` → property `fooBar`<!-- -->, attribute `foo-bar`<!-- -->). This matches the build-time `attribute-name-strategy` option in `@microsoft/fast-build`<!-- -->. - `"none"`<!-- -->: the binding key is used as-is for both the property name and the attribute name (e.g. `{{foo-bar}}` → property `foo-bar`<!-- -->, attribute `foo-bar`<!-- -->).
 
 
 </td></tr>

--- a/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.md
+++ b/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.md
@@ -38,9 +38,9 @@ AttributeMap provides functionality for detecting simple (leaf) properties in a 
 
 A property is a candidate for  when its schema entry has no nested `properties`<!-- -->, no `type`<!-- -->, and no `anyOf` — i.e. it is a plain binding like {<!-- -->{<!-- -->foo<!-- -->}<!-- -->} or id="<!-- -->{<!-- -->{<!-- -->foo-bar<!-- -->}<!-- -->}<!-- -->".
 
-When `attribute-name-strategy` is `"none"` (the default), the binding key is used as both the attribute name and property name — no normalization is applied.
+When `attribute-name-strategy` is `"camelCase"` (the default), the binding key is treated as a camelCase property name and the HTML attribute name is derived by converting it to kebab-case (e.g. property `fooBar` → attribute `foo-bar`<!-- -->). This matches the build-time `attribute-name-strategy` option in `@microsoft/fast-build`<!-- -->.
 
-When `attribute-name-strategy` is `"camelCase"`<!-- -->, the binding key is treated as a camelCase property name and the HTML attribute name is derived by converting it to kebab-case (e.g. property `fooBar` → attribute `foo-bar`<!-- -->). This matches the build-time `attribute-name-strategy` option in `@microsoft/fast-build`<!-- -->.
+When `attribute-name-strategy` is `"none"`<!-- -->, the binding key is used as both the attribute name and property name — no normalization is applied.
 
 Properties already decorated with `@attr` or `@observable` on the class are left untouched.
 

--- a/sites/website/src/docs/3.x/declarative-templates.md
+++ b/sites/website/src/docs/3.x/declarative-templates.md
@@ -1,0 +1,10 @@
+---
+layout: 3x
+eleventyNavigation:
+  key: declarative-templates3x
+  title: Declarative HTML
+  order: 3
+navigationOptions:
+  activeKey: declarative-templates3x
+permalink: false
+---

--- a/sites/website/src/docs/3.x/declarative-templates/defining-elements.md
+++ b/sites/website/src/docs/3.x/declarative-templates/defining-elements.md
@@ -24,14 +24,15 @@ keywords:
 
 # Defining Declarative Elements
 
-A declarative FASTElement component requires a JavaScript class definition, a `TemplateElement` registration, and an `<f-template>` in the HTML. This page covers the JavaScript setup, lifecycle callbacks, and configuration options.
+A declarative FASTElement component requires a JavaScript class definition with `template: declarativeTemplate()` and an `<f-template>` in the HTML. The `declarativeTemplate()` function automatically defines the `<f-template>` custom element and waits for the matching template before completing registration. This page covers the JavaScript setup, extensions, lifecycle callbacks, and configuration options.
 
 ## Basic Setup
 
-**1. Define the component class** with `templateOptions: "defer-and-hydrate"`:
+**1. Define the component class** with `template: declarativeTemplate()`:
 
 ```ts
 import { FASTElement, attr } from "@microsoft/fast-element";
+import { declarativeTemplate } from "@microsoft/fast-element/declarative.js";
 
 class MyCounter extends FASTElement {
     @attr count: number = 0;
@@ -39,21 +40,13 @@ class MyCounter extends FASTElement {
 
 MyCounter.define({
     name: "my-counter",
-    templateOptions: "defer-and-hydrate",
+    template: declarativeTemplate(),
 });
 ```
 
-The `templateOptions: "defer-and-hydrate"` setting tells FAST to wait for a template from an `<f-template>` element instead of rendering immediately. If pre-rendered content exists in the DOM, it will be hydrated rather than replaced.
+The `template: declarativeTemplate()` setting tells FAST to wait for a matching `<f-template>` element before completing registration. It automatically defines the `<f-template>` custom element in the relevant registry. If pre-rendered content exists in the DOM, it will be hydrated rather than replaced.
 
-**2. Register the `TemplateElement`** so the browser recognizes `<f-template>`:
-
-```ts
-import { TemplateElement } from "@microsoft/fast-element/declarative.js";
-
-TemplateElement.define({ name: "f-template" });
-```
-
-**3. Write the template** in an HTML file:
+**2. Write the template** in an HTML file:
 
 ```html
 <f-template name="my-counter">
@@ -65,7 +58,7 @@ TemplateElement.define({ name: "f-template" });
 ```
 
 :::important
-The `TemplateElement` must be defined **after** all component classes are defined, and the `<f-template>` elements must be present in the DOM when `TemplateElement` connects. A common pattern is to place `TemplateElement.define()` as the last registration call in your entry module and include the `<f-template>` elements directly in the HTML page.
+The `<f-template>` elements must be present in the DOM when the component definition resolves. A common pattern is to include the `<f-template>` elements directly in the HTML page before the script module loads.
 :::
 
 ## Complete File Structure
@@ -74,7 +67,7 @@ A typical declarative component setup involves these files:
 
 ```
 my-app/
-├── main.ts          # Component classes + TemplateElement registration
+├── main.ts          # Component classes + declarativeTemplate() setup
 ├── templates.html   # <f-template> elements
 ├── entry.html       # Page HTML with component instances
 ├── state.json       # Initial state for server rendering (optional)
@@ -85,7 +78,7 @@ my-app/
 
 ```ts
 import { FASTElement, attr, css, observable } from "@microsoft/fast-element";
-import { TemplateElement } from "@microsoft/fast-element/declarative.js";
+import { declarativeTemplate } from "@microsoft/fast-element/declarative.js";
 
 class TaskItem extends FASTElement {
     @attr text: string = "";
@@ -95,10 +88,8 @@ class TaskItem extends FASTElement {
 TaskItem.define({
     name: "task-item",
     styles: css`:host { display: block; }`,
-    templateOptions: "defer-and-hydrate",
+    template: declarativeTemplate(),
 });
-
-TemplateElement.define({ name: "f-template" });
 ```
 
 **`templates.html`:**
@@ -130,7 +121,7 @@ TemplateElement.define({ name: "f-template" });
 
 ## Lifecycle Callbacks
 
-`TemplateElement.config()` registers callbacks that fire during template processing and hydration. This is useful for tracking progress, gathering performance metrics, or coordinating initialization.
+`TemplateElement.config()` registers callbacks that fire during template processing and hydration. This is useful for tracking progress, gathering performance metrics, or coordinating initialization. `TemplateElement` remains available for lifecycle configuration even though `declarativeTemplate()` handles the registration automatically.
 
 ```ts
 import { TemplateElement } from "@microsoft/fast-element/declarative.js";
@@ -139,7 +130,7 @@ TemplateElement.config({
     hydrationComplete() {
         console.log("All elements hydrated");
     },
-}).define({ name: "f-template" });
+});
 ```
 
 ### Available Callbacks
@@ -209,20 +200,45 @@ TemplateElement.config({
 });
 ```
 
-## Element Options
+## Extensions
 
-`TemplateElement.options()` configures per-element behavior for `observerMap` and `attributeMap`. These are keyed by custom element name.
+The `observerMap()` and `attributeMap()` functions are define extensions — they are passed as the second argument to `define()` and run before the element is registered with the platform.
 
 ```ts
+import { FASTElement } from "@microsoft/fast-element";
+import {
+    declarativeTemplate,
+    observerMap,
+    attributeMap,
+} from "@microsoft/fast-element/declarative.js";
+
+class MyElement extends FASTElement {}
+
+MyElement.define(
+    {
+        name: "my-element",
+        template: declarativeTemplate(),
+    },
+    [observerMap(), attributeMap()],
+);
+```
+
+Calling `observerMap()` or `attributeMap()` with no arguments applies the default behavior for all properties. You can also pass configuration objects for fine-grained control (see below).
+
+`TemplateElement.options()` is also available for per-element configuration and can be combined with extensions:
+
+```ts
+import { TemplateElement } from "@microsoft/fast-element/declarative.js";
+
 TemplateElement.options({
     "my-element": {
         observerMap: "all",
         attributeMap: "all",
     },
-}).define({ name: "f-template" });
+});
 ```
 
-Both `.config()` and `.options()` are chainable and can be combined:
+Both `.config()` and `.options()` are chainable:
 
 ```ts
 TemplateElement
@@ -233,8 +249,7 @@ TemplateElement
         hydrationComplete() {
             console.log("Ready");
         },
-    })
-    .define({ name: "f-template" });
+    });
 ```
 
 ## ObserverMap
@@ -243,14 +258,18 @@ The `observerMap` option automatically sets up deep reactive observation for pro
 
 ### Observe All Properties
 
-Use `"all"` to observe every root property found in the template:
+Pass `observerMap()` with no arguments to observe every root property found in the template:
 
 ```ts
-TemplateElement.options({
-    "user-profile": {
-        observerMap: "all",
+import { declarativeTemplate, observerMap } from "@microsoft/fast-element/declarative.js";
+
+UserProfile.define(
+    {
+        name: "user-profile",
+        template: declarativeTemplate(),
     },
-});
+    [observerMap()],
+);
 ```
 
 With this template:
@@ -271,9 +290,13 @@ Changes to `user.name` or `user.address.city` will automatically trigger a re-re
 For fine-grained control, pass a configuration object with a `properties` key:
 
 ```ts
-TemplateElement.options({
-    "user-profile": {
-        observerMap: {
+UserProfile.define(
+    {
+        name: "user-profile",
+        template: declarativeTemplate(),
+    },
+    [
+        observerMap({
             properties: {
                 user: {
                     name: true,       // user.name — observed
@@ -283,9 +306,9 @@ TemplateElement.options({
                     },
                 },
             },
-        },
-    },
-});
+        }),
+    ],
+);
 ```
 
 Each entry in the path tree can be:
@@ -320,11 +343,15 @@ The `attributeMap` option automatically creates reactive `@attr` properties for 
 ### Enable for All Leaf Bindings
 
 ```ts
-TemplateElement.options({
-    "greeting-card": {
-        attributeMap: "all",
+import { declarativeTemplate, attributeMap } from "@microsoft/fast-element/declarative.js";
+
+GreetingCard.define(
+    {
+        name: "greeting-card",
+        template: declarativeTemplate(),
     },
-});
+    [attributeMap()],
+);
 ```
 
 With this template:
@@ -333,12 +360,12 @@ With this template:
 <f-template name="greeting-card">
     <template>
         <p>{{greeting}}</p>
-        <p>{{first-name}}</p>
+        <p>{{firstName}}</p>
     </template>
 </f-template>
 ```
 
-This automatically registers `greeting` and `first-name` as `@attr` properties. Setting `setAttribute("first-name", "Jane")` on the element triggers a re-render.
+This automatically registers `greeting` and `firstName` as `@attr` properties. By default, `attributeMap()` uses the `"camelCase"` attribute name strategy, so `firstName` maps to the HTML attribute `first-name`. Setting `setAttribute("first-name", "Jane")` on the element triggers a re-render.
 
 Properties already decorated with `@attr` or `@observable` on the class are left untouched.
 
@@ -348,50 +375,57 @@ The `attribute-name-strategy` option controls how template binding keys map to H
 
 | Strategy | Behavior | Example |
 |---|---|---|
-| `"none"` (default) | Binding key used as-is for both property and attribute | `{{foo-bar}}` → property `foo-bar`, attribute `foo-bar` |
-| `"camelCase"` | Binding key is the camelCase property; attribute is kebab-case | `{{fooBar}}` → property `fooBar`, attribute `foo-bar` |
+| `"camelCase"` (default) | Binding key is the camelCase property; attribute is kebab-case | `{{fooBar}}` → property `fooBar`, attribute `foo-bar` |
+| `"none"` | Binding key used as-is for both property and attribute | `{{foo-bar}}` → property `foo-bar`, attribute `foo-bar` |
 
 ```ts
-TemplateElement.options({
-    "my-element": {
-        attributeMap: {
-            "attribute-name-strategy": "camelCase",
-        },
+MyElement.define(
+    {
+        name: "my-element",
+        template: declarativeTemplate(),
     },
-});
+    [
+        attributeMap({
+            "attribute-name-strategy": "none",
+        }),
+    ],
+);
 ```
 
-With the `"camelCase"` strategy, a template binding `{{firstName}}` creates a property `firstName` with an HTML attribute `first-name`. This matches the behavior of the `--attribute-name-strategy` option in the `@microsoft/fast-build` CLI.
+With the `"camelCase"` strategy (the default), a template binding `{{firstName}}` creates a property `firstName` with an HTML attribute `first-name`. This matches the behavior of the `--attribute-name-strategy` option in the `@microsoft/fast-build` CLI.
 
 :::tip
-When using the `"camelCase"` strategy, ensure the server-side build tool uses the same strategy so that attribute names are consistent between the server-rendered HTML and the client-side runtime.
+Ensure the server-side build tool uses the same attribute name strategy as the client-side `attributeMap` configuration so that attribute names are consistent between the server-rendered HTML and the client-side runtime.
 :::
 
 ## Combining ObserverMap and AttributeMap
 
-Both options can be used together for a fully declarative component:
+Both extensions can be used together for a fully declarative component:
 
 ```ts
 import { FASTElement } from "@microsoft/fast-element";
-import { TemplateElement } from "@microsoft/fast-element/declarative.js";
+import {
+    declarativeTemplate,
+    observerMap,
+    attributeMap,
+    TemplateElement,
+} from "@microsoft/fast-element/declarative.js";
 
 class ProductCard extends FASTElement {}
 
-ProductCard.define({
-    name: "product-card",
-    templateOptions: "defer-and-hydrate",
-});
-
-TemplateElement.options({
-    "product-card": {
-        observerMap: "all",
-        attributeMap: "all",
+ProductCard.define(
+    {
+        name: "product-card",
+        template: declarativeTemplate(),
     },
-}).config({
+    [observerMap(), attributeMap()],
+);
+
+TemplateElement.config({
     hydrationComplete() {
         console.log("Ready");
     },
-}).define({ name: "f-template" });
+});
 ```
 
 ```html
@@ -409,9 +443,9 @@ In this example:
 - `observerMap: "all"` enables deep observation so that changes to `details.description` trigger re-renders.
 - The `details` property is not registered as an `@attr` because it has nested paths — it would typically be set programmatically.
 
-## Define Extensions
+## Custom Extensions
 
-The element's `define()` call accepts an optional second argument — an array of extension callbacks. Extensions run before the element is registered with the platform, enabling a plugin pattern:
+In addition to `observerMap()` and `attributeMap()`, the element's `define()` call accepts any extension callback in the extensions array. Extensions run before the element is registered with the platform, enabling a plugin pattern:
 
 ```ts
 import type { FASTElementExtension } from "@microsoft/fast-element";
@@ -424,8 +458,8 @@ function logDefinition(): FASTElementExtension {
 
 MyComponent.define({
     name: "my-component",
-    templateOptions: "defer-and-hydrate",
-}, [logDefinition()]);
+    template: declarativeTemplate(),
+}, [observerMap(), attributeMap(), logDefinition()]);
 ```
 
 This is the same extension mechanism available for imperative components. See [FASTElement — Define Extensions](../getting-started/fast-element#define-extensions) for details.

--- a/sites/website/src/docs/3.x/declarative-templates/defining-elements.md
+++ b/sites/website/src/docs/3.x/declarative-templates/defining-elements.md
@@ -8,23 +8,21 @@ eleventyNavigation:
   title: Defining Elements
 navigationOptions:
   activeKey: declarative-defining-elements3x
-description: Learn how to register declarative FASTElement components, configure lifecycle callbacks, and use observerMap and attributeMap.
+description: Learn how to register declarative FASTElement components and use observerMap and attributeMap extensions.
 keywords:
   - FASTElement
   - declarative
   - define
-  - TemplateElement
   - observerMap
   - attributeMap
-  - lifecycle
-  - hydration
+  - extensions
 ---
 
 {% raw %}
 
 # Defining Declarative Elements
 
-A declarative FASTElement component requires a JavaScript class definition with `template: declarativeTemplate()` and an `<f-template>` in the HTML. The `declarativeTemplate()` function automatically defines the `<f-template>` custom element and waits for the matching template before completing registration. This page covers the JavaScript setup, extensions, lifecycle callbacks, and configuration options.
+A declarative FASTElement component requires a JavaScript class definition with `template: declarativeTemplate()` and an `<f-template>` in the HTML. The `declarativeTemplate()` function automatically defines the `<f-template>` custom element and waits for the matching template before completing registration. This page covers the JavaScript setup and extension configuration.
 
 ## Basic Setup
 
@@ -119,87 +117,6 @@ TaskItem.define({
 </html>
 ```
 
-## Lifecycle Callbacks
-
-`TemplateElement.config()` registers callbacks that fire during template processing and hydration. This is useful for tracking progress, gathering performance metrics, or coordinating initialization. `TemplateElement` remains available for lifecycle configuration even though `declarativeTemplate()` handles the registration automatically.
-
-```ts
-import { TemplateElement } from "@microsoft/fast-element/declarative.js";
-
-TemplateElement.config({
-    hydrationComplete() {
-        console.log("All elements hydrated");
-    },
-});
-```
-
-### Available Callbacks
-
-**Template lifecycle:**
-
-| Callback | Description |
-|---|---|
-| `elementDidRegister(name)` | Called after the element class is registered |
-| `templateWillUpdate(name)` | Called before the template is evaluated and assigned |
-| `templateDidUpdate(name)` | Called after the template is assigned to the definition |
-| `elementDidDefine(name)` | Called after the custom element is defined with the platform |
-
-**Hydration lifecycle:**
-
-| Callback | Description |
-|---|---|
-| `hydrationStarted()` | Called once when the first pre-rendered element begins hydrating |
-| `elementWillHydrate(source)` | Called before an individual element starts hydration |
-| `elementDidHydrate(source)` | Called after an individual element completes hydration |
-| `hydrationComplete()` | Called after all pre-rendered elements have finished hydrating |
-
-### Lifecycle Order
-
-1. **Registration** — `elementDidRegister`
-2. **Template processing** — `templateWillUpdate` → template parsing → `templateDidUpdate` → `elementDidDefine`
-3. **Hydration** — `hydrationStarted` → `elementWillHydrate` → hydration → `elementDidHydrate`
-4. **Completion** — `hydrationComplete`
-
-:::note
-Template processing is asynchronous and happens independently for each element. The template and hydration phases can be interleaved when multiple elements are being processed simultaneously.
-:::
-
-### Performance Monitoring Example
-
-```ts
-TemplateElement.config({
-    elementWillHydrate(source) {
-        performance.mark(`${source.localName}-hydration-start`);
-    },
-    elementDidHydrate(source) {
-        performance.mark(`${source.localName}-hydration-end`);
-        performance.measure(
-            `${source.localName}-hydration`,
-            `${source.localName}-hydration-start`,
-            `${source.localName}-hydration-end`
-        );
-    },
-    hydrationComplete() {
-        const entries = performance.getEntriesByType("measure");
-        console.log("Hydration metrics:", entries);
-    },
-});
-```
-
-### Loading State Example
-
-```ts
-TemplateElement.config({
-    hydrationStarted() {
-        document.body.classList.add("hydrating");
-    },
-    hydrationComplete() {
-        document.body.classList.remove("hydrating");
-        document.body.classList.add("hydrated");
-    },
-});
-```
-
 ## Extensions
 
 The `observerMap()` and `attributeMap()` functions are define extensions — they are passed as the second argument to `define()` and run before the element is registered with the platform.
@@ -224,33 +141,6 @@ MyElement.define(
 ```
 
 Calling `observerMap()` or `attributeMap()` with no arguments applies the default behavior for all properties. You can also pass configuration objects for fine-grained control (see below).
-
-`TemplateElement.options()` is also available for per-element configuration and can be combined with extensions:
-
-```ts
-import { TemplateElement } from "@microsoft/fast-element/declarative.js";
-
-TemplateElement.options({
-    "my-element": {
-        observerMap: "all",
-        attributeMap: "all",
-    },
-});
-```
-
-Both `.config()` and `.options()` are chainable:
-
-```ts
-TemplateElement
-    .options({
-        "my-element": { observerMap: "all" },
-    })
-    .config({
-        hydrationComplete() {
-            console.log("Ready");
-        },
-    });
-```
 
 ## ObserverMap
 
@@ -408,7 +298,6 @@ import {
     declarativeTemplate,
     observerMap,
     attributeMap,
-    TemplateElement,
 } from "@microsoft/fast-element/declarative.js";
 
 class ProductCard extends FASTElement {}
@@ -420,12 +309,6 @@ ProductCard.define(
     },
     [observerMap(), attributeMap()],
 );
-
-TemplateElement.config({
-    hydrationComplete() {
-        console.log("Ready");
-    },
-});
 ```
 
 ```html

--- a/sites/website/src/docs/3.x/declarative-templates/defining-elements.md
+++ b/sites/website/src/docs/3.x/declarative-templates/defining-elements.md
@@ -1,0 +1,433 @@
+---
+id: declarative-defining-elements
+title: Defining Declarative Elements
+layout: 3x
+eleventyNavigation:
+  key: declarative-defining-elements3x
+  parent: declarative-templates3x
+  title: Defining Elements
+navigationOptions:
+  activeKey: declarative-defining-elements3x
+description: Learn how to register declarative FASTElement components, configure lifecycle callbacks, and use observerMap and attributeMap.
+keywords:
+  - FASTElement
+  - declarative
+  - define
+  - TemplateElement
+  - observerMap
+  - attributeMap
+  - lifecycle
+  - hydration
+---
+
+{% raw %}
+
+# Defining Declarative Elements
+
+A declarative FASTElement component requires a JavaScript class definition, a `TemplateElement` registration, and an `<f-template>` in the HTML. This page covers the JavaScript setup, lifecycle callbacks, and configuration options.
+
+## Basic Setup
+
+**1. Define the component class** with `templateOptions: "defer-and-hydrate"`:
+
+```ts
+import { FASTElement, attr } from "@microsoft/fast-element";
+
+class MyCounter extends FASTElement {
+    @attr count: number = 0;
+}
+
+MyCounter.define({
+    name: "my-counter",
+    templateOptions: "defer-and-hydrate",
+});
+```
+
+The `templateOptions: "defer-and-hydrate"` setting tells FAST to wait for a template from an `<f-template>` element instead of rendering immediately. If pre-rendered content exists in the DOM, it will be hydrated rather than replaced.
+
+**2. Register the `TemplateElement`** so the browser recognizes `<f-template>`:
+
+```ts
+import { TemplateElement } from "@microsoft/fast-element/declarative.js";
+
+TemplateElement.define({ name: "f-template" });
+```
+
+**3. Write the template** in an HTML file:
+
+```html
+<f-template name="my-counter">
+    <template>
+        <p>Count: {{count}}</p>
+        <button @click="{increment()}">+1</button>
+    </template>
+</f-template>
+```
+
+:::important
+The `TemplateElement` must be defined **after** all component classes are defined, and the `<f-template>` elements must be present in the DOM when `TemplateElement` connects. A common pattern is to place `TemplateElement.define()` as the last registration call in your entry module and include the `<f-template>` elements directly in the HTML page.
+:::
+
+## Complete File Structure
+
+A typical declarative component setup involves these files:
+
+```
+my-app/
+├── main.ts          # Component classes + TemplateElement registration
+├── templates.html   # <f-template> elements
+├── entry.html       # Page HTML with component instances
+├── state.json       # Initial state for server rendering (optional)
+└── styles.css       # Component styles (optional)
+```
+
+**`main.ts`:**
+
+```ts
+import { FASTElement, attr, css, observable } from "@microsoft/fast-element";
+import { TemplateElement } from "@microsoft/fast-element/declarative.js";
+
+class TaskItem extends FASTElement {
+    @attr text: string = "";
+    @attr({ mode: "boolean" }) done: boolean = false;
+}
+
+TaskItem.define({
+    name: "task-item",
+    styles: css`:host { display: block; }`,
+    templateOptions: "defer-and-hydrate",
+});
+
+TemplateElement.define({ name: "f-template" });
+```
+
+**`templates.html`:**
+
+```html
+<f-template name="task-item">
+    <template>
+        <label>
+            <input type="checkbox" ?checked="{{done}}">
+            <span>{{text}}</span>
+        </label>
+    </template>
+</f-template>
+```
+
+**`entry.html`:**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Tasks</title></head>
+<body>
+    <task-item text="Buy groceries"></task-item>
+    <task-item text="Write docs" done></task-item>
+    <script type="module" src="./main.ts"></script>
+</body>
+</html>
+```
+
+## Lifecycle Callbacks
+
+`TemplateElement.config()` registers callbacks that fire during template processing and hydration. This is useful for tracking progress, gathering performance metrics, or coordinating initialization.
+
+```ts
+import { TemplateElement } from "@microsoft/fast-element/declarative.js";
+
+TemplateElement.config({
+    hydrationComplete() {
+        console.log("All elements hydrated");
+    },
+}).define({ name: "f-template" });
+```
+
+### Available Callbacks
+
+**Template lifecycle:**
+
+| Callback | Description |
+|---|---|
+| `elementDidRegister(name)` | Called after the element class is registered |
+| `templateWillUpdate(name)` | Called before the template is evaluated and assigned |
+| `templateDidUpdate(name)` | Called after the template is assigned to the definition |
+| `elementDidDefine(name)` | Called after the custom element is defined with the platform |
+
+**Hydration lifecycle:**
+
+| Callback | Description |
+|---|---|
+| `hydrationStarted()` | Called once when the first pre-rendered element begins hydrating |
+| `elementWillHydrate(source)` | Called before an individual element starts hydration |
+| `elementDidHydrate(source)` | Called after an individual element completes hydration |
+| `hydrationComplete()` | Called after all pre-rendered elements have finished hydrating |
+
+### Lifecycle Order
+
+1. **Registration** — `elementDidRegister`
+2. **Template processing** — `templateWillUpdate` → template parsing → `templateDidUpdate` → `elementDidDefine`
+3. **Hydration** — `hydrationStarted` → `elementWillHydrate` → hydration → `elementDidHydrate`
+4. **Completion** — `hydrationComplete`
+
+:::note
+Template processing is asynchronous and happens independently for each element. The template and hydration phases can be interleaved when multiple elements are being processed simultaneously.
+:::
+
+### Performance Monitoring Example
+
+```ts
+TemplateElement.config({
+    elementWillHydrate(source) {
+        performance.mark(`${source.localName}-hydration-start`);
+    },
+    elementDidHydrate(source) {
+        performance.mark(`${source.localName}-hydration-end`);
+        performance.measure(
+            `${source.localName}-hydration`,
+            `${source.localName}-hydration-start`,
+            `${source.localName}-hydration-end`
+        );
+    },
+    hydrationComplete() {
+        const entries = performance.getEntriesByType("measure");
+        console.log("Hydration metrics:", entries);
+    },
+});
+```
+
+### Loading State Example
+
+```ts
+TemplateElement.config({
+    hydrationStarted() {
+        document.body.classList.add("hydrating");
+    },
+    hydrationComplete() {
+        document.body.classList.remove("hydrating");
+        document.body.classList.add("hydrated");
+    },
+});
+```
+
+## Element Options
+
+`TemplateElement.options()` configures per-element behavior for `observerMap` and `attributeMap`. These are keyed by custom element name.
+
+```ts
+TemplateElement.options({
+    "my-element": {
+        observerMap: "all",
+        attributeMap: "all",
+    },
+}).define({ name: "f-template" });
+```
+
+Both `.config()` and `.options()` are chainable and can be combined:
+
+```ts
+TemplateElement
+    .options({
+        "my-element": { observerMap: "all" },
+    })
+    .config({
+        hydrationComplete() {
+            console.log("Ready");
+        },
+    })
+    .define({ name: "f-template" });
+```
+
+## ObserverMap
+
+The `observerMap` option automatically sets up deep reactive observation for properties discovered in the template. When a nested object property changes, the template re-renders the affected bindings.
+
+### Observe All Properties
+
+Use `"all"` to observe every root property found in the template:
+
+```ts
+TemplateElement.options({
+    "user-profile": {
+        observerMap: "all",
+    },
+});
+```
+
+With this template:
+
+```html
+<f-template name="user-profile">
+    <template>
+        <p>{{user.name}}</p>
+        <p>{{user.address.city}}</p>
+    </template>
+</f-template>
+```
+
+Changes to `user.name` or `user.address.city` will automatically trigger a re-render.
+
+### Selective Observation
+
+For fine-grained control, pass a configuration object with a `properties` key:
+
+```ts
+TemplateElement.options({
+    "user-profile": {
+        observerMap: {
+            properties: {
+                user: {
+                    name: true,       // user.name — observed
+                    details: {
+                        age: true,    // user.details.age — observed
+                        history: false // user.details.history — NOT observed
+                    },
+                },
+            },
+        },
+    },
+});
+```
+
+Each entry in the path tree can be:
+
+| Value | Behavior |
+|---|---|
+| `true` | Observe this path and all descendants |
+| `false` | Skip this path and all descendants |
+| `{ ... }` | An object with child path overrides and an optional `$observe` flag |
+
+Use `$observe: false` on a node to skip it by default, then selectively include specific children:
+
+```ts
+observerMap: {
+    properties: {
+        analytics: {
+            charts: {
+                $observe: false,      // charts NOT observed by default
+                activeChart: true,    // ...except activeChart IS observed
+            },
+        },
+    },
+}
+```
+
+When `properties` is omitted or set to `"all"`, all root properties are observed. When `properties` is present but empty (`{ properties: {} }`), no root properties are observed.
+
+## AttributeMap
+
+The `attributeMap` option automatically creates reactive `@attr` properties for leaf bindings in the template — simple expressions like `{{greeting}}` that have no nested dot-notation paths.
+
+### Enable for All Leaf Bindings
+
+```ts
+TemplateElement.options({
+    "greeting-card": {
+        attributeMap: "all",
+    },
+});
+```
+
+With this template:
+
+```html
+<f-template name="greeting-card">
+    <template>
+        <p>{{greeting}}</p>
+        <p>{{first-name}}</p>
+    </template>
+</f-template>
+```
+
+This automatically registers `greeting` and `first-name` as `@attr` properties. Setting `setAttribute("first-name", "Jane")` on the element triggers a re-render.
+
+Properties already decorated with `@attr` or `@observable` on the class are left untouched.
+
+### Attribute Name Strategy
+
+The `attribute-name-strategy` option controls how template binding keys map to HTML attribute names:
+
+| Strategy | Behavior | Example |
+|---|---|---|
+| `"none"` (default) | Binding key used as-is for both property and attribute | `{{foo-bar}}` → property `foo-bar`, attribute `foo-bar` |
+| `"camelCase"` | Binding key is the camelCase property; attribute is kebab-case | `{{fooBar}}` → property `fooBar`, attribute `foo-bar` |
+
+```ts
+TemplateElement.options({
+    "my-element": {
+        attributeMap: {
+            "attribute-name-strategy": "camelCase",
+        },
+    },
+});
+```
+
+With the `"camelCase"` strategy, a template binding `{{firstName}}` creates a property `firstName` with an HTML attribute `first-name`. This matches the behavior of the `--attribute-name-strategy` option in the `@microsoft/fast-build` CLI.
+
+:::tip
+When using the `"camelCase"` strategy, ensure the server-side build tool uses the same strategy so that attribute names are consistent between the server-rendered HTML and the client-side runtime.
+:::
+
+## Combining ObserverMap and AttributeMap
+
+Both options can be used together for a fully declarative component:
+
+```ts
+import { FASTElement } from "@microsoft/fast-element";
+import { TemplateElement } from "@microsoft/fast-element/declarative.js";
+
+class ProductCard extends FASTElement {}
+
+ProductCard.define({
+    name: "product-card",
+    templateOptions: "defer-and-hydrate",
+});
+
+TemplateElement.options({
+    "product-card": {
+        observerMap: "all",
+        attributeMap: "all",
+    },
+}).config({
+    hydrationComplete() {
+        console.log("Ready");
+    },
+}).define({ name: "f-template" });
+```
+
+```html
+<f-template name="product-card">
+    <template>
+        <h2>{{name}}</h2>
+        <p>{{price}}</p>
+        <p>{{details.description}}</p>
+    </template>
+</f-template>
+```
+
+In this example:
+- `attributeMap: "all"` auto-registers `name` and `price` as `@attr` properties (leaf bindings).
+- `observerMap: "all"` enables deep observation so that changes to `details.description` trigger re-renders.
+- The `details` property is not registered as an `@attr` because it has nested paths — it would typically be set programmatically.
+
+## Define Extensions
+
+The element's `define()` call accepts an optional second argument — an array of extension callbacks. Extensions run before the element is registered with the platform, enabling a plugin pattern:
+
+```ts
+import type { FASTElementExtension } from "@microsoft/fast-element";
+
+function logDefinition(): FASTElementExtension {
+    return definition => {
+        console.log(`Defining: ${definition.name}`);
+    };
+}
+
+MyComponent.define({
+    name: "my-component",
+    templateOptions: "defer-and-hydrate",
+}, [logDefinition()]);
+```
+
+This is the same extension mechanism available for imperative components. See [FASTElement — Define Extensions](../getting-started/fast-element#define-extensions) for details.
+
+{% endraw %}

--- a/sites/website/src/docs/3.x/declarative-templates/f-templates.md
+++ b/sites/website/src/docs/3.x/declarative-templates/f-templates.md
@@ -1,0 +1,338 @@
+---
+id: declarative-f-templates
+title: Writing f-templates
+layout: 3x
+eleventyNavigation:
+  key: declarative-f-templates3x
+  parent: declarative-templates3x
+  title: Writing f-templates
+navigationOptions:
+  activeKey: declarative-f-templates3x
+description: Learn the declarative template syntax for bindings, directives, events, and expressions.
+keywords:
+  - f-template
+  - bindings
+  - directives
+  - declarative
+  - repeat
+  - when
+---
+
+{% raw %}
+
+# Writing f-templates
+
+An `<f-template>` element associates a declarative HTML template with a custom element by name. The inner `<template>` contains the markup that becomes the element's shadow DOM.
+
+```html
+<f-template name="my-element">
+    <template>
+        <!-- template content here -->
+    </template>
+</f-template>
+```
+
+The `name` attribute must match the custom element tag name registered in JavaScript. A single HTML file can contain multiple `<f-template>` elements for different components.
+
+## Binding Syntax
+
+Declarative templates use a handlebars-like syntax for data binding. There are two categories of bindings based on when they are evaluated:
+
+| Syntax | Evaluated | Purpose |
+|---|---|---|
+| `{{expression}}` | Server and client | Content and attribute bindings (HTML-escaped) |
+| `{{{expression}}}` | Server and client | Unescaped HTML content binding |
+| `{expression}` | Client only | Event handlers and attribute directives |
+
+Server-evaluated bindings (`{{}}` and `{{{}}}`) are resolved during server-side rendering and hydrated on the client. Client-only bindings (`{}`) are ignored by the server and activated when the component connects in the browser.
+
+## Content Bindings
+
+Use double curly braces to bind text content:
+
+```html
+<f-template name="greeting-card">
+    <template>
+        <h3>{{greeting}}</h3>
+        <p>Welcome, {{name}}!</p>
+    </template>
+</f-template>
+```
+
+Content bindings are HTML-escaped for security. To render raw HTML, use triple curly braces:
+
+```html
+<f-template name="rich-content">
+    <template>
+        {{{htmlContent}}}
+    </template>
+</f-template>
+```
+
+:::warning
+Triple-brace bindings insert unescaped HTML directly into the DOM. Only use them with trusted content to avoid cross-site scripting (XSS) vulnerabilities. An additional wrapping `div` element is created to host the binding.
+:::
+
+## Attribute Bindings
+
+Bind element attributes using double curly braces inside attribute values:
+
+```html
+<f-template name="styled-input">
+    <template>
+        <input type="{{inputType}}" class="{{cssClass}}">
+    </template>
+</f-template>
+```
+
+### Boolean Attributes
+
+Prefix the attribute name with `?` for boolean attribute bindings. When the value is truthy, the attribute is present; when falsy, it is removed:
+
+```html
+<f-template name="toggle-button">
+    <template>
+        <button ?disabled="{{isDisabled}}">Click me</button>
+    </template>
+</f-template>
+```
+
+Boolean bindings also support expressions with comparison operators:
+
+```html
+<button ?disabled="{{status == 'locked'}}">Submit</button>
+```
+
+## Event Bindings
+
+Event bindings use the `@` prefix and single curly braces (client-only). The handler name must include parentheses `()`:
+
+```html
+<f-template name="click-counter">
+    <template>
+        <button @click="{handleClick()}">Count: {{count}}</button>
+    </template>
+</f-template>
+```
+
+### Event Arguments
+
+You can pass special arguments to event handlers:
+
+| Argument | Description |
+|---|---|
+| `$e` | The DOM event object |
+| `$c` | The execution context |
+| `$c.parent` | The parent execution context (useful inside `<f-repeat>`) |
+| `$c.event` | The DOM event from the execution context |
+| Any other token | Resolved as a binding path on the data source |
+
+**Examples:**
+
+```html
+<!-- Pass the DOM event -->
+<button @click="{handleClick($e)}">Click</button>
+
+<!-- Pass the execution context -->
+<button @click="{handleClick($c)}">Click</button>
+
+<!-- Pass multiple arguments -->
+<button @click="{handleClick($e, $c)}">Click</button>
+
+<!-- Pass a data binding as an argument -->
+<button @click="{handleClick(user.id)}">Click</button>
+```
+
+:::note
+Event bindings use single curly braces `{...}` because they are client-only — the server does not need to evaluate them.
+:::
+
+## Dot-Notation Paths
+
+Binding expressions support dot-notation for accessing nested properties:
+
+```html
+<f-template name="user-card">
+    <template>
+        <p>{{user.name}}</p>
+        <p>{{user.address.city}}, {{user.address.state}}</p>
+    </template>
+</f-template>
+```
+
+## Directives
+
+Directives extend template behavior with conditional rendering, list iteration, element references, and more. Directives that serve as containers use the `<f-*>` element syntax. Directives that attach to an existing element use the `f-*` attribute syntax.
+
+### Conditional Rendering (`f-when`)
+
+The `<f-when>` directive renders its content only when the condition is truthy:
+
+```html
+<f-template name="user-status">
+    <template>
+        <f-when value="{{isLoggedIn}}">
+            <p>Welcome back, {{username}}!</p>
+        </f-when>
+        <f-when value="{{!isLoggedIn}}">
+            <p>Please log in.</p>
+        </f-when>
+    </template>
+</f-template>
+```
+
+Conditions support these comparison operators:
+
+| Operator | Description |
+|---|---|
+| `==` | Equal |
+| `!=` | Not equal |
+| `>` | Greater than |
+| `>=` | Greater than or equal |
+| `<` | Less than |
+| `<=` | Less than or equal |
+| `\|\|` | Logical OR |
+| `&&` | Logical AND |
+
+The right operand can be a string (`'bar'`), boolean (`true`/`false`), number (`3`), or another binding path:
+
+```html
+<f-when value="{{status == 'active'}}">Active</f-when>
+<f-when value="{{count > 0}}">Has items</f-when>
+<f-when value="{{role == adminRole}}">Admin panel</f-when>
+```
+
+### List Iteration (`f-repeat`)
+
+The `<f-repeat>` directive iterates over an array and renders its content for each item:
+
+```html
+<f-template name="todo-list">
+    <template>
+        <ul>
+            <f-repeat value="{{item in items}}">
+                <li>{{item.text}}</li>
+            </f-repeat>
+        </ul>
+    </template>
+</f-template>
+```
+
+Inside `<f-repeat>`, bindings without a context prefix resolve to the host element, not the repeat item. Use the declared variable name (e.g. `item`) to access the current iteration value:
+
+```html
+<f-repeat value="{{item in list}}">
+    <li>{{item}} - {{title}}</li>
+    <!-- {{item}} is the current list item -->
+    <!-- {{title}} resolves to the host element's title property -->
+</f-repeat>
+```
+
+#### Accessing the Parent Context
+
+Inside `<f-repeat>`, use `$c.parent` to access the host element's methods and properties from event handlers:
+
+```html
+<f-repeat value="{{item in items}}">
+    <button @click="{$c.parent.handleItemClick($e)}">
+        {{item.name}}
+    </button>
+</f-repeat>
+```
+
+#### Nested Directives
+
+`<f-when>` can be used inside `<f-repeat>` and vice versa:
+
+```html
+<f-repeat value="{{item in items}}">
+    <f-when value="{{item.visible}}">
+        <span>{{item.name}}</span>
+    </f-when>
+</f-repeat>
+```
+
+### Element Reference (`f-ref`)
+
+The `f-ref` attribute directive stores a reference to a DOM element on the component instance:
+
+```html
+<f-template name="video-player">
+    <template>
+        <video f-ref="{videoElement}"></video>
+        <button @click="{play()}">Play</button>
+    </template>
+</f-template>
+```
+
+### Slotted Content (`f-slotted`)
+
+The `f-slotted` attribute directive observes elements assigned to a `<slot>`:
+
+```html
+<f-template name="card-container">
+    <template>
+        <slot f-slotted="{slottedItems}"></slot>
+        <slot f-slotted="{slottedItems filter elements()}"></slot>
+        <slot f-slotted="{slottedItems filter elements(div, p)}"></slot>
+    </template>
+</f-template>
+```
+
+### Children (`f-children`)
+
+The `f-children` attribute directive observes child elements:
+
+```html
+<f-template name="item-list">
+    <template>
+        <ul f-children="{listItems}">
+            <f-repeat value="{{item in list}}">
+                <li>{{item}}</li>
+            </f-repeat>
+        </ul>
+    </template>
+</f-template>
+```
+
+:::note
+Attribute directives (`f-ref`, `f-slotted`, `f-children`) use single curly braces `{...}` because they are client-only.
+:::
+
+## Execution Context
+
+In imperative FAST templates, every binding receives the data source and the execution context: `${(x, c) => ...}`. Declarative templates access the same execution context using the `$c` prefix.
+
+This is especially useful inside `<f-repeat>` blocks:
+
+```html
+<!-- Call a method on the host element from inside a repeat -->
+<f-repeat value="{{item in items}}">
+    <button @click="{$c.parent.handleItemClick($c.event)}">
+        {{item.name}}
+    </button>
+</f-repeat>
+
+<!-- Conditionally render using a host property inside a repeat -->
+<f-repeat value="{{item in items}}">
+    <f-when value="{{$c.parent.showDetails}}">
+        <span>{{item.description}}</span>
+    </f-when>
+</f-repeat>
+```
+
+## Expression Limitations
+
+Declarative template expressions are **not** arbitrary JavaScript. They support:
+
+- Simple property access: `{{propertyName}}`
+- Dot-notation paths: `{{object.property.nested}}`
+- Negation: `{{!value}}`
+- Comparison operators: `==`, `!=`, `>`, `>=`, `<`, `<=`
+- Logical operators: `||`, `&&`
+- Context access: `$c`, `$c.parent`, `$e`
+- Iteration variables: `{{item in array}}`
+
+Complex JavaScript expressions, method calls in bindings (other than event handlers), and ternary operators are not supported.
+
+{% endraw %}

--- a/sites/website/src/docs/3.x/declarative-templates/overview.md
+++ b/sites/website/src/docs/3.x/declarative-templates/overview.md
@@ -47,7 +47,7 @@ A declarative FAST component requires three pieces: a JavaScript class, an `<f-t
 
 ```ts
 import { FASTElement, attr } from "@microsoft/fast-element";
-import { TemplateElement } from "@microsoft/fast-element/declarative.js";
+import { declarativeTemplate } from "@microsoft/fast-element/declarative.js";
 
 class HelloWorld extends FASTElement {
     @attr greeting: string = "Hello";
@@ -55,10 +55,8 @@ class HelloWorld extends FASTElement {
 
 HelloWorld.define({
     name: "hello-world",
-    templateOptions: "defer-and-hydrate",
+    template: declarativeTemplate(),
 });
-
-TemplateElement.define({ name: "f-template" });
 ```
 
 **2. Write the template** (`templates.html`):
@@ -84,15 +82,15 @@ TemplateElement.define({ name: "f-template" });
 </html>
 ```
 
-When the page loads, `TemplateElement` finds the `<f-template name="hello-world">` element, parses its inner `<template>`, and assigns it to the `hello-world` definition. The component hydrates any pre-rendered content or renders client-side, and reactive bindings keep the DOM in sync with property changes.
+When the page loads, `declarativeTemplate()` automatically defines `<f-template>` in the relevant registry, finds the `<f-template name="hello-world">` element, parses its inner `<template>`, and resolves the template for the `hello-world` definition. The component hydrates any pre-rendered content or renders client-side, and reactive bindings keep the DOM in sync with property changes.
 
 ## How It Works
 
 The declarative pipeline follows these steps:
 
-1. **Define** — The component class is registered with `templateOptions: "defer-and-hydrate"`, which tells FAST to wait for a template instead of rendering immediately.
+1. **Define** — The component class is registered with `template: declarativeTemplate()`, which tells FAST to wait for a matching `<f-template>` element and automatically defines the `<f-template>` custom element in the registry.
 2. **Parse** — When `<f-template>` connects to the DOM, `TemplateParser` converts the declarative markup into the same internal `ViewTemplate` that the imperative `html` tag produces.
-3. **Bind** — The template is assigned to the element definition and reactive bindings are established.
+3. **Resolve** — The template is resolved through the bridge and assigned to the element definition before `define()` completes.
 4. **Hydrate** — If the page contains pre-rendered content (from a server), existing DOM nodes are reused rather than replaced. If no pre-rendered content exists, the template renders client-side.
 
 ## Declarative vs. Imperative Syntax
@@ -119,7 +117,7 @@ NameTag.define({ name: "name-tag", template });
 
 ```ts
 import { FASTElement, attr } from "@microsoft/fast-element";
-import { TemplateElement } from "@microsoft/fast-element/declarative.js";
+import { declarativeTemplate } from "@microsoft/fast-element/declarative.js";
 
 class NameTag extends FASTElement {
     @attr greeting: string = "Hello";
@@ -127,10 +125,8 @@ class NameTag extends FASTElement {
 
 NameTag.define({
     name: "name-tag",
-    templateOptions: "defer-and-hydrate",
+    template: declarativeTemplate(),
 });
-
-TemplateElement.define({ name: "f-template" });
 ```
 
 ```html

--- a/sites/website/src/docs/3.x/declarative-templates/overview.md
+++ b/sites/website/src/docs/3.x/declarative-templates/overview.md
@@ -142,7 +142,7 @@ Both produce the same runtime behavior. The declarative version separates the te
 ## Next Steps
 
 - [Writing f-templates](./f-templates) — Template syntax, bindings, directives, and expressions.
-- [Defining Elements](./defining-elements) — Component registration, lifecycle callbacks, and configuration.
+- [Defining Elements](./defining-elements) — Component registration and extension configuration.
 - [Server-Side Rendering](./server-rendering) — Rendering templates on the server and hydrating on the client.
 
 {% endraw %}

--- a/sites/website/src/docs/3.x/declarative-templates/overview.md
+++ b/sites/website/src/docs/3.x/declarative-templates/overview.md
@@ -1,0 +1,152 @@
+---
+id: declarative-templates-overview
+title: Declarative HTML Overview
+layout: 3x
+eleventyNavigation:
+  key: declarative-templates-overview3x
+  parent: declarative-templates3x
+  title: Overview
+navigationOptions:
+  activeKey: declarative-templates-overview3x
+description: An overview of FAST's declarative HTML authoring model for web components.
+keywords:
+  - declarative
+  - html
+  - templates
+  - web components
+  - f-template
+---
+
+{% raw %}
+
+# Declarative HTML Overview
+
+FAST Element provides two ways to author web component templates:
+
+1. **Imperative** — JavaScript tagged template literals using the `html` function.
+2. **Declarative** — Plain HTML `<f-template>` elements parsed at runtime.
+
+The declarative model moves template authoring from JavaScript into HTML. Because templates are expressed as standard markup, they can be rendered by any server-side technology without a JavaScript runtime — enabling true stack-agnostic server-side rendering.
+
+## When to Use Declarative Templates
+
+Choose declarative HTML when:
+
+- You want **server-rendered initial HTML** that hydrates on the client.
+- Your rendering pipeline does not run JavaScript (e.g. Rust, Go, or .NET servers).
+- You prefer authoring templates in HTML files rather than JavaScript modules.
+- You need the same template to be consumable by both a build tool and the browser.
+
+The imperative `html` tagged template remains the right choice for purely client-side applications where templates are authored alongside component logic in TypeScript.
+
+## Hello World
+
+A declarative FAST component requires three pieces: a JavaScript class, an `<f-template>` element, and a host element in the page.
+
+**1. Define the component class** (`main.ts`):
+
+```ts
+import { FASTElement, attr } from "@microsoft/fast-element";
+import { TemplateElement } from "@microsoft/fast-element/declarative.js";
+
+class HelloWorld extends FASTElement {
+    @attr greeting: string = "Hello";
+}
+
+HelloWorld.define({
+    name: "hello-world",
+    templateOptions: "defer-and-hydrate",
+});
+
+TemplateElement.define({ name: "f-template" });
+```
+
+**2. Write the template** (`templates.html`):
+
+```html
+<f-template name="hello-world">
+    <template>
+        <p>{{greeting}}, world!</p>
+    </template>
+</f-template>
+```
+
+**3. Use the element in your page** (`index.html`):
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"></head>
+<body>
+    <hello-world greeting="Hi"></hello-world>
+    <script type="module" src="./main.ts"></script>
+</body>
+</html>
+```
+
+When the page loads, `TemplateElement` finds the `<f-template name="hello-world">` element, parses its inner `<template>`, and assigns it to the `hello-world` definition. The component hydrates any pre-rendered content or renders client-side, and reactive bindings keep the DOM in sync with property changes.
+
+## How It Works
+
+The declarative pipeline follows these steps:
+
+1. **Define** — The component class is registered with `templateOptions: "defer-and-hydrate"`, which tells FAST to wait for a template instead of rendering immediately.
+2. **Parse** — When `<f-template>` connects to the DOM, `TemplateParser` converts the declarative markup into the same internal `ViewTemplate` that the imperative `html` tag produces.
+3. **Bind** — The template is assigned to the element definition and reactive bindings are established.
+4. **Hydrate** — If the page contains pre-rendered content (from a server), existing DOM nodes are reused rather than replaced. If no pre-rendered content exists, the template renders client-side.
+
+## Declarative vs. Imperative Syntax
+
+The same component can be expressed either way. Here is a side-by-side comparison:
+
+**Imperative:**
+
+```ts
+import { FASTElement, attr, html } from "@microsoft/fast-element";
+
+const template = html<NameTag>`
+    <h3>${x => x.greeting}</h3>
+`;
+
+class NameTag extends FASTElement {
+    @attr greeting: string = "Hello";
+}
+
+NameTag.define({ name: "name-tag", template });
+```
+
+**Declarative:**
+
+```ts
+import { FASTElement, attr } from "@microsoft/fast-element";
+import { TemplateElement } from "@microsoft/fast-element/declarative.js";
+
+class NameTag extends FASTElement {
+    @attr greeting: string = "Hello";
+}
+
+NameTag.define({
+    name: "name-tag",
+    templateOptions: "defer-and-hydrate",
+});
+
+TemplateElement.define({ name: "f-template" });
+```
+
+```html
+<f-template name="name-tag">
+    <template>
+        <h3>{{greeting}}</h3>
+    </template>
+</f-template>
+```
+
+Both produce the same runtime behavior. The declarative version separates the template into HTML, making it available for server-side rendering without JavaScript.
+
+## Next Steps
+
+- [Writing f-templates](./f-templates) — Template syntax, bindings, directives, and expressions.
+- [Defining Elements](./defining-elements) — Component registration, lifecycle callbacks, and configuration.
+- [Server-Side Rendering](./server-rendering) — Rendering templates on the server and hydrating on the client.
+
+{% endraw %}

--- a/sites/website/src/docs/3.x/declarative-templates/server-rendering.md
+++ b/sites/website/src/docs/3.x/declarative-templates/server-rendering.md
@@ -78,7 +78,7 @@ The end-to-end flow from server to interactive page follows these steps:
 6. **Interactive** — The page is fully interactive. Property changes trigger targeted DOM updates.
 
 :::tip
-Use the `hydrationComplete()` lifecycle callback to know when all elements have finished hydrating and the page is fully interactive. See [Defining Elements — Lifecycle Callbacks](./defining-elements#lifecycle-callbacks) for details.
+The `isPrerendered` property on `$fastController` is a `Promise<boolean>` that resolves to `true` after hydration completes, or `false` for client-side rendered elements. Use this to detect when the page is fully interactive.
 :::
 
 ## State Propagation

--- a/sites/website/src/docs/3.x/declarative-templates/server-rendering.md
+++ b/sites/website/src/docs/3.x/declarative-templates/server-rendering.md
@@ -1,0 +1,232 @@
+---
+id: declarative-server-rendering
+title: Server-Side Rendering
+layout: 3x
+eleventyNavigation:
+  key: declarative-server-rendering3x
+  parent: declarative-templates3x
+  title: Server-Side Rendering
+navigationOptions:
+  activeKey: declarative-server-rendering3x
+description: Learn how to render declarative FAST templates on the server and hydrate them on the client.
+keywords:
+  - server-side rendering
+  - SSR
+  - hydration
+  - fast-build
+  - declarative shadow DOM
+  - prerendering
+---
+
+{% raw %}
+
+# Server-Side Rendering
+
+One of the core benefits of FAST's declarative HTML templates is stack-agnostic server-side rendering. Because `<f-template>` markup is standard HTML with binding expressions — not JavaScript — any server technology can render the initial page without a JS runtime.
+
+## The Rendering Contract
+
+A server-side renderer must produce HTML that follows these conventions so the client-side FAST runtime can hydrate it:
+
+1. **Declarative Shadow DOM** — Custom element content is rendered inside a `<template shadowrootmode="open">` element, which the browser expands into a shadow root.
+2. **Hydration markers** — Binding slots are annotated with `data-fe="N"` attributes on elements, and content bindings are wrapped in `<!--fe:b-->VALUE<!--fe:/b-->` comment markers.
+3. **State resolution** — Binding expressions like `{{title}}` are resolved to their initial values from a state object.
+
+**Example:** Given this template and state:
+
+```html
+<f-template name="greeting-card">
+    <template>
+        <h2>{{title}}</h2>
+        <p>{{message}}</p>
+    </template>
+</f-template>
+```
+
+```json
+{ "title": "Hello", "message": "Welcome to FAST" }
+```
+
+A server renderer produces:
+
+```html
+<greeting-card title="Hello" message="Welcome to FAST">
+    <template shadowrootmode="open">
+        <h2 data-fe="0"><!--fe:b-->Hello<!--fe:/b--></h2>
+        <p data-fe="1"><!--fe:b-->Welcome to FAST<!--fe:/b--></p>
+    </template>
+</greeting-card>
+```
+
+When the page loads, the FAST declarative runtime finds these markers and attaches reactive bindings to the existing DOM nodes instead of re-rendering.
+
+## Hydration Flow
+
+The end-to-end flow from server to interactive page follows these steps:
+
+1. **Server renders** — The renderer resolves `{{bindings}}` against the state, injects Declarative Shadow DOM `<template>` elements, and adds hydration markers.
+2. **Browser loads HTML** — The browser parses the page. Declarative Shadow DOM `<template>` elements are automatically expanded into shadow roots.
+3. **JavaScript loads** — Component classes are defined with `templateOptions: "defer-and-hydrate"` and `TemplateElement` is registered.
+4. **Template assignment** — `TemplateElement` parses `<f-template>` markup and assigns the compiled template to each element definition.
+5. **Hydration** — FAST detects the pre-rendered shadow DOM, maps existing DOM nodes to binding slots using hydration markers, and re-establishes reactive observations.
+6. **Interactive** — The page is fully interactive. Property changes trigger targeted DOM updates.
+
+:::tip
+Use the `hydrationComplete()` lifecycle callback to know when all elements have finished hydrating and the page is fully interactive. See [Defining Elements — Lifecycle Callbacks](./defining-elements#lifecycle-callbacks) for details.
+:::
+
+## State Propagation
+
+When the server renders custom elements, attribute values on the host element become the initial state for template bindings inside the shadow DOM.
+
+```html
+<greeting-card title="Hello" message="Welcome"></greeting-card>
+```
+
+The `title` and `message` attributes become state properties that resolve `{{title}}` and `{{message}}` in the element's template.
+
+### Nested Custom Elements
+
+State flows from parent to child elements. Unbound state keys — values from the parent state that the parent template does not consume — propagate automatically to child custom elements.
+
+```html
+<!-- Parent state: { "theme": "dark", "username": "Jane" } -->
+<app-header username="{{username}}">
+    <!-- theme propagates to user-avatar even though
+         app-header's template doesn't use it -->
+    <template shadowrootmode="open">
+        <user-avatar username="{{username}}"></user-avatar>
+    </template>
+</app-header>
+```
+
+### Special Attribute Handling
+
+The renderer applies special rules for certain HTML attributes:
+
+| Attribute pattern | State property | Example |
+|---|---|---|
+| `data-*` | `dataset.*` (camelCase) | `data-user-id` → `dataset.userId` |
+| `aria-*` | camelCase ARIA property | `aria-label` → `ariaLabel` |
+| Boolean (`?attr`) | Truthy/falsy evaluation | `?disabled="{{isOff}}"` → present or absent |
+
+## Using `@microsoft/fast-build`
+
+The `@microsoft/fast-build` package is a build-time renderer for declarative templates, powered by a WebAssembly core. It implements the rendering contract described above and is primarily used in testing and development workflows.
+
+:::note
+For production server-side rendering, consider the [`@microsoft/webui`](https://github.com/microsoft/webui) project, which provides a full rendering pipeline.
+:::
+
+### Installation
+
+```shell
+npm install --save @microsoft/fast-build
+```
+
+### CLI Usage
+
+The `fast build` command renders an entry HTML file with a JSON state file:
+
+```shell
+fast build --entry=index.html --state=state.json --output=output.html --templates="./components/**/*.html"
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `--entry` | `index.html` | Entry HTML template to render |
+| `--state` | `state.json` | JSON file containing the initial state |
+| `--output` | `output.html` | Where to write the rendered HTML |
+| `--templates` | _(none)_ | Glob pattern(s) for `<f-template>` HTML files |
+| `--attribute-name-strategy` | `none` | How to map attribute names to properties |
+| `--config` | `fast-build.config.json` | Path to a configuration file |
+
+### Example
+
+**`entry.html`:**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>My App</title></head>
+<body>
+    <greeting-card title="{{title}}" message="{{message}}"></greeting-card>
+    <script type="module" src="./main.ts"></script>
+</body>
+</html>
+```
+
+**`state.json`:**
+
+```json
+{
+    "title": "Hello FAST",
+    "message": "Server-rendered with WebAssembly"
+}
+```
+
+**`templates.html`:**
+
+```html
+<f-template name="greeting-card">
+    <template>
+        <h2>{{title}}</h2>
+        <p>{{message}}</p>
+    </template>
+</f-template>
+```
+
+Run the build:
+
+```shell
+fast build \
+    --entry=entry.html \
+    --state=state.json \
+    --output=index.html \
+    --templates=templates.html
+```
+
+The output (`index.html`) contains the fully resolved HTML with Declarative Shadow DOM and hydration markers.
+
+### Configuration File
+
+Instead of passing every option on the command line, create a `fast-build.config.json`:
+
+```json
+{
+    "entry": "entry.html",
+    "state": "state.json",
+    "output": "index.html",
+    "templates": "./components/**/*.html"
+}
+```
+
+The CLI automatically loads `fast-build.config.json` from the current directory when it exists. CLI arguments always take precedence over config file values. File paths in the config are resolved relative to the config file's directory.
+
+### Attribute Name Strategy
+
+The `--attribute-name-strategy` option controls how HTML attribute names on custom elements map to state property names:
+
+| Strategy | Behavior | Example |
+|---|---|---|
+| `none` (default) | Dashes preserved | `foo-bar` → `{{foo-bar}}` |
+| `camelCase` | Dashes converted to camelCase | `foo-bar` → `{{fooBar}}` |
+
+```shell
+fast build --attribute-name-strategy=camelCase --templates="./components/**/*.html"
+```
+
+:::important
+The attribute name strategy must match between the server-side build and the client-side `attributeMap` configuration. If the build uses `--attribute-name-strategy=camelCase`, configure the client with `attributeMap: { "attribute-name-strategy": "camelCase" }`.
+:::
+
+## Writing Components for SSR
+
+When designing components for server-side rendering, keep these guidelines in mind:
+
+- **Minimize JavaScript-dependent styling.** Prefer CSS-based state (`:host` attributes, CSS custom properties) over `elementInternals` state for initial styles, since the server cannot run JavaScript.
+- **Use `@attr` for initial state.** Attributes are visible to the server and can be rendered into the initial HTML. Observable properties set in `connectedCallback` are not available during server rendering.
+- **Keep templates self-contained.** Templates should produce meaningful content from attribute values alone without requiring imperative setup.
+- **Test both paths.** Verify that components work correctly with both client-side rendering (no pre-rendered content) and server-side rendering (hydration path).
+
+{% endraw %}

--- a/sites/website/src/docs/3.x/declarative-templates/server-rendering.md
+++ b/sites/website/src/docs/3.x/declarative-templates/server-rendering.md
@@ -29,7 +29,7 @@ One of the core benefits of FAST's declarative HTML templates is stack-agnostic 
 A server-side renderer must produce HTML that follows these conventions so the client-side FAST runtime can hydrate it:
 
 1. **Declarative Shadow DOM** — Custom element content is rendered inside a `<template shadowrootmode="open">` element, which the browser expands into a shadow root.
-2. **Hydration markers** — Binding slots are annotated with `data-fe="N"` attributes on elements, and content bindings are wrapped in `<!--fe:b-->VALUE<!--fe:/b-->` comment markers.
+2. **Hydration markers** — Attribute bindings are annotated with `data-fe="N"` attributes on elements (where `N` is the count of attribute bindings on that element). Content bindings are wrapped in `<!--fe:b-->VALUE<!--fe:/b-->` comment markers.
 3. **State resolution** — Binding expressions like `{{title}}` are resolved to their initial values from a state object.
 
 **Example:** Given this template and state:
@@ -38,25 +38,31 @@ A server-side renderer must produce HTML that follows these conventions so the c
 <f-template name="greeting-card">
     <template>
         <h2>{{title}}</h2>
-        <p>{{message}}</p>
+        <button ?disabled="{{!isActive}}" @click="{handleClick($e)}">
+            {{buttonLabel}}
+        </button>
     </template>
 </f-template>
 ```
 
 ```json
-{ "title": "Hello", "message": "Welcome to FAST" }
+{ "title": "Hello", "isActive": true, "buttonLabel": "Click me" }
 ```
 
 A server renderer produces:
 
 ```html
-<greeting-card title="Hello" message="Welcome to FAST">
+<greeting-card title="Hello" is-active button-label="Click me">
     <template shadowrootmode="open">
-        <h2 data-fe="0"><!--fe:b-->Hello<!--fe:/b--></h2>
-        <p data-fe="1"><!--fe:b-->Welcome to FAST<!--fe:/b--></p>
+        <h2><!--fe:b-->Hello<!--fe:/b--></h2>
+        <button data-fe="2">
+            <!--fe:b-->Click me<!--fe:/b-->
+        </button>
     </template>
 </greeting-card>
 ```
+
+Note that `data-fe="2"` appears on the `<button>` because it has two attribute bindings: the boolean `?disabled` binding and the `@click` event binding. Content bindings (`{{title}}` and `{{buttonLabel}}`) use comment markers instead. Event bindings and attribute directives are client-only — the server strips them but allocates binding slots for hydration.
 
 When the page loads, the FAST declarative runtime finds these markers and attaches reactive bindings to the existing DOM nodes instead of re-rendering.
 
@@ -66,8 +72,8 @@ The end-to-end flow from server to interactive page follows these steps:
 
 1. **Server renders** — The renderer resolves `{{bindings}}` against the state, injects Declarative Shadow DOM `<template>` elements, and adds hydration markers.
 2. **Browser loads HTML** — The browser parses the page. Declarative Shadow DOM `<template>` elements are automatically expanded into shadow roots.
-3. **JavaScript loads** — Component classes are defined with `templateOptions: "defer-and-hydrate"` and `TemplateElement` is registered.
-4. **Template assignment** — `TemplateElement` parses `<f-template>` markup and assigns the compiled template to each element definition.
+3. **JavaScript loads** — Component classes are defined with `template: declarativeTemplate()`, which waits for matching `<f-template>` elements and resolves the template.
+4. **Template resolution** — `declarativeTemplate()` coordinates with the `<f-template>` elements to parse the declarative markup and supply the compiled template to each element definition.
 5. **Hydration** — FAST detects the pre-rendered shadow DOM, maps existing DOM nodes to binding slots using hydration markers, and re-establishes reactive observations.
 6. **Interactive** — The page is fully interactive. Property changes trigger targeted DOM updates.
 
@@ -138,7 +144,7 @@ fast build --entry=index.html --state=state.json --output=output.html --template
 | `--state` | `state.json` | JSON file containing the initial state |
 | `--output` | `output.html` | Where to write the rendered HTML |
 | `--templates` | _(none)_ | Glob pattern(s) for `<f-template>` HTML files |
-| `--attribute-name-strategy` | `none` | How to map attribute names to properties |
+| `--attribute-name-strategy` | `camelCase` | How to map attribute names to properties |
 | `--config` | `fast-build.config.json` | Path to a configuration file |
 
 ### Example
@@ -209,15 +215,15 @@ The `--attribute-name-strategy` option controls how HTML attribute names on cust
 
 | Strategy | Behavior | Example |
 |---|---|---|
-| `none` (default) | Dashes preserved | `foo-bar` → `{{foo-bar}}` |
-| `camelCase` | Dashes converted to camelCase | `foo-bar` → `{{fooBar}}` |
+| `camelCase` (default) | Dashes converted to camelCase | `foo-bar` → `{{fooBar}}` |
+| `none` | Dashes preserved | `foo-bar` → `{{foo-bar}}` |
 
 ```shell
-fast build --attribute-name-strategy=camelCase --templates="./components/**/*.html"
+fast build --attribute-name-strategy=none --templates="./components/**/*.html"
 ```
 
 :::important
-The attribute name strategy must match between the server-side build and the client-side `attributeMap` configuration. If the build uses `--attribute-name-strategy=camelCase`, configure the client with `attributeMap: { "attribute-name-strategy": "camelCase" }`.
+The attribute name strategy must match between the server-side build and the client-side `attributeMap` configuration. If the build uses `--attribute-name-strategy=none`, configure the client with `attributeMap({ "attribute-name-strategy": "none" })`.
 :::
 
 ## Writing Components for SSR


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds a new **Declarative HTML** documentation section to the 3.x docs site with four pages covering the full declarative template authoring workflow:

- **Overview** — Purpose of declarative templates, when to use them, a hello world example, and comparison with imperative `html` tagged templates.
- **Writing f-templates** — Template syntax including content/attribute/boolean/event bindings, directives (`f-when`, `f-repeat`, `f-ref`, `f-slotted`, `f-children`), dot-notation paths, execution context access (`$e`, `$c`), and expression limitations.
- **Defining Elements** — `TemplateElement` registration, `templateOptions: "defer-and-hydrate"`, lifecycle callbacks (`config()`), element configuration (`options()`), `observerMap` and `attributeMap` usage.
- **Server-Side Rendering** — The renderer-agnostic SSR contract, hydration flow, Declarative Shadow DOM output, state propagation, and `@microsoft/fast-build` CLI usage.

Also adds cross-references from `packages/fast-element/README.md` and `DECLARATIVE_HTML.md` to the new docs.

Based on the declarative template features from PRs #7490, #7491, #7492, and #7493.

## 📑 Test Plan

- Website builds successfully with `npm run build -w sites/website`
- All four pages render correctly in the 11ty output
- `npm run checkchange` passes (no change files needed for docs-only changes to the website)

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.