### PR TITLE
feat: add customizable version banner to documentation site

### DIFF
--- a/sites/website/README.md
+++ b/sites/website/README.md
@@ -24,3 +24,32 @@ npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static content hosting service.
+
+## Version Banners
+
+The site supports configurable banners on documentation pages to communicate version status (e.g., prerelease, legacy). Banners are defined in `src/_data/versionBanners.js` and rendered via `src/_includes/version-banner.njk`.
+
+### Configuration
+
+Edit `src/_data/versionBanners.js` to add, remove, or modify banners. Each version key maps to a configuration object:
+
+```js
+"3.x": {
+    enabled: true,              // Toggle the banner on/off
+    type: "prerelease",         // "legacy" | "stable" | "prerelease"
+    version: fastElementVersion, // Optional version string
+    message: "This is a prerelease version of FAST (3.0.0-rc.1).",
+}
+```
+
+| Type | Color | Use case |
+|------|-------|----------|
+| `legacy` | Gray | Previous versions — links to latest docs |
+| `stable` | Green | Current stable release |
+| `prerelease` | Amber | Upcoming / release candidate versions |
+
+The prerelease banner reads the version from `@microsoft/fast-element`'s `package.json` automatically.
+
+### Styles
+
+Banner CSS lives in `src/css/version-banner.css` and is loaded on all pages via `root.njk`.

--- a/sites/website/eleventy.config.js
+++ b/sites/website/eleventy.config.js
@@ -1,53 +1,54 @@
+import { IdAttributePlugin } from "@11ty/eleventy";
 import eleventyNavigationPlugin from "@11ty/eleventy-navigation";
 import syntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
-import { IdAttributePlugin } from "@11ty/eleventy";
 import { admonitionPlugin } from "./plugins/admonitions.js";
 
-export default function(eleventyConfig) {
-  /**
-   * Styles
-   */
-  eleventyConfig.addPassthroughCopy("src/css/main.css");
-  eleventyConfig.addPassthroughCopy("src/css/prism-vsc-dark-plus.css");
-  eleventyConfig.addPassthroughCopy("src/css/variables.css");
+export default function (eleventyConfig) {
+    /**
+     * Styles
+     */
+    eleventyConfig.addPassthroughCopy("src/css/main.css");
+    eleventyConfig.addPassthroughCopy("src/css/prism-vsc-dark-plus.css");
+    eleventyConfig.addPassthroughCopy("src/css/variables.css");
+    eleventyConfig.addPassthroughCopy("src/css/version-banner.css");
 
-  /**
-   * Scripts
-   */
-  eleventyConfig.addPassthroughCopy("src/js/sidebar-navigation.js");
-  eleventyConfig.addPassthroughCopy("src/js/navbar-toggle.js");
+    /**
+     * Scripts
+     */
+    eleventyConfig.addPassthroughCopy("src/js/sidebar-navigation.js");
+    eleventyConfig.addPassthroughCopy("src/js/navbar-toggle.js");
 
-  /**
-   * Assets
-   */
-  eleventyConfig.addPassthroughCopy("src/static/favicon.ico");
-  eleventyConfig.addPassthroughCopy("src/static/fast-inline-logo.svg");
+    /**
+     * Assets
+     */
+    eleventyConfig.addPassthroughCopy("src/static/favicon.ico");
+    eleventyConfig.addPassthroughCopy("src/static/fast-inline-logo.svg");
 
-  /**
-   * Plugins
-   */
-  eleventyConfig.addPlugin(eleventyNavigationPlugin);
-  eleventyConfig.addPlugin(syntaxHighlight);
-  eleventyConfig.addPlugin(IdAttributePlugin);
+    /**
+     * Plugins
+     */
+    eleventyConfig.addPlugin(eleventyNavigationPlugin);
+    eleventyConfig.addPlugin(syntaxHighlight);
+    eleventyConfig.addPlugin(IdAttributePlugin);
 
-  /**
-   * Markdown
-   */
-  eleventyConfig.amendLibrary("md", (md) => {
-    md.use(admonitionPlugin);
-  });
+    /**
+     * Markdown
+     */
+    eleventyConfig.amendLibrary("md", md => {
+        md.use(admonitionPlugin);
+    });
 
-  /**
-   * Filters
-   */
-  eleventyConfig.addFilter("version", function(value) {
-    const version = "3.x";
+    /**
+     * Filters
+     */
+    eleventyConfig.addFilter("version", function (value) {
+        const version = "3.x";
 
-    if (typeof value === "string") {
-        const splitUrl = value.split("/");
-        return splitUrl[2] ?? version;
-    }
+        if (typeof value === "string") {
+            const splitUrl = value.split("/");
+            return splitUrl[2] ?? version;
+        }
 
-    return version;
-  });
-};
+        return version;
+    });
+}

--- a/sites/website/src/_data/versionBanners.js
+++ b/sites/website/src/_data/versionBanners.js
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function getFastElementVersion() {
+    const pkgPath = resolve(
+        __dirname,
+        "..",
+        "..",
+        "..",
+        "..",
+        "packages",
+        "fast-element",
+        "package.json",
+    );
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    return pkg.version;
+}
+
+/**
+ * Version banner configuration.
+ *
+ * Each key is a documentation version (e.g., "1.x", "2.x", "3.x").
+ *
+ * Properties:
+ * - enabled:  Whether the banner is displayed.
+ * - type:     "legacy" | "stable" | "prerelease" — controls color.
+ * - message:  Text shown in the banner.
+ * - version:  Optional version string (e.g., "3.0.0-rc.1") displayed
+ *             alongside the message for prerelease banners.
+ *
+ * To add a banner for a new version, add a new key here.
+ * To remove a banner, set `enabled: false` or delete the key.
+ */
+export default function () {
+    const fastElementVersion = getFastElementVersion();
+
+    return {
+        "1.x": {
+            enabled: true,
+            type: "legacy",
+            message:
+                "You are viewing documentation for a previous version of FAST. The latest version is 2.x.",
+        },
+        "2.x": {
+            enabled: false,
+            type: "stable",
+            message: "You are viewing the current stable version of FAST.",
+        },
+        "3.x": {
+            enabled: true,
+            type: "prerelease",
+            version: fastElementVersion,
+            message: `This is a prerelease version of FAST (${fastElementVersion}).`,
+        },
+    };
+}

--- a/sites/website/src/_includes/doc.njk
+++ b/sites/website/src/_includes/doc.njk
@@ -2,6 +2,7 @@
 layout: root.njk
 title: FAST
 ---
+{% include "version-banner.njk" %}
 <div class="docs-wrapper">
     <div class="doc-root">
         {{ content | safe }}

--- a/sites/website/src/_includes/root.njk
+++ b/sites/website/src/_includes/root.njk
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="/css/main.css">
     <link rel="stylesheet" href="/css/prism-vsc-dark-plus.css">
     <link rel="stylesheet" href="/css/variables.css">
+    <link rel="stylesheet" href="/css/version-banner.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" data-rh="true">
     <script src="/js/navbar-toggle.js"></script>
     </head>

--- a/sites/website/src/_includes/version-banner.njk
+++ b/sites/website/src/_includes/version-banner.njk
@@ -1,0 +1,12 @@
+{%- set currentVersion = page.url | version -%}
+{%- set banner = versionBanners[currentVersion] -%}
+{%- if banner and banner.enabled and page.url and "/docs/" in page.url -%}
+<div class="version-banner version-banner--{{ banner.type }}" role="status">
+    <p class="version-banner__message">
+        {{ banner.message }}
+        {%- if banner.type == "legacy" %}
+        <a href="/docs/2.x/introduction" class="version-banner__link">View latest docs →</a>
+        {%- endif %}
+    </p>
+</div>
+{%- endif -%}

--- a/sites/website/src/css/version-banner.css
+++ b/sites/website/src/css/version-banner.css
@@ -1,0 +1,54 @@
+.version-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 16px;
+    font-size: 14px;
+    line-height: 1.4;
+    text-align: center;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.version-banner__message {
+    margin: 0;
+}
+
+.version-banner__link {
+    margin-left: 8px;
+    text-decoration: underline;
+    font-weight: 600;
+}
+
+/* Legacy — muted gray to indicate an older version */
+.version-banner--legacy {
+    background-color: #3a3a3a;
+    color: #d4d4d4;
+    border-bottom: 2px solid #555;
+}
+
+.version-banner--legacy .version-banner__link {
+    color: #8bb4e0;
+}
+
+/* Stable — green to indicate the current release */
+.version-banner--stable {
+    background-color: #1a3a2a;
+    color: #a3d9b1;
+    border-bottom: 2px solid #2d6a4f;
+}
+
+.version-banner--stable .version-banner__link {
+    color: #6dd895;
+}
+
+/* Prerelease — amber/orange to indicate pre-release software */
+.version-banner--prerelease {
+    background-color: #3a2e1a;
+    color: #e8c96d;
+    border-bottom: 2px solid #b8860b;
+}
+
+.version-banner--prerelease .version-banner__link {
+    color: #f0d77b;
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds a modular, configurable banner system to the 11ty documentation site that communicates version status to readers. Each documentation version (1.x, 2.x, 3.x) can independently display a banner indicating whether it is a **prerelease**, **stable**, or **legacy** version.

Key changes:
- **`src/_data/versionBanners.js`** — 11ty global data file with per-version banner configuration. Reads the `@microsoft/fast-element` package.json version automatically for prerelease banners.
- **`src/_includes/version-banner.njk`** — Nunjucks partial that renders the appropriate banner based on the current page URL.
- **`src/css/version-banner.css`** — Three color themes: gray (legacy), green (stable), amber (prerelease).
- **`doc.njk`** — Includes the banner partial above the docs wrapper.
- **`eleventy.config.js`** and **`root.njk`** — Wire up the new CSS file.

Current configuration:
- **1.x** → Legacy banner with link to latest docs
- **2.x** → Disabled (current stable, no banner)
- **3.x** → Prerelease banner showing the `@microsoft/fast-element` version

## 👩‍💻 Reviewer Notes

The banner is fully data-driven. To modify, add, or remove banners, edit only `src/_data/versionBanners.js`. No template or CSS changes are needed for configuration adjustments.

## 📑 Test Plan

- All existing tests pass (`npm run test`).
- Site builds successfully (`npm run build`).
- Verified banner HTML appears in 1.x and 3.x build output, is absent from 2.x docs and the frontpage.
- Biome checks pass (`npm run biome:check`).
- No change files required (website is a private package).

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

- Update the 3.x banner version string once the package version is bumped to a `3.0.0-rc.*` prerelease.
- Enable the stable banner for 2.x if desired for visual consistency.
- Update the legacy banner link target when 3.x becomes the latest stable release.