### PR TITLE
chore: bump the version of fast-element to 3.0.0-rc.1

### DIFF
--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/todo-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^2.10.4",
+    "@microsoft/fast-element": "^3.0.0-rc.1",
     "tslib": "^2.6.3"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,12 @@
         "@genesiscommunitysuccess/custom-elements-lsp": "5.0.3"
       }
     },
+    "examples/todo-app/node_modules/@microsoft/fast-element": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-2.10.4.tgz",
+      "integrity": "sha512-OkHIlMztq7+PgkRF1LscgBd/MVzMhGrWPkJRDvOEqdqEdZOKocKvaKcUKZubIBz4RpLIrhLD3lOJzCsspk6jXg==",
+      "license": "MIT"
+    },
     "node_modules/@11ty/dependency-tree": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@11ty/dependency-tree/-/dependency-tree-4.0.2.tgz",
@@ -6971,7 +6977,7 @@
     },
     "packages/fast-element": {
       "name": "@microsoft/fast-element",
-      "version": "2.10.4",
+      "version": "3.0.0-rc.1",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/fast-build": "*",
@@ -6991,6 +6997,13 @@
       "peerDependencies": {
         "@microsoft/fast-element": "^2.10.4"
       }
+    },
+    "packages/fast-router/node_modules/@microsoft/fast-element": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-2.10.4.tgz",
+      "integrity": "sha512-OkHIlMztq7+PgkRF1LscgBd/MVzMhGrWPkJRDvOEqdqEdZOKocKvaKcUKZubIBz4RpLIrhLD3lOJzCsspk6jXg==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/fast-test-harness": {
       "name": "@microsoft/fast-test-harness",
@@ -7332,6 +7345,13 @@
         "@microsoft/tsdoc-config": "~0.18.1",
         "@rushstack/node-core-library": "5.20.3"
       }
+    },
+    "sites/website/node_modules/@microsoft/fast-element": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-2.10.4.tgz",
+      "integrity": "sha512-OkHIlMztq7+PgkRF1LscgBd/MVzMhGrWPkJRDvOEqdqEdZOKocKvaKcUKZubIBz4RpLIrhLD3lOJzCsspk6jXg==",
+      "dev": true,
+      "license": "MIT"
     },
     "sites/website/node_modules/@rushstack/node-core-library": {
       "version": "5.20.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,19 +53,13 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^2.10.4",
+        "@microsoft/fast-element": "^3.0.0-rc.1",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
         "@genesiscommunitysuccess/cep-fast-plugin": "5.0.3",
         "@genesiscommunitysuccess/custom-elements-lsp": "5.0.3"
       }
-    },
-    "examples/todo-app/node_modules/@microsoft/fast-element": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-2.10.4.tgz",
-      "integrity": "sha512-OkHIlMztq7+PgkRF1LscgBd/MVzMhGrWPkJRDvOEqdqEdZOKocKvaKcUKZubIBz4RpLIrhLD3lOJzCsspk6jXg==",
-      "license": "MIT"
     },
     "node_modules/@11ty/dependency-tree": {
       "version": "4.0.2",
@@ -6992,18 +6986,11 @@
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@microsoft/fast-element": "^2.10.4"
+        "@microsoft/fast-element": "^3.0.0-rc.1"
       },
       "peerDependencies": {
-        "@microsoft/fast-element": "^2.10.4"
+        "@microsoft/fast-element": "^3.0.0-rc.1"
       }
-    },
-    "packages/fast-router/node_modules/@microsoft/fast-element": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-2.10.4.tgz",
-      "integrity": "sha512-OkHIlMztq7+PgkRF1LscgBd/MVzMhGrWPkJRDvOEqdqEdZOKocKvaKcUKZubIBz4RpLIrhLD3lOJzCsspk6jXg==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/fast-test-harness": {
       "name": "@microsoft/fast-test-harness",
@@ -7024,7 +7011,7 @@
       },
       "peerDependencies": {
         "@microsoft/fast-build": ">=0.4.0 <1.0.0",
-        "@microsoft/fast-element": ">=2.10.4 <3.0.0",
+        "@microsoft/fast-element": ">=2.10.4 <=3.0.0-rc.1",
         "@playwright/test": ">=1.40.0",
         "vite": ">=7.0.0"
       },
@@ -7318,7 +7305,7 @@
       },
       "devDependencies": {
         "@microsoft/fast-build": "^0.4.0",
-        "@microsoft/fast-element": "^2.10.4"
+        "@microsoft/fast-element": "^3.0.0-rc.1"
       }
     },
     "sites/website/node_modules/@microsoft/api-documenter": {
@@ -7345,13 +7332,6 @@
         "@microsoft/tsdoc-config": "~0.18.1",
         "@rushstack/node-core-library": "5.20.3"
       }
-    },
-    "sites/website/node_modules/@microsoft/fast-element": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-2.10.4.tgz",
-      "integrity": "sha512-OkHIlMztq7+PgkRF1LscgBd/MVzMhGrWPkJRDvOEqdqEdZOKocKvaKcUKZubIBz4RpLIrhLD3lOJzCsspk6jXg==",
-      "dev": true,
-      "license": "MIT"
     },
     "sites/website/node_modules/@rushstack/node-core-library": {
       "version": "5.20.3",

--- a/packages/fast-element/package.json
+++ b/packages/fast-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/fast-element",
   "description": "A library for constructing Web Components",
-  "version": "2.10.4",
+  "version": "3.0.0-rc.1",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"

--- a/packages/fast-router/package.json
+++ b/packages/fast-router/package.json
@@ -38,10 +38,10 @@
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@microsoft/fast-element": "^2.10.4"
+    "@microsoft/fast-element": "^3.0.0-rc.1"
   },
   "peerDependencies": {
-    "@microsoft/fast-element": "^2.10.4"
+    "@microsoft/fast-element": "^3.0.0-rc.1"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/fast-test-harness/package.json
+++ b/packages/fast-test-harness/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@microsoft/fast-build": ">=0.4.0 <1.0.0",
-    "@microsoft/fast-element": ">=2.10.4 <3.0.0",
+    "@microsoft/fast-element": ">=2.10.4 <=3.0.0-rc.1",
     "@playwright/test": ">=1.40.0",
     "vite": ">=7.0.0"
   },

--- a/sites/website/package.json
+++ b/sites/website/package.json
@@ -30,6 +30,6 @@
   },
   "devDependencies": {
     "@microsoft/fast-build": "^0.4.0",
-    "@microsoft/fast-element": "^2.10.4"
+    "@microsoft/fast-element": "^3.0.0-rc.1"
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Bumping the `@microsoft/fast-element` to version 3.0.0 release candidate 1 aka `3.0.0-rc.1`.

This is intended to showcase the updated APIs that were part of the now deprecated `@microsoft/fast-html` package and update the docs with sections on declarative template writing. This release candidate should include all breaking changes except #7247 which is currently being evaluated.

## 👩‍💻 Reviewer Notes

This change manually sets the version as beachball does not yet have a stable-to-prerelease and prerelease-to-stable feature.

We intend to publish several release candidates before moving to stable, which we will do as soon as we perform more testing and get community feedback on the updates.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

- Publish the `@microsoft/fast-element` package
- Deploy the updated documentation